### PR TITLE
fix: expose alpha across the Dirichlet Gibbs models; registry family test (#21)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -210,6 +210,12 @@ class DMR:
         ...
 
     @property
+    def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
+        """The baseline document-topic Dirichlet prior alpha, shape (num_topics,):
+        exp(lambda_intercept), the per-topic prior at covariates = 0."""
+        ...
+
+    @property
     def prevalence_effects(self) -> numpy.typing.NDArray[numpy.float64]:
         """Learned prevalence weights gamma, shape (num_topics, num_features).
         Column 0 is the intercept; positive entries raise that topic's
@@ -680,6 +686,10 @@ class SupervisedLDA:
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
+    def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
+        """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,)."""
+        ...
+    @property
     def coefficients(self) -> numpy.typing.NDArray[numpy.float64]:
         """Regression coefficients eta, shape (num_topics,) — how each topic
         moves the response per unit of topic frequency."""
@@ -770,6 +780,13 @@ class SAGE:
         ...
 
     @property
+    def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
+        """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,).
+        SAGE's sparse additive parameterization is on the word side; the document
+        side is an ordinary Dirichlet."""
+        ...
+
+    @property
     def groups(self) -> list[str]:
         """Group names, in the index order of topic_word's second axis."""
         ...
@@ -835,6 +852,11 @@ class LabeledLDA:
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]:
         """theta matrix (num_docs, num_topics); only a document's label topics
         are non-zero, rows sum to 1."""
+        ...
+
+    @property
+    def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
+        """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,)."""
         ...
 
     @property
@@ -1116,6 +1138,10 @@ class PT:
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
+    def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
+        """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,)."""
+        ...
+    @property
     def num_topics(self) -> int: ...
     @property
     def vocabulary(self) -> list[str]: ...
@@ -1213,6 +1239,10 @@ class PA:
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]:
         """Document sub-topic matrix, shape (num_docs, num_sub)."""
+        ...
+    @property
+    def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
+        """The symmetric sub-topic Dirichlet prior alpha, shape (num_sub,)."""
         ...
     @property
     def super_sub(self) -> numpy.typing.NDArray[numpy.float64]:

--- a/src/python.rs
+++ b/src/python.rs
@@ -2771,6 +2771,19 @@ impl DMR {
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
     }
 
+    /// The baseline document-topic Dirichlet prior α, shape ``(num_topics,)``:
+    /// ``exp(λ_intercept)``, the per-topic prior at covariates = 0. DMR's prior is
+    /// per-document (``α_{d,k} = exp(λ_k · x_d)``), so this is the baseline; it
+    /// marks DMR as a Dirichlet model for :func:`topica.effects.composition_theta`.
+    #[getter]
+    fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        self.require_fitted()?;
+        // feature_effects is (num_topics, num_features); column 0 is the intercept.
+        let lam = self.feature_effects.as_ref().unwrap();
+        let a: Vec<f64> = lam.column(0).iter().map(|&l| l.exp()).collect();
+        Ok(Array1::from(a).to_pyarray_bound(py))
+    }
+
     /// Learned feature weights λ, shape ``(num_topics, num_features)`` — how
     /// each feature (column 0 is the intercept) shifts each topic's log-prior.
     /// Positive ⇒ the feature raises that topic's prevalence.
@@ -3206,6 +3219,15 @@ impl LabeledLDA {
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
     }
 
