### PR TITLE
feat: estimator conformance contract + check (phase 1)

### DIFF
--- a/docs/contributing/estimator-contract.md
+++ b/docs/contributing/estimator-contract.md
@@ -1,0 +1,161 @@
+# Estimator contract
+
+This page specifies the uniform interface every topica estimator must expose.
+Follow it when adding a new model or porting an existing one. The conformance
+test (`tests/test_conformance.py`) checks every registered estimator against
+this contract on every CI run, so gaps in a new model fail the suite rather
+than silently degrading the toolkit.
+
+## Constructor
+
+```python
+Model(num_topics, *, seed=42, **hyperparameters)
+```
+
+Every estimator takes `seed` in its constructor (not in `fit`). If the model
+requires non-standard arguments (for example a seed dict for `KeyATM`, a depth
+for `HLDA`, or super/sub counts for `PA`), those come first; `seed` is always a
+keyword-only argument.
+
+## The three tiers
+
+### Tier 0 — every estimator (the floor)
+
+All 20 estimators in the registry must pass every Tier 0 check.
+
+**fit signature**
+
+```python
+def fit(self, data, ..., *, iters: int = <default>, ...) -> Self:
+    ...
+```
+
+`iters` is the canonical iteration-count keyword. It controls the number of
+Gibbs sweeps, EM steps, or epochs, depending on the model family. Use `iters`
+even where the underlying algorithm calls them something else. The `validation`
+module's `_accepts_kwarg` helper checks for this at import time; do not hide
+`iters` behind `**kwargs` unless you explicitly check `'iters' in kwargs`.
+
+**Properties and methods**
+
+| Name | Shape / return type | Notes |
+|------|---------------------|-------|
+| `topic_word` | `(K, V)` float array | Each row sums to 1 for generative models; c-TF-IDF weights for cluster models |
+| `doc_topic` | `(D, K)` float array | Each row sums to 1 for mixed-membership models |
+| `vocabulary` | sequence of str, length V | Vocabulary aligned with `topic_word` columns |
+| `num_topics` | int | Number of topics K |
+| `topic_names` | list of str, length K | User-set labels; default `["topic_0", "topic_1", ...]` |
+| `doc_names` | list of str, length D | Row labels for `doc_topic`; default document indices as strings |
+| `top_words(n)` | list of K lists of `(word, weight)` | Top n words per topic |
+| `coherence(n)` | array of K floats | Per-topic UMass coherence over top n words |
+| `save(path)` | — | Serialize to disk |
+| `load(path)` | — | Class method; restore from disk |
+
+### Tier 1 — generative models
+
+Models whose `model_family` is `"dirichlet"` or `"logistic_normal"` must also
+expose:
+
+```python
+def transform(self, docs) -> np.ndarray:  # shape (n_docs, K)
+    ...
+```
+
+`transform` infers the topic mixture for new documents (without updating the
+model). It is the basis for held-out perplexity, `eval_heldout`, and `search_k`.
+Models with structural reasons for not supporting held-out inference (keyword-
+constrained models such as `KeyATM` and `SeededLDA`, or group-anchored models
+such as `SAGE` and `PA`) are listed in `EXEMPT` in `topica.conformance` and are
+not required to implement `transform`.
+
+### Tier 2 — family-specific attributes
+
+**Dirichlet family** (`model_family == "dirichlet"`, i.e. collapsed-Gibbs models):
+
+| Name | Shape | Notes |
+|------|-------|-------|
+| `alpha` | `(K,)` float array | Per-topic document-topic Dirichlet prior |
+| `theta_draws` | `(S, D, K)` float array | Retained MCMC draws of the doc-topic matrix; shape `(0,)` when not collected (pass `keep_theta_draws=True` to `fit`) |
+| `doc_lengths` | `(D,)` int array | Tokens per document; used by the Dirichlet theta sampler in `composition_theta` |
+
+**Logistic-normal family** (`model_family == "logistic_normal"`, i.e. STM/CTM):
+
+| Name | Shape | Notes |
+|------|-------|-------|
+| `eta_mean` | `(D, K-1)` float array | Variational mean of the logistic-normal document representation |
+| `eta_cov` | `(D, K-1, K-1)` float array | Variational covariance |
+
+## Principled exemptions
+
+Some requirements will never apply to certain models because their statistics
+differ structurally. These exemptions are recorded in
+`topica.conformance.EXEMPT`. Do not add a workaround to make a model fake-pass
+a requirement it cannot honestly satisfy; add it to `EXEMPT` instead with a
+brief reason.
+
+Current permanent exemptions:
+
+| Model | Requirement | Reason |
+|-------|-------------|--------|
+| `HLDA` | `doc_topic` | Topic tree; documents have paths, not a (D, K) theta matrix |
+| `HLDA` | `num_topics` | Tree model with `num_nodes`; no fixed scalar K |
+| `HLDA` | `doc_names` | No static per-document row index |
+| `HLDA` | `coherence` | Node-indexed tree structure is incompatible with flat (K, V) coherence |
+| `HLDA` | `transform` | No flat K-topic generative distribution |
+| `DTM` | `doc_topic` | Time-sliced; no single static theta matrix |
+| `DTM` | `doc_names` | No static per-document row index |
+| `DTM` | `coherence` | Time-varying phi is incompatible with flat (K, V) coherence |
+| `DTM` | `transform` | No time-slice-free held-out inference |
+| `BERTopic` | `coherence` | c-TF-IDF topic_word is not a probability; use `topica.coherence()` externally |
+| `BERTopic` | `doc_names` | Exposes cluster `labels`, not a doc_names property |
+| `Top2Vec` | `coherence` | Same as BERTopic |
+| `Top2Vec` | `doc_names` | Same as BERTopic |
+| `GSDMM` | `topic_names` | Mixture model (one topic per document); topic_names absent |
+| `SAGE` | `transform` | Keyword-anchored model; no held-out transform |
+| `PA` | `transform` | Super/sub-topic model; no held-out transform |
+| `PT` | `transform` | Pseudo-topic model; no held-out transform |
+| `KeyATM` | `transform` | Keyword-constrained; no held-out transform |
+| `SeededLDA` | `transform` | Seeded variant of KeyATM; no held-out transform |
+
+## Checking your model
+
+Run the conformance test in isolation:
+
+```bash
+VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/python -m pytest tests/test_conformance.py -v
+```
+
+Or call the helper directly from Python:
+
+```python
+import topica
+
+violations = topica.check_conformance(MyNewModel(num_topics=5))
+for v in violations:
+    print(v)
+```
+
+An empty list means the model satisfies every applicable requirement. A non-
+empty list tells you exactly which attributes or methods are missing before you
+open a pull request.
+
+## Adding a new estimator
+
+1. Implement the model in `src/<name>.rs` with PyO3 bindings in `src/python.rs`
+   (or in pure Python in `python/topica/`).
+2. Export it from `python/topica/__init__.py`.
+3. Add it to `REGISTRY` in `python/topica/conformance.py` with a zero-arg
+   factory lambda and the correct `model_family` string.
+4. Add the class to `_topica.pyi` to keep the stub in sync.
+5. Run `topica.check_conformance(MyModel())` to find any missing attributes.
+6. For each missing attribute:
+   - If it is a structural impossibility for this model, add it to `EXEMPT`
+     with a clear reason.
+   - Otherwise, implement it so the check passes.
+7. Run the full conformance test. All cells for the new model must either pass,
+   be exempted, or (temporarily) be listed in `KNOWN_GAPS`.
+
+Do not add entries to `KNOWN_GAPS` for a brand-new model unless you intend to
+fix them in an immediately following commit. The purpose of `KNOWN_GAPS` is to
+track pre-existing drift, not to grant new models a blanket deferred
+implementation.

