### PR TITLE
fix: expose alpha on KeyATM and SeededLDA so composition_theta works (#20)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1309,6 +1309,10 @@ class SeededLDA:
     @property
     def num_topics(self) -> int: ...
     @property
+    def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
+        """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,)."""
+        ...
+    @property
     def topic_names(self) -> list[str]:
         """The seed names you gave, then 'residual_1' ... for unseeded topics."""
         ...
@@ -1770,6 +1774,12 @@ class KeyATM:
     @property
     def keyword_rate(self) -> numpy.typing.NDArray[numpy.float64]:
         """Per-topic keyword switch rate (0 for regular topics)."""
+        ...
+    @property
+    def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
+        """The document-topic Dirichlet prior alpha, shape (num_topics,). Base model:
+        the estimated asymmetric prior; covariate/dynamic models fall back to the
+        symmetric base value."""
         ...
     @property
     def time_prevalence(self) -> numpy.typing.NDArray[numpy.float64]:

--- a/src/python.rs
+++ b/src/python.rs
@@ -250,6 +250,7 @@ struct KeyAtmState {
     #[serde(default)] log_likelihood_history: Vec<(usize, f64, f64)>,
     #[serde(default)] alpha_history: Vec<(usize, Vec<f64>)>,
     #[serde(default)] pi_history: Vec<(usize, Vec<f64>)>,
+    #[serde(default)] alpha_vec: Option<Vec<f64>>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct PaState {
@@ -6450,6 +6451,14 @@ impl SeededLDA {
     fn num_topics(&self) -> usize {
         self.num_topics_val()
     }
+    /// The symmetric document-topic Dirichlet prior α, broadcast to
+    /// ``(num_topics,)``. Marks SeededLDA as a Dirichlet model for
+    /// :func:`topica.effects.composition_theta`.
+    #[getter]
+    fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        self.require_fitted()?;
+        Ok(Array1::from(vec![self.alpha; self.num_topics_val()]).to_pyarray_bound(py))
+    }
     /// The topic labels: the seed names you gave, then ``residual_1`` … for any
     /// unseeded topics.
     #[getter]
@@ -8140,6 +8149,11 @@ pub struct KeyATM {
     // (iteration, alpha vector) and (iteration, pi vector) — plot_alpha / plot_pi.
     alpha_history: Vec<(usize, Vec<f64>)>,
     pi_history: Vec<(usize, Vec<f64>)>,
+    // Base model: the estimated asymmetric document-topic Dirichlet prior α_k
+    // (length K). None for the covariate model (which uses the DMR λ) and the
+    // dynamic model (per-state α); the `alpha` getter then falls back to the
+    // symmetric prior.
+    alpha_vec: Option<Vec<f64>>,
 }
 
 impl KeyATM {
@@ -8197,7 +8211,7 @@ impl KeyATM {
             feature_effects: None, feature_names: Vec::new(),
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
             transition_matrix: None, log_likelihood_history: Vec::new(),
-            alpha_history: Vec::new(), pi_history: Vec::new(),
+            alpha_history: Vec::new(), pi_history: Vec::new(), alpha_vec: None,
         })
     }
 
@@ -8224,7 +8238,7 @@ impl KeyATM {
             corpus: None, feature_effects: None, feature_names: Vec::new(),
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
             transition_matrix: None, log_likelihood_history: Vec::new(),
-            alpha_history: Vec::new(), pi_history: Vec::new(),
+            alpha_history: Vec::new(), pi_history: Vec::new(), alpha_vec: None,
         })
     }
 