+    /// The symmetric document-topic Dirichlet prior α, shape ``(num_topics,)``.
+    /// Marks LabeledLDA as a Dirichlet model for
+    /// :func:`topica.effects.composition_theta`.
+    #[getter]
+    fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        self.require_fitted()?;
+        Ok(Array1::from(vec![self.alpha; self.num_topics]).to_pyarray_bound(py))
+    }
+
     /// The label name for each topic, in topic (column) order.
     #[getter]
     fn labels(&self) -> PyResult<Vec<String>> {
@@ -3615,6 +3637,16 @@ impl SAGE {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+
+    /// The symmetric document-topic Dirichlet prior α, shape ``(num_topics,)``.
+    /// SAGE's sparse additive parameterization is on the word side; the
+    /// document side is an ordinary Dirichlet, so this marks SAGE as a Dirichlet
+    /// model for :func:`topica.effects.composition_theta`.
+    #[getter]
+    fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        self.require_fitted()?;
+        Ok(Array1::from(vec![self.alpha; self.num_topics]).to_pyarray_bound(py))
     }
 
     /// Group names, in the index order used by :attr:`topic_word`'s second axis.
@@ -5769,6 +5801,15 @@ impl SupervisedLDA {
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
     }
 
+    /// The symmetric document-topic Dirichlet prior α, shape ``(num_topics,)``.
+    /// Marks SupervisedLDA as a Dirichlet model for
+    /// :func:`topica.effects.composition_theta`.
+    #[getter]
+    fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        self.require_fitted()?;
+        Ok(Array1::from(vec![self.alpha; self.num_topics]).to_pyarray_bound(py))
+    }
+
     /// Regression coefficients η, shape ``(num_topics,)`` — how each topic moves
     /// the response (in the response's units, per unit of topic frequency).
     #[getter]