--- a/docs/contributing/estimator-contract.md
+++ b/docs/contributing/estimator-contract.md
@@ -63,10 +63,11 @@ def transform(self, docs) -> np.ndarray:  # shape (n_docs, K)
 
 `transform` infers the topic mixture for new documents (without updating the
 model). It is the basis for held-out perplexity, `eval_heldout`, and `search_k`.
-Models with structural reasons for not supporting held-out inference (keyword-
-constrained models such as `KeyATM` and `SeededLDA`, or group-anchored models
-such as `SAGE` and `PA`) are listed in `EXEMPT` in `topica.conformance` and are
-not required to implement `transform`.
+Only the models with no flat document-topic representation are structurally
+exempt: `HLDA` (a topic tree) and `DTM` (time-sliced). The keyword, seeded, and
+anchored Gibbs models (`KeyATM`, `SeededLDA`, `SAGE`, `PA`, `PT`) can infer a
+held-out theta from their fitted phi, so they are tracked in `KNOWN_GAPS` as
+work to do, not exempted.
 
 ### Tier 2 — family-specific attributes
 
@@ -93,6 +94,10 @@ differ structurally. These exemptions are recorded in
 a requirement it cannot honestly satisfy; add it to `EXEMPT` instead with a
 brief reason.
 
+`topica.conformance.EXEMPT` and `KNOWN_GAPS` are the authoritative lists; the
+table below is a snapshot. An exemption is permanent and principled; a gap is a
+fixable omission tracked for a later phase.
+
 Current permanent exemptions:
 
 | Model | Requirement | Reason |
@@ -106,16 +111,15 @@ Current permanent exemptions:
 | `DTM` | `doc_names` | No static per-document row index |
 | `DTM` | `coherence` | Time-varying phi is incompatible with flat (K, V) coherence |
 | `DTM` | `transform` | No time-slice-free held-out inference |
-| `BERTopic` | `coherence` | c-TF-IDF topic_word is not a probability; use `topica.coherence()` externally |
 | `BERTopic` | `doc_names` | Exposes cluster `labels`, not a doc_names property |
-| `Top2Vec` | `coherence` | Same as BERTopic |
-| `Top2Vec` | `doc_names` | Same as BERTopic |
-| `GSDMM` | `topic_names` | Mixture model (one topic per document); topic_names absent |
-| `SAGE` | `transform` | Keyword-anchored model; no held-out transform |
-| `PA` | `transform` | Super/sub-topic model; no held-out transform |
-| `PT` | `transform` | Pseudo-topic model; no held-out transform |
-| `KeyATM` | `transform` | Keyword-constrained; no held-out transform |
-| `SeededLDA` | `transform` | Seeded variant of KeyATM; no held-out transform |
+| `BERTopic` | `iters` | Not an iterative sampler (UMAP + HDBSCAN); no iteration count applies |
+| `Top2Vec` | `doc_names` | Exposes cluster `labels`, not a doc_names property |
+| `Top2Vec` | `iters` | Not an iterative sampler (UMAP + HDBSCAN); no iteration count applies |
+
+Everything else currently missing (for example `topic_names` on most models,
+`transform` on the keyword/seeded/anchored models, `theta_draws`/`doc_lengths`
+on the remaining Dirichlet models, `coherence`/`save`/`load` on the neural and
+cluster models) is a tracked gap in `KNOWN_GAPS`, not an exemption.
 
 ## Checking your model
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -120,4 +120,6 @@ nav:
       - STM toolkit: api/stm.md
       - keyATM toolkit: api/keyatm.md
       - Keywords & preprocessing: api/keywords.md
+  - Contributing:
+      - Estimator contract: contributing/estimator-contract.md
   - Citing: citing.md

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -111,6 +111,8 @@ from . import stm  # noqa: E402  (stm imports names defined above)
 from . import keyatm  # noqa: E402  (keyATM-specific workflow helpers)
 from . import effects  # noqa: E402  (model-neutral prevalence analysis)
 from . import validation  # noqa: E402  (post-hoc topic diagnostics surface)
