### PR TITLE
release: 0.12.1 — mask correlation-panel diagonal + paper update

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-06-08
+
+### Fixed
+
+- The `viz` topic-correlation panel (`TopicCorrelation`, and the correlation
+  sub-panel of `plot_report`) masks its always-1.0 diagonal instead of drawing
+  it. The self-correlation carried no information yet saturated the diverging
+  color scale and visually dominated the panel; the diagonal now renders as a
+  neutral background so the off-diagonal structure reads on a scale set by the
+  strongest real correlation. `to_frame()` is unchanged and still reports the
+  true diagonal.
+
+### Docs
+
+- Paper: added `ProdLDA` to the model-family table (count-based, with its
+  bibliography entry), and a worked example that aligns two model families and
+  compares their covariate effects with method-of-composition uncertainty.
+
 ## [0.12.0] - 2026-06-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.12.0"
+version = "0.12.1"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.12.0"
+version = "0.12.1"
 edition = "2021"
 
 [lib]

--- a/paper/topica.bib
+++ b/paper/topica.bib
@@ -311,6 +311,14 @@
   doi     = {10.1162/tacl_a_00325}
 }
 
+@inproceedings{srivastava2017prodlda,
+  author    = {Srivastava, Akash and Sutton, Charles},
+  title     = {Autoencoding Variational Inference for Topic Models},
+  booktitle = {5th International Conference on Learning Representations (ICLR)},
+  year      = {2017},
+  url       = {https://arxiv.org/abs/1703.01488}
+}
+
 @inproceedings{wu2024fastopic,
   author    = {Wu, Xiaobao and Nguyen, Thong and Zhang, Delvin Ce and Wang,
                William Yang and Luu, Anh Tuan},

--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -286,7 +286,8 @@ varies is the seed.
 The core depends only on \pkg{NumPy}. Features that pull heavier dependencies are
 optional extras, so the base install stays small and \pkg{PyTorch} is never
 required, even for the embedding-based models, which take vectors the user
-supplies from any embedder. The \code{viz} extra adds the plotting stack, the
+supplies from any embedder, and even for the neural \code{ProdLDA}, whose
+amortized variational autoencoder is hand-coded against \pkg{NumPy} alone. The \code{viz} extra adds the plotting stack, the
 \code{formula} extra adds \proglang{R}-style model formulas, and the \code{llm}
 extra adds optional large-language-model labeling and embedding through an API or
 a local model. The embedding models build on two pure-\proglang{Rust},
@@ -299,9 +300,9 @@ reducer \citep{mcinnes2018umap}.
 
 \pkg{topica} groups its models into two kinds by how they treat words.
 \emph{Count-based} models learn topics from word counts, by collapsed-Gibbs
-sampling or variational EM, and place topic-word weights on the probability
-simplex. \emph{Embedding-based} models start from document vectors the user
-supplies. Table~\ref{tab:models} lists the family and the question each model
+sampling, variational EM, or an amortized variational autoencoder, and present
+topic-word weights on the probability simplex. \emph{Embedding-based} models
+start from document vectors the user supplies. Table~\ref{tab:models} lists the family and the question each model
 answers. The breadth is the point: a single import covers the span from the LDA
 baseline to the structural topic model to neural clustering.
 
@@ -320,6 +321,7 @@ Model & What it is for & Reference \\
 \code{DMR}          & Topics conditioned on document metadata              & \citet{mimno2008dmr} \\
 \code{LabeledLDA}   & Supervised topics tied to document labels            & \citet{ramage2009llda} \\
 \code{CTM}          & Correlated topics (logistic-normal)                  & \citet{blei2007ctm} \\
+\code{ProdLDA}      & Sharper topics via a product-of-experts VAE          & \citet{srivastava2017prodlda} \\
 \code{STM}          & Prevalence \emph{and} content covariates             & \citet{roberts2016model} \\
 \code{SAGE}         & A topic worded differently across groups             & \citet{eisenstein2011sage} \\
 \code{HDP}          & Infers the number of topics                          & \citet{teh2006hdp} \\
@@ -625,6 +627,49 @@ Model & Family & Topics & Coherence ($c_v$) & Exclusivity & Diversity \\
 \bottomrule
 \end{tabular}
 \end{table}
+
+A comparison behind one contract need not stop at diagnostics. Two count-based
+models from different families can be aligned topic to topic and their covariate
+effects set side by side, each carried with the uncertainty its own posterior
+admits:
+
+\begin{CodeChunk}
+\begin{CodeInput}
+from topica import stm
+
+# lda (collapsed-Gibbs) and stm_model (variational) were fit above on the
+# same corpus, so their topic-word columns share a vocabulary. Match them.
+pairs = topica.align_topics(lda, stm_model)   # [(lda_topic, stm_topic, dist), ...]
+
+# One estimator, two families: it draws the posterior each admits --- Dirichlet
+# theta for the Gibbs LDA, logistic-normal theta for the STM --- so the
+# conservative effect carries method-of-composition uncertainty in both.
+eff_lda = stm.estimate_effect(lda, conservative, corpus=docs,
+                              feature_names=["conservative"], nsims=100)
+eff_stm = stm.estimate_effect(stm_model, conservative,
+                              feature_names=["conservative"], nsims=100)
+
+# Compare the conservative slope on matched topics, each with its own 95% CI.
+for i, j, _ in pairs:
+    a, b = eff_lda[i], eff_stm[j]   # coef[1] = conservative; coef[0] = intercept
+    print("%+.3f [%+.3f, %+.3f]   %+.3f [%+.3f, %+.3f]" % (
+        a.coef[1], a.ci_low[1], a.ci_high[1],
+        b.coef[1], b.ci_low[1], b.ci_high[1]))
+\end{CodeInput}
+\end{CodeChunk}
+
+The match is one assignment problem on the topic-word distances, and the single
+\code{estimate\_effect} call serves both families, drawing Dirichlet $\theta$ for
+the collapsed-Gibbs LDA and logistic-normal $\theta$ for the variational STM, so
+each conservative effect arrives with a method-of-composition interval rather than
+a bare point. Where two model families agree, within their intervals, on which
+topics are partisan, that agreement is a cross-model robustness check no
+single-model tool can pose; and the same call, asked of the embedding clustering
+of Table~\ref{tab:spanning}, finds no posterior over $\theta$ and declines the
+interval rather than manufacture one. This is the measurement stance of
+Section~\ref{sec:design} made operational: uncertainty is propagated from topic
+estimation into the effect where a posterior exists, and withheld where it does
+not, uniformly across the model family.
 
 \subsection{One model in depth: covariate effects with honest uncertainty}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.12.0"
+version = "0.12.1"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/python/topica/viz/correlation.py
+++ b/python/topica/viz/correlation.py
@@ -116,12 +116,21 @@ class TopicCorrelation(Panel):
         return (max(4.0, 0.4 * len(self._order) + 1.5),) * 2
 
     def _draw(self, fig):
+        import matplotlib as mpl
+
         order = self._order
         m = len(order)
         cor = self._cor[np.ix_(order, order)]
         vmax = max(float(np.abs(cor - np.eye(m)).max()), 1e-3)
+        # The diagonal is self-correlation (always 1); it carries no information and,
+        # left in, saturates the diverging scale and visually dominates the panel.
+        # Mask it to a neutral background so the off-diagonal structure reads.
+        disp = cor.copy()
+        np.fill_diagonal(disp, np.nan)
+        cmap = mpl.colormaps[DIV_CMAP].copy()
+        cmap.set_bad("#f0f0f0")
         ax = fig.subplots()
-        im = ax.imshow(cor, cmap=DIV_CMAP, vmin=-vmax, vmax=vmax)  # diverging, 0-centered
+        im = ax.imshow(disp, cmap=cmap, vmin=-vmax, vmax=vmax)  # diverging, 0-centered
         ax.set_xticks(range(m))
         ax.set_yticks(range(m))
         tick = [str(self._topics[i]) for i in order]


### PR DESCRIPTION
Patch release. Two changes plus the version bump.

## viz: mask the topic-correlation diagonal
The topic-correlation panel (`TopicCorrelation`, and the correlation sub-panel of `plot_report`) was drawing its always-1.0 diagonal. Self-correlation carries no information, but it saturated the diverging color scale and visually dominated the panel, washing out the off-diagonal structure that matters. The diagonal now renders as a neutral background; the color scale was already set from the off-diagonal max, so the off-diagonal correlations now read correctly. `to_frame()` is unchanged and still reports the true 1.0 diagonal.

## paper
- Added `ProdLDA` (the one model added since the last paper revision) to the model-family table as a count-based neural model, with its bibliography entry, and noted that even its VAE is hand-coded without PyTorch.
- Added a worked example to the breadth section that **aligns two model families and compares their covariate effects under method-of-composition uncertainty** — the same `estimate_effect` call drawing Dirichlet θ for the Gibbs LDA and logistic-normal θ for the STM, and declining for a model with no posterior. Makes the measurement-uncertainty stance operational rather than asserted.
- Regenerated `fig_poliblog_report` with the masked-diagonal correlation panel. All worked-example numbers (Table 3 and the effect estimates) reproduce **unchanged** from `paper/replication.py`.

## Validation
- Full suite: 1120 passed, 1 skipped.
- New paper code block smoke-tested against the live API (align + cross-family effects + the refusal path).
- Paper recompiles clean (17 pages, no undefined citations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)