@@ -8383,6 +8397,7 @@ impl KeyATM {
             self.log_likelihood_history = model.log_likelihood_history.clone();
             self.alpha_history = model.alpha_history.clone();
             self.pi_history = model.pi_history.clone();
+            self.alpha_vec = model.alpha_vec.clone();
             self.time_labels = labels;
 
             let mut names = self.key_names.clone();
@@ -8488,6 +8503,7 @@ impl KeyATM {
         self.log_likelihood_history = model.log_likelihood_history.clone();
         self.alpha_history = model.alpha_history.clone();
         self.pi_history = model.pi_history.clone();
+        self.alpha_vec = model.alpha_vec.clone();
         if let Some(lam) = &model.lambda {
             self.feature_effects = Some(vecs_to_arr2(lam));
             self.feature_names = cov_names;
@@ -8575,6 +8591,21 @@ impl KeyATM {
         Ok(Array1::from(self.keyword_rate.clone()).to_pyarray_bound(py))
     }
 
+    /// The document-topic Dirichlet prior α, shape ``(num_topics,)``. For the base
+    /// model this is the estimated asymmetric prior (R keyATM's ``alpha``); the
+    /// covariate and dynamic models use a per-document prior, so this falls back to
+    /// the symmetric base value. Marks keyATM as a Dirichlet model for
+    /// :func:`topica.effects.composition_theta`.
+    #[getter]
+    fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        self.require_fitted()?;
+        let a = match &self.alpha_vec {
+            Some(v) => v.clone(),
+            None => vec![self.alpha; self.num_topics],
+        };
+        Ok(Array1::from(a).to_pyarray_bound(py))
+    }
+
     /// Convergence trace as a list of ``(iteration, log_likelihood, perplexity)``
     /// triples — the three columns of keyATM's ``model_fit`` (``plot_modelfit``).
     /// ``log_likelihood`` is the collapsed marginal log-likelihood and
@@ -8650,6 +8681,7 @@ impl KeyATM {
             log_likelihood_history: self.log_likelihood_history.clone(),
             alpha_history: self.alpha_history.clone(),
             pi_history: self.pi_history.clone(),
+            alpha_vec: self.alpha_vec.clone(),
         })
     }
     /// Load a model previously written by :meth:`save`.
@@ -8666,6 +8698,7 @@ impl KeyATM {
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
             transition_matrix: None, log_likelihood_history: s.log_likelihood_history,
             alpha_history: s.alpha_history, pi_history: s.pi_history,
+            alpha_vec: s.alpha_vec,
         })
     }
 

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -39,6 +39,30 @@ def test_model_family_detection():
     assert topica.model_family(topica.BERTopic(min_cluster_size=5)) == "none"
 
 
+def test_collapsed_gibbs_models_are_dirichlet():
+    """Issue #20: KeyATM and SeededLDA are collapsed-Gibbs Dirichlet models, so
+    `model_family` must classify them as "dirichlet" (they expose `alpha`) and
+    `composition_theta` must draw the full posterior, not silently fall back."""
+    docs = [list(np.random.default_rng(i).choice(
+        [f"a{j}" for j in range(6)] + [f"b{j}" for j in range(6)], size=12))
+        for i in range(60)]
+    corpus = topica.Corpus.from_documents(docs)
+
+    seeded = topica.SeededLDA({"a": ["a0", "a1"], "b": ["b0", "b1"]}, residual=1)
+    seeded.fit(corpus, iters=150)
+    key = topica.KeyATM({"a": ["a0", "a1"], "b": ["b0", "b1"]}, num_topics=3)
+    key.fit(corpus, iters=150)
+
+    k = len(corpus.doc_lengths)
+    for model in (seeded, key):
+        assert topica.model_family(model) == "dirichlet"
+        assert np.asarray(model.alpha).shape == (model.num_topics,)
+        draws = topica.effects.composition_theta(model, corpus, nsims=5)
+        assert draws.shape == (5, k, model.num_topics)
+        # Real posterior draws vary across simulations (not a repeated point estimate).
+        assert draws.std(axis=0).max() > 0.0
+
+
 def test_composition_effect_inflates_over_ols():
     m, corpus, x = _planted()
     X = x[:, None]


### PR DESCRIPTION
## Summary

Fixes #20. `effects.model_family` misclassified `KeyATM` and `SeededLDA` as `"none"`, so `composition_theta` raised for them and tempotm's `period_prevalence` silently degraded `R_t` to a single point estimate (dropping the topic-estimation-uncertainty term).

The `hasattr(cls, "alpha")` check in `model_family` is the correct discriminator — it separates the Dirichlet-prior Gibbs models from the embedding models, which also expose `doc_topic` (so the alternative "doc_topic present and not logistic-normal" rule would have wrongly swept in ETM/ProdLDA/FASTopic/Top2Vec/BERTopic). The defect was simply that KeyATM and SeededLDA never exposed `alpha`.

## Changes

- **`SeededLDA.alpha`** — returns the symmetric prior broadcast to `(num_topics,)`.
- **`KeyATM.alpha`** — returns the document-topic Dirichlet prior `(num_topics,)`: the estimated asymmetric α for the base model (now stored in `alpha_vec` and threaded through `KeyAtmState` save/load), falling back to the symmetric base value for the covariate/dynamic models (whose prior is per-document).
- `.pyi` stubs for both.
- Regression test `test_collapsed_gibbs_models_are_dirichlet`.

`model_family`'s logic/docstring were unchanged — the docstring already named keyATM/SeededLDA as `"dirichlet"`; now the code matches.

## Tests

1089 Python + 49 Rust pass. `composition_theta` now returns `(nsims, num_docs, num_topics)` for both models; save/load round-trips `alpha`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)