+from . import conformance  # noqa: E402  (estimator contract and registry)
+from .conformance import check_conformance  # noqa: E402
 from .effects import (  # noqa: E402  general, work on any model's theta
     estimate_effect,
     by_strata,
@@ -287,6 +289,8 @@ __all__ = [
     "HeldoutResult",
     "mmr",
     "keywords",
+    "conformance",
+    "check_conformance",
     "preprocess",
     "learn_phrases",
     "apply_phrases",

--- a/python/topica/conformance.py
+++ b/python/topica/conformance.py
@@ -150,34 +150,20 @@ EXEMPT: dict[tuple[str, str], str] = {
     ("DTM", "transform"):   "DTM has no time-slice-free held-out inference",
 
     # --- BERTopic / Top2Vec: embedding-cluster models ---
-    # topic_names and doc_names: these models DO expose them (already present).
-    # coherence: they do NOT expose it as a model method (no class attr).
-    ("BERTopic", "coherence"): "BERTopic c-TF-IDF topic_word is not a probability; model-level coherence() method absent (use topica.coherence() externally)",
-    ("Top2Vec",  "coherence"): "Top2Vec c-TF-IDF topic_word is not a probability; model-level coherence() method absent (use topica.coherence() externally)",
+    # topic_names and doc_names: topic_names is present; doc_names is not (these
+    # models expose cluster `labels`, and a names index is cluster-specific).
     ("BERTopic", "doc_names"): "BERTopic exposes labels (cluster ids) not a doc_names property; mapping to names is cluster-specific",
     ("Top2Vec",  "doc_names"): "Top2Vec exposes labels (cluster ids) not a doc_names property",
+    # iters: these models are not iterative samplers in the Gibbs/EM sense (the
+    # fit is UMAP + HDBSCAN clustering), so a standardized iteration count does
+    # not apply.
+    ("BERTopic", "iters"): "BERTopic is not an iterative sampler (UMAP + HDBSCAN); no iteration count applies",
+    ("Top2Vec",  "iters"): "Top2Vec is not an iterative sampler (UMAP + HDBSCAN); no iteration count applies",
     # transform: both DO expose transform; NOT exempted.
     # Tier 2: family is 'none'; no Tier 2 applies.
-    # iters: neither model is iterative in the Gibbs/EM sense; NOT exempted
-    # (they simply do not have iters, which is a KNOWN_GAP not an exemption
-    # because it is left open pending a decision on whether to standardize
-    # embedding models' epochs as 'iters').
-
-    # --- GSDMM: Dirichlet mixture (one topic per document) ---
-    # topic_names: not present at class level.
-    ("GSDMM", "topic_names"): "GSDMM is a mixture model (one topic per document); topic_names property absent",
-
-    # --- SAGE / PA / PT / DMR: no transform ---
-    # SAGE: anchored word counts; inference is not a simple projection.
-    ("SAGE", "transform"):  "SAGE keyword-anchored model has no held-out transform",
-    # PA: super/sub structure; no flat single-theta held-out path.
-    ("PA",   "transform"):  "PA super/sub-topic model has no held-out transform",
-    # PT: pseudo-topic prior; no held-out transform implemented.
-    ("PT",   "transform"):  "PT pseudo-topic model has no held-out transform",
-    # KeyATM: keyword-constrained; transform omitted by design.
-    ("KeyATM", "transform"): "KeyATM keyword-constrained model has no held-out transform",
-    # SeededLDA: seeded variant; transform omitted (same reasoning as KeyATM).
-    ("SeededLDA", "transform"): "SeededLDA seeded model has no held-out transform",
+    # coherence: a count-based UMass/NPMI is computable from any top-word list,
+    # so a model-level coherence() is a fixable gap (see KNOWN_GAPS), not an
+    # exemption — even though their topic_word is c-TF-IDF rather than P(w|t).
 }
 
 # ---------------------------------------------------------------------------
@@ -199,8 +185,6 @@ KNOWN_GAPS: dict[tuple[str, str], str] = {
     ("ETM",          "iters"): "phase 2: expose iters in ETM.fit (currently none)",
     ("ProdLDA",      "iters"): "phase 2: expose iters in ProdLDA.fit (currently none)",
     ("FASTopic",     "iters"): "phase 2: expose iters in FASTopic.fit (currently none)",
-    ("BERTopic",     "iters"): "phase 2: expose iters in BERTopic.fit if applicable, or document non-iterative",
-    ("Top2Vec",      "iters"): "phase 2: expose iters in Top2Vec.fit if applicable, or document non-iterative",
 
     # --- Phase 3: add topic_names to all models that lack it ---
     ("LDA",          "topic_names"): "phase 3: add topic_names property to LDA",
@@ -215,8 +199,9 @@ KNOWN_GAPS: dict[tuple[str, str], str] = {
     ("CTM",          "topic_names"): "phase 3: add topic_names property to CTM",
     ("HLDA",         "topic_names"): "phase 3: add topic_names property to HLDA (tree nodes)",
     ("DTM",          "topic_names"): "phase 3: add topic_names property to DTM",
+    ("GSDMM",        "topic_names"): "phase 3: add topic_names to GSDMM (it has doc_topic + num_topics)",
 
-    # --- Phase 4: add coherence + save/load + doc_names to neural models ---
+    # --- Phase 4: universal members on the neural / cluster models ---
     ("ETM",          "doc_names"):  "phase 4: add doc_names property to ETM",
     ("ETM",          "coherence"):  "phase 4: add coherence method to ETM",
     ("ETM",          "save"):       "phase 4: add save method to ETM",
@@ -227,6 +212,19 @@ KNOWN_GAPS: dict[tuple[str, str], str] = {
     ("FASTopic",     "load"):       "phase 4: add load method to FASTopic",
     ("ProdLDA",      "save"):       "phase 4: add save method to ProdLDA",
     ("ProdLDA",      "load"):       "phase 4: add load method to ProdLDA",
+    # count-based UMass/NPMI is valid over c-TF-IDF top words.
+    ("BERTopic",     "coherence"):  "phase 4: add coherence method to BERTopic (UMass over top words)",
+    ("Top2Vec",      "coherence"):  "phase 4: add coherence method to Top2Vec (UMass over top words)",
+
+    # --- Phase 6: held-out transform for the remaining generative models ---
+    # All five are fittable Dirichlet models whose held-out theta can be inferred
+    # with the fitted phi (Gibbs inference for the keyword/seeded/pseudo models;
+    # a baseline, covariate-free projection for SAGE's sparse-additive phi).
+    ("KeyATM",       "transform"): "phase 6: add transform (Gibbs held-out inference with fitted phi)",
+    ("SeededLDA",    "transform"): "phase 6: add transform (Gibbs held-out inference with fitted phi)",
+    ("SAGE",         "transform"): "phase 6: add transform (baseline, covariate-free projection)",
+    ("PA",           "transform"): "phase 6: add transform (sub-topic held-out inference)",
+    ("PT",           "transform"): "phase 6: add transform (pseudo-topic held-out inference)",
 
     # --- Phase 5: add theta_draws + doc_lengths to remaining Gibbs models ---
     ("DMR",          "theta_draws"):    "phase 5: add theta_draws to DMR (retained MCMC draws)",

--- a/python/topica/conformance.py
+++ b/python/topica/conformance.py
@@ -1,0 +1,341 @@
+"""Estimator conformance: registry, contract definition, and check helper.
+
+Every topica estimator must expose a uniform interface organized into three tiers.
+This module encodes that contract, the principled exemptions from it, and the
+known gaps (fixable drift tracked as a burn-down worklist). It also provides
+``check_conformance(model_or_class) -> list[str]``, which callers and the
+conformance test use to verify a model against its required tier.
+
+The three tiers
+---------------
+Tier 0  (floor, every estimator):
+    ``fit(data, ...)`` — with the canonical iteration kwarg ``iters`` where the
+    model is iterative.
+    Properties/methods: ``topic_word``, ``doc_topic``, ``vocabulary``,
+    ``num_topics``, ``topic_names``, ``doc_names``, ``top_words``,
+    ``coherence``, ``save``, ``load``.
+
+Tier 1  (generative models, i.e. ``model_family != "none"``):
+    ``transform(docs) -> (n, num_topics)``.
+
+Tier 2  (family-specific):
+    ``model_family == "dirichlet"``  ->  ``alpha``, ``theta_draws``,
+    ``doc_lengths``.
+    ``model_family == "logistic_normal"``  ->  ``eta_mean``, ``eta_cov``.
+
+Exemptions
+----------
+Some requirements are principled exemptions that will never be closed, because
+the model's statistics differ structurally from the requirement. These are
+recorded in :data:`EXEMPT` as ``(model_name, requirement) -> reason``.
+
+Known gaps
+----------
+:data:`KNOWN_GAPS` records temporary non-conformance:
+``(model_name, requirement) -> phase_note``. The conformance test treats these
+as expected failures so the suite is green today while this map is the
+burn-down worklist. The program ends when ``KNOWN_GAPS == {}``.
+"""
+
+from __future__ import annotations
+
+import inspect
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+# Each entry: (name, factory_callable, expected_model_family)
+# Factories are zero/low-arg lambdas; construction follows the same patterns
+# used in tests/test_standard_errors.py::_FAMILY_REGISTRY.
+
+import topica as _topica
+
+REGISTRY: list[tuple[str, object, str]] = [
+    # collapsed-Gibbs / Dirichlet doc-topic posterior
+    ("LDA",          lambda: _topica.LDA(2),                                     "dirichlet"),
+    ("DMR",          lambda: _topica.DMR(2),                                     "dirichlet"),
+    ("SAGE",         lambda: _topica.SAGE(2),                                    "dirichlet"),
+    ("PA",           lambda: _topica.PA(num_super=2, num_sub=4),                 "dirichlet"),
+    ("PT",           lambda: _topica.PT(num_topics=2, num_pseudo=10),            "dirichlet"),
+    ("HDP",          lambda: _topica.HDP(),                                      "dirichlet"),
+    ("LabeledLDA",   lambda: _topica.LabeledLDA(),                               "dirichlet"),
+    ("SupervisedLDA",lambda: _topica.SupervisedLDA(num_topics=2),                "dirichlet"),
+    ("HLDA",         lambda: _topica.HLDA(),                                     "none"),
+    ("DTM",          lambda: _topica.DTM(2),                                     "none"),
+    ("KeyATM",       lambda: _topica.KeyATM({"a": ["x"]}, num_topics=2),         "dirichlet"),
+    ("SeededLDA",    lambda: _topica.SeededLDA({"a": ["x"], "b": ["y"]}),        "dirichlet"),
+    ("GSDMM",        lambda: _topica.GSDMM(num_topics=5),                        "none"),
+    # logistic-normal (variational eta posterior)
+    ("STM",          lambda: _topica.STM(2),                                     "logistic_normal"),
+    ("CTM",          lambda: _topica.CTM(2),                                     "logistic_normal"),
+    # neural / embedding-based — no theta posterior
+    ("ETM",          lambda: _topica.ETM(2),                                     "none"),
+    ("ProdLDA",      lambda: _topica.ProdLDA(2),                                 "none"),
+    ("FASTopic",     lambda: _topica.FASTopic(2),                                "none"),
+    # embedding-cluster — no generative word distribution
+    ("BERTopic",     lambda: _topica.BERTopic(min_cluster_size=5),               "none"),
+    ("Top2Vec",      lambda: _topica.Top2Vec(),                                  "none"),
+    # EmbeddingLDA is EXCLUDED: it is a Python wrapper around SeededLDA (see
+    # module-level note in python/topica/embedding.py). It delegates every
+    # fitted-model getter to self._model via __getattr__, has no class-level
+    # PyO3 attributes, and its __init__ requires embeddings and vocabulary, so
+    # it cannot be constructed generically. The underlying SeededLDA (which is
+    # in this registry) covers the contract. Treat EmbeddingLDA as a user-facing
+    # convenience wrapper, not a first-class estimator, until it graduates to a
+    # proper PyO3 binding with its own class attributes.
+]
+
+# ---------------------------------------------------------------------------
+# Contract tiers
+# ---------------------------------------------------------------------------
+
+# Tier 0: every estimator
+TIER0_ATTRS = [
+    "topic_word",
+    "doc_topic",
+    "vocabulary",
+    "num_topics",
+    "topic_names",
+    "doc_names",
+    "top_words",
+    "coherence",
+    "save",
+    "load",
+]
+TIER0_ITERS = "iters"   # canonical iteration kwarg name
+
+# Tier 1: generative models (model_family != "none")
+TIER1_ATTRS = ["transform"]
+
+# Tier 2: family-specific
+TIER2_DIRICHLET = ["alpha", "theta_draws", "doc_lengths"]
+TIER2_LOGISTIC_NORMAL = ["eta_mean", "eta_cov"]
+
+# ---------------------------------------------------------------------------
+# Principled exemptions — PERMANENT, will not be closed
+# ---------------------------------------------------------------------------
+# Key: (model_name, requirement)   Value: human-readable reason
+
+EXEMPT: dict[tuple[str, str], str] = {
+
+    # --- HLDA: topic-tree model, not a flat K-topic model ---
+    # doc_topic: HLDA assigns each document to a root-to-leaf *path*, not a
+    # K-vector simplex; there is no static (D, K) theta matrix.
+    ("HLDA", "doc_topic"):  "HLDA is a topic tree (nested CRP); documents have paths, not a (D,K) theta simplex",
+    # num_topics: the number of active nodes is discovered, not fixed to a
+    # scalar K.  The model exposes num_nodes instead.
+    ("HLDA", "num_topics"): "HLDA has num_nodes (tree), not a fixed scalar K",
+    # doc_names: no static doc rows -> no doc_names index.
+    ("HLDA", "doc_names"):  "HLDA has no static per-document row index (tree paths, not theta)",
+    # coherence: requires a (K, V) topic_word matrix; HLDA's topic_word is
+    # node-indexed, not a flat K-topic array.
+    ("HLDA", "coherence"):  "HLDA coherence requires a flat (K,V) topic_word; node-indexed tree structure is incompatible",
+    # transform: no flat K-topic generative model -> cannot infer a (n, K) theta.
+    ("HLDA", "transform"):  "HLDA has no flat K-topic generative distribution; held-out transform is undefined",
+    # iters: HLDA does accept iters, so this is NOT exempted.
+    # alpha/theta_draws/doc_lengths: family is 'none' so Tier 2 dirichlet
+    # does not apply.
+
+    # --- DTM: time-sliced model, no static single theta ---
+    # doc_topic: DTM's theta is time-conditioned; there is no single static
+    # (D, K) matrix.  Use topic_word(time) and word_evolution for trajectories.
+    ("DTM", "doc_topic"):   "DTM is time-sliced; doc_topic is undefined without a time slice argument",
+    # doc_names: follows from no static doc_topic rows.
+    ("DTM", "doc_names"):   "DTM has no static per-document row index (time-sliced model)",
+    # coherence: coherence needs a static (K, V) phi matrix; DTM's topic_word
+    # varies by time slice (callable, not a property).
+    ("DTM", "coherence"):   "DTM coherence requires a static (K,V) topic_word; time-varying phi is incompatible",
+    # transform: DTM's EM is time-conditioned; there is no time-slice-free
+    # held-out inference.
+    ("DTM", "transform"):   "DTM has no time-slice-free held-out inference",
+
+    # --- BERTopic / Top2Vec: embedding-cluster models ---
+    # topic_names and doc_names: these models DO expose them (already present).
+    # coherence: they do NOT expose it as a model method (no class attr).
+    ("BERTopic", "coherence"): "BERTopic c-TF-IDF topic_word is not a probability; model-level coherence() method absent (use topica.coherence() externally)",
+    ("Top2Vec",  "coherence"): "Top2Vec c-TF-IDF topic_word is not a probability; model-level coherence() method absent (use topica.coherence() externally)",
+    ("BERTopic", "doc_names"): "BERTopic exposes labels (cluster ids) not a doc_names property; mapping to names is cluster-specific",
+    ("Top2Vec",  "doc_names"): "Top2Vec exposes labels (cluster ids) not a doc_names property",
+    # transform: both DO expose transform; NOT exempted.
+    # Tier 2: family is 'none'; no Tier 2 applies.
+    # iters: neither model is iterative in the Gibbs/EM sense; NOT exempted
+    # (they simply do not have iters, which is a KNOWN_GAP not an exemption
+    # because it is left open pending a decision on whether to standardize
+    # embedding models' epochs as 'iters').
+
+    # --- GSDMM: Dirichlet mixture (one topic per document) ---
+    # topic_names: not present at class level.
+    ("GSDMM", "topic_names"): "GSDMM is a mixture model (one topic per document); topic_names property absent",
+
+    # --- SAGE / PA / PT / DMR: no transform ---
+    # SAGE: anchored word counts; inference is not a simple projection.
+    ("SAGE", "transform"):  "SAGE keyword-anchored model has no held-out transform",
+    # PA: super/sub structure; no flat single-theta held-out path.
+    ("PA",   "transform"):  "PA super/sub-topic model has no held-out transform",
+    # PT: pseudo-topic prior; no held-out transform implemented.
+    ("PT",   "transform"):  "PT pseudo-topic model has no held-out transform",
+    # KeyATM: keyword-constrained; transform omitted by design.
+    ("KeyATM", "transform"): "KeyATM keyword-constrained model has no held-out transform",
+    # SeededLDA: seeded variant; transform omitted (same reasoning as KeyATM).
+    ("SeededLDA", "transform"): "SeededLDA seeded model has no held-out transform",
+}
+
+# ---------------------------------------------------------------------------
+# Known gaps — TEMPORARY, tracked as a burn-down worklist
+# ---------------------------------------------------------------------------
+# Key: (model_name, requirement)   Value: phase note
+
+KNOWN_GAPS: dict[tuple[str, str], str] = {
+
+    # --- Phase 2: rename iteration param to iters ---
+    ("LDA",          "iters"): "phase 2: rename 'iterations' -> 'iters' in LDA.fit",
+    ("DMR",          "iters"): "phase 2: rename 'iterations' -> 'iters' in DMR.fit",
+    ("SAGE",         "iters"): "phase 2: rename 'iterations' -> 'iters' in SAGE.fit",
+    ("LabeledLDA",   "iters"): "phase 2: rename 'iterations' -> 'iters' in LabeledLDA.fit",
+    ("SupervisedLDA","iters"): "phase 2: rename 'em_iters' -> 'iters' in SupervisedLDA.fit",
+    ("STM",          "iters"): "phase 2: rename 'em_iters' -> 'iters' in STM.fit",
+    ("CTM",          "iters"): "phase 2: rename 'em_iters' -> 'iters' in CTM.fit",
+    ("DTM",          "iters"): "phase 2: rename 'em_iters' -> 'iters' in DTM.fit",
+    ("ETM",          "iters"): "phase 2: expose iters in ETM.fit (currently none)",
+    ("ProdLDA",      "iters"): "phase 2: expose iters in ProdLDA.fit (currently none)",
+    ("FASTopic",     "iters"): "phase 2: expose iters in FASTopic.fit (currently none)",
+    ("BERTopic",     "iters"): "phase 2: expose iters in BERTopic.fit if applicable, or document non-iterative",
+    ("Top2Vec",      "iters"): "phase 2: expose iters in Top2Vec.fit if applicable, or document non-iterative",
+
+    # --- Phase 3: add topic_names to all models that lack it ---
+    ("LDA",          "topic_names"): "phase 3: add topic_names property to LDA",
+    ("DMR",          "topic_names"): "phase 3: add topic_names property to DMR",
+    ("SAGE",         "topic_names"): "phase 3: add topic_names property to SAGE",
+    ("PA",           "topic_names"): "phase 3: add topic_names property to PA",
+    ("PT",           "topic_names"): "phase 3: add topic_names property to PT",
+    ("HDP",          "topic_names"): "phase 3: add topic_names property to HDP",
+    ("LabeledLDA",   "topic_names"): "phase 3: add topic_names property to LabeledLDA",
+    ("SupervisedLDA","topic_names"): "phase 3: add topic_names property to SupervisedLDA",
+    ("STM",          "topic_names"): "phase 3: add topic_names property to STM",
+    ("CTM",          "topic_names"): "phase 3: add topic_names property to CTM",
+    ("HLDA",         "topic_names"): "phase 3: add topic_names property to HLDA (tree nodes)",
+    ("DTM",          "topic_names"): "phase 3: add topic_names property to DTM",
+
+    # --- Phase 4: add coherence + save/load + doc_names to neural models ---
+    ("ETM",          "doc_names"):  "phase 4: add doc_names property to ETM",
+    ("ETM",          "coherence"):  "phase 4: add coherence method to ETM",
+    ("ETM",          "save"):       "phase 4: add save method to ETM",
+    ("ETM",          "load"):       "phase 4: add load method to ETM",
+    ("FASTopic",     "doc_names"):  "phase 4: add doc_names property to FASTopic",
+    ("FASTopic",     "coherence"):  "phase 4: add coherence method to FASTopic",
+    ("FASTopic",     "save"):       "phase 4: add save method to FASTopic",
+    ("FASTopic",     "load"):       "phase 4: add load method to FASTopic",
+    ("ProdLDA",      "save"):       "phase 4: add save method to ProdLDA",
+    ("ProdLDA",      "load"):       "phase 4: add load method to ProdLDA",
+
+    # --- Phase 5: add theta_draws + doc_lengths to remaining Gibbs models ---
+    ("DMR",          "theta_draws"):    "phase 5: add theta_draws to DMR (retained MCMC draws)",
+    ("DMR",          "doc_lengths"):    "phase 5: add doc_lengths to DMR",
+    ("SAGE",         "theta_draws"):    "phase 5: add theta_draws to SAGE",
+    ("SAGE",         "doc_lengths"):    "phase 5: add doc_lengths to SAGE",
+    ("PA",           "theta_draws"):    "phase 5: add theta_draws to PA",
+    ("PA",           "doc_lengths"):    "phase 5: add doc_lengths to PA",
+    ("PT",           "theta_draws"):    "phase 5: add theta_draws to PT",
+    ("PT",           "doc_lengths"):    "phase 5: add doc_lengths to PT",
+    ("HDP",          "theta_draws"):    "phase 5: add theta_draws to HDP",
+    ("HDP",          "doc_lengths"):    "phase 5: add doc_lengths to HDP",
+    ("LabeledLDA",   "theta_draws"):    "phase 5: add theta_draws to LabeledLDA",
+    ("LabeledLDA",   "doc_lengths"):    "phase 5: add doc_lengths to LabeledLDA",
+    ("SupervisedLDA","theta_draws"):    "phase 5: add theta_draws to SupervisedLDA",
+    ("SupervisedLDA","doc_lengths"):    "phase 5: add doc_lengths to SupervisedLDA",
+}
+
+# ---------------------------------------------------------------------------
+# check_conformance helper
+# ---------------------------------------------------------------------------
+
+def _accepts_kwarg(fn, name: str) -> bool:
+    """Whether ``fn`` accepts the keyword argument ``name``."""
+    try:
+        params = inspect.signature(fn).parameters
+    except (ValueError, TypeError):
+        return False
+    if name in params:
+        return True
+    return any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params.values())
+
+
+def check_conformance(model_or_class) -> list[str]:
+    """Check ``model_or_class`` against the topica estimator contract.
+
+    Returns a list of violation strings. An empty list means the model
+    satisfies every applicable tier requirement (or has a valid exemption).
+    Does NOT look up KNOWN_GAPS or EXEMPT — it reports all raw violations so
+    the conformance test can categorize them. Call this from the test or from
+    your own CI after adding a new estimator.
+
+    Parameters
+    ----------
+    model_or_class : an estimator instance or class.
+
+    Returns
+    -------
+    list of str
+        Each entry is a human-readable description of the violation, e.g.
+        ``"missing class attribute: topic_names"``.
+    """
+    if isinstance(model_or_class, type):
+        cls = model_or_class
+        instance = None
+    else:
+        cls = type(model_or_class)
+        instance = model_or_class
+
+    name = cls.__name__
+    violations: list[str] = []
+
+    # Tier 0: class-level attribute checks
+    for attr in TIER0_ATTRS:
+        if not hasattr(cls, attr):
+            violations.append(f"missing class attribute: {attr}")
+
+    # Tier 0: iters kwarg
+    fit_fn = getattr(cls, "fit", None)
+    if fit_fn is None:
+        violations.append("missing fit method")
+    else:
+        if not _accepts_kwarg(fit_fn, TIER0_ITERS):
+            violations.append(f"fit() does not accept kwarg: {TIER0_ITERS}")
+
+    # Determine family from an instance (works on unfitted instances per model_family docstring)
+    if instance is None:
+        # Construct a minimal instance from the registry if possible
+        _instance = None
+        for reg_name, factory, _ in REGISTRY:
+            if reg_name == name:
+                try:
+                    _instance = factory()
+                except Exception:
+                    pass
+                break
+        family_instance = _instance if _instance is not None else cls.__new__(cls)
+    else:
+        family_instance = instance
+
+    from .effects import model_family as _model_family
+    try:
+        family = _model_family(family_instance)
+    except Exception:
+        family = "none"
+
+    # Tier 1: transform required for generative models
+    if family != "none":
+        if not hasattr(cls, "transform"):
+            violations.append("missing class attribute: transform (Tier 1 generative model)")
+
+    # Tier 2: family-specific
+    if family == "dirichlet":
+        for attr in TIER2_DIRICHLET:
+            if not hasattr(cls, attr):
+                violations.append(f"missing class attribute: {attr} (Tier 2 dirichlet)")
+    elif family == "logistic_normal":
+        for attr in TIER2_LOGISTIC_NORMAL:
+            if not hasattr(cls, attr):
+                violations.append(f"missing class attribute: {attr} (Tier 2 logistic_normal)")
+
+    return violations

--- a/tests/test_conformance.py
+++ b/tests/test_conformance.py
@@ -1,0 +1,179 @@
+"""Estimator-interface conformance test.
+
+Every estimator in the topica registry must expose a three-tier interface.
+Tier 0 is the universal floor (topic_word, doc_topic, vocabulary, num_topics,
+topic_names, doc_names, top_words, coherence, save, load; and iters in fit).
+Tier 1 applies to generative models (model_family != "none"): transform.
+Tier 2 is family-specific (alpha/theta_draws/doc_lengths for dirichlet;
+eta_mean/eta_cov for logistic_normal).
+
+The suite is green today because principled exemptions (EXEMPT) and known
+temporary gaps (KNOWN_GAPS) are recorded in topica.conformance. Violations
+that are neither exempted nor tracked land as real test failures — that is
+the enforcement mechanism for new estimators and regressions.
+"""
+
+import inspect
+
+import pytest
+
+import topica
+from topica.conformance import (
+    EXEMPT,
+    KNOWN_GAPS,
+    REGISTRY,
+    TIER0_ATTRS,
+    TIER0_ITERS,
+    TIER1_ATTRS,
+    TIER2_DIRICHLET,
+    TIER2_LOGISTIC_NORMAL,
+    _accepts_kwarg,
+)
+
+
+# ---------------------------------------------------------------------------
+# Build (model, requirement) parametrize list
+# ---------------------------------------------------------------------------
+# We build the full cross-product of (model, requirement) pairs upfront so
+# every cell is a named pytest parameter. Cells in EXEMPT skip; cells in
+# KNOWN_GAPS xfail; everything else must pass.
+
+
+def _all_requirements_for(name: str, family: str) -> list[str]:
+    """The requirements that apply to a given (name, family) pair."""
+    reqs = list(TIER0_ATTRS) + [TIER0_ITERS]
+    if family != "none":
+        reqs += TIER1_ATTRS
+    if family == "dirichlet":
+        reqs += TIER2_DIRICHLET
+    elif family == "logistic_normal":
+        reqs += TIER2_LOGISTIC_NORMAL
+    return reqs
+
+
+# Build flat list of (model_name, requirement, family, cls) for parametrize.
+_PARAMS: list[tuple[str, str, str, type]] = []
+for _reg_name, _factory, _family in REGISTRY:
+    try:
+        _inst = _factory()
+    except Exception as _exc:
+        pytest.fail(f"Registry factory for {_reg_name} failed: {_exc}")
+    _cls = type(_inst)
+    for _req in _all_requirements_for(_reg_name, _family):
+        _PARAMS.append((_reg_name, _req, _family, _cls))
+
+
+def _param_ids():
+    return [f"{p[0]}-{p[1]}" for p in _PARAMS]
+
+
+@pytest.mark.parametrize("model_name,requirement,family,cls", _PARAMS, ids=_param_ids())
+def test_conformance(model_name: str, requirement: str, family: str, cls: type) -> None:
+    """Each (estimator, requirement) cell must conform, be exempted, or be
+    listed in KNOWN_GAPS.
+
+    - EXEMPT  -> pytest.skip (principled, permanent)
+    - KNOWN_GAPS -> pytest.xfail (expected failure; worklist item)
+    - neither  -> the check must pass (a new gap or regression = hard failure)
+    """
+    key = (model_name, requirement)
+
+    if key in EXEMPT:
+        pytest.skip(f"exempted: {EXEMPT[key]}")
+
+    if key in KNOWN_GAPS:
+        pytest.xfail(f"known gap: {KNOWN_GAPS[key]}")
+
+    # --- run the actual check ---
+    _check_requirement(model_name, requirement, family, cls)
+
+
+def _check_requirement(model_name: str, requirement: str, family: str, cls: type) -> None:
+    """Assert that (model_name, requirement) is satisfied."""
+    if requirement == TIER0_ITERS:
+        fit_fn = getattr(cls, "fit", None)
+        assert fit_fn is not None, f"{model_name}: no fit method"
+        assert _accepts_kwarg(fit_fn, TIER0_ITERS), (
+            f"{model_name}.fit() does not accept kwarg '{TIER0_ITERS}'"
+        )
+    elif requirement == "transform":
+        assert hasattr(cls, "transform"), (
+            f"{model_name} is missing class attribute 'transform' (Tier 1 generative)"
+        )
+    else:
+        assert hasattr(cls, requirement), (
+            f"{model_name} is missing class attribute '{requirement}'"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Guard: no undeclared gap
+# ---------------------------------------------------------------------------
+
+def test_no_unexpected_gaps() -> None:
+    """Every (model, requirement) in KNOWN_GAPS must map to a real registry
+    entry with a real requirement that actually fails today.
+
+    If this test fails it means either:
+    (a) a gap was closed (the entry should be removed from KNOWN_GAPS), or
+    (b) the model was renamed or removed (update the registry), or
+    (c) a gap was listed for a non-existent (model, requirement) combination
+        (fix the typo in KNOWN_GAPS).
+    """
+    # Build lookup of (name, family) from registry
+    registry_map: dict[str, str] = {name: fam for name, _, fam in REGISTRY}
+
+    for (model_name, requirement), note in KNOWN_GAPS.items():
+        assert model_name in registry_map, (
+            f"KNOWN_GAPS entry ({model_name!r}, {requirement!r}) references a model "
+            f"not in the registry. Remove this entry or add {model_name!r} to the "
+            "registry."
+        )
+        family = registry_map[model_name]
+        applicable = _all_requirements_for(model_name, family)
+        assert requirement in applicable, (
+            f"KNOWN_GAPS entry ({model_name!r}, {requirement!r}): this requirement "
+            f"does not apply to {model_name} (family={family!r}). Remove it from "
+            "KNOWN_GAPS."
+        )
+        # Verify the gap actually fails today (i.e. is not already fixed).
+        # If the check passes, the gap is stale and should be removed.
+        try:
+            factory = next(f for n, f, _ in REGISTRY if n == model_name)
+            cls = type(factory())
+        except Exception:
+            continue
+        try:
+            _check_requirement(model_name, requirement, family, cls)
+            actually_passes = True
+        except AssertionError:
+            actually_passes = False
+
+        assert not actually_passes, (
+            f"KNOWN_GAPS entry ({model_name!r}, {requirement!r}) is STALE: the "
+            f"check passes today (note: {note!r}). Remove it from KNOWN_GAPS."
+        )
+
+
+def test_exempt_entries_are_consistent() -> None:
+    """Every EXEMPT entry must name a real registry model and an applicable
+    requirement (or a requirement that would apply if the exemption were not
+    there). This prevents typos in the exemption map."""
+    registry_names = {name for name, _, _ in REGISTRY}
+    for (model_name, requirement), reason in EXEMPT.items():
+        assert model_name in registry_names, (
+            f"EXEMPT entry ({model_name!r}, {requirement!r}) references a model not "
+            f"in the registry."
+        )
+        # Requirement must be one of the known requirement names
+        all_reqs = (
+            TIER0_ATTRS
+            + [TIER0_ITERS]
+            + TIER1_ATTRS
+            + TIER2_DIRICHLET
+            + TIER2_LOGISTIC_NORMAL
+        )
+        assert requirement in all_reqs, (
+            f"EXEMPT entry ({model_name!r}, {requirement!r}) names an unknown "
+            f"requirement. Known: {all_reqs}"
+        )


### PR DESCRIPTION
Phase 1 of bringing all estimators to a uniform interface. This establishes the contract and the enforcement; it changes no estimator behavior.

## What's here
- `topica/conformance.py` — the registry (20 estimators; EmbeddingLDA excluded as a `SeededLDA` wrapper), the three-tier contract (Tier 0 floor, Tier 1 generative `transform`, Tier 2 family-specific), an `EXEMPT` map (principled, permanent) and a `KNOWN_GAPS` map (fixable drift, the burn-down worklist), and `check_conformance(model)` (exported at `topica.check_conformance`).
- `tests/test_conformance.py` — parametrized over (estimator × requirement). Green today because EXEMPT cells skip and KNOWN_GAPS cells xfail; a violation that is neither **hard-fails**, so a new/regressed estimator that drops part of the contract trips CI. `test_no_unexpected_gaps` verifies each gap *actually fails today*, so closing a gap forces removing its entry (real burn-down).
- `docs/contributing/estimator-contract.md` (+ nav) — the contributor contract: what to accept (`iters`, `seed` in the constructor, `keep_theta_draws`/`num_theta_draws` for Dirichlet-Gibbs) and what to return (tiered surface with shapes).

## Canonical decisions
- Iteration option standardized to `iters` everywhere (no aliases — sole user).
- `seed` stays a constructor arg.

## Review re-adjudication (the maps lean toward fixing, not exempting)
The agent's first pass over-exempted. I moved into `KNOWN_GAPS`: `transform` for KeyATM/SeededLDA/SAGE/PA/PT (the motivating gap), GSDMM `topic_names`, BERTopic/Top2Vec `coherence`. I moved into `EXEMPT`: BERTopic/Top2Vec `iters` (UMAP+HDBSCAN, not iterative). Only HLDA (tree) and DTM (time-sliced) are structurally exempt from the theta-shaped requirements.

## The worklist this produces (later phases)
- **Phase 2** rename iteration param → `iters` (13 models).
- **Phase 3** `topic_names` on the 13 that lack it.
- **Phase 4** `coherence`/`save`/`load`/`doc_names` on neural + cluster models.
- **Phase 5** `theta_draws`/`doc_lengths` on the remaining Dirichlet-Gibbs models.
- **Phase 6** `transform` on KeyATM/SeededLDA/SAGE/PA/PT.

## Validation
- `tests/test_conformance.py`: 202 passed, 11 skipped, 55 xfailed.
- `tests/test_standard_errors.py`: unchanged. `mkdocs build --strict`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)