### PR TITLE
feat: retain MCMC theta draws for Gibbs models (#31)

### DIFF
--- a/docs/guides/uncertainty.md
+++ b/docs/guides/uncertainty.md
@@ -23,10 +23,21 @@ quantity on each draw, and pools by Rubin's rules, so the standard errors inflat
 over a naive regression on point `θ`. It is cheap (no refit) and honest for
 covariate effects and group prevalence.
 
-`standard_errors` detects the model family and picks the right sampler for you:
-STM and CTM have a logistic-normal posterior; the Gibbs models (LDA, keyATM,
-SeededLDA, ...) have a per-document Dirichlet conditional, which needs the
-document lengths, so pass the `Corpus` you fit on.
+`standard_errors` detects the model family and picks the right sampler for you.
+STM and CTM draw from their logistic-normal variational posterior. The Gibbs
+models (LDA, keyATM, SeededLDA) retain thinned MCMC `θ` draws during the fit by
+default (`model.theta_draws`, shape `(num_draws, num_docs, num_topics)`), so the
+standard errors propagate real topic-estimation uncertainty: how much each
+document's mixture moves across sweeps, which grows when topics overlap and
+shrinks when the model is confident. No `Corpus` is needed in this case.
+
+If you fit with `keep_theta_draws=False` (to save the
+`num_draws x num_docs x num_topics` of f32 storage), the Gibbs path falls back to
+a per-document Dirichlet conditional built from the token counts, which needs the
+document lengths, so pass the `Corpus` you fit on. That approximation captures
+within-document sampling noise (it scales with `1 / N_d`) but is blind to whether
+the topics are actually identified, so its intervals can be wider than the real
+posterior for short documents and narrower for long ones.
 
 ```python
 # Covariate effects, uncertainty propagated (one regression per topic):

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -954,8 +954,15 @@ class LDA:
         sample_interval: int = 25,
         progress: Optional[object] = None,
         progress_interval: int = 50,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
     ) -> None:
-        """Run Gibbs sampling to fit the model on data."""
+        """Run Gibbs sampling to fit the model on data.
+
+        With ``keep_theta_draws`` (default on), the last ``num_theta_draws``
+        thinned MCMC theta snapshots are retained as :attr:`theta_draws` for
+        ``composition_theta`` standard errors. Set ``keep_theta_draws=False`` to
+        save memory (``num_theta_draws x num_docs x num_topics`` f32)."""
         ...
 
     @property
@@ -966,6 +973,13 @@ class LDA:
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]:
         """theta matrix of shape (num_docs, num_topics); rows sum to 1."""
+        ...
+
+    @property
+    def theta_draws(self) -> Optional[numpy.typing.NDArray[numpy.float32]]:
+        """Thinned MCMC theta draws, shape (num_draws, num_docs, num_topics), or
+        None when fit with keep_theta_draws=False. Real cross-sweep posterior
+        samples that composition_theta prefers over the Dirichlet approximation."""
         ...
 
     @property
@@ -1334,11 +1348,18 @@ class SeededLDA:
         data: Corpus | Sequence[Sequence[str]],
         *,
         iters: int = 2000,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
     ) -> None: ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
+    @property
+    def theta_draws(self) -> Optional[numpy.typing.NDArray[numpy.float32]]:
+        """Thinned MCMC theta draws, shape (num_draws, num_docs, num_topics), or
+        None when fit with keep_theta_draws=False."""
+        ...
     @property
     def num_topics(self) -> int: ...
     @property
@@ -1749,6 +1770,8 @@ class KeyATM:
         prior_variance: float = 1.0,
         lbfgs_iters: int = 20,
         report_interval: int = 0,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
     ) -> None:
         """Fit by collapsed Gibbs. Pass `covariates` (num_docs x F) for the
         covariate keyATM: the document-topic prior becomes a DMR,
@@ -1795,6 +1818,13 @@ class KeyATM:
         ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
+    @property
+    def theta_draws(self) -> Optional[numpy.typing.NDArray[numpy.float32]]:
+        """Thinned MCMC theta draws, shape (num_draws, num_docs, num_topics), or
+        None when fit with keep_theta_draws=False. Real cross-sweep posterior
+        samples that composition_theta prefers over the Dirichlet approximation.
+        Collected for the base, covariate, and dynamic variants."""
+        ...
     @property
     def feature_effects(self) -> numpy.typing.NDArray[numpy.float64]:
         """Covariate model: learned lambda, shape (num_topics, F+1); column 0 is

--- a/python/topica/effects.py
+++ b/python/topica/effects.py
@@ -144,13 +144,38 @@ def _doc_lengths_for(model, corpus):
     return lengths
 
 
+def _resample_draws(draws, nsims, seed):
+    """Match a stored draw stack ``(S, D, K)`` to exactly ``nsims`` draws: return
+    as-is when ``S == nsims``, take an evenly spaced subset when ``S > nsims``, or
+    resample with replacement when ``S < nsims`` (Rubin's-rules pooling still sees
+    only the ``S`` distinct draws, but the downstream shape is honored)."""
+    draws = np.asarray(draws, dtype=np.float64)
+    s = draws.shape[0]
+    if s == nsims:
+        return draws
+    if s > nsims:
+        idx = np.linspace(0, s - 1, nsims).round().astype(int)
+        return draws[idx]
+    rng = np.random.default_rng(seed)
+    return draws[rng.integers(0, s, size=nsims)]
+
+
 def composition_theta(model, corpus=None, *, nsims=25, seed=0):
     """Draw ``nsims`` theta matrices for method-of-composition, auto-selecting the
-    sampler from the model family. Returns ``(nsims, num_docs, num_topics)``."""
+    sampler from the model family. Returns ``(nsims, num_docs, num_topics)``.
+
+    For the Gibbs family this prefers a model's retained MCMC ``theta_draws`` (real
+    cross-sweep posterior samples; issue #31) when present, which also means no
+    ``corpus`` is needed. It falls back to :func:`dirichlet_theta_samples` (the
+    within-document Dirichlet approximation, which does need ``corpus`` for the
+    document lengths) when the model was fit with ``keep_theta_draws=False``."""
     fam = model_family(model)
     if fam == "logistic_normal":
         return posterior_theta_samples(model, nsims=nsims, seed=seed)
     if fam == "dirichlet":
+        draws = getattr(model, "theta_draws", None)
+        if draws is not None and len(draws):
+            return _resample_draws(draws, nsims, seed)
         lengths = _doc_lengths_for(model, corpus)
         return dirichlet_theta_samples(
             np.asarray(model.doc_topic, dtype=np.float64), lengths, nsims=nsims, seed=seed

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -191,6 +191,14 @@ pub struct KeyAtmModel {
     /// keyword-free model or when tracing is disabled.
     #[serde(default)]
     pub pi_history: Vec<(usize, Vec<f64>)>,
+    /// Thinned MCMC θ snapshots (issue #31): the last `num_theta_draws` per-doc
+    /// topic distributions taken every `thin` sweeps of the fit loop, stored as
+    /// f32 to halve the (S × D × K) footprint. Real cross-sweep posterior draws
+    /// that `composition_theta` prefers over the within-document Dirichlet
+    /// approximation. A fit-time artifact: empty unless `keep_theta_draws` was
+    /// on, and not persisted across save/load.
+    #[serde(skip)]
+    pub theta_draws: Vec<Vec<Vec<f32>>>,
 }
 
 /// Fitted state of the keyATM **Dynamic** model (Eshima, Imai & Sasaki 2024,
@@ -926,6 +934,7 @@ pub fn fit_keyatm<R: Rng>(
     estimate_alpha: bool,
     weights: WeightScheme,
     num_threads: usize,
+    draws: ThetaDrawOpts,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(
@@ -958,6 +967,7 @@ pub fn fit_keyatm<R: Rng>(
         vec![alpha; num_topics] // fixed symmetric
     };
     let mut doc_alpha: Vec<Vec<f64>> = vec![alpha_vec.clone(); docs.len()];
+    let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
 
     for it in 0..iters {
         run_sweep(&mut model, docs, &mut assignments, &ki, &doc_alpha, num_threads, rng);
@@ -970,6 +980,7 @@ pub fn fit_keyatm<R: Rng>(
                 row.clone_from(&alpha_vec);
             }
         }
+        draws.maybe_collect(&mut theta_draw_buf, it + 1, &model.ndk, &doc_alpha);
         if record_ll(it + 1, ll_interval, iters) {
             model.alpha_vec = Some(alpha_vec.clone());
             model
@@ -986,6 +997,7 @@ pub fn fit_keyatm<R: Rng>(
         }
     }
     model.alpha_vec = Some(alpha_vec);
+    model.theta_draws = theta_draw_buf;
     model
 }
 
@@ -1086,6 +1098,7 @@ fn init_state<R: Rng>(
         log_likelihood_history: Vec::new(),
         alpha_history: Vec::new(),
         pi_history: Vec::new(),
+        theta_draws: Vec::new(),
     };
     (model, assignments, ki)
 }
@@ -1096,6 +1109,55 @@ fn init_state<R: Rng>(
 #[inline]
 fn record_ll(iter: usize, interval: usize, iters: usize) -> bool {
     interval > 0 && (iter % interval == 0 || iter == iters)
+}
+
+/// Thinned θ-draw retention schedule (issue #31): snapshot every `thin` sweeps
+/// and keep the last `cap` on a ring buffer, so the kept draws are the converged
+/// tail of the chain. `cap == 0` disables collection.
+#[derive(Clone, Copy)]
+pub struct ThetaDrawOpts {
+    pub cap: usize,
+    pub thin: usize,
+}
+
+impl ThetaDrawOpts {
+    /// Derive the schedule from the fit knobs and run length. Takes ~`2·cap`
+    /// snapshots over the run so the ring-buffered `cap` land in the back half.
+    pub fn new(keep: bool, num_draws: usize, iters: usize) -> Self {
+        let cap = if keep { num_draws } else { 0 };
+        let thin = if cap == 0 { 0 } else { (iters / (2 * cap)).max(1) };
+        ThetaDrawOpts { cap, thin }
+    }
+
+    /// At 1-based sweep `iter`, snapshot the smoothed θ = (n_dk + α_dk)/(N_d +
+    /// Σα_d) from the current counts and per-document prior, pushing onto `buf`
+    /// (capped at the last `cap`). No-op off-schedule or when disabled.
+    fn maybe_collect(
+        &self,
+        buf: &mut Vec<Vec<Vec<f32>>>,
+        iter: usize,
+        ndk: &[Vec<f64>],
+        doc_alpha: &[Vec<f64>],
+    ) {
+        if self.thin == 0 || iter % self.thin != 0 {
+            return;
+        }
+        let snap: Vec<Vec<f32>> = ndk
+            .iter()
+            .zip(doc_alpha.iter())
+            .map(|(row, a)| {
+                let denom = row.iter().sum::<f64>() + a.iter().sum::<f64>();
+                row.iter()
+                    .zip(a.iter())
+                    .map(|(&c, &av)| ((c + av) / denom) as f32)
+                    .collect()
+            })
+            .collect();
+        buf.push(snap);
+        if buf.len() > self.cap {
+            buf.remove(0);
+        }
+    }
 }
 
 /// Fit a keyATM **Covariate** model. The document-topic prior is a
@@ -1125,6 +1187,7 @@ pub fn fit_keyatm_cov<R: Rng>(
     weights: WeightScheme,
     num_threads: usize,
     offset: Option<&[Vec<f64>]>,
+    draws: ThetaDrawOpts,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(keywords.len(), num_topics, "keywords length must equal num_topics");
@@ -1144,6 +1207,7 @@ pub fn fit_keyatm_cov<R: Rng>(
 
     let mut lambda = vec![vec![0.0f64; num_features]; num_topics];
     let mut doc_alpha = crate::dmr::compute_doc_alpha(&lambda, features, offset);
+    let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
     // So the log-likelihood trace uses the covariate doc-topic prior: doc_topic()
     // takes the (lambda, features) path only when both are set on the model.
     if ll_interval > 0 {
@@ -1166,6 +1230,7 @@ pub fn fit_keyatm_cov<R: Rng>(
             );
             doc_alpha = crate::dmr::compute_doc_alpha(&lambda, features, offset);
         }
+        draws.maybe_collect(&mut theta_draw_buf, it + 1, &model.ndk, &doc_alpha);
         if record_ll(it + 1, ll_interval, iters) {
             model.lambda = Some(lambda.clone());
             model.prior_offset = offset.map(|o| o.to_vec());
@@ -1179,6 +1244,7 @@ pub fn fit_keyatm_cov<R: Rng>(
     model.lambda = Some(lambda);
     model.features = Some(features.to_vec());
     model.prior_offset = offset.map(|o| o.to_vec());
+    model.theta_draws = theta_draw_buf;
     model
 }
 
@@ -1333,6 +1399,7 @@ pub fn fit_keyatm_dynamic<R: Rng>(
     ll_interval: usize,
     weights: WeightScheme,
     num_threads: usize,
+    draws: ThetaDrawOpts,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(keywords.len(), num_topics, "keywords length must equal num_topics");
@@ -1414,6 +1481,7 @@ pub fn fit_keyatm_dynamic<R: Rng>(
     }
 
     let mut prk = vec![vec![0.0f64; num_states]; num_time];
+    let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
 
     for it in 0..iters {
         // 1. Token (z, s) sweep with each doc's α tied to its segment's state.
@@ -1422,6 +1490,9 @@ pub fn fit_keyatm_dynamic<R: Rng>(
             .map(|&t| alphas[r_est[t]].clone())
             .collect();
         run_sweep(&mut model, docs, &mut assignments, &ki, &doc_alpha, num_threads, rng);
+        // Snapshot under the (ndk, doc_alpha) pair this sweep just used — coherent
+        // smoothing even though r_est/alphas are resampled below.
+        draws.maybe_collect(&mut theta_draw_buf, it + 1, &model.ndk, &doc_alpha);
 
         // 2. Slice-sample each state's α over the documents it currently owns.
         // States are contiguous in time; their document ranges are disjoint, so
@@ -1565,6 +1636,7 @@ pub fn fit_keyatm_dynamic<R: Rng>(
         r_est,
         p_est,
     });
+    model.theta_draws = theta_draw_buf;
     model
 }
 
@@ -1624,7 +1696,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 200, 0, true, WeightScheme::None, 1, &mut rng,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 200, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
         );
 
         // Helper: block with max probability mass in topic_word(k).
@@ -1671,7 +1743,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let model = fit_keyatm(
-            &docs, v, 4, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 50, 0, true, WeightScheme::None, 1, &mut rng,
+            &docs, v, 4, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 50, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
         );
 
         let rates = model.keyword_rate();
@@ -1707,7 +1779,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(123);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.5, 0.1, 0.5, 1.0, 1.0, 30, 0, true, WeightScheme::None, 1, &mut rng,
+            &docs, v, 3, &keywords, 0.5, 0.1, 0.5, 1.0, 1.0, 30, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
         );
 
         let d = docs.len();
@@ -1765,7 +1837,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let model = fit_keyatm_dynamic(
             &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0,
-            2.0, 1.0, 300, 0, WeightScheme::None, 1, &mut rng,
+            2.0, 1.0, 300, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
         );
 
         let dyn_ = model.dynamic.as_ref().expect("dynamic state present");
@@ -1799,10 +1871,10 @@ mod tests {
         let mut r1 = ChaCha8Rng::seed_from_u64(9);
         let mut r2 = ChaCha8Rng::seed_from_u64(9);
         let m1 = fit_keyatm_dynamic(
-            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, &mut r1,
+            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut r1,
         );
         let m2 = fit_keyatm_dynamic(
-            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, &mut r2,
+            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut r2,
         );
         assert_eq!(
             m1.dynamic.as_ref().unwrap().r_est,
@@ -1828,8 +1900,8 @@ mod tests {
         let mut r1 = ChaCha8Rng::seed_from_u64(77);
         let mut r2 = ChaCha8Rng::seed_from_u64(77);
 
-        let m1 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, &mut r1);
-        let m2 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, &mut r2);
+        let m1 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut r1);
+        let m2 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut r2);
 
         assert_eq!(
             m1.topic_word_all(),
@@ -1859,7 +1931,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(3);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 10, true, WeightScheme::None, 1, &mut rng,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 10, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
         );
         let h = &model.log_likelihood_history;
         // iters=60, interval=10 -> sweeps 10,20,30,40,50,60.
@@ -1875,7 +1947,7 @@ mod tests {
         // interval 0 disables tracing.
         let mut rng2 = ChaCha8Rng::seed_from_u64(3);
         let none = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true, WeightScheme::None, 1, &mut rng2,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng2,
         );
         assert!(none.log_likelihood_history.is_empty());
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -717,6 +717,9 @@ pub struct LDA {
     fitted: bool,
     phi: Option<Array2<f64>>,   // (num_topics, num_words)
     theta: Option<Array2<f64>>, // (num_docs, num_topics)
+    // Thinned MCMC θ snapshots (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Feeds composition_theta's cross-sweep uncertainty.
+    theta_draws: Option<Array3<f32>>,
     model: Option<TopicModel>,
     corpus: Option<corpus::Corpus>,
 }
@@ -892,6 +895,7 @@ impl LDA {
             fitted: false,
             phi: None,
             theta: None,
+            theta_draws: None,
             model: None,
             corpus: None,
         })
@@ -907,7 +911,8 @@ impl LDA {
     /// `progress`, if given, is called as ``progress(iteration, ll_per_token)``
     /// every `progress_interval` iterations during the main loop.
     #[pyo3(signature = (data, *, iterations=1000, num_samples=5, sample_interval=25,
-                        progress=None, progress_interval=50))]
+                        progress=None, progress_interval=50,
+                        keep_theta_draws=true, num_theta_draws=25))]
     fn fit(
         &mut self,
         py: Python<'_>,
@@ -917,6 +922,8 @@ impl LDA {
         sample_interval: usize,
         progress: Option<PyObject>,
         progress_interval: usize,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
     ) -> PyResult<()> {
         // Accept either a Corpus or a list[list[str]].
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -940,6 +947,12 @@ impl LDA {
         let alpha_sum = self.alpha_sum.unwrap_or(num_topics as f64);
         let total_tokens = corpus.total_tokens().max(1) as f64;
 
+        // Thinned θ-draw retention (issue #31): keep the last `draw_cap` snapshots
+        // taken every `draw_thin` sweeps of the main loop. 0 ⇒ collection off.
+        let draw_cap = if keep_theta_draws { num_theta_draws } else { 0 };
+        let draw_thin = theta_draw_thin(iterations, draw_cap);
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, num_topics)?;
+
         let mut model = TopicModel::new(num_topics, alpha_sum, self.beta, num_types);
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         model.initialize(&corpus, &mut rng);
@@ -957,13 +970,24 @@ impl LDA {
         // into a TopicModel at the end. Separate from the SparseLDA path below so
         // the well-tested MALLET sampler is left untouched.
         if light {
-            let (acc_phi, acc_theta, model) = py.allow_threads(move || {
+            let (acc_phi, acc_theta, theta_draw_buf, model) = py.allow_threads(move || {
                 let alpha0 = vec![alpha_sum / num_topics as f64; num_topics];
                 let mut ls = lightlda::LightLda::new(&corpus, num_topics, &alpha0, beta, &mut rng);
                 ls.mh_steps = mh_steps;
+                let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
 
                 for iter in 1..=iterations {
                     ls.sweep(&corpus, &mut rng);
+                    if draw_thin > 0 && iter % draw_thin == 0 {
+                        // One snapshot: theta_into accumulates, so start from zero.
+                        let mut tmp = vec![vec![0.0f64; num_topics]; num_docs];
+                        ls.theta_into(&corpus, &mut tmp);
+                        let snap = tmp
+                            .iter()
+                            .map(|r| r.iter().map(|&v| v as f32).collect())
+                            .collect();
+                        push_capped(&mut theta_draw_buf, snap, draw_cap);
+                    }
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                         let mut m = ls.to_topic_model();
                         if use_symmetric_alpha {
@@ -1002,16 +1026,17 @@ impl LDA {
                     for v in row.iter_mut() { *v /= n; }
                 }
                 let model = ls.to_topic_model();
-                (acc_phi, acc_theta, (model, corpus))
+                (acc_phi, acc_theta, theta_draw_buf, (model, corpus))
             });
             let (model, corpus) = model;
+            self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
             self.finalize_fit(num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus);
             return Ok(());
         }
 
         // Heavy loop runs with the GIL released; the progress callback briefly
         // re-acquires it. allow_threads returns the owned model + accumulators.
-        let (acc_phi, acc_theta, model) = py.allow_threads(move || {
+        let (acc_phi, acc_theta, theta_draw_buf, model) = py.allow_threads(move || {
             // One Gibbs sweep: exact sequential path when single-threaded,
             // approximate parallel sampling otherwise. `sweep` seeds the
             // per-worker RNGs so parallel runs are deterministic.
@@ -1027,10 +1052,19 @@ impl LDA {
                         parallel_sweep(model, &corpus.docs, num_threads, s);
                     }
                 };
+            let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
 
             // ---- main training loop (ports src/bin/train.rs) ----
             for iter in 1..=iterations {
                 do_sweep(&mut model, &mut rng);
+
+                if draw_thin > 0 && iter % draw_thin == 0 {
+                    push_capped(
+                        &mut theta_draw_buf,
+                        theta_snapshot_f32(&model, &corpus),
+                        draw_cap,
+                    );
+                }
 
                 if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                     if use_symmetric_alpha {
@@ -1076,9 +1110,10 @@ impl LDA {
             }
 
             // Return the corpus too (move it back out for storage).
-            (acc_phi, acc_theta, (model, corpus))
+            (acc_phi, acc_theta, theta_draw_buf, (model, corpus))
         });
         let (model, corpus) = model;
+        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
         self.finalize_fit(num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus);
         Ok(())
     }
@@ -1095,6 +1130,15 @@ impl LDA {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+
+    /// Thinned MCMC θ draws, shape ``(num_draws, num_docs, num_topics)``, or
+    /// ``None`` when fit with ``keep_theta_draws=False``. These are real
+    /// cross-sweep posterior samples; :func:`topica.composition_theta` prefers
+    /// them over the within-document Dirichlet approximation.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
     }
 
     /// The vocabulary: word for each column of :attr:`topic_word`.
@@ -1403,6 +1447,7 @@ impl LDA {
             fitted: true,
             phi: Some(phi),
             theta: Some(theta),
+            theta_draws: None,
             model: Some(model),
             corpus: Some(corpus),
         })
@@ -1777,7 +1822,8 @@ impl LDA {
             optimize_interval: s.optimize_interval, burn_in: s.burn_in, seed: s.seed,
             num_threads: s.num_threads, light: false, mh_steps: 2, fitted: s.fitted,
             use_symmetric_alpha: s.use_symmetric_alpha,
-            phi: arr2_back(s.phi), theta: arr2_back(s.theta), model: s.model, corpus: s.corpus,
+            phi: arr2_back(s.phi), theta: arr2_back(s.theta), theta_draws: None,
+            model: s.model, corpus: s.corpus,
         })
     }
 
@@ -1820,6 +1866,111 @@ fn accumulate_theta(m: &TopicModel, c: &corpus::Corpus, acc: &mut [Vec<f64>]) {
             acc[doc_idx][t] += (counts[t] as f64 + m.alpha[t]) / denom;
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// Thinned MCMC theta-draw retention (issue #31)
+// ---------------------------------------------------------------------------
+//
+// A single normalized θ snapshot from the current sampler state, kept as f32 to
+// halve the (num_draws × D × K) store. Collected on a ring buffer during the
+// main sweep loop so the retained draws are the converged tail of the chain;
+// `composition_theta` then propagates real cross-sweep variance instead of the
+// within-document Dirichlet approximation.
+
+/// Thinning period given the run length and how many draws we want to keep:
+/// take ~`2·cap` snapshots over the run so the kept `cap` (ring-buffered) sit in
+/// the back half. `0` disables collection.
+fn theta_draw_thin(iters: usize, cap: usize) -> usize {
+    if cap == 0 {
+        return 0;
+    }
+    (iters / (2 * cap)).max(1)
+}
+
+/// One normalized θ snapshot (D×K) as f32 from a `TopicModel`'s current counts.
+fn theta_snapshot_f32(m: &TopicModel, c: &corpus::Corpus) -> Vec<Vec<f32>> {
+    let mut counts = vec![0u32; m.num_topics];
+    let mut out = Vec::with_capacity(c.num_docs());
+    for doc_idx in 0..c.num_docs() {
+        for t in counts.iter_mut() {
+            *t = 0;
+        }
+        for &t in &m.doc_topics[doc_idx] {
+            counts[t as usize] += 1;
+        }
+        let denom = c.docs[doc_idx].len() as f64 + m.alpha_sum;
+        out.push(
+            (0..m.num_topics)
+                .map(|t| ((counts[t] as f64 + m.alpha[t]) / denom) as f32)
+                .collect(),
+        );
+    }
+    out
+}
+
+/// Push a draw onto a ring buffer that keeps only the last `cap`.
+fn push_capped(buf: &mut Vec<Vec<Vec<f32>>>, draw: Vec<Vec<f32>>, cap: usize) {
+    buf.push(draw);
+    if buf.len() > cap {
+        buf.remove(0);
+    }
+}
+
+/// Warn (once, before the heavy loop) when retaining θ draws would cost more
+/// than ~512 MB, so a large corpus does not silently balloon memory. The user
+/// can pass `keep_theta_draws=False` or a smaller `num_theta_draws`.
+fn warn_theta_draw_memory(
+    py: Python<'_>,
+    keep: bool,
+    num_draws: usize,
+    num_docs: usize,
+    num_topics: usize,
+) -> PyResult<()> {
+    if !keep || num_draws == 0 {
+        return Ok(());
+    }
+    const THRESHOLD: usize = 512 * 1024 * 1024; // 512 MB of f32
+    let bytes = num_draws
+        .saturating_mul(num_docs)
+        .saturating_mul(num_topics)
+        .saturating_mul(4);
+    if bytes > THRESHOLD {
+        let mb = bytes / (1024 * 1024);
+        let msg = format!(
+            "keep_theta_draws will retain ~{mb} MB of MCMC theta draws \
+             ({num_draws} draws x {num_docs} docs x {num_topics} topics, f32). \
+             Pass keep_theta_draws=False, or a smaller num_theta_draws, to avoid this."
+        );
+        let warnings = py.import_bound("warnings")?;
+        warnings.call_method1("warn", (msg,))?;
+    }
+    Ok(())
+}
+
+/// Stack the collected draws into an `(S, D, K)` array, or `None` if empty.
+/// When `order` is given, row `i` of each draw is scattered to document
+/// `order[i]` (the keyATM dynamic model fits on time-sorted documents, so its
+/// draws come back sorted and must be unsorted to match the other outputs).
+fn draws_to_array3(
+    buf: &[Vec<Vec<f32>>],
+    num_docs: usize,
+    num_topics: usize,
+    order: Option<&[usize]>,
+) -> Option<Array3<f32>> {
+    if buf.is_empty() {
+        return None;
+    }
+    let mut arr = Array3::<f32>::zeros((buf.len(), num_docs, num_topics));
+    for (s, draw) in buf.iter().enumerate() {
+        for (i, row) in draw.iter().enumerate() {
+            let d = order.map_or(i, |o| o[i]);
+            for (t, &v) in row.iter().enumerate() {
+                arr[[s, d, t]] = v;
+            }
+        }
+    }
+    Some(arr)
 }
 
 // ---------------------------------------------------------------------------
@@ -6366,6 +6517,9 @@ pub struct SeededLDA {
     topic_names: Vec<String>,
     phi: Option<Array2<f64>>,
     theta: Option<Array2<f64>>,
+    // Thinned MCMC θ snapshots (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Feeds composition_theta's cross-sweep uncertainty.
+    theta_draws: Option<Array3<f32>>,
     corpus: Option<corpus::Corpus>,
 }
 
@@ -6407,7 +6561,8 @@ impl SeededLDA {
         }
         Ok(SeededLDA {
             seed_names: names, seed_words: words, residual, alpha, beta, weight, seed,
-            fitted: false, topic_names: Vec::new(), phi: None, theta: None, corpus: None,
+            fitted: false, topic_names: Vec::new(), phi: None, theta: None,
+            theta_draws: None, corpus: None,
         })
     }
 
@@ -6419,13 +6574,16 @@ impl SeededLDA {
     /// symmetric `alpha`, biasing each document's topic mixture toward chosen
     /// topics (e.g. from a document embedding). It is a prior, so the sampler
     /// can still move a document away from it.
-    #[pyo3(signature = (data, *, iters=2000, doc_topic_prior=None))]
+    #[pyo3(signature = (data, *, iters=2000, doc_topic_prior=None,
+                        keep_theta_draws=true, num_theta_draws=25))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
         doc_topic_prior: Option<&Bound<'_, PyAny>>,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -6466,16 +6624,19 @@ impl SeededLDA {
             None => None,
         };
 
+        let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, corpus.num_docs(), num_topics)?;
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let (model, corpus) = py.allow_threads(move || {
             let m = seeded::fit_seeded_lda(
                 &corpus.docs, num_types, num_topics, &seeds, alpha, beta, seed_weight, doc_alpha,
-                iters, &mut rng,
+                iters, draws_opts, &mut rng,
             );
             (m, corpus)
         });
         self.phi = Some(vecs_to_arr2(&model.topic_word_all()));
         self.theta = Some(vecs_to_arr2(&model.doc_topic()));
+        self.theta_draws = draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
         let mut names = self.seed_names.clone();
         for i in 0..self.residual {
             names.push(format!("residual_{}", i + 1));
@@ -6495,6 +6656,14 @@ impl SeededLDA {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+    /// Thinned MCMC θ draws, shape ``(num_draws, num_docs, num_topics)``, or
+    /// ``None`` when fit with ``keep_theta_draws=False``. Real cross-sweep
+    /// posterior samples that :func:`topica.composition_theta` prefers over the
+    /// within-document Dirichlet approximation.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
     }
     #[getter]
     fn num_topics(&self) -> usize {
@@ -6557,7 +6726,7 @@ impl SeededLDA {
             residual: s.num_topics.saturating_sub(s.topic_names.iter().filter(|n| !n.starts_with("residual_")).count()),
             alpha: s.alpha, beta: s.beta, weight: s.weight, seed: s.seed, fitted: s.fitted,
             topic_names: s.topic_names, phi: arr2_back(s.phi), theta: arr2_back(s.theta),
-            corpus: s.corpus,
+            theta_draws: None, corpus: s.corpus,
         })
     }
 
@@ -8203,6 +8372,9 @@ pub struct KeyATM {
     // dynamic model (per-state α); the `alpha` getter then falls back to the
     // symmetric prior.
     alpha_vec: Option<Vec<f64>>,
+    // Thinned MCMC θ snapshots (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Feeds composition_theta's cross-sweep uncertainty.
+    theta_draws: Option<Array3<f32>>,
 }
 
 impl KeyATM {
@@ -8261,6 +8433,7 @@ impl KeyATM {
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
             transition_matrix: None, log_likelihood_history: Vec::new(),
             alpha_history: Vec::new(), pi_history: Vec::new(), alpha_vec: None,
+            theta_draws: None,
         })
     }
 
@@ -8288,6 +8461,7 @@ impl KeyATM {
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
             transition_matrix: None, log_likelihood_history: Vec::new(),
             alpha_history: Vec::new(), pi_history: Vec::new(), alpha_vec: None,
+            theta_draws: None,
         })
     }
 
@@ -8310,7 +8484,8 @@ impl KeyATM {
     #[pyo3(signature = (data, *, iters=1500, covariates=None, feature_names=None,
                         timestamps=None, num_states=5, weights="information-theory",
                         num_threads=1, optimize_interval=50, burn_in=200, prior_variance=1.0,
-                        lbfgs_iters=20, report_interval=0, prior_offset=None))]
+                        lbfgs_iters=20, report_interval=0, prior_offset=None,
+                        keep_theta_draws=true, num_theta_draws=25))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -8329,6 +8504,8 @@ impl KeyATM {
         lbfgs_iters: usize,
         report_interval: usize,
         prior_offset: Option<&Bound<'_, PyAny>>,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -8343,6 +8520,9 @@ impl KeyATM {
         }
         let num_topics = self.num_topics;
         let num_types = corpus.num_types();
+        // Thinned θ-draw retention schedule (issue #31), shared by all three fits.
+        let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, corpus.num_docs(), num_topics)?;
         // Warn about keywords absent from the (pruned) vocabulary: a "seeded"
         // topic whose keywords were all dropped was never actually seeded, and
         // pruning (rm_top / min_doc_freq) or a typo/stemming mismatch silently
@@ -8425,7 +8605,7 @@ impl KeyATM {
                     &sorted_docs, num_types, num_topics, &keys, &sorted_time, num_states,
                     beta, beta_key, g1, g2,
                     1.0, 1.0, 2.0, 1.0, // keyATM α-prior defaults: eta_1, eta_2, eta_1_reg, eta_2_reg
-                    iters, ll_interval, weight_scheme, nthreads, &mut rng,
+                    iters, ll_interval, weight_scheme, nthreads, draws_opts, &mut rng,
                 )
             });
 
@@ -8436,6 +8616,9 @@ impl KeyATM {
                 theta[d] = theta_sorted[i].clone();
             }
             self.theta = Some(vecs_to_arr2(&theta));
+            // θ draws are also sorted; unsort their rows via `order` to match θ.
+            self.theta_draws =
+                draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, Some(&order));
             self.phi = Some(vecs_to_arr2(&model.topic_word_all()));
             self.keyword_rate = model.keyword_rate();
             self.time_prevalence = model.time_prevalence().map(|tp| vecs_to_arr2(&tp));
@@ -8537,17 +8720,19 @@ impl KeyATM {
                     &corpus.docs, num_types, num_topics, &keys, f, f[0].len(),
                     beta, beta_key, g1, g2, iters, optimize_interval, burn_in,
                     prior_variance, lbfgs_iters, ll_interval, weight_scheme, nthreads,
-                    offset.as_deref(), &mut rng,
+                    offset.as_deref(), draws_opts, &mut rng,
                 ),
                 None => keyatm::fit_keyatm(
                     &corpus.docs, num_types, num_topics, &keys, alpha, beta, beta_key, g1, g2,
-                    iters, ll_interval, estimate_alpha, weight_scheme, nthreads, &mut rng,
+                    iters, ll_interval, estimate_alpha, weight_scheme, nthreads, draws_opts, &mut rng,
                 ),
             };
             (m, corpus)
         });
         self.phi = Some(vecs_to_arr2(&model.topic_word_all()));
         self.theta = Some(vecs_to_arr2(&model.doc_topic()));
+        self.theta_draws =
+            draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
         self.keyword_rate = model.keyword_rate();
         self.log_likelihood_history = model.log_likelihood_history.clone();
         self.alpha_history = model.alpha_history.clone();
@@ -8631,6 +8816,14 @@ impl KeyATM {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+    /// Thinned MCMC θ draws, shape ``(num_draws, num_docs, num_topics)``, or
+    /// ``None`` when fit with ``keep_theta_draws=False``. Real cross-sweep
+    /// posterior samples that :func:`topica.composition_theta` prefers over the
+    /// within-document Dirichlet approximation.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
     }
     /// Per-topic keyword switch rate ``π_k`` (the share of a keyword topic's mass
     /// drawn from its keyword distribution); 0 for regular topics.
@@ -8747,7 +8940,7 @@ impl KeyATM {
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
             transition_matrix: None, log_likelihood_history: s.log_likelihood_history,
             alpha_history: s.alpha_history, pi_history: s.pi_history,
-            alpha_vec: s.alpha_vec,
+            alpha_vec: s.alpha_vec, theta_draws: None,
         })
     }
 

--- a/src/seeded.rs
+++ b/src/seeded.rs
@@ -61,6 +61,12 @@ pub struct SeededModel {
     /// prevalence). `None` for the ordinary symmetric-α model.
     #[serde(default)]
     pub doc_alpha: Option<Vec<Vec<f64>>>,
+    /// Thinned MCMC θ snapshots (issue #31): the last `num_theta_draws` per-doc
+    /// topic distributions taken every `thin` sweeps, f32. Real cross-sweep
+    /// posterior draws that `composition_theta` prefers over the within-document
+    /// Dirichlet approximation. A fit-time artifact, not persisted.
+    #[serde(skip)]
+    pub theta_draws: Vec<Vec<Vec<f32>>>,
 }
 
 impl SeededModel {
@@ -164,6 +170,37 @@ fn sample_index<R: Rng>(scores: &[f64], rng: &mut R) -> usize {
 // Public fit function
 // ---------------------------------------------------------------------------
 
+/// One smoothed θ snapshot (D×K) as f32 from the current counts:
+/// θ_{d,k} = (n_dk + α_dk) / (N_d + Σα_d), using the per-document prior when
+/// present and the symmetric `alpha` otherwise.
+fn seeded_theta_snapshot(
+    ndk: &[Vec<u32>],
+    doc_alpha: Option<&Vec<Vec<f64>>>,
+    alpha: f64,
+    k: usize,
+) -> Vec<Vec<f32>> {
+    ndk.iter()
+        .enumerate()
+        .map(|(d, row)| {
+            let n_d: u32 = row.iter().sum();
+            match doc_alpha {
+                Some(da) => {
+                    let a = &da[d];
+                    let denom = n_d as f64 + a.iter().sum::<f64>();
+                    row.iter()
+                        .zip(a)
+                        .map(|(&c, &av)| ((c as f64 + av) / denom) as f32)
+                        .collect()
+                }
+                None => {
+                    let denom = n_d as f64 + k as f64 * alpha;
+                    row.iter().map(|&c| ((c as f64 + alpha) / denom) as f32).collect()
+                }
+            }
+        })
+        .collect()
+}
+
 /// Fit a Seeded-LDA model by collapsed Gibbs sampling.
 ///
 /// # Arguments
@@ -178,6 +215,7 @@ fn sample_index<R: Rng>(scores: &[f64], rng: &mut R) -> usize {
 /// * `seed_weight` — extra pseudocount added to a seed word in its topic.
 ///                   Set to 0.0 for ordinary LDA with symmetric priors.
 /// * `iters`       — number of full Gibbs sweeps.
+/// * `draws`       — thinned θ-draw retention schedule (issue #31).
 /// * `rng`         — random-number source; deterministic for a fixed seed.
 #[allow(clippy::too_many_arguments)]
 pub fn fit_seeded_lda<R: Rng>(
@@ -190,6 +228,7 @@ pub fn fit_seeded_lda<R: Rng>(
     seed_weight: f64,
     doc_alpha: Option<Vec<Vec<f64>>>,
     iters: usize,
+    draws: crate::keyatm::ThetaDrawOpts,
     rng: &mut R,
 ) -> SeededModel {
     let k = num_topics;
@@ -273,8 +312,9 @@ pub fn fit_seeded_lda<R: Rng>(
 
     // --- Gibbs sweeps ---
     let mut scores: Vec<f64> = vec![0.0f64; k];
+    let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
 
-    for _ in 0..iters {
+    for it in 0..iters {
         for d in 0..d_count {
             let doc = &docs[d];
             // The document's α row: per-document when supplied, else symmetric.
@@ -309,6 +349,12 @@ pub fn fit_seeded_lda<R: Rng>(
                 z[d][i] = new_t;
             }
         }
+        if draws.thin > 0 && (it + 1) % draws.thin == 0 {
+            theta_draw_buf.push(seeded_theta_snapshot(&ndk, doc_alpha.as_ref(), alpha, k));
+            if theta_draw_buf.len() > draws.cap {
+                theta_draw_buf.remove(0);
+            }
+        }
     }
 
     SeededModel {
@@ -322,6 +368,7 @@ pub fn fit_seeded_lda<R: Rng>(
         nk,
         ndk,
         doc_alpha,
+        theta_draws: theta_draw_buf,
     }
 }
 
@@ -420,7 +467,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let model = fit_seeded_lda(
             &docs, v, 3, &seeds,
-            0.1, 0.01, 50.0, None, 300, &mut rng,
+            0.1, 0.01, 50.0, None, 300, crate::keyatm::ThetaDrawOpts::new(false, 0, 0), &mut rng,
         );
 
         // For each seeded topic (0 and 1), the seed words' total φ mass should
@@ -463,7 +510,7 @@ mod tests {
         let seeds: Vec<Vec<usize>> = vec![vec![]; k];
 
         let mut rng = ChaCha8Rng::seed_from_u64(123);
-        let model = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 0.0, None, 50, &mut rng);
+        let model = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 0.0, None, 50, crate::keyatm::ThetaDrawOpts::new(false, 0, 0), &mut rng);
 
         // topic_word rows sum to 1.
         for t in 0..k {
@@ -501,8 +548,8 @@ mod tests {
 
         let mut r1 = ChaCha8Rng::seed_from_u64(55);
         let mut r2 = ChaCha8Rng::seed_from_u64(55);
-        let m1 = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 2.0, None, 80, &mut r1);
-        let m2 = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 2.0, None, 80, &mut r2);
+        let m1 = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 2.0, None, 80, crate::keyatm::ThetaDrawOpts::new(false, 0, 0), &mut r1);
+        let m2 = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 2.0, None, 80, crate::keyatm::ThetaDrawOpts::new(false, 0, 0), &mut r2);
 
         assert_eq!(
             m1.topic_word_all(),

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -130,7 +130,15 @@ def test_composition_theta_runs_for_every_dirichlet_model():
 
 
 def test_composition_effect_inflates_over_ols():
-    m, corpus, x = _planted()
+    # The within-document Dirichlet approximation (keep_theta_draws=False) adds
+    # 1/N_d sampling noise on top of the point estimate, so method-of-composition
+    # SEs are always >= naive OLS that treats theta as fixed. (Real retained
+    # draws, issue #31, instead reflect model confidence and can fall below OLS
+    # for a well-identified corpus like this one; see
+    # test_real_draws_reflect_identifiability in test_theta_draws.py.)
+    _, corpus, x = _planted()
+    m = topica.LDA(2, seed=1)
+    m.fit(corpus, iterations=250, keep_theta_draws=False)
     X = x[:, None]
     ols = topica.estimate_effect(m.doc_topic, X, feature_names=["x"])
     moc = topica.standard_errors(m, corpus, of="effect", X=X, feature_names=["x"], nsims=30)
@@ -141,7 +149,12 @@ def test_composition_effect_inflates_over_ols():
 
 
 def test_composition_needs_corpus_for_gibbs_and_rejects_embedding():
-    m, corpus, _ = _planted()
+    # Without retained draws the Gibbs path falls back to the Dirichlet
+    # approximation, which needs per-document lengths -> a corpus. (With the
+    # default keep_theta_draws=True it would use the draws and need no corpus.)
+    _, corpus, _ = _planted()
+    m = topica.LDA(2, seed=1)
+    m.fit(corpus, iterations=250, keep_theta_draws=False)
     with pytest.raises(ValueError, match="corpus"):
         topica.standard_errors(m, of="prevalence", nsims=10)  # Gibbs needs lengths
     bert = topica.BERTopic(min_cluster_size=5)

--- a/tests/test_theta_draws.py
+++ b/tests/test_theta_draws.py
@@ -1,0 +1,151 @@
+"""Retained MCMC theta draws for the Gibbs family (issue #31).
+
+LDA, KeyATM, and SeededLDA snapshot thinned, post-burn-in theta during the fit
+loop and expose them as ``model.theta_draws`` (num_draws, num_docs, num_topics).
+``composition_theta`` prefers these real cross-sweep posterior samples over the
+within-document Dirichlet approximation, falling back cleanly when a model was
+fit with ``keep_theta_draws=False``.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+from topica.effects import composition_theta, dirichlet_theta_samples
+
+
+def _toy_docs(n=40, vocab=12, lo=8, hi=15, seed=0):
+    rng = np.random.default_rng(seed)
+    words = [f"w{i}" for i in range(vocab)]
+    return [list(rng.choice(words, size=int(rng.integers(lo, hi)))) for _ in range(n)]
+
+
+# A fitted model of each instrumented Gibbs family on a shared toy corpus.
+def _fit_each(docs, *, keep=True, num_draws=25):
+    out = {}
+    m = topica.LDA(num_topics=4, seed=1)
+    m.fit(docs, iterations=120, keep_theta_draws=keep, num_theta_draws=num_draws)
+    out["LDA"] = m
+    m = topica.SeededLDA({"a": ["w0", "w1"], "b": ["w5", "w6"]}, residual=2, seed=1)
+    m.fit(docs, iters=120, keep_theta_draws=keep, num_theta_draws=num_draws)
+    out["SeededLDA"] = m
+    m = topica.KeyATM({"a": ["w0", "w1"], "b": ["w5", "w6"]}, num_topics=4, seed=1)
+    m.fit(docs, iters=120, keep_theta_draws=keep, num_theta_draws=num_draws)
+    out["KeyATM"] = m
+    return out
+
+
+@pytest.mark.parametrize("name", ["LDA", "SeededLDA", "KeyATM"])
+def test_theta_draws_shape_and_simplex(name):
+    docs = _toy_docs()
+    model = _fit_each(docs, num_draws=20)[name]
+    td = np.asarray(model.theta_draws)
+    d, k = np.asarray(model.doc_topic).shape
+    assert td.shape == (20, d, k), name
+    assert td.dtype == np.float32, name
+    # Each draw's rows are probability simplices.
+    assert np.allclose(td.sum(axis=2), 1.0, atol=1e-4), name
+    assert (td >= 0).all(), name
+    # Genuine cross-sweep variation, not a repeated point estimate.
+    assert td.std(axis=0).max() > 0.0, name
+
+
+@pytest.mark.parametrize("name", ["LDA", "SeededLDA", "KeyATM"])
+def test_keep_theta_draws_false_disables(name):
+    docs = _toy_docs()
+    model = _fit_each(docs, keep=False)[name]
+    assert model.theta_draws is None, name
+
+
+@pytest.mark.parametrize("name", ["LDA", "SeededLDA", "KeyATM"])
+def test_composition_theta_uses_draws_without_corpus(name):
+    # When draws are present, composition_theta needs no corpus and returns the
+    # draws resampled to nsims.
+    docs = _toy_docs()
+    model = _fit_each(docs, num_draws=30)[name]
+    out = composition_theta(model, nsims=12)
+    d, k = np.asarray(model.doc_topic).shape
+    assert out.shape == (12, d, k), name
+    assert np.allclose(out.sum(axis=2), 1.0, atol=1e-4), name
+
+
+@pytest.mark.parametrize("name", ["LDA", "SeededLDA", "KeyATM"])
+def test_fallback_identical_to_dirichlet_when_absent(name):
+    # keep_theta_draws=False -> composition_theta reproduces the Dirichlet
+    # approximation byte-for-byte (same seed, same lengths).
+    docs = _toy_docs()
+    model = _fit_each(docs, keep=False)[name]
+    lengths = np.array([len(d) for d in docs], dtype=float)
+    fallback = composition_theta(model, corpus=docs, nsims=15, seed=3)
+    ref = dirichlet_theta_samples(
+        np.asarray(model.doc_topic, dtype=float), lengths, nsims=15, seed=3
+    )
+    assert np.array_equal(fallback, ref), name
+
+
+def test_real_draws_capture_cross_sweep_variance():
+    # In a poorly-identified regime (longer documents, no topic structure) the
+    # within-document Dirichlet noise (~1/N_d) is small, so the real MCMC draws
+    # carry strictly more cross-draw variance than the approximation -- the gap
+    # issue #31 is closing. (For short documents the ordering reverses, because
+    # the 1/N_d term dominates; that is expected, not a regression.)
+    rng = np.random.default_rng(2)
+    vocab = [f"w{i}" for i in range(24)]
+    docs = [list(rng.choice(vocab, size=int(rng.integers(160, 240)))) for _ in range(40)]
+    m = topica.LDA(num_topics=4, seed=2)
+    m.fit(docs, iterations=300, num_theta_draws=40)
+
+    real = np.asarray(m.theta_draws, dtype=float)
+    lengths = np.array([len(d) for d in docs], dtype=float)
+    approx = dirichlet_theta_samples(
+        np.asarray(m.doc_topic, dtype=float), lengths, nsims=real.shape[0], seed=0
+    )
+    assert real.var(axis=0).mean() > approx.var(axis=0).mean()
+
+
+def test_real_draws_reflect_identifiability():
+    # Real draws track model confidence: a cleanly separated corpus pins theta,
+    # so cross-draw variance is far smaller than the length-only approximation
+    # (which is blind to identifiability). This is the behavior change that lets
+    # composition SEs fall below the approximation for well-identified data.
+    rng = np.random.default_rng(0)
+    a = [f"a{i}" for i in range(6)]
+    b = [f"b{i}" for i in range(6)]
+    docs = []
+    for _ in range(80):
+        block = a if rng.random() < 0.5 else b
+        docs.append(list(rng.choice(block, size=40)))
+    m = topica.LDA(num_topics=2, seed=1)
+    m.fit(docs, iterations=250, num_theta_draws=40)
+
+    real = np.asarray(m.theta_draws, dtype=float)
+    lengths = np.array([len(d) for d in docs], dtype=float)
+    approx = dirichlet_theta_samples(
+        np.asarray(m.doc_topic, dtype=float), lengths, nsims=real.shape[0], seed=0
+    )
+    assert real.var(axis=0).mean() < approx.var(axis=0).mean()
+
+
+def test_num_theta_draws_bounds_count():
+    docs = _toy_docs()
+    m = topica.LDA(num_topics=3, seed=1)
+    m.fit(docs, iterations=200, num_theta_draws=10)
+    assert np.asarray(m.theta_draws).shape[0] == 10
+
+
+def test_keyatm_dynamic_draws_match_doc_order():
+    # The dynamic model fits on time-sorted documents; its draws must be unsorted
+    # back to the caller's document order, so the draw mean tracks doc_topic.
+    rng = np.random.default_rng(1)
+    vocab = [f"w{i}" for i in range(12)]
+    docs = [list(rng.choice(vocab, size=12)) for _ in range(30)]
+    timestamps = list(rng.permutation(np.repeat(np.arange(6), 5)))
+    m = topica.KeyATM({"a": ["w0", "w1"]}, num_topics=3, seed=1)
+    m.fit(docs, iters=120, timestamps=timestamps, num_states=2)
+
+    td = np.asarray(m.theta_draws, dtype=float)
+    d, k = np.asarray(m.doc_topic).shape
+    assert td.shape == (25, d, k)
+    assert np.allclose(td.sum(axis=2), 1.0, atol=1e-4)
+    # Per-document draw mean is close to the reported doc_topic (same ordering).
+    assert np.abs(td.mean(axis=0) - np.asarray(m.doc_topic)).mean() < 0.1


### PR DESCRIPTION
Closes #31.

LDA, KeyATM (base/covariate/dynamic), and SeededLDA now retain thinned, post-burn-in MCMC theta snapshots as `model.theta_draws` (num_draws, num_docs, num_topics), f32. Default on (`keep_theta_draws=True`, `num_theta_draws=25`); opt out to save the (num_draws x docs x topics) f32 store, with a warning past ~512 MB.

## What changed
- Retention rides on sweeps that already run, so it costs ~no estimation time. The schedule (`keyatm::ThetaDrawOpts`) takes ~2*cap snapshots and ring-buffers the converged tail. Draws are not persisted across save/load.
- `composition_theta` (and thus `standard_errors` / `estimate_effect` with `method="composition"`) prefers these real cross-sweep posterior samples over the within-document Dirichlet approximation, and needs no `corpus` when draws are present; it falls back byte-for-byte to the old approximation otherwise.

## Behavior change worth noting
This propagates genuine topic-estimation uncertainty: it grows when topics overlap, shrinks when the model is confident, where the length-only approximation was blind to identifiability. **Gibbs-model standard errors now differ from 0.12.1** and can fall below the approximation for well-identified data.

Note: issue #31's acceptance criterion #2 (real draws "strictly larger" variance for *short* docs) was empirically backwards — the Dirichlet approx scales with 1/N_d, so it is wider for short docs and the real draws only dominate for long / poorly-identified corpora. Tests cover both regimes; two `test_standard_errors.py` invariants were repinned to `keep_theta_draws=False` (the approximation path) since they only held there.

## Validation
- Rust: `cargo test --lib` (49 passed).
- Python: full suite 1136 passed, 1 skipped; new `tests/test_theta_draws.py` (16 tests).
- `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)