@@ -5987,6 +6028,14 @@ impl PT {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+    /// The symmetric document-topic Dirichlet prior α, shape ``(num_topics,)``.
+    /// Marks PT as a Dirichlet model for
+    /// :func:`topica.effects.composition_theta`.
+    #[getter]
+    fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        self.require_fitted()?;
+        Ok(Array1::from(vec![self.alpha; self.num_topics]).to_pyarray_bound(py))
     }
     #[getter]
     fn num_topics(&self) -> usize {
@@ -8798,6 +8847,14 @@ impl PA {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+    /// The symmetric sub-topic Dirichlet prior α, broadcast to the columns of
+    /// :attr:`doc_topic`, shape ``(num_sub,)``. Marks PA as a Dirichlet model for
+    /// :func:`topica.effects.composition_theta`.
+    #[getter]
+    fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        self.require_fitted()?;
+        Ok(Array1::from(vec![self.alpha; self.num_sub]).to_pyarray_bound(py))
     }
     /// Super-topic → sub-topic association, shape ``(num_super, num_sub)``; row s
     /// shows which sub-topics super-topic s groups together (the correlations).

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -39,28 +39,94 @@ def test_model_family_detection():
     assert topica.model_family(topica.BERTopic(min_cluster_size=5)) == "none"
 
 
-def test_collapsed_gibbs_models_are_dirichlet():
-    """Issue #20: KeyATM and SeededLDA are collapsed-Gibbs Dirichlet models, so
-    `model_family` must classify them as "dirichlet" (they expose `alpha`) and
-    `composition_theta` must draw the full posterior, not silently fall back."""
-    docs = [list(np.random.default_rng(i).choice(
-        [f"a{j}" for j in range(6)] + [f"b{j}" for j in range(6)], size=12))
-        for i in range(60)]
+# Issue #21: model_family must classify the *whole* registry, not just the
+# handful of models that happened to expose `alpha`. `model_family` inspects the
+# class (a PyO3 getter is a class attribute even before fit), so unfitted
+# instances are enough to pin every model's family. New models added without a
+# deliberate family land here as a failure.
+_FAMILY_REGISTRY = [
+    # collapsed-Gibbs / Dirichlet doc-topic posterior
+    ("LDA", lambda: topica.LDA(2), "dirichlet"),
+    ("HDP", lambda: topica.HDP(), "dirichlet"),
+    ("KeyATM", lambda: topica.KeyATM({"a": ["x"]}, num_topics=2), "dirichlet"),
+    ("SeededLDA", lambda: topica.SeededLDA({"a": ["x"], "b": ["y"]}), "dirichlet"),
+    ("LabeledLDA", lambda: topica.LabeledLDA(), "dirichlet"),
+    ("SupervisedLDA", lambda: topica.SupervisedLDA(num_topics=2), "dirichlet"),
+    ("DMR", lambda: topica.DMR(2), "dirichlet"),
+    ("PA", lambda: topica.PA(num_super=2, num_sub=4), "dirichlet"),
+    ("PT", lambda: topica.PT(num_topics=2, num_pseudo=10), "dirichlet"),
+    ("SAGE", lambda: topica.SAGE(2), "dirichlet"),
+    # logistic-normal (variational eta posterior)
+    ("STM", lambda: topica.STM(2), "logistic_normal"),
+    ("CTM", lambda: topica.CTM(2), "logistic_normal"),
+    # no theta posterior -> method='bootstrap'. GSDMM is a Dirichlet *mixture*
+    # (one topic per document), so a Dirichlet theta draw would misstate its
+    # uncertainty; it stays "none" deliberately, alongside the embedding models.
+    ("GSDMM", lambda: topica.GSDMM(num_topics=5), "none"),
+    ("BERTopic", lambda: topica.BERTopic(min_cluster_size=5), "none"),
+    ("Top2Vec", lambda: topica.Top2Vec(), "none"),
+    ("ETM", lambda: topica.ETM(2), "none"),
+    ("ProdLDA", lambda: topica.ProdLDA(2), "none"),
+    ("FASTopic", lambda: topica.FASTopic(2), "none"),
+]
+
+
+@pytest.mark.parametrize("name, make, expected", _FAMILY_REGISTRY,
+                         ids=[r[0] for r in _FAMILY_REGISTRY])
+def test_model_family_registry(name, make, expected):
+    assert topica.model_family(make()) == expected
+
+
+def _fit_for_composition():
+    """Fit one model of each Dirichlet family on a shared toy corpus, with the
+    extra inputs each one needs, so composition_theta can be exercised."""
+    rng = np.random.default_rng(0)
+    vocab = [f"w{i}" for i in range(12)]
+    docs = [list(rng.choice(vocab, size=10)) for _ in range(40)]
     corpus = topica.Corpus.from_documents(docs)
+    y = rng.normal(size=len(docs))
+    X = rng.normal(size=(len(docs), 1))
 
-    seeded = topica.SeededLDA({"a": ["a0", "a1"], "b": ["b0", "b1"]}, residual=1)
-    seeded.fit(corpus, iters=150)
-    key = topica.KeyATM({"a": ["a0", "a1"], "b": ["b0", "b1"]}, num_topics=3)
-    key.fit(corpus, iters=150)
+    models = {}
+    m = topica.LDA(3, seed=1); m.fit(corpus, iterations=120); models["LDA"] = m
+    m = topica.HDP(seed=1); m.fit(corpus, iters=120); models["HDP"] = m
+    m = topica.KeyATM({"a": ["w0"], "b": ["w1"]}, num_topics=3)
+    m.fit(corpus, iters=120); models["KeyATM"] = m
+    m = topica.SeededLDA({"a": ["w0"], "b": ["w1"]}, residual=1)
+    m.fit(corpus, iters=120); models["SeededLDA"] = m
+    m = topica.LabeledLDA(seed=1); m.fit(docs, [["x", "y"]] * len(docs), iterations=120)
+    models["LabeledLDA"] = m
+    m = topica.SupervisedLDA(num_topics=3, seed=1); m.fit(docs, y, em_iters=8)
+    models["SupervisedLDA"] = m
+    m = topica.DMR(num_topics=3, seed=1, optimize_interval=25, burn_in=20)
+    m.fit(docs, X, feature_names=["x"], iterations=120, num_samples=2, sample_interval=10)
+    models["DMR"] = m
+    m = topica.PA(num_super=2, num_sub=4, seed=1); m.fit(corpus, iters=120)
+    models["PA"] = m
+    m = topica.PT(num_topics=3, num_pseudo=10, seed=1); m.fit(corpus, iters=120)
+    models["PT"] = m
+    m = topica.SAGE(num_topics=3, seed=1, optimize_interval=25, burn_in=20)
+    m.fit(docs, ["g"] * len(docs), iterations=120, num_samples=2, sample_interval=10)
+    models["SAGE"] = m
+    return corpus, models
 
-    k = len(corpus.doc_lengths)
-    for model in (seeded, key):
-        assert topica.model_family(model) == "dirichlet"
-        assert np.asarray(model.alpha).shape == (model.num_topics,)
+
+def test_composition_theta_runs_for_every_dirichlet_model():
+    """Issue #21: composition_theta must not raise for any Dirichlet model, and
+    must return a genuine posterior sample (varying across draws), not a silently
+    repeated point estimate that would zero out tempotm's between-draw variance."""
+    corpus, models = _fit_for_composition()
+    n = len(corpus.doc_lengths)
+    for name, model in models.items():
+        assert topica.model_family(model) == "dirichlet", name
+        k = np.asarray(model.doc_topic).shape[1]
+        # HDP's `alpha` is the DP concentration scalar by design; every other
+        # Dirichlet model exposes a per-topic prior aligned with doc_topic.
+        if name != "HDP":
+            assert np.asarray(model.alpha).shape == (k,), name
         draws = topica.effects.composition_theta(model, corpus, nsims=5)
-        assert draws.shape == (5, k, model.num_topics)
-        # Real posterior draws vary across simulations (not a repeated point estimate).
-        assert draws.std(axis=0).max() > 0.0
+        assert draws.shape == (5, n, k), name
+        assert draws.std(axis=0).max() > 0.0, name
 
 
 def test_composition_effect_inflates_over_ols():


### PR DESCRIPTION
Fixes #21. Stacked on #22 (the #20 fix) — base this PR's review/merge after #22, or retarget to `main` once #22 lands.

## Summary

#21 audited the whole registry: `model_family` keys `"dirichlet"` off the presence of an `alpha` getter (the right discriminator — it separates Dirichlet-prior Gibbs models from the embedding models, which also expose `doc_topic`), but `alpha` was present on only `LDA`/`HDP` plus the `KeyATM`/`SeededLDA` added in #20. Every other collapsed-Gibbs model fell through to `"none"`, so `composition_theta` raised and `viz/capability` silently showed point estimates instead of CI bands.

## Changes

Expose an `alpha` getter on **`LabeledLDA`, `SupervisedLDA`, `DMR`, `PA`, `PT`, `SAGE`**, each returning the per-topic document-topic Dirichlet prior aligned with `doc_topic`'s columns:
- symmetric prior for the scalar-alpha models (`LabeledLDA`, `SupervisedLDA`, `PT`, `SAGE`),
- sub-topic prior for `PA` (`num_sub`),
- `exp(λ_intercept)` for `DMR` — its prior is per-document, so this is the baseline at covariates = 0.

`SAGE`'s sparse-additive parameterization is on the word side only; its document side is an ordinary Dirichlet.

**`GSDMM` stays `"none"` deliberately** — it's a Dirichlet *mixture* (one topic per document), so a Dirichlet θ draw would misstate its uncertainty; bootstrap is correct.

Added `.pyi` stubs; `alpha` round-trips through save/load (DMR via `feature_effects`, others via the scalar field, all already persisted).

## Tests

- `test_model_family_registry` — parametrized over the **full** model class table (the gap that let this survive: the old test asserted only LDA/STM/BERTopic). `model_family` inspects the class, so unfitted instances pin every family; a new model added without a deliberate family fails here.
- `test_composition_theta_runs_for_every_dirichlet_model` — fits one of each Dirichlet family and asserts `composition_theta` returns a varying `(nsims, num_docs, num_topics)` posterior (not a silently-repeated point estimate).

Full suite: 1108 Python + 49 Rust pass; `mkdocs build --strict` clean.

## Deferred (same as #20)

`composition_theta` still passes `prior=0` to `dirichlet_theta_samples` for all Dirichlet models, matching current `LDA` behavior. Now that every model exposes its prior, wiring `prior=Σα` for the proper `α + n_d` concentration is a clean follow-up, but it changes existing SE outputs uniformly, so I kept it out of this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)