### PR TITLE
feat: retain doc_lengths on fitted Gibbs models (#32)

### DIFF
--- a/docs/guides/uncertainty.md
+++ b/docs/guides/uncertainty.md
@@ -33,11 +33,12 @@ shrinks when the model is confident. No `Corpus` is needed in this case.
 
 If you fit with `keep_theta_draws=False` (to save the
 `num_draws x num_docs x num_topics` of f32 storage), the Gibbs path falls back to
-a per-document Dirichlet conditional built from the token counts, which needs the
-document lengths, so pass the `Corpus` you fit on. That approximation captures
-within-document sampling noise (it scales with `1 / N_d`) but is blind to whether
-the topics are actually identified, so its intervals can be wider than the real
-posterior for short documents and narrower for long ones.
+a per-document Dirichlet conditional built from the token counts. A fitted model
+retains its own per-document lengths (`model.doc_lengths`), so this still needs no
+`Corpus`; pass one only to draw against a different corpus on purpose. That
+approximation captures within-document sampling noise (it scales with `1 / N_d`)
+but is blind to whether the topics are actually identified, so its intervals can
+be wider than the real posterior for short documents and narrower for long ones.
 
 ```python
 # Covariate effects, uncertainty propagated (one regression per topic):

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -983,6 +983,12 @@ class LDA:
         ...
 
     @property
+    def doc_lengths(self) -> list[int]:
+        """Per-document token counts (length num_docs), in doc_topic row order.
+        Lets composition_theta recover N_d without re-threading the Corpus."""
+        ...
+
+    @property
     def vocabulary(self) -> list[str]:
         """Vocabulary list; column order matches topic_word."""
         ...
@@ -1359,6 +1365,10 @@ class SeededLDA:
     def theta_draws(self) -> Optional[numpy.typing.NDArray[numpy.float32]]:
         """Thinned MCMC theta draws, shape (num_draws, num_docs, num_topics), or
         None when fit with keep_theta_draws=False."""
+        ...
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Per-document token counts (length num_docs), in doc_topic row order."""
         ...
     @property
     def num_topics(self) -> int: ...
@@ -1824,6 +1834,10 @@ class KeyATM:
         None when fit with keep_theta_draws=False. Real cross-sweep posterior
         samples that composition_theta prefers over the Dirichlet approximation.
         Collected for the base, covariate, and dynamic variants."""
+        ...
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Per-document token counts (length num_docs), in doc_topic row order."""
         ...
     @property
     def feature_effects(self) -> numpy.typing.NDArray[numpy.float64]:

--- a/python/topica/effects.py
+++ b/python/topica/effects.py
@@ -126,11 +126,18 @@ def model_family(model):
 
 def _doc_lengths_for(model, corpus):
     if corpus is None:
-        raise ValueError(
-            "a Gibbs model needs corpus= (the Corpus it was fit on, or the token "
-            "lists) to recover per-document lengths for Dirichlet theta draws"
-        )
-    if hasattr(corpus, "doc_lengths"):
+        # A fitted Gibbs model retains its own per-document lengths (issue #32),
+        # so the Dirichlet fallback is self-sufficient without re-threading the
+        # corpus. Older / other models that did not retain them still need one.
+        own = getattr(model, "doc_lengths", None)
+        if own is None or len(own) == 0:
+            raise ValueError(
+                "a Gibbs model needs corpus= (the Corpus it was fit on, or the "
+                "token lists) to recover per-document lengths for Dirichlet theta "
+                "draws; this model did not retain its own doc_lengths"
+            )
+        lengths = np.asarray(own, dtype=np.float64)
+    elif hasattr(corpus, "doc_lengths"):
         lengths = np.asarray(corpus.doc_lengths, dtype=np.float64)
     else:
         lengths = np.asarray([len(d) for d in corpus], dtype=np.float64)

--- a/src/python.rs
+++ b/src/python.rs
@@ -1141,6 +1141,19 @@ impl LDA {
         self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
     }
 
+    /// Per-document token counts (length D), in :attr:`doc_topic` row order. Lets
+    /// :func:`topica.composition_theta` recover the Dirichlet concentration N_d
+    /// without re-threading the original :class:`Corpus`.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
+    }
+
     /// The vocabulary: word for each column of :attr:`topic_word`.
     #[getter]
     fn vocabulary(&self) -> PyResult<Vec<String>> {
@@ -6665,6 +6678,17 @@ impl SeededLDA {
     fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
         self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
     }
+    /// Per-document token counts (length D), in ``doc_topic`` row order, so
+    /// ``composition_theta`` can recover N_d without re-threading the Corpus.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
+    }
     #[getter]
     fn num_topics(&self) -> usize {
         self.num_topics_val()
@@ -8824,6 +8848,17 @@ impl KeyATM {
     #[getter]
     fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
         self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
+    }
+    /// Per-document token counts (length D), in ``doc_topic`` row order, so
+    /// ``composition_theta`` can recover N_d without re-threading the Corpus.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
     }
     /// Per-topic keyword switch rate ``π_k`` (the share of a keyword topic's mass
     /// drawn from its keyword distribution); 0 for regular topics.

--- a/tests/test_doc_lengths.py
+++ b/tests/test_doc_lengths.py
@@ -1,0 +1,92 @@
+"""Fitted Gibbs models retain their own per-document token lengths (issue #32),
+so the Dirichlet-approximation path of composition_theta is self-sufficient
+without re-threading the Corpus.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+from topica.effects import composition_theta
+
+
+def _toy_docs(n=40, vocab=12, lo=8, hi=15, seed=0):
+    rng = np.random.default_rng(seed)
+    words = [f"w{i}" for i in range(vocab)]
+    return [list(rng.choice(words, size=int(rng.integers(lo, hi)))) for _ in range(n)]
+
+
+def _fit_each(corpus, *, keep_draws):
+    out = {}
+    m = topica.LDA(num_topics=4, seed=1)
+    m.fit(corpus, iterations=120, keep_theta_draws=keep_draws)
+    out["LDA"] = m
+    m = topica.SeededLDA({"a": ["w0", "w1"], "b": ["w5", "w6"]}, residual=2, seed=1)
+    m.fit(corpus, iters=120, keep_theta_draws=keep_draws)
+    out["SeededLDA"] = m
+    m = topica.KeyATM({"a": ["w0", "w1"], "b": ["w5", "w6"]}, num_topics=4, seed=1)
+    m.fit(corpus, iters=120, keep_theta_draws=keep_draws)
+    out["KeyATM"] = m
+    return out
+
+
+@pytest.mark.parametrize("name", ["LDA", "SeededLDA", "KeyATM"])
+def test_doc_lengths_matches_corpus(name):
+    docs = _toy_docs()
+    corpus = topica.Corpus.from_documents(docs)
+    model = _fit_each(corpus, keep_draws=False)[name]
+    lengths = np.asarray(model.doc_lengths)
+    d = np.asarray(model.doc_topic).shape[0]
+    assert lengths.shape == (d,), name
+    # Raw token counts, in doc_topic row order, matching the Corpus.
+    assert np.array_equal(lengths, np.asarray(corpus.doc_lengths)), name
+
+
+@pytest.mark.parametrize("name", ["LDA", "SeededLDA", "KeyATM"])
+def test_composition_self_sufficient_without_corpus(name):
+    # With draws disabled, composition_theta falls back to the Dirichlet
+    # approximation. It must now work with no corpus= and match the corpus path
+    # byte-for-byte (same seed, same recovered N_d).
+    docs = _toy_docs()
+    corpus = topica.Corpus.from_documents(docs)
+    model = _fit_each(corpus, keep_draws=False)[name]
+    assert model.theta_draws is None, name
+
+    without = composition_theta(model, nsims=20, seed=7)
+    withc = composition_theta(model, corpus=corpus, nsims=20, seed=7)
+    assert np.array_equal(without, withc), name
+    d, k = np.asarray(model.doc_topic).shape
+    assert without.shape == (20, d, k), name
+
+
+def test_corpus_takes_precedence_over_retained_lengths():
+    # Passing corpus= still wins, so an alternate corpus can be used deliberately.
+    docs = _toy_docs()
+    corpus = topica.Corpus.from_documents(docs)
+    m = topica.LDA(num_topics=4, seed=1)
+    m.fit(corpus, iterations=120, keep_theta_draws=False)
+
+    # A corpus with deliberately different (here, longer) documents changes the
+    # Dirichlet concentration, so the draws differ from the retained-length path.
+    longer = [d * 3 for d in docs]
+    alt = topica.Corpus.from_documents(longer)
+    a = composition_theta(m, corpus=alt, nsims=20, seed=7)
+    b = composition_theta(m, nsims=20, seed=7)
+    assert not np.array_equal(a, b)
+
+
+def test_doc_lengths_dynamic_keyatm_in_caller_order():
+    # The dynamic model fits on time-sorted docs but reports in caller order;
+    # doc_lengths must line up with that (and with doc_topic).
+    rng = np.random.default_rng(1)
+    vocab = [f"w{i}" for i in range(12)]
+    docs = [list(rng.choice(vocab, size=int(rng.integers(8, 16)))) for _ in range(30)]
+    timestamps = list(rng.permutation(np.repeat(np.arange(6), 5)))
+    m = topica.KeyATM({"a": ["w0", "w1"]}, num_topics=3, seed=1)
+    m.fit(docs, iters=120, timestamps=timestamps, num_states=2, keep_theta_draws=False)
+
+    lengths = np.asarray(m.doc_lengths)
+    assert np.array_equal(lengths, np.asarray([len(d) for d in docs]))
+    # And the fallback composition path works with no corpus.
+    out = composition_theta(m, nsims=10, seed=0)
+    assert out.shape == (10, len(docs), 3)

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -148,15 +148,21 @@ def test_composition_effect_inflates_over_ols():
         assert moc[t].se[1] >= ols[t].se[1] - 1e-9
 
 
-def test_composition_needs_corpus_for_gibbs_and_rejects_embedding():
-    # Without retained draws the Gibbs path falls back to the Dirichlet
-    # approximation, which needs per-document lengths -> a corpus. (With the
-    # default keep_theta_draws=True it would use the draws and need no corpus.)
+def test_composition_self_sufficient_for_gibbs_and_rejects_embedding():
+    # A fitted LDA/keyATM/SeededLDA retains its own per-document lengths (issue
+    # #32), so even with draws disabled the Dirichlet fallback needs no corpus=.
     _, corpus, _ = _planted()
     m = topica.LDA(2, seed=1)
     m.fit(corpus, iterations=250, keep_theta_draws=False)
+    prev = topica.standard_errors(m, of="prevalence", nsims=10)  # no corpus needed
+    assert len(prev) == 2
+
+    # HDP is Dirichlet-family but does not retain lengths, so it still needs one.
+    hdp = topica.HDP(seed=1)
+    hdp.fit(corpus, iters=120)
     with pytest.raises(ValueError, match="corpus"):
-        topica.standard_errors(m, of="prevalence", nsims=10)  # Gibbs needs lengths
+        topica.standard_errors(hdp, of="prevalence", nsims=10)
+
     bert = topica.BERTopic(min_cluster_size=5)
     with pytest.raises(ValueError, match="bootstrap"):
         topica.standard_errors(bert, corpus, of="prevalence", method="composition", nsims=10)


### PR DESCRIPTION
Closes #32.

Fitted LDA, KeyATM (base/covariate/dynamic), and SeededLDA now expose `model.doc_lengths` (length D, raw token counts in `doc_topic` row order, derived from the retained corpus). `composition_theta` / `_doc_lengths_for` fall back to it when `corpus=None`, so the Dirichlet-approximation path (`keep_theta_draws=False`) is self-sufficient: `composition_theta(model)` "just works" for any fitted Gibbs model, draws or no draws. Passing `corpus=` still takes precedence (draw against an alternate corpus deliberately).

Pairs with #31: #31 made the *draws* path corpus-free; this makes the *fallback* path corpus-free too, closing the silent-degradation footgun where a downstream `try/except` around `composition_theta(model, corpus=None)` would swallow the "needs corpus" error and quietly degrade to sampling-only uncertainty.

Other Dirichlet models (HDP, DMR, PA, ...) are out of scope and still require `corpus=`.

## Validation
- Rust: `cargo test --lib` (49 passed).
- Python: full suite 1144 passed, 1 skipped; new `tests/test_doc_lengths.py` (8 tests). The #31-era `test_composition_needs_corpus_...` became `test_composition_self_sufficient_for_gibbs_and_rejects_embedding` (LDA needs no corpus now; HDP still does).
- `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)