### PR TITLE
refactor: standardize fit iteration kwarg to iters (conformance phase 2)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,7 +119,7 @@ score higher on coherence while collapsing distinctions the researcher cares
 about. Use the diagnostics as evidence, not as an optimizer:
 
 ```python
-rows = topica.search_k(docs, [10, 15, 20, 25, 30], iterations=1000)
+rows = topica.search_k(docs, [10, 15, 20, 25, 30], iters=1000)
 # coherence, exclusivity, and held-out perplexity per K
 ```
 
@@ -144,7 +144,7 @@ model = topica.STM(num_topics=20, seed=42)
 model.fit(docs, prevalence=X, prevalence_names=names)   # content=... for SAGE
 ```
 
-A plain LDA fit is `topica.LDA(num_topics=20, seed=42).fit(docs, iterations=1000)`.
+A plain LDA fit is `topica.LDA(num_topics=20, seed=42).fit(docs, iters=1000)`.
 Check that the fit converged (the EM models expose a bound / `converged` flag;
 the Gibbs models expose log-likelihood history). A model that did not converge is
 not a result. Read topics off `top_words`, `label_topics` (prob / FREX / lift /

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ OpenAI or local via ollama). PyTorch is never required.
 from topica import LDA
 
 model = LDA(num_topics=2, seed=42)
-model.fit([["cat", "dog", "fish"]] * 15 + [["planet", "star", "moon"]] * 15, iterations=1000)
+model.fit([["cat", "dog", "fish"]] * 15 + [["planet", "star", "moon"]] * 15, iters=1000)
 
 for i, words in enumerate(model.top_words(3)):
     print(f"Topic {i}:", " ".join(w for w, _ in words))

--- a/benchmarks/bench_stm.py
+++ b/benchmarks/bench_stm.py
@@ -67,7 +67,7 @@ def synthetic_corpus(v, d, k_true, seed=0, length=TOKENS_PER_DOC):
 def time_topica(docs, x, k, iters):
     t0 = time.perf_counter()
     m = STM(num_topics=k, init="spectral", seed=1)
-    m.fit(docs, x, prevalence_names=["cov"], em_iters=iters)
+    m.fit(docs, x, prevalence_names=["cov"], iters=iters)
     return time.perf_counter() - t0
 
 

--- a/benchmarks/speed_vs_r.py
+++ b/benchmarks/speed_vs_r.py
@@ -102,7 +102,7 @@ def bench_stm() -> dict:
     # topica: same fixed EM iterations (em_tol=0 disables early stop).
     t0 = time.perf_counter()
     TopicaSTM(num_topics=STM_K, init="spectral").fit(
-        docs, X, prevalence_names=feat, em_iters=STM_EM_ITERS, em_tol=0.0
+        docs, X, prevalence_names=feat, iters=STM_EM_ITERS, em_tol=0.0
     )
     tt_time = time.perf_counter() - t0
     return {
@@ -199,7 +199,7 @@ def bench_lda() -> dict:
     def topica_fit(threads):
         t0 = time.perf_counter()
         LDA(num_topics=LDA_K, seed=1, optimize_interval=0, num_threads=threads).fit(
-            docs, iterations=LDA_ITERS
+            docs, iters=LDA_ITERS
         )
         return time.perf_counter() - t0
 

--- a/docs/examples/dubois.md
+++ b/docs/examples/dubois.md
@@ -55,7 +55,7 @@ print("vocab", corpus.num_words)                  # 3418
 
 ```python
 lda = topica.LDA(num_topics=15, seed=1)
-lda.fit(corpus, iterations=400, num_samples=4, sample_interval=25)
+lda.fit(corpus, iters=400, num_samples=4, sample_interval=25)
 for t in range(15):
     print(f"T{t:>2}: " + ", ".join(w.replace("_", " ") for w, _ in lda.top_words(8, topic=t)))
 
@@ -88,7 +88,7 @@ ordered time slices. `chain_variance=0.05` lets real trends show; the default
 decades = sorted(by_decade)
 times = [decades.index(r["decade"]) for r in rows]
 dtm = topica.DTM(num_topics=8, chain_variance=0.05, seed=1)
-dtm.fit(corpus, times, em_iters=20)
+dtm.fit(corpus, times, iters=20)
 
 vocab = list(dtm.vocabulary)
 per_time = np.stack([dtm.topic_word(s) for s in range(dtm.num_times)])

--- a/docs/examples/gadarian.md
+++ b/docs/examples/gadarian.md
@@ -36,7 +36,7 @@ treatment = np.array([float(r["treatment"]) for r in rows]).reshape(-1, 1)
 print("treated:", int(treatment.sum()), "control:", int((1 - treatment).sum()))
 
 model = topica.STM(num_topics=3, seed=1)
-model.fit(docs, treatment, prevalence_names=["treatment"], em_iters=40)
+model.fit(docs, treatment, prevalence_names=["treatment"], iters=40)
 ```
 
 ```

--- a/docs/examples/poliblog.md
+++ b/docs/examples/poliblog.md
@@ -39,7 +39,7 @@ print(corpus.num_docs, "docs, vocab", corpus.num_words)
 ## 3. Choose and justify K
 
 ```python
-for r in topica.search_k(docs, ks=[10, 15, 20], iterations=500):
+for r in topica.search_k(docs, ks=[10, 15, 20], iters=500):
     print(f"K={r['k']:>2}  coherence={r['coherence']:.1f}  exclusivity={r['exclusivity']:.3f}")
 ```
 
@@ -59,7 +59,7 @@ and we confirm the substantive effects below survive `K ∈ {10, 20}`.
 ```python
 conservative = np.array([r["rating"] == "Conservative" for r in rows], float).reshape(-1, 1)
 model = topica.STM(num_topics=15, seed=1)
-model.fit(docs, conservative, prevalence_names=["conservative"], em_iters=25)
+model.fit(docs, conservative, prevalence_names=["conservative"], iters=25)
 
 labels = stm.label_topics(model.topic_word, model.vocabulary, n=6)
 for t in range(15):
@@ -86,7 +86,7 @@ print(topica.word_intrusion(model, n_words=5, seed=0)[0])
 # {'topic': 0, 'words': ['voter','mccain','poll','state','obama','investig'],
 #  'intruder': 'investig', 'intruder_index': 5}
 
-boot = topica.bootstrap_stability(docs, k=15, n_boot=20, iterations=400)
+boot = topica.bootstrap_stability(docs, k=15, n_boot=20, iters=400)
 print("mean topic stability:", round(boot["mean"], 2))   # 0.36
 ```
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -27,7 +27,7 @@ space_docs  = [["planet", "star", "moon", "rocket", "planet"]] * 15
 documents   = animal_docs + space_docs
 
 model = topica.LDA(num_topics=2, seed=42)
-model.fit(documents, iterations=1000)
+model.fit(documents, iters=1000)
 ```
 
 ## Read the results

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -31,7 +31,7 @@ multi-threaded training.
 ```python
 import topica
 model = topica.LDA(num_topics=20, seed=42)
-model.fit(docs, iterations=1000)
+model.fit(docs, iters=1000)
 model.top_words(10)
 ```
 
@@ -53,7 +53,7 @@ model.top_words(10)
 
 ```python
 model = topica.LDA(num_topics=500, seed=1, sampler="lightlda", mh_steps=2)
-model.fit(docs, iterations=1000)
+model.fit(docs, iters=1000)
 ```
 
 Both samplers target the same posterior and recover the same topics (matched
@@ -141,7 +141,7 @@ rose and fell most within a topic — what makes its vocabulary evolve.
 
 ```python
 dtm = topica.DTM(num_topics=10, chain_variance=0.05, seed=1)
-dtm.fit(docs, times, em_iters=20)   # `times` = per-doc slice index
+dtm.fit(docs, times, iters=20)   # `times` = per-doc slice index
 
 drift = dtm.word_drift(topic=3)     # first vs last slice by default
 print("rising: ", [w for w, _ in drift["rising"][:5]])

--- a/docs/guides/transform.md
+++ b/docs/guides/transform.md
@@ -8,7 +8,7 @@ freshly collected texts.
 import topica
 
 model = topica.LDA(num_topics=20, seed=42)
-model.fit(train_docs, iterations=1000)
+model.fit(train_docs, iters=1000)
 
 theta = model.transform(new_docs, seed=0)     # (len(new_docs), num_topics)
 theta.argmax(axis=1)                          # dominant topic per new document

--- a/docs/index.md
+++ b/docs/index.md
@@ -18,7 +18,7 @@ import topica
 
 docs = [["cat", "dog", "fish"]] * 15 + [["planet", "star", "moon"]] * 15
 model = topica.LDA(num_topics=2, seed=42)
-model.fit(docs, iterations=1000)
+model.fit(docs, iters=1000)
 
 for i, words in enumerate(model.top_words(5)):
     print(f"Topic {i}:", " ".join(w for w, _ in words))

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -44,7 +44,7 @@ import numpy as np
 held_out = test_docs                     # a held-out split for perplexity
 results = topica.search_k(
     train_docs, ks=[10, 15, 20, 25, 30],
-    held_out=held_out, iterations=800,
+    held_out=held_out, iters=800,
 )
 for r in results:
     print(f"K={r['k']:>3}  coherence={r['coherence']:.3f}  "

--- a/docs/publishing/effects.md
+++ b/docs/publishing/effects.md
@@ -68,7 +68,7 @@ method-of-composition machinery:
 import numpy as np, topica
 
 model = topica.LDA(num_topics=20, seed=1)
-model.fit(docs, iterations=1000)
+model.fit(docs, iters=1000)
 
 lengths = np.array([len(d) for d in docs])
 draws = topica.dirichlet_theta_samples(model.doc_topic, lengths, nsims=50, seed=0)

--- a/docs/publishing/validation.md
+++ b/docs/publishing/validation.md
@@ -59,7 +59,7 @@ A topic that dissolves when you perturb the corpus is not a finding. Refit on
 bootstrap resamples and report which topics are robust:
 
 ```python
-boot = topica.bootstrap_stability(docs, k=20, n_boot=50, iterations=800)
+boot = topica.bootstrap_stability(docs, k=20, n_boot=50, iters=800)
 for t, s in zip(boot["topic"], boot["stability"]):
     print(f"Topic {t}: stability {s:.2f}")     # mean top-word Jaccard across resamples
 print("overall:", boot["mean"])
@@ -69,8 +69,8 @@ Also check that the *same* topics emerge across **random seeds**, aligning topic
 between fits and scoring their overlap:
 
 ```python
-a = topica.LDA(num_topics=20, seed=1); a.fit(docs, iterations=800)
-b = topica.LDA(num_topics=20, seed=2); b.fit(docs, iterations=800)
+a = topica.LDA(num_topics=20, seed=1); a.fit(docs, iters=800)
+b = topica.LDA(num_topics=20, seed=2); b.fit(docs, iters=800)
 pairs = topica.align_topics(a, b)                    # one-to-one matching (Hungarian)
 print("stability across seeds:", topica.topic_stability([a, b], topn=10))
 ```

--- a/examples/dubois_tutorial.ipynb
+++ b/examples/dubois_tutorial.ipynb
@@ -330,7 +330,7 @@
    "source": [
     "K = 15\n",
     "lda = LDA(num_topics=K, seed=1)\n",
-    "lda.fit(pcorpus, iterations=400, num_samples=4, sample_interval=25)\n",
+    "lda.fit(pcorpus, iters=400, num_samples=4, sample_interval=25)\n",
     "print(f\"Fit LDA(K={K}). Top words per topic:\")\n",
     "for t in range(K):\n",
     "    words = [w for w, _ in lda.top_words(8, topic=t)]\n",
@@ -428,7 +428,7 @@
     "\n",
     "stm_model = STM(num_topics=Ks, seed=1)\n",
     "# em_iters modest for runtime; ~75-100 for a real fit.\n",
-    "stm_model.fit(phrased_docs, X_decade, prevalence_names=decade_names, em_iters=30)\n",
+    "stm_model.fit(phrased_docs, X_decade, prevalence_names=decade_names, iters=30)\n",
     "print(f\"Fit STM(K={Ks}) with decade prevalence.\")"
    ]
   },
@@ -605,7 +605,7 @@
     "times = [didx[r[\"decade\"]] for r in rows]\n",
     "\n",
     "dtm = DTM(num_topics=8, chain_variance=0.05, seed=1)\n",
-    "dtm.fit(pcorpus, times, em_iters=20)   # ~30+ EM iters for a real run\n",
+    "dtm.fit(pcorpus, times, iters=20)   # ~30+ EM iters for a real run\n",
     "print(f\"Fit DTM(K=8) over {dtm.num_times} decade slices \"\n",
     "      f\"({decades[0]}s ... {decades[-1]}s).\")\n",
     "\n",

--- a/examples/dubois_tutorial.py
+++ b/examples/dubois_tutorial.py
@@ -149,7 +149,7 @@ def main():
     K = 15
     lda = LDA(num_topics=K, seed=1)
     # progress callback prints likelihood as it samples.
-    lda.fit(pcorpus, iterations=400, num_samples=4, sample_interval=25)
+    lda.fit(pcorpus, iters=400, num_samples=4, sample_interval=25)
     print(f"Fit LDA(K={K}). Top words per topic:")
     for t in range(K):
         words = [w for w, _ in lda.top_words(8, topic=t)]
@@ -188,7 +188,7 @@ def main():
     stm_model = STM(num_topics=Ks, seed=1)
     # em_iters modest for runtime; ~75-100 for a real fit.
     stm_model.fit(phrased_docs, X_decade,
-                  prevalence_names=decade_names, em_iters=30)
+                  prevalence_names=decade_names, iters=30)
     print(f"Fit STM(K={Ks}) with decade prevalence.")
 
     # Interpret topics with stm-style word lists: prob (frequent) vs FREX
@@ -240,7 +240,7 @@ def main():
     didx = {d: i for i, d in enumerate(decades)}
     times = [didx[r["decade"]] for r in rows]
     dtm = DTM(num_topics=8, chain_variance=0.05, seed=1)
-    dtm.fit(pcorpus, times, em_iters=20)   # ~30+ EM iters for a real run
+    dtm.fit(pcorpus, times, iters=20)   # ~30+ EM iters for a real run
     print(f"Fit DTM(K=8) over {dtm.num_times} decade slices "
           f"({decades[0]}s ... {decades[-1]}s).")
 

--- a/examples/plot_report_example.py
+++ b/examples/plot_report_example.py
@@ -37,7 +37,7 @@ def main():
     period = [f"P{p}" for p in period]
 
     model = topica.LDA(num_topics=8, seed=1)
-    model.fit(docs, iterations=800)
+    model.fit(docs, iters=800)
 
     fig = topica.plot_report(
         model, texts=texts, timestamps=period, groups=rating, n=6,

--- a/examples/quickstart.py
+++ b/examples/quickstart.py
@@ -53,7 +53,7 @@ model = LDA(
 print("Training (500 iterations, progress every 100) …")
 model.fit(
     documents,
-    iterations=500,
+    iters=500,
     num_samples=5,          # average this many snapshots for final φ/θ
     sample_interval=25,     # Gibbs sweeps between snapshots
     progress=on_progress,

--- a/examples/stm_vignette.py
+++ b/examples/stm_vignette.py
@@ -73,7 +73,7 @@ def main():
     # [3] Fit STM with prevalence covariates (treatment + party id).
     K = 3
     model = STM(num_topics=K, seed=1)
-    model.fit(docs, X, prevalence_names=["treatment", "pid_rep"], em_iters=80)
+    model.fit(docs, X, prevalence_names=["treatment", "pid_rep"], iters=80)
     print(f"[3] Fit STM with K={K}, prevalence = ~treatment + pid_rep")
 
     # [4] labelTopics: prob + FREX words per topic.

--- a/paper/replication.py
+++ b/paper/replication.py
@@ -97,11 +97,11 @@ def spanning_comparison(docs, conservative):
         return m
 
     run("LDA", lambda: topica.LDA(num_topics=K, seed=SEED),
-        lambda m: m.fit(docs, iterations=500))
+        lambda m: m.fit(docs, iters=500))
     run("CTM", lambda: topica.CTM(num_topics=K, seed=SEED),
-        lambda m: m.fit(docs, em_iters=25))
+        lambda m: m.fit(docs, iters=25))
     run("STM", lambda: topica.STM(num_topics=K, seed=SEED),
-        lambda m: m.fit(docs, conservative, prevalence_names=["conservative"], em_iters=25))
+        lambda m: m.fit(docs, conservative, prevalence_names=["conservative"], iters=25))
     try:
         emb = lsa_embeddings(docs)
         run("BERTopic", lambda: topica.BERTopic(reducer="pca", n_components=5,
@@ -127,7 +127,7 @@ def effect_figure(docs, conservative):
     print(f"  {corpus.num_docs} docs, vocab {corpus.num_words}")
 
     model = topica.STM(num_topics=K, seed=SEED)
-    model.fit(docs, conservative, prevalence_names=["conservative"], em_iters=25)
+    model.fit(docs, conservative, prevalence_names=["conservative"], iters=25)
 
     labeled = stm.label_topics(model.topic_word, model.vocabulary, n=3)
     topica.set_topic_labels(

--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -223,7 +223,7 @@ document-topic distribution $\theta$ as \code{doc\_topic}, both as plain
 import topica
 
 model = topica.LDA(num_topics=20, seed=42)
-model.fit(docs, iterations=1000)
+model.fit(docs, iters=1000)
 
 model.topic_word        # phi: ndarray (num_topics, vocab_size)
 model.doc_topic         # theta: ndarray (num_docs, num_topics)
@@ -583,11 +583,11 @@ def score(m):                # the SAME diagnostics for every model
             topica.exclusivity(m).mean(),
             topica.topic_diversity(m))
 
-lda = topica.LDA(num_topics=15, seed=1); lda.fit(docs, iterations=500)
-ctm = topica.CTM(num_topics=15, seed=1); ctm.fit(docs, em_iters=25)
+lda = topica.LDA(num_topics=15, seed=1); lda.fit(docs, iters=500)
+ctm = topica.CTM(num_topics=15, seed=1); ctm.fit(docs, iters=25)
 stm_model = topica.STM(num_topics=15, seed=1)
 stm_model.fit(docs, conservative,
-              prevalence_names=["conservative"], em_iters=25)
+              prevalence_names=["conservative"], iters=25)
 
 # An embedding model joins the same comparison: bring vectors,
 # fit, and score it too.
@@ -686,7 +686,7 @@ corpus = Corpus.from_documents(
     docs, min_doc_freq=10, max_doc_fraction=0.5, rm_top=20)
 model = topica.STM(num_topics=15, seed=1)
 model.fit(docs, conservative,
-          prevalence_names=["conservative"], em_iters=25)
+          prevalence_names=["conservative"], iters=25)
 
 labels = stm.label_topics(model.topic_word, model.vocabulary, n=3)
 panel = viz.effect_plot(model, corpus, X=conservative,

--- a/parity/ctm_r_compare.py
+++ b/parity/ctm_r_compare.py
@@ -91,7 +91,7 @@ def run(verbose: bool = True) -> dict:
         r_rand2 = _read_r_beta(os.path.join(d, "r_rand2.csv"), r_vocab)
 
         model = CTM(num_topics=K, init="spectral")
-        model.fit(docs, em_iters=EM_ITERS)
+        model.fit(docs, iters=EM_ITERS)
         idx = {w: i for i, w in enumerate(model.vocabulary)}
         raw = np.asarray(model.topic_word)
         tt = np.zeros((K, len(r_vocab)))

--- a/parity/mallet_parity.py
+++ b/parity/mallet_parity.py
@@ -76,7 +76,7 @@ def _ensure_compiled(java_name: str) -> bool:
     return True
 
 
-def labeled_parity(seed: int = 0, iterations: int = 800, top_n: int = 6):
+def labeled_parity(seed: int = 0, iters: int = 800, top_n: int = 6):
     """Compare topica.LabeledLDA to Java MALLET's LabeledLDA on a shared
     multi-label corpus. Topics correspond to labels, so they align by name.
     Returns a dict with mean cosine and per-label detail."""
@@ -109,7 +109,7 @@ def labeled_parity(seed: int = 0, iterations: int = 800, top_n: int = 6):
                 f.write(f"{','.join(labs)}\t{' '.join(toks)}\n")
         subprocess.run(
             ["java", "-cp", f"{cp}:{HERE}", "LabeledLDADriver", inp,
-             str(iterations), "1", "0.1", "0.01", out],
+             str(iters), "1", "0.1", "0.01", out],
             check=True, capture_output=True, text=True,
         )
         lines = open(out).read().splitlines()
@@ -136,7 +136,7 @@ def labeled_parity(seed: int = 0, iterations: int = 800, top_n: int = 6):
             mal_phi[t, j] = (c + beta) / (tpt[t] + beta * W)
 
     model = LabeledLDA(alpha=0.1, beta=0.01, seed=1)
-    model.fit(docs, labels, iterations=iterations, num_samples=5, sample_interval=25)
+    model.fit(docs, labels, iters=iters, num_samples=5, sample_interval=25)
     oi = {w: i for i, w in enumerate(model.vocabulary)}
     olabels = model.labels
     our_phi = np.zeros((K, W))
@@ -168,7 +168,7 @@ def planted_corpus(seed: int = 0, num_docs: int = 250, doc_len: int = 12):
     return docs, len(topics)
 
 
-def _mallet_phi(docs, k, iterations, seed, beta=0.01):
+def _mallet_phi(docs, k, iters, seed, beta=0.01):
     """Run Java MALLET train-topics; return (phi (k, V), vocab)."""
     mallet = shutil.which("mallet")
     d = tempfile.mkdtemp()
@@ -187,7 +187,7 @@ def _mallet_phi(docs, k, iterations, seed, beta=0.01):
         wtc = os.path.join(d, "wtc.txt")
         subprocess.run(
             [mallet, "train-topics", "--input", mal, "--num-topics", str(k),
-             "--num-iterations", str(iterations), "--random-seed", str(seed),
+             "--num-iterations", str(iters), "--random-seed", str(seed),
              "--optimize-interval", "0", "--word-topic-counts-file", wtc, "--num-top-words", "1"],
             check=True, capture_output=True, text=True,
         )
@@ -228,7 +228,7 @@ def _align(a_phi, b_phi):
     return pairs
 
 
-def lda_parity(seed: int = 0, k: int | None = None, iterations: int = 800, top_n: int = 6):
+def lda_parity(seed: int = 0, k: int | None = None, iters: int = 800, top_n: int = 6):
     """Compare topica LDA to Java MALLET on a shared planted corpus.
 
     Returns a dict with `mean_jaccard`, `mean_cosine`, and per-topic detail.
@@ -238,11 +238,11 @@ def lda_parity(seed: int = 0, k: int | None = None, iterations: int = 800, top_n
     docs, planted_k = planted_corpus(seed=seed)
     k = planted_k if k is None else k
 
-    mal_phi, vocab = _mallet_phi(docs, k, iterations, seed=1)
+    mal_phi, vocab = _mallet_phi(docs, k, iters, seed=1)
     vi = {w: j for j, w in enumerate(vocab)}
 
     model = LDA(num_topics=k, seed=1, optimize_interval=0)
-    model.fit(docs, iterations=iterations, num_samples=5, sample_interval=25)
+    model.fit(docs, iters=iters, num_samples=5, sample_interval=25)
     ophi, ovocab = model.topic_word, model.vocabulary
     our_phi = np.zeros((k, len(vocab)))
     for j, w in enumerate(vocab):
@@ -265,7 +265,7 @@ def lda_parity(seed: int = 0, k: int | None = None, iterations: int = 800, top_n
     }
 
 
-def dmr_parity(seed: int = 0, iterations: int = 800, num_docs: int = 160):
+def dmr_parity(seed: int = 0, iters: int = 800, num_docs: int = 160):
     """Compare topica.DMR to Java MALLET's DMRTopicModel. Because DMR fits
     feature weights with L-BFGS (which differs between implementations), this is
     a *statistical* check: do the topics align, and does the covariate's effect
@@ -294,7 +294,7 @@ def dmr_parity(seed: int = 0, iterations: int = 800, num_docs: int = 160):
             for toks, x in zip(docs, cov):
                 f.write(f"is_space={x}\t{' '.join(toks)}\n")
         subprocess.run(
-            ["java", "-cp", f"{cp}:{HERE}", "DMRDriver", inp, "2", str(iterations), "1", oc, op],
+            ["java", "-cp", f"{cp}:{HERE}", "DMRDriver", inp, "2", str(iters), "1", oc, op],
             check=True, capture_output=True, text=True,
         )
         import collections
@@ -320,7 +320,7 @@ def dmr_parity(seed: int = 0, iterations: int = 800, num_docs: int = 160):
 
     model = DMR(num_topics=2, seed=1, optimize_interval=25, burn_in=50)
     model.fit(docs, np.array(cov, float)[:, None], feature_names=["is_space"],
-              iterations=iterations, num_samples=5, sample_interval=25)
+              iters=iters, num_samples=5, sample_interval=25)
     oi = {w: i for i, w in enumerate(model.vocabulary)}
     ours = np.zeros((K, W))
     for j, w in enumerate(words):

--- a/parity/stm_content_r_compare.py
+++ b/parity/stm_content_r_compare.py
@@ -106,7 +106,7 @@ def run(verbose: bool = True) -> dict:
         levs = open(os.path.join(d, "r_levels.txt")).read().split()
 
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, content=groups, em_iters=80)
+        m.fit(docs, content=groups, iters=80)
         vidx = {w: i for i, w in enumerate(m.vocabulary)}
         twg = np.asarray(m.topic_word_by_group)
 

--- a/parity/stm_poliblog_compare.py
+++ b/parity/stm_poliblog_compare.py
@@ -190,7 +190,7 @@ def run(verbose: bool = True) -> dict:
         r_rand2 = _read_r_beta(os.path.join(d, "r_rand2.csv"), r_vocab)
 
         model = STM(num_topics=K, init="spectral")
-        model.fit(docs, X, prevalence_names=feat_names, em_iters=EM_ITERS, em_tol=1e-5)
+        model.fit(docs, X, prevalence_names=feat_names, iters=EM_ITERS, em_tol=1e-5)
         tt_converged = bool(model.converged)
         tt_em_iters = len(model.bound_history)
         tt_vocab = list(model.vocabulary)

--- a/parity/stm_r_compare.py
+++ b/parity/stm_r_compare.py
@@ -186,7 +186,7 @@ def run(verbose: bool = True) -> dict:
         # topica, spectral init (its default), same docs + covariates.
         X = np.column_stack([treatment, pid])
         model = STM(num_topics=3, init="spectral")
-        model.fit(docs, X, prevalence_names=["treatment", "pid_rep"], em_iters=80)
+        model.fit(docs, X, prevalence_names=["treatment", "pid_rep"], iters=80)
         tt_vocab = list(model.vocabulary)
         tt_beta_raw = np.asarray(model.topic_word)  # K x |tt_vocab|
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -188,7 +188,7 @@ class DMR:
         features: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]],
         *,
         feature_names: list[str] | None = None,
-        iterations: int = 1000,
+        iters: int = 1000,
         num_samples: int = 5,
         sample_interval: int = 25,
         progress: object | None = None,
@@ -294,12 +294,12 @@ class CTM:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        em_iters: int = 500,
+        iters: int = 500,
         em_tol: float = 1e-5,
     ) -> None:
         """EM stops once the relative change in the variational bound falls below
-        em_tol or after em_iters iterations, whichever comes first. Pass em_tol=0
-        to always run em_iters steps. Check converged and bound afterward."""
+        em_tol or after iters iterations, whichever comes first. Pass em_tol=0
+        to always run iters steps. Check converged and bound afterward."""
         ...
 
     @property
@@ -314,7 +314,7 @@ class CTM:
         ...
     @property
     def converged(self) -> bool:
-        """True if EM met em_tol; False if it hit the em_iters cap."""
+        """True if EM met em_tol; False if it hit the iters cap."""
         ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
@@ -387,7 +387,7 @@ class STM:
         prevalence_names: list[str] | None = None,
         content: Sequence[str] | Sequence[int] | None = None,
         content_names: list[str] | None = None,
-        em_iters: int = 500,
+        iters: int = 500,
         em_tol: float = 1e-5,
     ) -> None:
         """Fit. prevalence is (num_docs, F) covariates driving topic proportions
@@ -396,8 +396,8 @@ class STM:
         one of prevalence/content must be given.
 
         EM stops once the relative change in the variational bound falls below
-        em_tol (R stm's emtol) or after em_iters iterations, whichever comes
-        first. Pass em_tol=0 to always run em_iters steps. Check converged and
+        em_tol (R stm's emtol) or after iters iterations, whichever comes
+        first. Pass em_tol=0 to always run iters steps. Check converged and
         bound afterward."""
         ...
 
@@ -414,7 +414,7 @@ class STM:
         ...
     @property
     def converged(self) -> bool:
-        """True if EM met em_tol; False if it hit the em_iters cap."""
+        """True if EM met em_tol; False if it hit the iters cap."""
         ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
@@ -612,7 +612,7 @@ class DTM:
         data: Corpus | Sequence[Sequence[str]],
         times: Sequence[int],
         *,
-        em_iters: int = 20,
+        iters: int = 20,
     ) -> None:
         """Fit by variational EM. `times` is each document's integer time-slice
         index (0-based, contiguous); the slice count is max(times)+1."""
@@ -670,7 +670,7 @@ class SupervisedLDA:
         data: Corpus | Sequence[Sequence[str]],
         y: Sequence[float],
         *,
-        em_iters: int = 25,
+        iters: int = 25,
         var_iters: int = 15,
     ) -> None:
         """Fit by variational EM. `y` is the per-document response (length =
@@ -757,7 +757,7 @@ class SAGE:
         groups: Sequence[str] | Sequence[int],
         *,
         group_names: list[str] | None = None,
-        iterations: int = 1000,
+        iters: int = 1000,
         num_samples: int = 5,
         sample_interval: int = 25,
         progress: Optional[object] = None,
@@ -835,7 +835,7 @@ class LabeledLDA:
         labels: Sequence[Sequence[str]],
         *,
         label_names: list[str] | None = None,
-        iterations: int = 1000,
+        iters: int = 1000,
         num_samples: int = 5,
         sample_interval: int = 25,
         progress: Optional[object] = None,
@@ -949,7 +949,7 @@ class LDA:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 1000,
+        iters: int = 1000,
         num_samples: int = 5,
         sample_interval: int = 25,
         progress: Optional[object] = None,

--- a/python/topica/conformance.py
+++ b/python/topica/conformance.py
@@ -173,15 +173,7 @@ EXEMPT: dict[tuple[str, str], str] = {
 
 KNOWN_GAPS: dict[tuple[str, str], str] = {
 
-    # --- Phase 2: rename iteration param to iters ---
-    ("LDA",          "iters"): "phase 2: rename 'iterations' -> 'iters' in LDA.fit",
-    ("DMR",          "iters"): "phase 2: rename 'iterations' -> 'iters' in DMR.fit",
-    ("SAGE",         "iters"): "phase 2: rename 'iterations' -> 'iters' in SAGE.fit",
-    ("LabeledLDA",   "iters"): "phase 2: rename 'iterations' -> 'iters' in LabeledLDA.fit",
-    ("SupervisedLDA","iters"): "phase 2: rename 'em_iters' -> 'iters' in SupervisedLDA.fit",
-    ("STM",          "iters"): "phase 2: rename 'em_iters' -> 'iters' in STM.fit",
-    ("CTM",          "iters"): "phase 2: rename 'em_iters' -> 'iters' in CTM.fit",
-    ("DTM",          "iters"): "phase 2: rename 'em_iters' -> 'iters' in DTM.fit",
+    # --- Phase 2: rename iteration param to iters (ETM/ProdLDA/FASTopic deferred) ---
     ("ETM",          "iters"): "phase 2: expose iters in ETM.fit (currently none)",
     ("ProdLDA",      "iters"): "phase 2: expose iters in ProdLDA.fit (currently none)",
     ("FASTopic",     "iters"): "phase 2: expose iters in FASTopic.fit (currently none)",

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -706,8 +706,7 @@ def search_k(
     model="lda",
     prevalence=None,
     held_out=None,
-    iterations=500,
-    em_iters=30,
+    iters=500,
     num_samples=3,
     sample_interval=10,
     seed=42,
@@ -735,10 +734,10 @@ def search_k(
     for k in ks:
         if model == "stm":
             m = STM(num_topics=k, seed=seed)
-            m.fit(docs, prevalence, em_iters=em_iters)
+            m.fit(docs, prevalence, iters=iters)
         else:
             m = LDA(num_topics=k, seed=seed)
-            m.fit(docs, iterations=iterations, num_samples=num_samples,
+            m.fit(docs, iters=iters, num_samples=num_samples,
                   sample_interval=sample_interval)
         row = {
             "k": k,
@@ -1365,7 +1364,7 @@ def bootstrap_stability(
         the resample topics are matched back to it (rather than to a fresh
         full-corpus fit), so the per-topic stability lines up with that model's
         topic indices. ``model_factory`` should rebuild the same model type.
-    fit_kwargs : forwarded to each model's ``fit`` (e.g. ``iterations=500``).
+    fit_kwargs : forwarded to each model's ``fit`` (e.g. ``iters=500``).
 
     Returns
     -------

--- a/src/python.rs
+++ b/src/python.rs
@@ -910,14 +910,14 @@ impl LDA {
     ///
     /// `progress`, if given, is called as ``progress(iteration, ll_per_token)``
     /// every `progress_interval` iterations during the main loop.
-    #[pyo3(signature = (data, *, iterations=1000, num_samples=5, sample_interval=25,
+    #[pyo3(signature = (data, *, iters=1000, num_samples=5, sample_interval=25,
                         progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
-        iterations: usize,
+        iters: usize,
         num_samples: usize,
         sample_interval: usize,
         progress: Option<PyObject>,
@@ -950,7 +950,7 @@ impl LDA {
         // Thinned θ-draw retention (issue #31): keep the last `draw_cap` snapshots
         // taken every `draw_thin` sweeps of the main loop. 0 ⇒ collection off.
         let draw_cap = if keep_theta_draws { num_theta_draws } else { 0 };
-        let draw_thin = theta_draw_thin(iterations, draw_cap);
+        let draw_thin = theta_draw_thin(iters, draw_cap);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, num_topics)?;
 
         let mut model = TopicModel::new(num_topics, alpha_sum, self.beta, num_types);
@@ -976,7 +976,7 @@ impl LDA {
                 ls.mh_steps = mh_steps;
                 let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
 
-                for iter in 1..=iterations {
+                for iter in 1..=iters {
                     ls.sweep(&corpus, &mut rng);
                     if draw_thin > 0 && iter % draw_thin == 0 {
                         // One snapshot: theta_into accumulates, so start from zero.
@@ -1055,7 +1055,7 @@ impl LDA {
             let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
 
             // ---- main training loop (ports src/bin/train.rs) ----
-            for iter in 1..=iterations {
+            for iter in 1..=iters {
                 do_sweep(&mut model, &mut rng);
 
                 if draw_thin > 0 && iter % draw_thin == 0 {
@@ -2725,7 +2725,7 @@ impl DMR {
     /// `features` is a `(num_docs, F)` numpy array or list of float lists (an
     /// intercept column is prepended automatically). `feature_names` (length F)
     /// names the columns; an "intercept" name is prepended.
-    #[pyo3(signature = (data, features, *, feature_names=None, iterations=1000,
+    #[pyo3(signature = (data, features, *, feature_names=None, iters=1000,
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
@@ -2734,7 +2734,7 @@ impl DMR {
         data: &Bound<'_, PyAny>,
         features: &Bound<'_, PyAny>,
         feature_names: Option<Vec<String>>,
-        iterations: usize,
+        iters: usize,
         num_samples: usize,
         sample_interval: usize,
         progress: Option<PyObject>,
@@ -2807,7 +2807,7 @@ impl DMR {
         let lbfgs_iters = self.lbfgs_iters;
 
         let (acc_phi, acc_theta, feat_eff, model, corpus) = py.allow_threads(move || {
-            for iter in 1..=iterations {
+            for iter in 1..=iters {
                 let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
                 dmr::run_sweep_dmr(
                     &mut model.type_topic_counts,
@@ -3217,7 +3217,7 @@ impl LabeledLDA {
     /// `labels` is a list (one per document) of label lists. The topic set is
     /// the union of all labels (or `label_names`, which also fixes topic order).
     /// An empty label list leaves that document unconstrained.
-    #[pyo3(signature = (data, labels, *, label_names=None, iterations=1000,
+    #[pyo3(signature = (data, labels, *, label_names=None, iters=1000,
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
@@ -3226,7 +3226,7 @@ impl LabeledLDA {
         data: &Bound<'_, PyAny>,
         labels: Vec<Vec<String>>,
         label_names: Option<Vec<String>>,
-        iterations: usize,
+        iters: usize,
         num_samples: usize,
         sample_interval: usize,
         progress: Option<PyObject>,
@@ -3296,7 +3296,7 @@ impl LabeledLDA {
         labeled::initialize_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
 
         let (acc_phi, acc_theta, model, corpus) = py.allow_threads(move || {
-            for iter in 1..=iterations {
+            for iter in 1..=iters {
                 labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
                 if let Some(cb) = &progress {
                     if progress_interval > 0 && iter % progress_interval == 0 {
@@ -3628,7 +3628,7 @@ impl SAGE {
     /// Fit the model. `data` is a :class:`Corpus` or `list[list[str]]`;
     /// `groups` is a per-document group label (strings or ints), one per
     /// document. `group_names` fixes the group order (defaults to sorted union).
-    #[pyo3(signature = (data, groups, *, group_names=None, iterations=1000,
+    #[pyo3(signature = (data, groups, *, group_names=None, iters=1000,
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
@@ -3637,7 +3637,7 @@ impl SAGE {
         data: &Bound<'_, PyAny>,
         groups: &Bound<'_, PyAny>,
         group_names: Option<Vec<String>>,
-        iterations: usize,
+        iters: usize,
         num_samples: usize,
         sample_interval: usize,
         progress: Option<PyObject>,
@@ -3706,7 +3706,7 @@ impl SAGE {
         let lbfgs_iters = self.lbfgs_iters;
 
         let (beta, acc_theta, corpus) = py.allow_threads(move || {
-            for iter in 1..=iterations {
+            for iter in 1..=iters {
                 sage::run_sweep_sage(&mut model, &corpus.docs, &groups_idx, &mut rng);
                 if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                     sage::optimize_kappa(&mut model, lbfgs_iters);
@@ -4148,15 +4148,15 @@ impl CTM {
 
     /// Fit by variational EM. `data` is a :class:`Corpus` or `list[list[str]]`.
     /// EM runs until the relative change in the variational bound drops below
-    /// `em_tol` (R `stm`'s `emtol`) or `em_iters` iterations are reached,
-    /// whichever comes first. Pass ``em_tol=0`` to always run `em_iters` steps.
+    /// `em_tol` (R `stm`'s `emtol`) or `iters` iterations are reached,
+    /// whichever comes first. Pass ``em_tol=0`` to always run `iters` steps.
     /// Check :attr:`converged` and :attr:`bound` afterward.
-    #[pyo3(signature = (data, *, em_iters=500, em_tol=1e-5))]
+    #[pyo3(signature = (data, *, iters=500, em_tol=1e-5))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
-        em_iters: usize,
+        iters: usize,
         em_tol: f64,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -4179,7 +4179,7 @@ impl CTM {
 
         let (model, corpus) = py.allow_threads(move || {
             let m = ctm::fit_ctm(
-                &corpus.docs, k, num_types, em_iters, em_tol, shrink, None, None, spectral,
+                &corpus.docs, k, num_types, iters, em_tol, shrink, None, None, spectral,
                 &mut rng,
             );
             (m, corpus)
@@ -4247,7 +4247,7 @@ impl CTM {
     }
 
     /// ``True`` if EM stopped on the `em_tol` criterion; ``False`` if it hit the
-    /// `em_iters` cap first (the fit may not have converged).
+    /// `iters` cap first (the fit may not have converged).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -4530,12 +4530,12 @@ impl STM {
     /// `prevalence`/`content` should be given (else use :class:`CTM`).
     ///
     /// EM runs until the relative change in the variational bound drops below
-    /// `em_tol` (R `stm`'s `emtol`) or `em_iters` iterations are reached,
+    /// `em_tol` (R `stm`'s `emtol`) or `iters` iterations are reached,
     /// whichever comes first — matching `stm`'s convergence behavior rather than
-    /// a fixed iteration count. Pass ``em_tol=0`` to always run `em_iters`
+    /// a fixed iteration count. Pass ``em_tol=0`` to always run `iters`
     /// steps. Inspect :attr:`converged` and :attr:`bound` after fitting.
     #[pyo3(signature = (data, prevalence=None, *, prevalence_names=None,
-                        content=None, content_names=None, em_iters=500, em_tol=1e-5))]
+                        content=None, content_names=None, iters=500, em_tol=1e-5))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -4545,7 +4545,7 @@ impl STM {
         prevalence_names: Option<Vec<String>>,
         content: Option<&Bound<'_, PyAny>>,
         content_names: Option<Vec<String>>,
-        em_iters: usize,
+        iters: usize,
         em_tol: f64,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -4654,7 +4654,7 @@ impl STM {
             let prev_ref = prevalence_x.as_deref();
             let cont_ref = content_groups.as_ref().map(|(g, n)| (g.as_slice(), *n));
             let m = ctm::fit_ctm(
-                &corpus.docs, k, num_types, em_iters, em_tol, shrink, prev_ref, cont_ref,
+                &corpus.docs, k, num_types, iters, em_tol, shrink, prev_ref, cont_ref,
                 spectral, &mut rng,
             );
             (m, corpus)
@@ -4735,7 +4735,7 @@ impl STM {
     }
 
     /// ``True`` if EM stopped on the `em_tol` criterion; ``False`` if it hit the
-    /// `em_iters` cap first (the fit may not have converged).
+    /// `iters` cap first (the fit may not have converged).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -5541,13 +5541,13 @@ impl DTM {
     /// Fit by variational EM. `data` is a :class:`Corpus` or `list[list[str]]`;
     /// `times` gives each document's integer time-slice index (0-based,
     /// contiguous). The number of slices is inferred as ``max(times) + 1``.
-    #[pyo3(signature = (data, times, *, em_iters=20))]
+    #[pyo3(signature = (data, times, *, iters=20))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         times: Vec<i64>,
-        em_iters: usize,
+        iters: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -5590,7 +5590,7 @@ impl DTM {
 
         let (model, corpus) = py.allow_threads(move || {
             let m = dtm::fit_dtm(
-                &corpus.docs, &times_u, num_types, k, num_times, alpha, cv, ov, em_iters, &mut rng,
+                &corpus.docs, &times_u, num_types, k, num_times, alpha, cv, ov, iters, &mut rng,
             );
             (m, corpus)
         });
@@ -5845,13 +5845,13 @@ impl SupervisedLDA {
 
     /// Fit by variational EM. `data` is a :class:`Corpus` or `list[list[str]]`;
     /// `y` is the per-document real-valued response (length = number of docs).
-    #[pyo3(signature = (data, y, *, em_iters=25, var_iters=15))]
+    #[pyo3(signature = (data, y, *, iters=25, var_iters=15))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         y: Vec<f64>,
-        em_iters: usize,
+        iters: usize,
         var_iters: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -5878,7 +5878,7 @@ impl SupervisedLDA {
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
 
         let (model, corpus) = py.allow_threads(move || {
-            let m = slda::fit_slda(&corpus.docs, &y, num_types, k, alpha, em_iters, var_iters, &mut rng);
+            let m = slda::fit_slda(&corpus.docs, &y, num_types, k, alpha, iters, var_iters, &mut rng);
             (m, corpus)
         });
 

--- a/tests/test_cli_parity.py
+++ b/tests/test_cli_parity.py
@@ -116,7 +116,7 @@ def test_python_matches_train_cli(cli_binaries: dict[str, Path], tmp_path: Path)
     )
     model.fit(
         corpus,
-        iterations=ITERATIONS,
+        iters=ITERATIONS,
         num_samples=NUM_SAMPLES,
         sample_interval=SAMPLE_INTERVAL,
     )

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -69,7 +69,7 @@ class TestApi:
     def test_accepts_fitted_model(self, reference):
         docs = [["cat", "dog", "pet"]] * 20 + [["star", "moon", "sky"]] * 20
         m = LDA(num_topics=2, seed=1)
-        m.fit(docs, iterations=300)
+        m.fit(docs, iters=300)
         s = topica.coherence(m, docs, coherence_type="c_npmi", topn=3)
         assert s.shape == (2,)
         assert np.all(np.isfinite(s))
@@ -100,7 +100,7 @@ class TestDiversity:
     def test_accepts_model(self):
         docs = [["cat", "dog", "pet"]] * 20 + [["star", "moon", "sky"]] * 20
         m = LDA(num_topics=2, seed=1)
-        m.fit(docs, iterations=300)
+        m.fit(docs, iters=300)
         d = topica.topic_diversity(m, topn=3)
         assert 0.0 < d <= 1.0
 
@@ -115,7 +115,7 @@ class TestAnalysisContract:
     def test_duck_typed_model_works_without_top_words(self):
         docs = [["cat", "dog", "pet"]] * 30 + [["star", "moon", "sky"]] * 30
         m = LDA(num_topics=2, seed=1)
-        m.fit(docs, iterations=300)
+        m.fit(docs, iters=300)
 
         class Contract:  # the four members, NO top_words
             topic_word = m.topic_word

--- a/tests/test_coherence_fast.py
+++ b/tests/test_coherence_fast.py
@@ -17,7 +17,7 @@ DOCS = (
 
 def _fit():
     m = topica.LDA(num_topics=4, seed=1)
-    m.fit(DOCS, iterations=200)
+    m.fit(DOCS, iters=200)
     return m
 
 

--- a/tests/test_css_extras.py
+++ b/tests/test_css_extras.py
@@ -94,7 +94,7 @@ class TestSplitDocuments:
 def two_topic():
     docs = [["mob", "lynch", "south", "murder"]] * 40 + [["school", "child", "teach", "college"]] * 40
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=400)
+    m.fit(docs, iters=400)
     return m, docs
 
 
@@ -129,7 +129,7 @@ class TestQualityFrontier:
 class TestBootstrapStability:
     def test_stable_topics_score_high(self, two_topic):
         _, docs = two_topic
-        res = topica.bootstrap_stability(docs, k=2, n_boot=4, iterations=200, topn=4)
+        res = topica.bootstrap_stability(docs, k=2, n_boot=4, iters=200, topn=4)
         assert res["stability"].shape == (2,)
         assert 0.0 <= res["mean"] <= 1.0
         # Two clean, well-separated topics should be highly reproducible.
@@ -140,7 +140,7 @@ class TestBootstrapStability:
         # siblings perplexity / prepare_pyldavis), so it must not raise.
         _, docs = two_topic
         corpus = topica.Corpus.from_documents(docs)
-        res = topica.bootstrap_stability(corpus, k=2, n_boot=2, iterations=80, topn=4)
+        res = topica.bootstrap_stability(corpus, k=2, n_boot=2, iters=80, topn=4)
         assert res["stability"].shape == (2,)
         assert 0.0 <= res["mean"] <= 1.0
 
@@ -155,7 +155,7 @@ class TestBootstrapStability:
         for i in range(120):
             blk = blocks[i % 2]
             docs.append(blk + [blk[int(rng.integers(3))], f"uniq_{i}"])
-        res = topica.bootstrap_stability(docs, k=2, n_boot=6, iterations=200, topn=3)
+        res = topica.bootstrap_stability(docs, k=2, n_boot=6, iters=200, topn=3)
         assert res["mean"] > 0.4          # two clean blocks must stay reproducible
 
 

--- a/tests/test_ctm.py
+++ b/tests/test_ctm.py
@@ -101,10 +101,10 @@ def _identify_topics(model):
 
 @pytest.fixture(scope="module")
 def fitted_ctm():
-    """CTM(3, seed=1) fitted on the 300-doc correlated corpus (em_iters=50)."""
+    """CTM(3, seed=1) fitted on the 300-doc correlated corpus (iters=50)."""
     docs = _make_correlated_corpus(n=300, seed=0)
     m = CTM(num_topics=3, seed=1)
-    m.fit(docs, em_iters=50)
+    m.fit(docs, iters=50)
     return m
 
 
@@ -291,9 +291,9 @@ class TestCTMDeterminism:
     def test_same_seed_identical_topic_word(self):
         docs = _make_correlated_corpus(n=60, seed=7)
         m1 = CTM(3, seed=42)
-        m1.fit(docs, em_iters=20)
+        m1.fit(docs, iters=20)
         m2 = CTM(3, seed=42)
-        m2.fit(docs, em_iters=20)
+        m2.fit(docs, iters=20)
         # Variational EM is deterministic; any divergence is pure floating-point noise (< 1e-14)
         npt.assert_allclose(
             m1.topic_word, m2.topic_word, atol=1e-14,
@@ -303,9 +303,9 @@ class TestCTMDeterminism:
     def test_same_seed_allclose_doc_topic(self):
         docs = _make_correlated_corpus(n=60, seed=7)
         m1 = CTM(3, seed=42)
-        m1.fit(docs, em_iters=20)
+        m1.fit(docs, iters=20)
         m2 = CTM(3, seed=42)
-        m2.fit(docs, em_iters=20)
+        m2.fit(docs, iters=20)
         npt.assert_allclose(
             m1.doc_topic, m2.doc_topic, atol=1e-14,
             err_msg="Identical seeds must produce identical doc_topic"
@@ -321,22 +321,22 @@ class TestCTMInputTypes:
         docs = [["cat", "dog", "fish"]] * 20 + [["planet", "star", "moon"]] * 20
         corpus = Corpus.from_documents(docs)
         m = CTM(2, seed=1)
-        m.fit(corpus, em_iters=10)
+        m.fit(corpus, iters=10)
         assert m.doc_topic.shape == (40, 2)
 
     def test_list_input_accepted(self):
         docs = [["cat", "dog", "fish"]] * 20 + [["planet", "star", "moon"]] * 20
         m = CTM(2, seed=1)
-        m.fit(docs, em_iters=10)
+        m.fit(docs, iters=10)
         assert m.doc_topic.shape == (40, 2)
 
     def test_corpus_and_list_give_same_topic_word(self):
         docs = [["cat", "dog", "fish"]] * 30 + [["planet", "star", "moon"]] * 30
         corpus = Corpus.from_documents(docs)
         m1 = CTM(2, seed=5)
-        m1.fit(corpus, em_iters=15)
+        m1.fit(corpus, iters=15)
         m2 = CTM(2, seed=5)
-        m2.fit(docs, em_iters=15)
+        m2.fit(docs, iters=15)
         # Results are identical up to floating-point precision (< 1e-14)
         npt.assert_allclose(
             m1.topic_word, m2.topic_word, atol=1e-14,
@@ -353,7 +353,7 @@ class TestCTMTopWords:
     def small_model(self):
         docs = [["cat", "dog", "fish"]] * 20 + [["planet", "star", "moon"]] * 20
         m = CTM(2, seed=1)
-        m.fit(docs, em_iters=20)
+        m.fit(docs, iters=20)
         return m
 
     def test_all_topics_returns_num_topics_lists(self, small_model):
@@ -452,7 +452,7 @@ class TestSpectralInit:
         # separate the three topics by their vocabularies.
         docs = _make_correlated_corpus(seed=5)
         m = CTM(3, init="spectral")
-        m.fit(docs, em_iters=30)
+        m.fit(docs, iters=30)
         labels = _identify_topics(m)
         assert set(labels) == {"A", "B", "C"}
 

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -18,7 +18,7 @@ def _fit(seed: int, **kwargs) -> np.ndarray:
     model = LDA(2, seed=seed, optimize_interval=0, **kwargs)
     model.fit(
         _TOY_DOCS,
-        iterations=100,
+        iters=100,
         num_samples=2,
         sample_interval=5,
     )
@@ -40,7 +40,7 @@ class TestSameSeed:
     def test_same_seed_identical_doc_topic(self):
         model_a = LDA(2, seed=7, optimize_interval=0)
         model_b = LDA(2, seed=7, optimize_interval=0)
-        kw = dict(iterations=100, num_samples=2, sample_interval=5)
+        kw = dict(iters=100, num_samples=2, sample_interval=5)
         model_a.fit(_TOY_DOCS, **kw)
         model_b.fit(_TOY_DOCS, **kw)
         assert np.array_equal(model_a.doc_topic, model_b.doc_topic)
@@ -75,7 +75,7 @@ class TestProgressCallback:
         model = LDA(2, seed=42, optimize_interval=0)
         model.fit(
             _TOY_DOCS,
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
             progress=cb,
@@ -93,7 +93,7 @@ class TestProgressCallback:
         model = LDA(2, seed=42, optimize_interval=0)
         model.fit(
             _TOY_DOCS,
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
             progress=cb,
@@ -111,7 +111,7 @@ class TestProgressCallback:
         model = LDA(2, seed=42, optimize_interval=0)
         model.fit(
             _TOY_DOCS,
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
             progress=cb,
@@ -129,7 +129,7 @@ class TestProgressCallback:
         model = LDA(2, seed=42, optimize_interval=0)
         model.fit(
             _TOY_DOCS,
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
             progress=cb,
@@ -145,7 +145,7 @@ class TestProgressCallback:
         model = LDA(2, seed=42, optimize_interval=0)
         model.fit(
             _TOY_DOCS,
-            iterations=50,
+            iters=50,
             num_samples=2,
             sample_interval=5,
             progress=None,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -11,7 +11,7 @@ from topica import LDA, stm, validation as diagnostics
 def two_topic():
     docs = [["cat", "dog", "pet", "cat", "dog"]] * 40 + [["star", "moon", "sky", "star", "moon"]] * 40
     m = LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=400)
+    m.fit(docs, iters=400)
     return m, docs
 
 
@@ -88,7 +88,7 @@ class TestAlignment:
     def test_matches_swapped_topics(self, two_topic):
         m, docs = two_topic
         b = LDA(num_topics=2, seed=2)
-        b.fit(docs, iterations=400)
+        b.fit(docs, iters=400)
         pairs = stm.align_topics(m, b)
         assert len(pairs) == 2
         # one-to-one: each a-topic and b-topic used once.
@@ -100,7 +100,7 @@ class TestAlignment:
     def test_js_metric(self, two_topic):
         m, docs = two_topic
         b = LDA(num_topics=2, seed=3)
-        b.fit(docs, iterations=400)
+        b.fit(docs, iters=400)
         pairs = stm.align_topics(m, b, metric="js")
         assert len(pairs) == 2
 
@@ -123,7 +123,7 @@ class TestStability:
     def test_identical_fits_perfectly_stable(self, two_topic):
         m, docs = two_topic
         b = LDA(num_topics=2, seed=2)
-        b.fit(docs, iterations=400)
+        b.fit(docs, iters=400)
         s = stm.topic_stability([m, b], topn=3)
         assert s == 1.0  # the two clean topics recur exactly
 
@@ -132,7 +132,7 @@ class TestStability:
         runs = []
         for seed in (1, 2, 3):
             r = LDA(num_topics=2, seed=seed)
-            r.fit(docs, iterations=300)
+            r.fit(docs, iters=300)
             runs.append(r)
         s = stm.topic_stability(runs, topn=3)
         assert 0.0 <= s <= 1.0

--- a/tests/test_diagnostics_table.py
+++ b/tests/test_diagnostics_table.py
@@ -11,7 +11,7 @@ def fitted():
     docs = [["cat", "dog", "pet", "vet", "cat"]] * 15 + \
            [["star", "moon", "sky", "sun", "star"]] * 15
     m = topica.LDA(2, seed=1)
-    m.fit(docs, iterations=300)
+    m.fit(docs, iters=300)
     return m, docs
 
 

--- a/tests/test_dmr.py
+++ b/tests/test_dmr.py
@@ -34,7 +34,7 @@ def _make_corpus(n=120, doc_length=8, seed=0):
     return docs, covariate, features
 
 
-def _fit_dmr(docs, features, seed=1, iterations=300, feature_names=None, **kwargs):
+def _fit_dmr(docs, features, seed=1, iters=300, feature_names=None, **kwargs):
     """Return a fitted DMR with fast but reliable settings for the synthetic corpus."""
     model = DMR(
         num_topics=2,
@@ -47,7 +47,7 @@ def _fit_dmr(docs, features, seed=1, iterations=300, feature_names=None, **kwarg
         docs,
         features,
         feature_names=feature_names if feature_names is not None else ["is_A"],
-        iterations=iterations,
+        iters=iters,
         num_samples=3,
         sample_interval=10,
     )
@@ -161,7 +161,7 @@ class TestDMRFitValidation:
             self.docs,
             self.features,
             feature_names=["my_feature"],
-            iterations=50,
+            iters=50,
             num_samples=1,
             sample_interval=5,
         )
@@ -267,17 +267,17 @@ class TestDMRDeterminism:
     def test_identical_seed_gives_identical_feature_effects(self):
         docs, _, features = _make_corpus(n=40, seed=5)
         m1 = DMR(num_topics=2, seed=42)
-        m1.fit(docs, features, feature_names=["is_A"], iterations=100, num_samples=2, sample_interval=5)
+        m1.fit(docs, features, feature_names=["is_A"], iters=100, num_samples=2, sample_interval=5)
         m2 = DMR(num_topics=2, seed=42)
-        m2.fit(docs, features, feature_names=["is_A"], iterations=100, num_samples=2, sample_interval=5)
+        m2.fit(docs, features, feature_names=["is_A"], iters=100, num_samples=2, sample_interval=5)
         assert np.array_equal(m1.feature_effects, m2.feature_effects)
 
     def test_identical_seed_gives_identical_topic_word(self):
         docs, _, features = _make_corpus(n=40, seed=5)
         m1 = DMR(num_topics=2, seed=42)
-        m1.fit(docs, features, feature_names=["is_A"], iterations=100, num_samples=2, sample_interval=5)
+        m1.fit(docs, features, feature_names=["is_A"], iters=100, num_samples=2, sample_interval=5)
         m2 = DMR(num_topics=2, seed=42)
-        m2.fit(docs, features, feature_names=["is_A"], iterations=100, num_samples=2, sample_interval=5)
+        m2.fit(docs, features, feature_names=["is_A"], iters=100, num_samples=2, sample_interval=5)
         assert np.array_equal(m1.topic_word, m2.topic_word)
 
 
@@ -291,10 +291,10 @@ class TestDMRInputTypeParity:
         features_list = features_np.tolist()
 
         m1 = DMR(num_topics=2, seed=7)
-        m1.fit(docs, features_np, feature_names=["is_A"], iterations=100, num_samples=2, sample_interval=5)
+        m1.fit(docs, features_np, feature_names=["is_A"], iters=100, num_samples=2, sample_interval=5)
 
         m2 = DMR(num_topics=2, seed=7)
-        m2.fit(docs, features_list, feature_names=["is_A"], iterations=100, num_samples=2, sample_interval=5)
+        m2.fit(docs, features_list, feature_names=["is_A"], iters=100, num_samples=2, sample_interval=5)
 
         assert np.array_equal(m1.feature_effects, m2.feature_effects)
         assert np.array_equal(m1.topic_word, m2.topic_word)
@@ -304,10 +304,10 @@ class TestDMRInputTypeParity:
         corpus = Corpus.from_documents(docs)
 
         m1 = DMR(num_topics=2, seed=7)
-        m1.fit(docs, features, feature_names=["is_A"], iterations=100, num_samples=2, sample_interval=5)
+        m1.fit(docs, features, feature_names=["is_A"], iters=100, num_samples=2, sample_interval=5)
 
         m2 = DMR(num_topics=2, seed=7)
-        m2.fit(corpus, features, feature_names=["is_A"], iterations=100, num_samples=2, sample_interval=5)
+        m2.fit(corpus, features, feature_names=["is_A"], iters=100, num_samples=2, sample_interval=5)
 
         assert np.array_equal(m1.feature_effects, m2.feature_effects)
         assert np.array_equal(m1.topic_word, m2.topic_word)
@@ -322,7 +322,7 @@ class TestDMRTopWordsAndCoherence:
     def fitted_model(self):
         docs, _, features = _make_corpus(n=60, seed=0)
         model = DMR(num_topics=2, seed=1)
-        model.fit(docs, features, feature_names=["is_A"], iterations=200, num_samples=2, sample_interval=10)
+        model.fit(docs, features, feature_names=["is_A"], iters=200, num_samples=2, sample_interval=10)
         return model
 
     def test_top_words_all_topics_structure(self, fitted_model):
@@ -453,7 +453,7 @@ class TestOneHot:
             docs,
             matrix,
             feature_names=names,
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
         )

--- a/tests/test_doc_lengths.py
+++ b/tests/test_doc_lengths.py
@@ -19,7 +19,7 @@ def _toy_docs(n=40, vocab=12, lo=8, hi=15, seed=0):
 def _fit_each(corpus, *, keep_draws):
     out = {}
     m = topica.LDA(num_topics=4, seed=1)
-    m.fit(corpus, iterations=120, keep_theta_draws=keep_draws)
+    m.fit(corpus, iters=120, keep_theta_draws=keep_draws)
     out["LDA"] = m
     m = topica.SeededLDA({"a": ["w0", "w1"], "b": ["w5", "w6"]}, residual=2, seed=1)
     m.fit(corpus, iters=120, keep_theta_draws=keep_draws)
@@ -64,7 +64,7 @@ def test_corpus_takes_precedence_over_retained_lengths():
     docs = _toy_docs()
     corpus = topica.Corpus.from_documents(docs)
     m = topica.LDA(num_topics=4, seed=1)
-    m.fit(corpus, iterations=120, keep_theta_draws=False)
+    m.fit(corpus, iters=120, keep_theta_draws=False)
 
     # A corpus with deliberately different (here, longer) documents changes the
     # Dirichlet concentration, so the draws differ from the retained-length path.

--- a/tests/test_dtm.py
+++ b/tests/test_dtm.py
@@ -33,7 +33,7 @@ def fitted():
     # Looser chain_variance: the planted drift is abrupt, so the topic chain
     # needs room to move between slices.
     m = DTM(num_topics=2, chain_variance=0.5, seed=1)
-    m.fit(docs, times, em_iters=20)
+    m.fit(docs, times, iters=20)
     return m
 
 
@@ -122,9 +122,9 @@ class TestApi:
     def test_deterministic(self):
         docs, times, _ = _drift_corpus()
         a = DTM(num_topics=2, chain_variance=0.5, seed=2)
-        a.fit(docs, times, em_iters=12)
+        a.fit(docs, times, iters=12)
         b = DTM(num_topics=2, chain_variance=0.5, seed=2)
-        b.fit(docs, times, em_iters=12)
+        b.fit(docs, times, iters=12)
         for t in range(a.num_times):
             assert np.array_equal(a.topic_word(t), b.topic_word(t))
 
@@ -132,19 +132,19 @@ class TestApi:
         docs, times, _ = _drift_corpus()
         c = Corpus.from_documents(docs)
         m = DTM(num_topics=2, seed=1)
-        m.fit(c, times, em_iters=5)
+        m.fit(c, times, iters=5)
         assert m.num_times == 3
 
     def test_times_length_mismatch_raises(self):
         docs, times, _ = _drift_corpus()
         with pytest.raises(ValueError):
-            DTM(num_topics=2).fit(docs, times[:-1], em_iters=2)
+            DTM(num_topics=2).fit(docs, times[:-1], iters=2)
 
     def test_noncontiguous_slices_raise(self):
         docs, times, _ = _drift_corpus()
         bad = [t if t != 1 else 3 for t in times]  # slice 1 empty, slice 3 used
         with pytest.raises(ValueError):
-            DTM(num_topics=2).fit(docs, bad, em_iters=2)
+            DTM(num_topics=2).fit(docs, bad, iters=2)
 
     def test_unfitted_raises(self):
         m = DTM(num_topics=2)

--- a/tests/test_dubois_tutorial.py
+++ b/tests/test_dubois_tutorial.py
@@ -59,7 +59,7 @@ def test_corpus_is_model_ready():
     assert corpus.num_words > 50, f"vocab too small: {corpus.num_words}"
 
     lda = LDA(num_topics=3, seed=0)
-    lda.fit(corpus, iterations=50, num_samples=1, sample_interval=5)
+    lda.fit(corpus, iters=50, num_samples=1, sample_interval=5)
     assert lda.num_topics == 3
 
     topics = lda.top_words(5)

--- a/tests/test_effects_promotion.py
+++ b/tests/test_effects_promotion.py
@@ -27,7 +27,7 @@ def _corpus(n=80):
 def test_dirichlet_theta_samples_shape_and_determinism():
     docs, _ = _corpus()
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=150)
+    m.fit(docs, iters=150)
     lengths = np.array([len(d) for d in docs])
     a = topica.dirichlet_theta_samples(m.doc_topic, lengths, nsims=15, seed=0)
     b = topica.dirichlet_theta_samples(m.doc_topic, lengths, nsims=15, seed=0)
@@ -43,7 +43,7 @@ def test_dirichlet_theta_samples_shape_and_determinism():
 def test_estimate_effect_on_gibbs_draws_and_point():
     docs, x = _corpus()
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=200)
+    m.fit(docs, iters=200)
     lengths = np.array([len(d) for d in docs])
     draws = topica.dirichlet_theta_samples(m.doc_topic, lengths, nsims=20, seed=0)
 

--- a/tests/test_estimate_effect_moc.py
+++ b/tests/test_estimate_effect_moc.py
@@ -18,7 +18,7 @@ def treated_model():
         treat.append(float(t))
     X = np.array(treat).reshape(-1, 1)
     m = STM(num_topics=2, seed=1)
-    m.fit(docs, X, prevalence_names=["treatment"], em_iters=60)
+    m.fit(docs, X, prevalence_names=["treatment"], iters=60)
     return m, X
 
 
@@ -40,7 +40,7 @@ class TestVariationalPosterior:
     def test_ctm_also_exposes_posterior(self):
         docs = [["a", "b", "c"]] * 30 + [["x", "y", "z"]] * 30
         m = CTM(num_topics=2, seed=1)
-        m.fit(docs, em_iters=30)
+        m.fit(docs, iters=30)
         assert m.eta_mean.shape == (60, 1)
         assert m.eta_cov.shape == (60, 1, 1)
 

--- a/tests/test_fit_stats.py
+++ b/tests/test_fit_stats.py
@@ -19,10 +19,10 @@ from topica import LDA, Corpus
 # Available as `toy_docs` session fixture.
 
 
-def _fitted_toy(toy_docs, seed=42, num_topics=2, iterations=300, **kwargs):
+def _fitted_toy(toy_docs, seed=42, num_topics=2, iters=300, **kwargs):
     """Return a fitted LDA on toy_docs with sensible defaults."""
     model = LDA(num_topics, seed=seed, optimize_interval=0, **kwargs)
-    model.fit(toy_docs, iterations=iterations, num_samples=3, sample_interval=10)
+    model.fit(toy_docs, iters=iters, num_samples=3, sample_interval=10)
     return model
 
 
@@ -242,7 +242,7 @@ class TestPerplexityRecoversK:
 
     def _fit(self, k, train_docs):
         model = LDA(k, seed=42, optimize_interval=0)
-        model.fit(train_docs, iterations=300, num_samples=3, sample_interval=10)
+        model.fit(train_docs, iters=300, num_samples=3, sample_interval=10)
         return model
 
     def test_k2_lower_than_k1(self, cluster_data):
@@ -270,7 +270,7 @@ class TestHeldOutVsTrainingPerplexity:
         space = [["planet", "star", "moon"]] * 5
         held_docs = animal + space
 
-        model = _fitted_toy(toy_docs, seed=42, iterations=300)
+        model = _fitted_toy(toy_docs, seed=42, iters=300)
         train_perp = model.perplexity(toy_docs, num_particles=10, seed=42)
         held_perp = model.perplexity(held_docs, num_particles=10, seed=42)
         assert held_perp >= train_perp, (
@@ -317,9 +317,9 @@ class TestCoherence:
         than a random-looking single-topic model."""
         train, _ = _make_cluster_corpus(n_per_cluster=40, doc_len=10, seed=0)
         good_model = LDA(2, seed=42, optimize_interval=0)
-        good_model.fit(train, iterations=300, num_samples=3, sample_interval=10)
+        good_model.fit(train, iters=300, num_samples=3, sample_interval=10)
         bad_model = LDA(1, seed=42, optimize_interval=0)
-        bad_model.fit(train, iterations=300, num_samples=3, sample_interval=10)
+        bad_model.fit(train, iters=300, num_samples=3, sample_interval=10)
         # k=2 mean coherence should be closer to 0 than k=1
         assert np.mean(good_model.coherence(5)) > np.mean(bad_model.coherence(5))
 
@@ -412,7 +412,7 @@ class TestDiagnosticsSemantics:
     def cluster_model(self):
         train, _ = _make_cluster_corpus(n_per_cluster=40, doc_len=10, seed=0)
         m = LDA(2, seed=42, optimize_interval=0)
-        m.fit(train, iterations=300, num_samples=3, sample_interval=10)
+        m.fit(train, iters=300, num_samples=3, sample_interval=10)
         return m
 
     def test_top_words_disjoint_between_topics(self, cluster_model):

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -71,7 +71,7 @@ def test_from_dataframe_explicit_columns_and_stm_payoff():
     # The aligned metadata feeds an STM prevalence design with no manual hstack.
     X = c.metadata["party"].eq("D").astype(float).values.reshape(-1, 1)
     model = topica.STM(num_topics=2, seed=1)
-    model.fit(c, X, prevalence_names=["is_D"], em_iters=10)
+    model.fit(c, X, prevalence_names=["is_D"], iters=10)
     assert model.doc_topic.shape == (3, 2)
 
 

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -142,13 +142,13 @@ class TestEvalHeldout:
 
     def test_returns_heldoutresult_dataclass(self, heldout):
         m = topica.LDA(2, seed=1)
-        m.fit(heldout.documents, iterations=100)
+        m.fit(heldout.documents, iters=100)
         result = topica.eval_heldout(m, heldout)
         assert isinstance(result, HeldoutResult)
 
     def test_lda_finite_negative_loglik(self, heldout):
         m = topica.LDA(2, seed=1)
-        m.fit(heldout.documents, iterations=100)
+        m.fit(heldout.documents, iters=100)
         result = topica.eval_heldout(m, heldout)
         assert np.isfinite(result.mean_per_doc_loglik)
         assert result.mean_per_doc_loglik < 0.0
@@ -158,14 +158,14 @@ class TestEvalHeldout:
         rng = np.random.default_rng(3)
         prevalence = rng.normal(size=(D, 2))
         m = topica.STM(2, seed=1)
-        m.fit(heldout.documents, prevalence, em_iters=20)
+        m.fit(heldout.documents, prevalence, iters=20)
         result = topica.eval_heldout(m, heldout)
         assert np.isfinite(result.mean_per_doc_loglik)
         assert result.mean_per_doc_loglik < 0.0
 
     def test_ctm_finite_negative_loglik(self, heldout):
         m = topica.CTM(2, seed=1)
-        m.fit(heldout.documents, em_iters=20)
+        m.fit(heldout.documents, iters=20)
         result = topica.eval_heldout(m, heldout)
         assert np.isfinite(result.mean_per_doc_loglik)
         assert result.mean_per_doc_loglik < 0.0
@@ -175,14 +175,14 @@ class TestEvalHeldout:
         rng = np.random.default_rng(5)
         feats = rng.normal(size=(D, 2))
         m = topica.DMR(2, seed=1)
-        m.fit(heldout.documents, feats, iterations=100)
+        m.fit(heldout.documents, feats, iters=100)
         result = topica.eval_heldout(m, heldout)
         assert np.isfinite(result.mean_per_doc_loglik)
         assert result.mean_per_doc_loglik < 0.0
 
     def test_shapes_and_counts_consistent(self, heldout):
         m = topica.LDA(2, seed=1)
-        m.fit(heldout.documents, iterations=100)
+        m.fit(heldout.documents, iters=100)
         result = topica.eval_heldout(m, heldout)
         assert result.n_docs == len(result.per_doc_loglik)
         assert result.n_docs > 0
@@ -216,7 +216,7 @@ class TestEvalHeldout:
 
     def test_per_doc_loglik_all_negative(self, heldout):
         m = topica.LDA(2, seed=1)
-        m.fit(heldout.documents, iterations=100)
+        m.fit(heldout.documents, iters=100)
         result = topica.eval_heldout(m, heldout)
         assert np.all(result.per_doc_loglik < 0.0)
 
@@ -229,7 +229,7 @@ def test_roundtrip_lda():
     docs = _planted(n_per=60, doc_len=20, seed=0)
     h = topica.make_heldout(docs, prop_docs=0.3, prop_words=0.5, seed=42)
     m = topica.LDA(2, seed=1)
-    m.fit(h.documents, iterations=150)
+    m.fit(h.documents, iters=150)
     result = topica.eval_heldout(m, h)
     assert isinstance(result, HeldoutResult)
     assert result.n_docs > 0
@@ -243,7 +243,7 @@ def test_roundtrip_stm():
     rng = np.random.default_rng(7)
     prevalence = rng.normal(size=(len(h.documents), 2))
     m = topica.STM(2, seed=1)
-    m.fit(h.documents, prevalence, em_iters=20)
+    m.fit(h.documents, prevalence, iters=20)
     result = topica.eval_heldout(m, h)
     assert isinstance(result, HeldoutResult)
     assert result.mean_per_doc_loglik < 0.0
@@ -253,7 +253,7 @@ def test_roundtrip_ctm():
     docs = _planted(n_per=60, doc_len=20, seed=2)
     h = topica.make_heldout(docs, prop_docs=0.4, prop_words=0.5, seed=13)
     m = topica.CTM(2, seed=1)
-    m.fit(h.documents, em_iters=20)
+    m.fit(h.documents, iters=20)
     result = topica.eval_heldout(m, h)
     assert isinstance(result, HeldoutResult)
     assert result.mean_per_doc_loglik < 0.0
@@ -277,33 +277,33 @@ class TestSearchKHeldout:
 
     def test_lda_reports_perplexity_with_held_out(self, small_corpus_held_prevalence):
         docs, held, _ = small_corpus_held_prevalence
-        rows = topica.search_k(docs, [2], iterations=80, held_out=held, seed=0)
+        rows = topica.search_k(docs, [2], iters=80, held_out=held, seed=0)
         assert "perplexity" in rows[0]
         assert np.isfinite(rows[0]["perplexity"]) and rows[0]["perplexity"] > 1.0
 
     def test_stm_reports_perplexity_with_held_out(self, small_corpus_held_prevalence):
         docs, held, prevalence = small_corpus_held_prevalence
         rows = topica.search_k(docs, [2], model="stm", prevalence=prevalence,
-                               em_iters=10, held_out=held, seed=0)
+                               iters=10, held_out=held, seed=0)
         assert "perplexity" in rows[0]
         assert np.isfinite(rows[0]["perplexity"]) and rows[0]["perplexity"] > 1.0
 
     def test_lda_no_held_out_no_perplexity(self, small_corpus_held_prevalence):
         docs, _, _ = small_corpus_held_prevalence
-        rows = topica.search_k(docs, [2], iterations=80, seed=0)
+        rows = topica.search_k(docs, [2], iters=80, seed=0)
         assert "perplexity" not in rows[0]
 
     def test_stm_no_held_out_no_perplexity(self, small_corpus_held_prevalence):
         docs, _, prevalence = small_corpus_held_prevalence
         rows = topica.search_k(docs, [2], model="stm", prevalence=prevalence,
-                               em_iters=10, seed=0)
+                               iters=10, seed=0)
         assert "perplexity" not in rows[0]
 
     def test_existing_coherence_metric_label_intact(self, small_corpus_held_prevalence):
         docs, held, prevalence = small_corpus_held_prevalence
         for m_type, prev in (("lda", None), ("stm", prevalence)):
             rows = topica.search_k(docs, [2], model=m_type, prevalence=prev,
-                                   held_out=held, iterations=60, em_iters=8, seed=0)
+                                   held_out=held, iters=10, seed=0)
             assert rows[0]["coherence_metric"] == "u_mass"
 
 
@@ -318,10 +318,10 @@ def test_better_fit_scores_higher_loglik():
     h = topica.make_heldout(docs, prop_docs=0.5, prop_words=0.5, seed=0)
 
     m_good = topica.LDA(2, seed=1)
-    m_good.fit(h.documents, iterations=300)
+    m_good.fit(h.documents, iters=300)
 
     m_bad = topica.LDA(1, seed=1)
-    m_bad.fit(h.documents, iterations=300)
+    m_bad.fit(h.documents, iters=300)
 
     r_good = topica.eval_heldout(m_good, h)
     r_bad = topica.eval_heldout(m_bad, h)

--- a/tests/test_inference.py
+++ b/tests/test_inference.py
@@ -43,7 +43,7 @@ def cluster_model():
     animal_docs, space_docs = _make_cluster_docs()
     all_docs = animal_docs + space_docs
     model = LDA(2, seed=1, optimize_interval=0)
-    model.fit(all_docs, iterations=300, num_samples=3, sample_interval=10)
+    model.fit(all_docs, iters=300, num_samples=3, sample_interval=10)
     # Sanity: topics are distinct
     vocab = model.vocabulary
     animal_t = int(model.topic_word[:, vocab.index("cat")].argmax())

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -52,7 +52,7 @@ def test_other_constructors_reject_nan():
 
 def test_valid_hyperparameters_still_construct_and_fit():
     m = LDA(num_topics=2, beta=0.01, alpha_sum=1.0, seed=42)
-    m.fit(DOCS, iterations=20)
+    m.fit(DOCS, iters=20)
     assert not np.any(np.isnan(m.topic_word))
     assert m.topic_word.shape == (2, len(m.vocabulary))
 
@@ -62,7 +62,7 @@ def test_valid_hyperparameters_still_construct_and_fit():
 def test_empty_documents_rejected():
     m = LDA(num_topics=2, seed=42)
     with pytest.raises(ValueError):
-        m.fit([[], [], []], iterations=20)
+        m.fit([[], [], []], iters=20)
 
 
 def test_all_words_filtered_rejected():
@@ -78,7 +78,7 @@ def test_all_words_filtered_rejected():
 @pytest.fixture(scope="module")
 def model():
     m = LDA(num_topics=2, seed=42)
-    m.fit(DOCS, iterations=30)
+    m.fit(DOCS, iters=30)
     return m
 
 

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -31,7 +31,7 @@ def test_prepare_pyldavis_accepts_corpus():
     docs = [["cat", "dog", "pet"]] * 10 + [["star", "moon", "sky"]] * 10
     c = topica.Corpus.from_documents(docs)
     m = topica.LDA(2, seed=1)
-    m.fit(c, iterations=100)
+    m.fit(c, iters=100)
     out = topica.prepare_pyldavis(m, c)  # must not raise on a Corpus
     assert out is not None
 
@@ -101,7 +101,7 @@ def test_flexible_first_arg_accepts_model_or_matrix():
     # fitted model (the failing convention) as well as the raw matrix.
     docs = [["cat", "dog", "pet", "vet"]] * 12 + [["star", "moon", "sky", "sun"]] * 12
     m = topica.LDA(2, seed=1)
-    m.fit(docs, iterations=150)
+    m.fit(docs, iters=150)
     texts = [" ".join(d) for d in docs]
 
     # model-first (previously raised "float() argument ... not 'topica.LDA'")
@@ -123,7 +123,7 @@ def test_flexible_first_arg_accepts_model_or_matrix():
 def test_search_k_labels_its_coherence_metric():
     # #14: search_k reports UMass; label it so its scale isn't confused with c_v.
     docs = [["cat", "dog", "pet"]] * 12 + [["star", "moon", "sky"]] * 12
-    rows = topica.search_k(docs, [2, 3], iterations=60, num_samples=1)
+    rows = topica.search_k(docs, [2, 3], iters=60, num_samples=1)
     assert all(r["coherence_metric"] == "u_mass" for r in rows)
 
 
@@ -208,6 +208,6 @@ def test_report_is_callable():
     assert callable(topica.report)
     docs = [["cat", "dog"], ["star", "moon"]] * 8
     m = topica.LDA(2, seed=1)
-    m.fit(docs, iterations=50)
+    m.fit(docs, iters=50)
     assert topica.report(m) == topica.summary(m)
     assert "num_topics" in topica.report(m)

--- a/tests/test_labeled.py
+++ b/tests/test_labeled.py
@@ -40,13 +40,13 @@ def _make_corpus(n=150, words_per_label=8, seed=1):
     return docs, labels
 
 
-def _fit_recovery(docs, labels, seed=1, iterations=300):
+def _fit_recovery(docs, labels, seed=1, iters=300):
     """Fit LabeledLDA with settings known to recover the 3-label corpus cleanly."""
     model = LabeledLDA(alpha=0.1, seed=seed)
     model.fit(
         docs,
         labels,
-        iterations=iterations,
+        iters=iters,
         num_samples=3,
         sample_interval=10,
     )
@@ -221,7 +221,7 @@ class TestLabeledLDALabelNames:
             docs,
             labels,
             label_names=["tech", "sports", "politics"],
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
         )
@@ -235,7 +235,7 @@ class TestLabeledLDALabelNames:
             docs,
             labels,
             label_names=["tech", "sports", "politics"],
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
         )
@@ -260,7 +260,7 @@ class TestLabeledLDAEmptyLabels:
             all_docs,
             all_labels,
             label_names=_ALL_LABELS,
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
         )
@@ -278,7 +278,7 @@ class TestLabeledLDAEmptyLabels:
             all_docs,
             all_labels,
             label_names=_ALL_LABELS,
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
         )
@@ -294,17 +294,17 @@ class TestLabeledLDADeterminism:
     def test_identical_seed_identical_topic_word(self):
         docs, labels = _make_corpus(n=60, seed=4)
         m1 = LabeledLDA(alpha=0.1, seed=7)
-        m1.fit(docs, labels, iterations=100, num_samples=2, sample_interval=5)
+        m1.fit(docs, labels, iters=100, num_samples=2, sample_interval=5)
         m2 = LabeledLDA(alpha=0.1, seed=7)
-        m2.fit(docs, labels, iterations=100, num_samples=2, sample_interval=5)
+        m2.fit(docs, labels, iters=100, num_samples=2, sample_interval=5)
         assert np.array_equal(m1.topic_word, m2.topic_word)
 
     def test_identical_seed_identical_doc_topic(self):
         docs, labels = _make_corpus(n=60, seed=4)
         m1 = LabeledLDA(alpha=0.1, seed=7)
-        m1.fit(docs, labels, iterations=100, num_samples=2, sample_interval=5)
+        m1.fit(docs, labels, iters=100, num_samples=2, sample_interval=5)
         m2 = LabeledLDA(alpha=0.1, seed=7)
-        m2.fit(docs, labels, iterations=100, num_samples=2, sample_interval=5)
+        m2.fit(docs, labels, iters=100, num_samples=2, sample_interval=5)
         assert np.array_equal(m1.doc_topic, m2.doc_topic)
 
 
@@ -319,10 +319,10 @@ class TestLabeledLDAInputTypeParity:
         corpus = Corpus.from_documents(docs)
 
         m1 = LabeledLDA(alpha=0.1, seed=99)
-        m1.fit(docs, labels, iterations=100, num_samples=2, sample_interval=5)
+        m1.fit(docs, labels, iters=100, num_samples=2, sample_interval=5)
 
         m2 = LabeledLDA(alpha=0.1, seed=99)
-        m2.fit(corpus, labels, iterations=100, num_samples=2, sample_interval=5)
+        m2.fit(corpus, labels, iters=100, num_samples=2, sample_interval=5)
 
         assert np.array_equal(m1.topic_word, m2.topic_word)
         assert np.array_equal(m1.doc_topic, m2.doc_topic)
@@ -333,7 +333,7 @@ class TestLabeledLDAInputTypeParity:
         assert isinstance(labels, list)
         assert all(isinstance(l, list) for l in labels)
         model = LabeledLDA(alpha=0.1, seed=1)
-        model.fit(docs, labels, iterations=50, num_samples=1, sample_interval=5)
+        model.fit(docs, labels, iters=50, num_samples=1, sample_interval=5)
         assert model.num_topics == 3
 
 
@@ -346,7 +346,7 @@ class TestLabeledLDATopWordsAndCoherence:
     def fitted(self):
         docs, labels = _make_corpus(n=60, seed=0)
         model = LabeledLDA(alpha=0.1, seed=1)
-        model.fit(docs, labels, iterations=200, num_samples=2, sample_interval=10)
+        model.fit(docs, labels, iters=200, num_samples=2, sample_interval=10)
         return model
 
     def test_top_words_all_topics_structure(self, fitted):

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -17,7 +17,7 @@ def model_and_texts():
     docs = [d.split() for d in (pets * 20 + sky * 20)]
     texts = pets * 20 + sky * 20
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=300)
+    m.fit(docs, iters=300)
     return m, texts
 
 

--- a/tests/test_lda.py
+++ b/tests/test_lda.py
@@ -16,7 +16,7 @@ from topica import LDA, Corpus
 def _quick_model(docs, seed=42, num_topics=2, **kwargs):
     """Return a fitted LDA with fast settings."""
     model = LDA(num_topics, seed=seed, **kwargs)
-    model.fit(docs, iterations=200, num_samples=3, sample_interval=5)
+    model.fit(docs, iters=200, num_samples=3, sample_interval=5)
     return model
 
 

--- a/tests/test_lda_mallet.py
+++ b/tests/test_lda_mallet.py
@@ -19,19 +19,19 @@ DOCS = (
 def test_symmetric_alpha_stays_symmetric():
     sym = topica.LDA(num_topics=4, seed=1, optimize_interval=10, burn_in=20,
                      use_symmetric_alpha=True)
-    sym.fit(DOCS, iterations=300)
+    sym.fit(DOCS, iters=300)
     assert np.allclose(sym.alpha, sym.alpha[0])  # every alpha[t] equal
 
 
 def test_asymmetric_alpha_is_default_and_varies():
     asym = topica.LDA(num_topics=4, seed=1, optimize_interval=10, burn_in=20)
-    asym.fit(DOCS, iterations=300)
+    asym.fit(DOCS, iters=300)
     assert not np.allclose(asym.alpha, asym.alpha[0])  # learned per-topic shape
 
 
 def test_symmetric_flag_survives_save_load(tmp_path):
     m = topica.LDA(num_topics=3, seed=1, use_symmetric_alpha=True)
-    m.fit(DOCS, iterations=100)
+    m.fit(DOCS, iters=100)
     path = str(tmp_path / "m.tt")
     m.save(path)
     loaded = topica.LDA.load(path)
@@ -41,7 +41,7 @@ def test_symmetric_flag_survives_save_load(tmp_path):
 
 def test_load_state_round_trip(tmp_path):
     m = topica.LDA(num_topics=3, seed=1)
-    m.fit(DOCS, iterations=200)
+    m.fit(DOCS, iters=200)
     state = str(tmp_path / "state.gz")
     m.save_state(state)
 
@@ -66,7 +66,7 @@ def test_load_state_reconstructs_assignments(tmp_path):
     # A planted corpus with disjoint vocab: load_state must preserve which words
     # land in which topic (up to topic relabeling).
     m = topica.LDA(num_topics=3, seed=3)
-    m.fit(DOCS, iterations=300)
+    m.fit(DOCS, iters=300)
     state = str(tmp_path / "s.gz")
     m.save_state(state)
     r = topica.LDA.load_state(state)
@@ -79,7 +79,7 @@ def test_load_state_reconstructs_assignments(tmp_path):
 def test_load_state_plain_text(tmp_path):
     # load_state accepts an uncompressed state file too.
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(DOCS, iterations=100)
+    m.fit(DOCS, iters=100)
     gz = str(tmp_path / "s.gz")
     m.save_state(gz)
     plain = str(tmp_path / "s.txt")
@@ -91,7 +91,7 @@ def test_load_state_plain_text(tmp_path):
 
 def test_diagnostics_has_mallet_fields():
     m = topica.LDA(num_topics=3, seed=1)
-    m.fit(DOCS, iterations=200)
+    m.fit(DOCS, iters=200)
     diag = m.diagnostics(n=5)
     assert len(diag) == 3
     required = {

--- a/tests/test_lightlda.py
+++ b/tests/test_lightlda.py
@@ -28,7 +28,7 @@ def _fit(sampler, docs, k=2, **kw):
     opts = dict(num_topics=k, seed=1, sampler=sampler, optimize_interval=0)
     opts.update(kw)
     m = topica.LDA(**opts)
-    m.fit(docs, iterations=300, num_samples=5, sample_interval=10)
+    m.fit(docs, iters=300, num_samples=5, sample_interval=10)
     return m
 
 
@@ -71,7 +71,7 @@ def test_sampler_aliases_accepted():
     # Friendly aliases resolve to the same backend.
     for name in ["lightlda", "light", "alias"]:
         m = topica.LDA(num_topics=2, sampler=name)
-        m.fit(TWO_TOPIC_DOCS, iterations=50)
+        m.fit(TWO_TOPIC_DOCS, iters=50)
         assert m.topic_word.shape[0] == 2
     for name in ["sparse", "mallet"]:
         topica.LDA(num_topics=2, sampler=name)
@@ -107,7 +107,7 @@ def test_topic_quality_matches_sparse_on_real_corpus():
 
     def mean_cv(sampler):
         m = topica.LDA(num_topics=15, seed=1, sampler=sampler)
-        m.fit(corpus, iterations=400)
+        m.fit(corpus, iters=400)
         return float(np.mean(topica.coherence(m, docs, coherence_type="c_v", topn=10)))
 
     sparse_cv = mean_cv("sparse")

--- a/tests/test_mallet_parity.py
+++ b/tests/test_mallet_parity.py
@@ -19,7 +19,7 @@ pytestmark = pytest.mark.parity
 
 @pytest.mark.skipif(not mallet_parity.mallet_available(), reason="mallet CLI not installed")
 def test_lda_matches_java_mallet():
-    r = mallet_parity.lda_parity(iterations=600)
+    r = mallet_parity.lda_parity(iters=600)
     # Planted disjoint-vocabulary topics: both implementations recover them, so
     # aligned topics should overlap almost entirely.
     assert r["mean_jaccard"] > 0.8, r
@@ -28,7 +28,7 @@ def test_lda_matches_java_mallet():
 
 @pytest.mark.skipif(not mallet_parity.java_drivers_available(), reason="mallet jars / javac not available")
 def test_labeled_matches_java_mallet():
-    r = mallet_parity.labeled_parity(iterations=600)
+    r = mallet_parity.labeled_parity(iters=600)
     # Topics correspond to labels and align by name; the per-label topic-word
     # distributions should be nearly identical to Java MALLET's LabeledLDA.
     assert r["mean_cosine"] > 0.95, r
@@ -36,7 +36,7 @@ def test_labeled_matches_java_mallet():
 
 @pytest.mark.skipif(not mallet_parity.java_drivers_available(), reason="mallet jars / javac not available")
 def test_dmr_matches_java_mallet():
-    r = mallet_parity.dmr_parity(iterations=600)
+    r = mallet_parity.dmr_parity(iters=600)
     # DMR fits feature weights by L-BFGS (implementation-specific), so this is a
     # statistical check: topics align, and the covariate effect agrees in sign
     # and is substantial in both implementations.

--- a/tests/test_mmr.py
+++ b/tests/test_mmr.py
@@ -41,7 +41,7 @@ def test_accepts_model_and_validates():
     rng = np.random.default_rng(0)
     docs = [["cat", "dog", "pet"]] * 12 + [["star", "moon", "sky"]] * 12
     m = topica.LDA(2, seed=1)
-    m.fit(docs, iterations=100)
+    m.fit(docs, iters=100)
     word_emb = rng.normal(0, 1, (len(m.vocabulary), 8))
     out = topica.mmr(m, word_emb, n=3, diversity=0.3)  # model-first, vocab from model
     assert len(out) == 2 and len(out[0]) == 3

--- a/tests/test_parallel.py
+++ b/tests/test_parallel.py
@@ -86,14 +86,14 @@ _N_DOCS_4 = len(_CORPUS_4)   # 400
 def _fit_2topic(num_threads, seed=1):
     """Fit a 2-topic model on the two-cluster corpus."""
     model = LDA(2, seed=seed, optimize_interval=0, num_threads=num_threads)
-    model.fit(_CORPUS_2, iterations=300, num_samples=3, sample_interval=10)
+    model.fit(_CORPUS_2, iters=300, num_samples=3, sample_interval=10)
     return model
 
 
 def _fit_4topic(num_threads, seed=1):
     """Fit a 4-topic model on the four-cluster corpus."""
     model = LDA(4, seed=seed, optimize_interval=0, num_threads=num_threads)
-    model.fit(_CORPUS_4, iterations=300, num_samples=3, sample_interval=10)
+    model.fit(_CORPUS_4, iters=300, num_samples=3, sample_interval=10)
     return model
 
 
@@ -153,7 +153,7 @@ class TestNumThreadsConstructor:
 
     def test_num_threads_zero_clamped_identical_to_one(self):
         """num_threads=0 is clamped to 1: results must equal num_threads=1 for same seed."""
-        kw = dict(iterations=200, num_samples=3, sample_interval=10)
+        kw = dict(iters=200, num_samples=3, sample_interval=10)
         m0 = LDA(2, seed=7, optimize_interval=0, num_threads=0)
         m1 = LDA(2, seed=7, optimize_interval=0, num_threads=1)
         m0.fit(_CORPUS_2, **kw)

--- a/tests/test_perplexity.py
+++ b/tests/test_perplexity.py
@@ -20,7 +20,7 @@ def split():
 def test_perplexity_is_positive_and_finite(split):
     train, held = split
     m = topica.LDA(4, seed=1)
-    m.fit(train, iterations=300)
+    m.fit(train, iters=300)
     pp = topica.perplexity(m, held)
     assert np.isfinite(pp) and pp > 1.0
 
@@ -33,7 +33,7 @@ def test_perplexity_discriminates_k(split):
     pp = {}
     for k in (2, 4):
         m = topica.LDA(k, seed=1)
-        m.fit(train, iterations=300)
+        m.fit(train, iters=300)
         pp[k] = topica.perplexity(m, held)
     assert pp[4] < pp[2]
 
@@ -41,7 +41,7 @@ def test_perplexity_discriminates_k(split):
 def test_perplexity_accepts_corpus_and_variational(split):
     train, held = split
     m = topica.CTM(4, seed=1)
-    m.fit(train, em_iters=20)
+    m.fit(train, iters=20)
     corpus = topica.Corpus.from_documents(held)
     assert np.isfinite(topica.perplexity(m, corpus))
 
@@ -60,6 +60,6 @@ def test_perplexity_rejects_clustering_models(split):
 def test_perplexity_needs_scorable_documents(split):
     train, _ = split
     m = topica.LDA(4, seed=1)
-    m.fit(train, iterations=150)
+    m.fit(train, iters=150)
     with pytest.raises(ValueError, match="at least 2 tokens"):
         topica.perplexity(m, [["a0"], ["b1"]])  # single-token docs cannot be split

--- a/tests/test_plot_search_k.py
+++ b/tests/test_plot_search_k.py
@@ -36,6 +36,6 @@ def test_missing_metric_raises():
 
 def test_real_search_k_output_plots():
     docs = [["cat", "dog", "fish"]] * 30 + [["sun", "moon", "star"]] * 30
-    rows = topica.search_k(docs, ks=[2, 3], iterations=80)
+    rows = topica.search_k(docs, ks=[2, 3], iters=80)
     ax = topica.plot_search_k(rows)
     assert ax is not None

--- a/tests/test_predicted_prevalence.py
+++ b/tests/test_predicted_prevalence.py
@@ -64,7 +64,7 @@ def _make_docs_continuous(n=100, seed=1):
 def lda_model():
     docs, treat = _make_docs(n=100, seed=0)
     m = topica.LDA(2, seed=1)
-    m.fit(docs, iterations=200)
+    m.fit(docs, iters=200)
     return m, treat
 
 
@@ -73,7 +73,7 @@ def stm_model():
     docs, treat = _make_docs(n=100, seed=0)
     X = treat.reshape(-1, 1)
     m = topica.STM(2, seed=1)
-    m.fit(docs, X, prevalence_names=["treat"], em_iters=50)
+    m.fit(docs, X, prevalence_names=["treat"], iters=50)
     return m, treat
 
 
@@ -82,7 +82,7 @@ def stm_continuous_model():
     docs, x = _make_docs_continuous(n=100, seed=1)
     X = x.reshape(-1, 1)
     m = topica.STM(2, seed=2)
-    m.fit(docs, X, prevalence_names=["x"], em_iters=50)
+    m.fit(docs, X, prevalence_names=["x"], iters=50)
     return m, x
 
 

--- a/tests/test_reference_default_contracts.py
+++ b/tests/test_reference_default_contracts.py
@@ -110,7 +110,7 @@ def test_stm_fit_defaults_match_r_stm() -> None:
     fit_defaults = _topica_defaults("STM", "fit")
 
     assert init_defaults["init"] == r["init"].lower()
-    assert fit_defaults["em_iters"] == int(r["max_em_its"])
+    assert fit_defaults["iters"] == int(r["max_em_its"])
     assert math.isclose(fit_defaults["em_tol"], float(r["emtol"]), rel_tol=0, abs_tol=0)
 
 
@@ -186,7 +186,7 @@ def test_mallet_defaults_match_topica_for_shared_lda_controls() -> None:
     assert init_defaults["burn_in"] == int(mallet["optimize-burn-in"])
     assert init_defaults["num_threads"] == int(mallet["num-threads"])
     assert init_defaults["use_symmetric_alpha"] is (mallet["use-symmetric-alpha"] == "true")
-    assert fit_defaults["iterations"] == int(mallet["num-iterations"])
+    assert fit_defaults["iters"] == int(mallet["num-iterations"])
 
 
 def test_mallet_default_mismatches_are_explicit_contracts() -> None:

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -19,7 +19,7 @@ def lda_corpus():
     timestamps = ([2019] * 10 + [2020] * 10) + ([2019] * 10 + [2020] * 10)
     groups = (["pets"] * 20) + (["sky"] * 20)
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=200)
+    m.fit(docs, iters=200)
     return m, docs, texts, timestamps, groups
 
 

--- a/tests/test_sage.py
+++ b/tests/test_sage.py
@@ -82,7 +82,7 @@ def _fit_bilingual(docs, groups, seed=1):
     model.fit(
         docs,
         groups,
-        iterations=300,
+        iters=300,
         num_samples=3,
         sample_interval=10,
     )
@@ -187,26 +187,26 @@ class TestSAGEFitValidation:
 
     def test_top_words_topic_out_of_range_raises(self):
         model = SAGE(2, seed=1)
-        model.fit(self.docs, self.groups, iterations=50, num_samples=1, sample_interval=5)
+        model.fit(self.docs, self.groups, iters=50, num_samples=1, sample_interval=5)
         with pytest.raises(ValueError):
             model.top_words(99)
 
     def test_top_words_unknown_group_name_raises(self):
         model = SAGE(2, seed=1)
-        model.fit(self.docs, self.groups, iterations=50, num_samples=1, sample_interval=5)
+        model.fit(self.docs, self.groups, iters=50, num_samples=1, sample_interval=5)
         with pytest.raises(ValueError):
             model.top_words(0, group="z")
 
     def test_top_words_group_index_out_of_range_raises(self):
         model = SAGE(2, seed=1)
-        model.fit(self.docs, self.groups, iterations=50, num_samples=1, sample_interval=5)
+        model.fit(self.docs, self.groups, iters=50, num_samples=1, sample_interval=5)
         with pytest.raises(ValueError):
             model.top_words(0, group=99)
 
     def test_word_contrast_topic_out_of_range_raises(self):
         model = SAGE(2, seed=1)
         model.fit(self.docs + [["bird"]], self.groups + ["b"],
-                  iterations=50, num_samples=1, sample_interval=5)
+                  iters=50, num_samples=1, sample_interval=5)
         with pytest.raises(ValueError):
             model.word_contrast(99, "a", "b")
 
@@ -395,14 +395,14 @@ class TestSAGEIntegerGroups:
         docs   = [["cat", "dog"]] * 10 + [["bird", "fish"]] * 10
         groups = [0] * 10 + [1] * 10
         model = SAGE(num_topics=2, seed=1)
-        model.fit(docs, groups, iterations=50, num_samples=1, sample_interval=5)
+        model.fit(docs, groups, iters=50, num_samples=1, sample_interval=5)
         assert model.groups == ["0", "1"]
 
     def test_int_groups_fit_completes(self):
         docs   = [["cat", "dog"]] * 10 + [["bird", "fish"]] * 10
         groups = [0] * 10 + [1] * 10
         model = SAGE(num_topics=2, seed=1)
-        model.fit(docs, groups, iterations=50, num_samples=1, sample_interval=5)
+        model.fit(docs, groups, iters=50, num_samples=1, sample_interval=5)
         assert model.doc_topic.shape == (20, 2)
 
 
@@ -417,7 +417,7 @@ class TestSAGEGroupNames:
         groups = ["en"] * 10 + ["de"] * 10
         model = SAGE(num_topics=2, seed=1)
         model.fit(docs, groups, group_names=["en", "de"],
-                  iterations=50, num_samples=1, sample_interval=5)
+                  iters=50, num_samples=1, sample_interval=5)
         assert model.groups == ["en", "de"]
         # Index 0 should be 'en'
         assert model.groups[0] == "en"
@@ -428,7 +428,7 @@ class TestSAGEGroupNames:
         groups = ["en"] * 10 + ["de"] * 10
         model = SAGE(num_topics=2, seed=1)
         model.fit(docs, groups, group_names=["de", "en"],
-                  iterations=50, num_samples=1, sample_interval=5)
+                  iters=50, num_samples=1, sample_interval=5)
         assert model.groups == ["de", "en"]
         assert model.groups[0] == "de"
 
@@ -438,10 +438,10 @@ class TestSAGEGroupNames:
         groups = ["en"] * 10 + ["de"] * 10
         m_en0 = SAGE(num_topics=2, seed=1)
         m_en0.fit(docs, groups, group_names=["en", "de"],
-                  iterations=50, num_samples=1, sample_interval=5)
+                  iters=50, num_samples=1, sample_interval=5)
         m_de0 = SAGE(num_topics=2, seed=1)
         m_de0.fit(docs, groups, group_names=["de", "en"],
-                  iterations=50, num_samples=1, sample_interval=5)
+                  iters=50, num_samples=1, sample_interval=5)
         # group_names ordering should change which slice is index 0
         tw_en0_g0 = m_en0.top_words(0, group=0, n=3)
         tw_en0_gname = m_en0.top_words(0, group="en", n=3)
@@ -459,10 +459,10 @@ class TestSAGEInputTypeParity:
         corpus = Corpus.from_documents(docs)
 
         m1 = SAGE(num_topics=2, seed=5)
-        m1.fit(docs, groups, iterations=100, num_samples=2, sample_interval=5)
+        m1.fit(docs, groups, iters=100, num_samples=2, sample_interval=5)
 
         m2 = SAGE(num_topics=2, seed=5)
-        m2.fit(corpus, groups, iterations=100, num_samples=2, sample_interval=5)
+        m2.fit(corpus, groups, iters=100, num_samples=2, sample_interval=5)
 
         npt.assert_array_equal(m1.topic_word, m2.topic_word)
         npt.assert_array_equal(m1.doc_topic, m2.doc_topic)

--- a/tests/test_save_load.py
+++ b/tests/test_save_load.py
@@ -25,15 +25,15 @@ def _fit_all():
     groups = ["a"] * 30 + ["b"] * 30
     times = [0] * 30 + [1] * 30
 
-    lda = topica.LDA(num_topics=2, seed=1); lda.fit(DOCS, iterations=200)
+    lda = topica.LDA(num_topics=2, seed=1); lda.fit(DOCS, iters=200)
     dmr = topica.DMR(num_topics=2, seed=1); dmr.fit(DOCS, X, feature_names=["g"])
     lab = topica.LabeledLDA(seed=1); lab.fit(DOCS, [["x"]] * 60)
     sage = topica.SAGE(num_topics=2, seed=1); sage.fit(DOCS, groups)
-    ctm = topica.CTM(num_topics=2, seed=1); ctm.fit(DOCS, em_iters=20)
-    stm = topica.STM(num_topics=2, seed=1); stm.fit(DOCS, X, prevalence_names=["g"], em_iters=20)
+    ctm = topica.CTM(num_topics=2, seed=1); ctm.fit(DOCS, iters=20)
+    stm = topica.STM(num_topics=2, seed=1); stm.fit(DOCS, X, prevalence_names=["g"], iters=20)
     hdp = topica.HDP(seed=1); hdp.fit(DOCS, iters=40)
-    dtm = topica.DTM(num_topics=2, seed=1); dtm.fit(DOCS, times, em_iters=8)
-    slda = topica.SupervisedLDA(num_topics=2, seed=1); slda.fit(DOCS, y, em_iters=10)
+    dtm = topica.DTM(num_topics=2, seed=1); dtm.fit(DOCS, times, iters=8)
+    slda = topica.SupervisedLDA(num_topics=2, seed=1); slda.fit(DOCS, y, iters=10)
     return {
         "LDA": lda, "DMR": dmr, "LabeledLDA": lab, "SAGE": sage, "CTM": ctm,
         "STM": stm, "HDP": hdp, "DTM": dtm, "SupervisedLDA": slda,
@@ -60,7 +60,7 @@ def test_roundtrip(name, tmp):
 
 def test_lda_transform_after_load(tmp):
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(DOCS, iterations=200)
+    m.fit(DOCS, iters=200)
     before = m.transform([["cat", "dog"], ["star", "moon"]])
     m.save(tmp)
     loaded = topica.LDA.load(tmp)
@@ -72,7 +72,7 @@ def test_lda_save_state_mallet_format(tmp_path):
     import gzip
 
     m = topica.LDA(num_topics=3, seed=1)
-    m.fit(DOCS, iterations=200)
+    m.fit(DOCS, iters=200)
     path = str(tmp_path / "state.gz")
     m.save_state(path)
 
@@ -99,7 +99,7 @@ def test_lda_save_state_mallet_format(tmp_path):
 
 def test_lda_save_state_after_load(tmp_path):
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(DOCS, iterations=150)
+    m.fit(DOCS, iters=150)
     model_path = str(tmp_path / "m.tt")
     m.save(model_path)
     loaded = topica.LDA.load(model_path)
@@ -116,7 +116,7 @@ def test_save_state_unfitted_raises(tmp_path):
 def test_stm_posterior_survives(tmp):
     m = topica.STM(num_topics=2, seed=1)
     X = np.array([[0.0]] * 30 + [[1.0]] * 30)
-    m.fit(DOCS, X, prevalence_names=["g"], em_iters=20)
+    m.fit(DOCS, X, prevalence_names=["g"], iters=20)
     m.save(tmp)
     loaded = topica.STM.load(tmp)
     assert np.array_equal(m.eta_mean, loaded.eta_mean)
@@ -127,7 +127,7 @@ def test_stm_posterior_survives(tmp):
 def test_slda_predict_after_load(tmp):
     m = topica.SupervisedLDA(num_topics=2, seed=1)
     y = np.array([0.0] * 30 + [1.0] * 30)
-    m.fit(DOCS, y, em_iters=10)
+    m.fit(DOCS, y, iters=10)
     m.save(tmp)
     loaded = topica.SupervisedLDA.load(tmp)
     assert np.allclose(m.coefficients, loaded.coefficients)

--- a/tests/test_silent_degradation.py
+++ b/tests/test_silent_degradation.py
@@ -51,7 +51,7 @@ def _pruned_setup():
     texts = ["Text0", "DROPPED1", "Text2", "Text3"]
     corpus = topica.Corpus.from_documents(docs, min_doc_freq=2)  # drops doc 1
     m = topica.LDA(num_topics=2, seed=42)
-    m.fit(corpus, iterations=100)
+    m.fit(corpus, iters=100)
     return m, corpus, texts
 
 
@@ -90,7 +90,7 @@ def test_bootstrap_refit_hook_typeerror_is_not_swallowed():
     misread as an arity mismatch and silently retried at the default seed."""
     _, corpus = _toy_corpus()
     model = topica.LDA(num_topics=2, seed=1)
-    model.fit(corpus, iterations=80)
+    model.fit(corpus, iters=80)
 
     def broken_refit(picks, seed):
         raise TypeError("genuine bug inside the hook")
@@ -105,7 +105,7 @@ def test_bootstrap_refit_hook_typeerror_is_not_swallowed():
 def test_quality_frontier_warns_when_coherence_type_needs_texts():
     _, corpus = _toy_corpus()
     m = topica.LDA(num_topics=3, seed=1)
-    m.fit(corpus, iterations=80)
+    m.fit(corpus, iters=80)
     with pytest.warns(UserWarning, match="needs texts"):
         validation.quality_frontier(m, coherence_type="c_v")  # no texts
 
@@ -117,7 +117,7 @@ def test_coherence_works_for_sage_via_marginal():
     must still work by falling back to the group-marginal matrix."""
     docs, _ = _toy_corpus()
     s = topica.SAGE(num_topics=3, seed=1, optimize_interval=25, burn_in=20)
-    s.fit(docs, ["g"] * len(docs), iterations=80, num_samples=2, sample_interval=10)
+    s.fit(docs, ["g"] * len(docs), iters=80, num_samples=2, sample_interval=10)
     coh = topica.coherence(s, docs, coherence_type="u_mass")
     assert coh.shape == (3,) and np.all(np.isfinite(coh))
     assert topica.exclusivity(s).shape == (3,)
@@ -128,7 +128,7 @@ def test_coherence_rejects_dtm_with_clear_message():
     a bound method into an object array."""
     docs, _ = _toy_corpus()
     dtm = topica.DTM(num_topics=2, seed=1)
-    dtm.fit(docs, [0] * 20 + [1] * 20, em_iters=3)
+    dtm.fit(docs, [0] * 20 + [1] * 20, iters=3)
     with pytest.raises(ValueError, match="time-sliced"):
         topica.coherence(dtm, docs)
 
@@ -136,7 +136,7 @@ def test_coherence_rejects_dtm_with_clear_message():
 def test_capability_no_doc_topic_models_are_not_soft_theta():
     docs, _ = _toy_corpus()
     dtm = topica.DTM(num_topics=2, seed=1)
-    dtm.fit(docs, [0] * 20 + [1] * 20, em_iters=3)
+    dtm.fit(docs, [0] * 20 + [1] * 20, iters=3)
     h = topica.HLDA(depth=2, seed=1)
     h.fit(docs, iters=50)
     assert capabilities(dtm).soft_theta is False
@@ -149,6 +149,6 @@ def test_dmr_stub_matches_runtime():
     docs, _ = _toy_corpus()
     X = np.random.default_rng(0).normal(size=(len(docs), 1))
     m = topica.DMR(num_topics=3, seed=1, optimize_interval=25, burn_in=20)
-    m.fit(docs, X, feature_names=["x"], iterations=80, num_samples=2, sample_interval=10)
+    m.fit(docs, X, feature_names=["x"], iters=80, num_samples=2, sample_interval=10)
     assert np.asarray(m.feature_effects).shape[0] == 3
     assert not hasattr(m, "prevalence_effects")

--- a/tests/test_slda.py
+++ b/tests/test_slda.py
@@ -30,7 +30,7 @@ def _supervised_corpus(n=200, seed=0):
 def fitted():
     docs, y = _supervised_corpus()
     m = SupervisedLDA(num_topics=2, seed=7)
-    m.fit(docs, y, em_iters=25, var_iters=15)
+    m.fit(docs, y, iters=25, var_iters=15)
     return m, docs, y
 
 
@@ -96,9 +96,9 @@ class TestApi:
     def test_deterministic(self):
         docs, y = _supervised_corpus()
         a = SupervisedLDA(num_topics=2, seed=3)
-        a.fit(docs, y, em_iters=10, var_iters=10)
+        a.fit(docs, y, iters=10, var_iters=10)
         b = SupervisedLDA(num_topics=2, seed=3)
-        b.fit(docs, y, em_iters=10, var_iters=10)
+        b.fit(docs, y, iters=10, var_iters=10)
         assert np.array_equal(a.coefficients, b.coefficients)
         assert np.array_equal(a.topic_word, b.topic_word)
 
@@ -106,7 +106,7 @@ class TestApi:
         docs, y = _supervised_corpus(n=80)
         c = Corpus.from_documents(docs)
         m = SupervisedLDA(num_topics=2, seed=1)
-        m.fit(c, y, em_iters=8)
+        m.fit(c, y, iters=8)
         assert m.topic_word.shape[0] == 2
 
     def test_predict_ignores_oov(self, fitted):

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -22,7 +22,7 @@ def _planted(seed=0, n=240):
         docs.append(list(rng.choice(block, size=12)))
     corpus = topica.Corpus.from_documents(docs)
     m = topica.LDA(2, seed=1)
-    m.fit(corpus, iterations=250)
+    m.fit(corpus, iters=250)
     return m, corpus, x
 
 
@@ -88,25 +88,25 @@ def _fit_for_composition():
     X = rng.normal(size=(len(docs), 1))
 
     models = {}
-    m = topica.LDA(3, seed=1); m.fit(corpus, iterations=120); models["LDA"] = m
+    m = topica.LDA(3, seed=1); m.fit(corpus, iters=120); models["LDA"] = m
     m = topica.HDP(seed=1); m.fit(corpus, iters=120); models["HDP"] = m
     m = topica.KeyATM({"a": ["w0"], "b": ["w1"]}, num_topics=3)
     m.fit(corpus, iters=120); models["KeyATM"] = m
     m = topica.SeededLDA({"a": ["w0"], "b": ["w1"]}, residual=1)
     m.fit(corpus, iters=120); models["SeededLDA"] = m
-    m = topica.LabeledLDA(seed=1); m.fit(docs, [["x", "y"]] * len(docs), iterations=120)
+    m = topica.LabeledLDA(seed=1); m.fit(docs, [["x", "y"]] * len(docs), iters=120)
     models["LabeledLDA"] = m
-    m = topica.SupervisedLDA(num_topics=3, seed=1); m.fit(docs, y, em_iters=8)
+    m = topica.SupervisedLDA(num_topics=3, seed=1); m.fit(docs, y, iters=8)
     models["SupervisedLDA"] = m
     m = topica.DMR(num_topics=3, seed=1, optimize_interval=25, burn_in=20)
-    m.fit(docs, X, feature_names=["x"], iterations=120, num_samples=2, sample_interval=10)
+    m.fit(docs, X, feature_names=["x"], iters=120, num_samples=2, sample_interval=10)
     models["DMR"] = m
     m = topica.PA(num_super=2, num_sub=4, seed=1); m.fit(corpus, iters=120)
     models["PA"] = m
     m = topica.PT(num_topics=3, num_pseudo=10, seed=1); m.fit(corpus, iters=120)
     models["PT"] = m
     m = topica.SAGE(num_topics=3, seed=1, optimize_interval=25, burn_in=20)
-    m.fit(docs, ["g"] * len(docs), iterations=120, num_samples=2, sample_interval=10)
+    m.fit(docs, ["g"] * len(docs), iters=120, num_samples=2, sample_interval=10)
     models["SAGE"] = m
     return corpus, models
 
@@ -138,7 +138,7 @@ def test_composition_effect_inflates_over_ols():
     # test_real_draws_reflect_identifiability in test_theta_draws.py.)
     _, corpus, x = _planted()
     m = topica.LDA(2, seed=1)
-    m.fit(corpus, iterations=250, keep_theta_draws=False)
+    m.fit(corpus, iters=250, keep_theta_draws=False)
     X = x[:, None]
     ols = topica.estimate_effect(m.doc_topic, X, feature_names=["x"])
     moc = topica.standard_errors(m, corpus, of="effect", X=X, feature_names=["x"], nsims=30)
@@ -153,7 +153,7 @@ def test_composition_self_sufficient_for_gibbs_and_rejects_embedding():
     # #32), so even with draws disabled the Dirichlet fallback needs no corpus=.
     _, corpus, _ = _planted()
     m = topica.LDA(2, seed=1)
-    m.fit(corpus, iterations=250, keep_theta_draws=False)
+    m.fit(corpus, iters=250, keep_theta_draws=False)
     prev = topica.standard_errors(m, of="prevalence", nsims=10)  # no corpus needed
     assert len(prev) == 2
 
@@ -178,7 +178,7 @@ def test_bootstrap_prevalence_matches_composition_on_clean_data():
     m, corpus, _ = _planted()
     comp = topica.standard_errors(m, corpus, of="prevalence", nsims=40)
     boot = topica.standard_errors(m, corpus, of="prevalence", method="bootstrap",
-                                  n_boot=40, topn=5, iterations=150, seed=0)
+                                  n_boot=40, topn=5, iters=150, seed=0)
     for t in range(2):
         assert boot[t].reliable
         assert boot[t].alignment_quality > 0.5 and boot[t].alignment_margin > 0.1
@@ -189,7 +189,7 @@ def test_bootstrap_prevalence_matches_composition_on_clean_data():
 def test_bootstrap_top_words_inclusion_probs():
     m, corpus, _ = _planted()
     res = topica.standard_errors(m, corpus, of="top_words", method="bootstrap",
-                                 n_boot=30, topn=5, iterations=150, seed=0)
+                                 n_boot=30, topn=5, iters=150, seed=0)
     assert len(res) == 2
     for r in res:
         assert r.reliable
@@ -206,7 +206,7 @@ def test_alignment_margin_flags_indistinct_topics():
     # margin diagnostic must catch this and suppress the SE.
     m, corpus, _ = _planted()
     res = topica.standard_errors(m, corpus, of="prevalence", method="bootstrap",
-                                 n_boot=20, topn=20, iterations=150, seed=0)
+                                 n_boot=20, topn=20, iters=150, seed=0)
     for r in res:
         assert r.alignment_margin < 0.1
         assert not r.reliable
@@ -221,7 +221,7 @@ def test_bootstrap_via_refit_hook():
 
     def refit(picks):
         mm = topica.LDA(2, seed=int(picks[0]) + 1)
-        mm.fit([docs[i] for i in picks], iterations=150)
+        mm.fit([docs[i] for i in picks], iters=150)
         return mm
 
     res = topica.standard_errors(m, corpus, of="prevalence", method="bootstrap",

--- a/tests/test_stm.py
+++ b/tests/test_stm.py
@@ -52,7 +52,7 @@ def synthetic_model_and_x():
     rng = np.random.default_rng(0)
     docs, x = _make_synthetic_corpus(rng, n_per_class=80)
     model = LDA(num_topics=2, seed=1)
-    model.fit(docs, iterations=300, num_samples=3, sample_interval=10)
+    model.fit(docs, iters=300, num_samples=3, sample_interval=10)
     return model, x
 
 
@@ -461,7 +461,7 @@ class TestSearchK:
         results = stm.search_k(
             docs,
             ks=[2, 3],
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
             seed=42,
@@ -506,7 +506,7 @@ class TestSearchK:
             docs,
             ks=[2],
             held_out=held,
-            iterations=100,
+            iters=100,
             num_samples=2,
             sample_interval=5,
             seed=42,

--- a/tests/test_stm_content.py
+++ b/tests/test_stm_content.py
@@ -77,10 +77,10 @@ def _make_bilingual_corpus(n_per_cell: int = 50, seed: int = 42):
 
 @pytest.fixture(scope="module")
 def bilingual_content_model():
-    """STM(2, seed=1) fitted content-only on the bilingual corpus (em_iters=60)."""
+    """STM(2, seed=1) fitted content-only on the bilingual corpus (iters=60)."""
     docs, groups = _make_bilingual_corpus(n_per_cell=50, seed=42)
     m = STM(num_topics=2, seed=1)
-    m.fit(docs, content=groups, em_iters=60)
+    m.fit(docs, content=groups, iters=60)
     return m
 
 
@@ -331,7 +331,7 @@ class TestSTMCombinedPrevalenceContent:
         x = np.array([1.0] * 100 + [0.0] * 100, dtype=np.float64).reshape(-1, 1)
 
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x, prevalence_names=["x"], content=groups, em_iters=60)
+        m.fit(docs, x, prevalence_names=["x"], content=groups, iters=60)
         return m, x
 
     def test_topic_word_by_group_shape(self, combined_model_and_x):
@@ -381,14 +381,14 @@ class TestSTMContentIntegerGroups:
         docs   = [["cat", "dog"]] * 10 + [["bird", "fish"]] * 10
         groups = [0] * 10 + [1] * 10
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, content=groups, em_iters=10)
+        m.fit(docs, content=groups, iters=10)
         assert m.groups == ["0", "1"]
 
     def test_int_groups_fit_succeeds(self):
         docs   = [["cat", "dog"]] * 10 + [["bird", "fish"]] * 10
         groups = [0] * 10 + [1] * 10
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, content=groups, em_iters=10)
+        m.fit(docs, content=groups, iters=10)
         assert m.topic_word_by_group.shape == (2, 2, 4)
 
 
@@ -402,7 +402,7 @@ class TestSTMContentNames:
         docs   = [["cat", "dog"]] * 10 + [["bird", "fish"]] * 10
         groups = ["en"] * 10 + ["de"] * 10
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, content=groups, content_names=["en", "de"], em_iters=10)
+        m.fit(docs, content=groups, content_names=["en", "de"], iters=10)
         assert m.groups == ["en", "de"]
 
     def test_content_names_de_en_fixes_order(self):
@@ -410,7 +410,7 @@ class TestSTMContentNames:
         docs   = [["cat", "dog"]] * 10 + [["bird", "fish"]] * 10
         groups = ["en"] * 10 + ["de"] * 10
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, content=groups, content_names=["de", "en"], em_iters=10)
+        m.fit(docs, content=groups, content_names=["de", "en"], iters=10)
         assert m.groups == ["de", "en"]
 
     def test_default_order_is_sorted(self):
@@ -418,7 +418,7 @@ class TestSTMContentNames:
         docs   = [["cat", "dog"]] * 10 + [["bird", "fish"]] * 10
         groups = ["en"] * 10 + ["de"] * 10
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, content=groups, em_iters=10)
+        m.fit(docs, content=groups, iters=10)
         assert m.groups == ["de", "en"]   # sorted
 
 
@@ -436,27 +436,27 @@ class TestSTMContentValidation:
     def test_neither_prevalence_nor_content_raises_value_error(self):
         m = STM(num_topics=2, seed=1)
         with pytest.raises(ValueError, match="STM needs prevalence and/or content"):
-            m.fit(self.docs, em_iters=5)
+            m.fit(self.docs, iters=5)
 
     def test_content_length_mismatch_raises_value_error(self):
         m = STM(num_topics=2, seed=1)
         with pytest.raises(ValueError):
-            m.fit(self.docs, content=self.groups[:-1], em_iters=5)  # 19 groups, 20 docs
+            m.fit(self.docs, content=self.groups[:-1], iters=5)  # 19 groups, 20 docs
 
     def test_group_not_in_content_names_raises_value_error(self):
         m = STM(num_topics=2, seed=1)
         with pytest.raises(ValueError):
-            m.fit(self.docs, content=self.groups, content_names=["x", "y"], em_iters=5)
+            m.fit(self.docs, content=self.groups, content_names=["x", "y"], iters=5)
 
     def test_word_contrast_bad_topic_raises_value_error(self):
         m = STM(num_topics=2, seed=1)
-        m.fit(self.docs, content=self.groups, em_iters=10)
+        m.fit(self.docs, content=self.groups, iters=10)
         with pytest.raises(ValueError):
             m.word_contrast(99, "a", "b")
 
     def test_word_contrast_unknown_group_raises_value_error(self):
         m = STM(num_topics=2, seed=1)
-        m.fit(self.docs, content=self.groups, em_iters=10)
+        m.fit(self.docs, content=self.groups, iters=10)
         with pytest.raises(ValueError):
             m.word_contrast(0, "z", "a")
 
@@ -469,9 +469,9 @@ class TestSTMContentDeterminism:
     def test_same_seed_identical_topic_word_by_group(self):
         docs, groups = _make_bilingual_corpus(n_per_cell=20, seed=7)
         m1 = STM(num_topics=2, seed=42)
-        m1.fit(docs, content=groups, em_iters=20)
+        m1.fit(docs, content=groups, iters=20)
         m2 = STM(num_topics=2, seed=42)
-        m2.fit(docs, content=groups, em_iters=20)
+        m2.fit(docs, content=groups, iters=20)
         assert np.array_equal(m1.topic_word_by_group, m2.topic_word_by_group), (
             "Same seed must produce identical topic_word_by_group"
         )
@@ -479,9 +479,9 @@ class TestSTMContentDeterminism:
     def test_same_seed_identical_doc_topic(self):
         docs, groups = _make_bilingual_corpus(n_per_cell=20, seed=7)
         m1 = STM(num_topics=2, seed=42)
-        m1.fit(docs, content=groups, em_iters=20)
+        m1.fit(docs, content=groups, iters=20)
         m2 = STM(num_topics=2, seed=42)
-        m2.fit(docs, content=groups, em_iters=20)
+        m2.fit(docs, content=groups, iters=20)
         assert np.array_equal(m1.doc_topic, m2.doc_topic), (
             "Same seed must produce identical doc_topic"
         )

--- a/tests/test_stm_model.py
+++ b/tests/test_stm_model.py
@@ -64,10 +64,10 @@ def stm_corpus_and_x():
 
 @pytest.fixture(scope="module")
 def fitted_stm(stm_corpus_and_x):
-    """STM(num_topics=2, seed=1) fitted on the synthetic corpus (em_iters=60)."""
+    """STM(num_topics=2, seed=1) fitted on the synthetic corpus (iters=60)."""
     docs, x_2d = stm_corpus_and_x
     model = STM(num_topics=2, seed=1)
-    model.fit(docs, x_2d, prevalence_names=["x"], em_iters=60)
+    model.fit(docs, x_2d, prevalence_names=["x"], iters=60)
     return model
 
 
@@ -306,9 +306,9 @@ class TestSTMDeterminism:
     def test_same_seed_identical_topic_word(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m1 = STM(2, seed=42)
-        m1.fit(docs, x_2d, prevalence_names=["x"], em_iters=20)
+        m1.fit(docs, x_2d, prevalence_names=["x"], iters=20)
         m2 = STM(2, seed=42)
-        m2.fit(docs, x_2d, prevalence_names=["x"], em_iters=20)
+        m2.fit(docs, x_2d, prevalence_names=["x"], iters=20)
         assert np.array_equal(m1.topic_word, m2.topic_word), (
             "Same seed must produce identical topic_word"
         )
@@ -316,9 +316,9 @@ class TestSTMDeterminism:
     def test_same_seed_identical_doc_topic(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m1 = STM(2, seed=42)
-        m1.fit(docs, x_2d, prevalence_names=["x"], em_iters=20)
+        m1.fit(docs, x_2d, prevalence_names=["x"], iters=20)
         m2 = STM(2, seed=42)
-        m2.fit(docs, x_2d, prevalence_names=["x"], em_iters=20)
+        m2.fit(docs, x_2d, prevalence_names=["x"], iters=20)
         assert np.array_equal(m1.doc_topic, m2.doc_topic), (
             "Same seed must produce identical doc_topic"
         )
@@ -326,9 +326,9 @@ class TestSTMDeterminism:
     def test_same_seed_identical_prevalence_effects(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m1 = STM(2, seed=42)
-        m1.fit(docs, x_2d, prevalence_names=["x"], em_iters=20)
+        m1.fit(docs, x_2d, prevalence_names=["x"], iters=20)
         m2 = STM(2, seed=42)
-        m2.fit(docs, x_2d, prevalence_names=["x"], em_iters=20)
+        m2.fit(docs, x_2d, prevalence_names=["x"], iters=20)
         assert np.array_equal(m1.prevalence_effects, m2.prevalence_effects), (
             "Same seed must produce identical prevalence_effects"
         )
@@ -342,14 +342,14 @@ class TestSTMInputTypes:
     def test_numpy_array_input_accepted(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m = STM(2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], em_iters=10)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=10)
         assert m.doc_topic.shape == (250, 2)
 
     def test_list_of_float_lists_accepted(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         x_list = x_2d.tolist()  # list of [float]
         m = STM(2, seed=1)
-        m.fit(docs, x_list, prevalence_names=["x"], em_iters=10)
+        m.fit(docs, x_list, prevalence_names=["x"], iters=10)
         assert m.doc_topic.shape == (250, 2)
 
     def test_numpy_and_list_give_identical_topic_word(self, stm_corpus_and_x):
@@ -357,9 +357,9 @@ class TestSTMInputTypes:
         docs, x_2d = stm_corpus_and_x
         x_list = x_2d.tolist()
         m1 = STM(2, seed=5)
-        m1.fit(docs, x_2d, prevalence_names=["x"], em_iters=15)
+        m1.fit(docs, x_2d, prevalence_names=["x"], iters=15)
         m2 = STM(2, seed=5)
-        m2.fit(docs, x_list, prevalence_names=["x"], em_iters=15)
+        m2.fit(docs, x_list, prevalence_names=["x"], iters=15)
         assert np.array_equal(m1.topic_word, m2.topic_word), (
             "numpy array and list[list[float]] input must produce identical topic_word"
         )
@@ -368,7 +368,7 @@ class TestSTMInputTypes:
         docs, x_2d = stm_corpus_and_x
         corpus = Corpus.from_documents(docs)
         m = STM(2, seed=1)
-        m.fit(corpus, x_2d, prevalence_names=["x"], em_iters=10)
+        m.fit(corpus, x_2d, prevalence_names=["x"], iters=10)
         assert m.doc_topic.shape == (250, 2)
 
     def test_corpus_and_list_give_identical_topic_word(self, stm_corpus_and_x):
@@ -376,9 +376,9 @@ class TestSTMInputTypes:
         docs, x_2d = stm_corpus_and_x
         corpus = Corpus.from_documents(docs)
         m1 = STM(2, seed=7)
-        m1.fit(corpus, x_2d, prevalence_names=["x"], em_iters=15)
+        m1.fit(corpus, x_2d, prevalence_names=["x"], iters=15)
         m2 = STM(2, seed=7)
-        m2.fit(docs, x_2d, prevalence_names=["x"], em_iters=15)
+        m2.fit(docs, x_2d, prevalence_names=["x"], iters=15)
         assert np.array_equal(m1.topic_word, m2.topic_word)
 
 
@@ -395,7 +395,7 @@ class TestSTMMultipleCovariates:
         ctrl = rng.standard_normal((250, 1))
         x2 = np.hstack([x_2d, ctrl])
         m = STM(2, seed=1)
-        m.fit(docs, x2, em_iters=30)
+        m.fit(docs, x2, iters=30)
         return m
 
     def test_prevalence_effects_shape_two_covariates(self, multi_cov_model):
@@ -411,7 +411,7 @@ class TestSTMMultipleCovariates:
         ctrl = rng.standard_normal((250, 1))
         x2 = np.hstack([x_2d, ctrl])
         m = STM(2, seed=1)
-        m.fit(docs, x2, prevalence_names=["treatment", "control"], em_iters=30)
+        m.fit(docs, x2, prevalence_names=["treatment", "control"], iters=30)
         assert m.feature_names == ["intercept", "treatment", "control"]
 
     def test_prevalence_effects_shape_with_names(self, stm_corpus_and_x):
@@ -420,7 +420,7 @@ class TestSTMMultipleCovariates:
         ctrl = rng.standard_normal((250, 1))
         x2 = np.hstack([x_2d, ctrl])
         m = STM(2, seed=1)
-        m.fit(docs, x2, prevalence_names=["x", "ctrl"], em_iters=30)
+        m.fit(docs, x2, prevalence_names=["x", "ctrl"], iters=30)
         assert m.prevalence_effects.shape == (3, 1)
 
 
@@ -434,20 +434,20 @@ class TestSTMFitValidation:
         bad_x = x_2d[:-5]  # 245 rows, corpus has 250
         m = STM(2, seed=1)
         with pytest.raises(ValueError):
-            m.fit(docs, bad_x, em_iters=5)
+            m.fit(docs, bad_x, iters=5)
 
     def test_ragged_prevalence_rows_raises(self, stm_corpus_and_x):
         docs, _ = stm_corpus_and_x
         ragged = [[1.0, 2.0]] * 100 + [[1.0]] * 150
         m = STM(2, seed=1)
         with pytest.raises(ValueError):
-            m.fit(docs, ragged, em_iters=5)
+            m.fit(docs, ragged, iters=5)
 
     def test_prevalence_names_length_mismatch_raises(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m = STM(2, seed=1)
         with pytest.raises(ValueError):
-            m.fit(docs, x_2d, prevalence_names=["x", "wrong_extra"], em_iters=5)
+            m.fit(docs, x_2d, prevalence_names=["x", "wrong_extra"], iters=5)
 
 
 # ---------------------------------------------------------------------------
@@ -523,7 +523,7 @@ class TestSTMConvergence:
     def test_bound_history_monotone_increasing(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], em_iters=200, em_tol=1e-6)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=200, em_tol=1e-6)
         h = m.bound_history
         assert len(h) >= 2
         assert all(h[i + 1] >= h[i] - 1e-6 for i in range(len(h) - 1))
@@ -533,21 +533,21 @@ class TestSTMConvergence:
     def test_converges_before_cap(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], em_iters=500, em_tol=1e-5)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=500, em_tol=1e-5)
         assert m.converged is True
         assert len(m.bound_history) < 500
 
     def test_em_tol_zero_runs_full_cap(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], em_iters=15, em_tol=0.0)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=15, em_tol=0.0)
         assert m.converged is False
         assert len(m.bound_history) == 15
 
     def test_convergence_state_survives_save_load(self, stm_corpus_and_x, tmp_path):
         docs, x_2d = stm_corpus_and_x
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], em_iters=500, em_tol=1e-5)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=500, em_tol=1e-5)
         path = str(tmp_path / "stm.bin")
         m.save(path)
         reloaded = STM.load(path)

--- a/tests/test_theta_draws.py
+++ b/tests/test_theta_draws.py
@@ -24,7 +24,7 @@ def _toy_docs(n=40, vocab=12, lo=8, hi=15, seed=0):
 def _fit_each(docs, *, keep=True, num_draws=25):
     out = {}
     m = topica.LDA(num_topics=4, seed=1)
-    m.fit(docs, iterations=120, keep_theta_draws=keep, num_theta_draws=num_draws)
+    m.fit(docs, iters=120, keep_theta_draws=keep, num_theta_draws=num_draws)
     out["LDA"] = m
     m = topica.SeededLDA({"a": ["w0", "w1"], "b": ["w5", "w6"]}, residual=2, seed=1)
     m.fit(docs, iters=120, keep_theta_draws=keep, num_theta_draws=num_draws)
@@ -93,7 +93,7 @@ def test_real_draws_capture_cross_sweep_variance():
     vocab = [f"w{i}" for i in range(24)]
     docs = [list(rng.choice(vocab, size=int(rng.integers(160, 240)))) for _ in range(40)]
     m = topica.LDA(num_topics=4, seed=2)
-    m.fit(docs, iterations=300, num_theta_draws=40)
+    m.fit(docs, iters=300, num_theta_draws=40)
 
     real = np.asarray(m.theta_draws, dtype=float)
     lengths = np.array([len(d) for d in docs], dtype=float)
@@ -116,7 +116,7 @@ def test_real_draws_reflect_identifiability():
         block = a if rng.random() < 0.5 else b
         docs.append(list(rng.choice(block, size=40)))
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=250, num_theta_draws=40)
+    m.fit(docs, iters=250, num_theta_draws=40)
 
     real = np.asarray(m.theta_draws, dtype=float)
     lengths = np.array([len(d) for d in docs], dtype=float)
@@ -129,7 +129,7 @@ def test_real_draws_reflect_identifiability():
 def test_num_theta_draws_bounds_count():
     docs = _toy_docs()
     m = topica.LDA(num_topics=3, seed=1)
-    m.fit(docs, iterations=200, num_theta_draws=10)
+    m.fit(docs, iters=200, num_theta_draws=10)
     assert np.asarray(m.theta_draws).shape[0] == 10
 
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -52,14 +52,14 @@ class TestVariationalTransform:
     def test_ctm(self):
         docs, _ = _two_topic_corpus()
         m = topica.CTM(num_topics=2, seed=1)
-        m.fit(docs, em_iters=60)
+        m.fit(docs, iters=60)
         _check_basic(m.transform(NEW))
 
     def test_ctm_reproduces_training_theta(self):
         # The held-out E-step on the training docs matches the stored θ.
         docs, _ = _two_topic_corpus()
         m = topica.CTM(num_topics=2, seed=1)
-        m.fit(docs, em_iters=60)
+        m.fit(docs, iters=60)
         np.testing.assert_allclose(m.transform(docs), m.doc_topic, atol=1e-3)
 
     def test_stm_prevalence(self):
@@ -72,7 +72,7 @@ class TestVariationalTransform:
     def test_save_load_parity(self, tmp_path):
         docs, _ = _two_topic_corpus()
         m = topica.CTM(num_topics=2, seed=1)
-        m.fit(docs, em_iters=40)
+        m.fit(docs, iters=40)
         p = str(tmp_path / "ctm.tt")
         m.save(p)
         loaded = topica.CTM.load(p)
@@ -83,7 +83,7 @@ class TestGibbsTransform:
     def test_lda(self):
         docs, _ = _two_topic_corpus()
         m = topica.LDA(num_topics=2, seed=1)
-        m.fit(docs, iterations=300)
+        m.fit(docs, iters=300)
         _check_basic(m.transform(NEW))
 
     def test_hdp(self):
@@ -142,7 +142,7 @@ class TestGibbsTransform:
 def test_transform_accepts_corpus_object():
     docs, _ = _two_topic_corpus()
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=200)
+    m.fit(docs, iters=200)
     corpus = topica.Corpus.from_documents(NEW)
     theta = m.transform(corpus)
     assert theta.shape[0] == len(NEW)
@@ -151,5 +151,5 @@ def test_transform_accepts_corpus_object():
 def test_transform_deterministic():
     docs, _ = _two_topic_corpus()
     m = topica.LDA(num_topics=2, seed=1)
-    m.fit(docs, iterations=200)
+    m.fit(docs, iters=200)
     np.testing.assert_array_equal(m.transform(NEW, seed=7), m.transform(NEW, seed=7))

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -25,7 +25,7 @@ def _two_topic_model(seed=1, n=80):
         docs.append([v[int(rng.integers(len(v)))] for _ in range(10)])
         is_a.append(a)
     m = topica.LDA(num_topics=2, seed=seed)
-    m.fit(docs, iterations=400)
+    m.fit(docs, iters=400)
     return m, docs, np.array(is_a)
 
 

--- a/tests/test_vignette.py
+++ b/tests/test_vignette.py
@@ -49,7 +49,7 @@ def test_vignette_recovers_treatment_effect():
     assert len(docs) > 300  # gadarian is 341 responses, a couple drop out
 
     model = STM(num_topics=3, seed=1)
-    model.fit(docs, X, prevalence_names=["treatment", "pid_rep"], em_iters=80)
+    model.fit(docs, X, prevalence_names=["treatment", "pid_rep"], iters=80)
 
     # Outputs are well-formed.
     assert model.topic_word.shape == (3, len(model.vocabulary))
@@ -66,5 +66,5 @@ def test_vignette_recovers_treatment_effect():
 
     # Determinism.
     m2 = STM(num_topics=3, seed=1)
-    m2.fit(docs, X, prevalence_names=["treatment", "pid_rep"], em_iters=80)
+    m2.fit(docs, X, prevalence_names=["treatment", "pid_rep"], iters=80)
     assert np.array_equal(model.topic_word, m2.topic_word)

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -34,7 +34,7 @@ def covariate_lda():
         docs.append(list(rng.choice(block, size=12)))
     corpus = topica.Corpus.from_documents(docs)
     m = topica.LDA(2, seed=1)
-    m.fit(corpus, iterations=300)
+    m.fit(corpus, iters=300)
     return m, corpus, x, [" ".join(d) for d in docs]
 
 
@@ -76,7 +76,7 @@ def test_every_panel_frames_and_renders(covariate_lda):
     panels = [
         viz.coherence_frontier(m, texts),
         viz.search_k(topica.search_k(
-            [t.split() for t in texts], [2, 3], iterations=80, num_samples=1)),
+            [t.split() for t in texts], [2, 3], iters=80, num_samples=1)),
         viz.effect_plot(m, corpus, X=x[:, None], feature_names=["x"], nsims=15),
         viz.term_barchart(m, topic=0, mode="frex", n=6),
         viz.topic_similarity(m),
@@ -163,7 +163,7 @@ def lda_k4():
         group.append(["north", "south"][g % 2])
         year.append(2000 + int(rng.integers(0, 3)))
     m = topica.LDA(4, seed=1)
-    m.fit(docs, iterations=300)
+    m.fit(docs, iters=300)
     return m, group, year, docs
 
 
@@ -226,7 +226,7 @@ def test_topic_correlation_eta_uses_model_sigma():
         base = ["a", "a", "b", "c"] if rng.random() < 0.5 else ["x", "y", "y", "z"]
         docs.append(list(rng.choice(base, size=10)))
     m = topica.CTM(3, seed=1)
-    m.fit(docs, em_iters=15)
+    m.fit(docs, iters=15)
     cov = m.topic_covariance
     assert cov.shape == (2, 2)                      # K-1, reference dropped
     cc = viz.topic_correlation(m, method="eta")
@@ -347,7 +347,7 @@ def sage_content():
         docs.append(list(rng.choice(base, size=8)))
         groups.append(["north", "south"][g])
     m = topica.SAGE(2, seed=1)
-    m.fit(docs, groups, iterations=300, num_samples=2)
+    m.fit(docs, groups, iters=300, num_samples=2)
     return m, [" ".join(d) for d in docs]
 
 
@@ -394,7 +394,7 @@ def test_interactive_browser():
     rng = np.random.default_rng(0)
     docs = [["a", "b", "c"]] * 15 + [["x", "y", "z"]] * 15
     m = topica.LDA(2, seed=1)
-    m.fit(docs, iterations=100)
+    m.fit(docs, iters=100)
     fig = viz.term_topic_browser(m, n=5)
     html = fig.to_html(full_html=False)
     assert "plotly" in html.lower()

--- a/tests/test_vocab_filter.py
+++ b/tests/test_vocab_filter.py
@@ -45,7 +45,7 @@ class TestSummary:
     def test_summary_has_topics_and_words(self):
         docs = [["cat", "dog", "pet"]] * 20 + [["star", "moon", "sky"]] * 20
         m = topica.LDA(num_topics=2, seed=1)
-        m.fit(docs, iterations=200)
+        m.fit(docs, iters=200)
         s = topica.summary(m, topn=3)
         assert "num_topics: 2" in s
         assert "vocab_size: 6" in s
@@ -54,7 +54,7 @@ class TestSummary:
     def test_summary_graceful_for_dtm(self):
         docs = [["cat", "dog", "pet"]] * 20 + [["star", "moon", "sky"]] * 20
         m = topica.DTM(num_topics=2, seed=1)
-        m.fit(docs, [0] * 20 + [1] * 20, em_iters=5)
+        m.fit(docs, [0] * 20 + [1] * 20, iters=5)
         s = topica.summary(m)  # DTM.top_words needs (topic, time) -> per-topic omitted
         assert "num_times: 2" in s
         assert isinstance(s, str)


### PR DESCRIPTION
Phase 2 of the estimator-conformance program. Standardizes the fit-time iteration-count keyword to the canonical **`iters`** across the sampler/EM estimators. Intentional breaking rename, no aliases (sole user).

## Renamed (fit kwarg → `iters`)
- `iterations` → `iters`: LDA, DMR, SAGE, LabeledLDA
- `em_iters` → `iters`: STM, CTM, DTM, SupervisedLDA (its separate `var_iters` is preserved)

HDP/PA/PT/GSDMM/HLDA/KeyATM/SeededLDA already used `iters`. So **every sampler/EM estimator now takes `iters` in fit**.

## Out of scope (untouched)
- Neural three (ETM/ProdLDA/FASTopic): their training length is a constructor arg (`epochs`/`em_iters`), a constructor→fit redesign deferred to a later phase. Their conformance `iters` gaps remain xfail.
- Non-`fit` methods (held-out/evaluate scorers) that take their own `iterations` — left as is; only `fit` is in the contract.

## Also
- `search_k` unified from `iterations=`/`em_iters=` to a single `iters=`.
- `conformance.py`: the 8 now-closed `iters` gaps removed from `KNOWN_GAPS` (the parametrized test + `test_no_unexpected_gaps` enforce that exactly the closed ones are removed).
- ~77 files of call sites updated (tests, docs, examples, paper, parity, benchmarks, README, AGENTS.md). Surgical: only `fit`/`search_k` calls, never other methods' `iterations`.

## Validation
- `cargo test --lib`: 49 passed. Rebuilt with `maturin develop --release`.
- Full suite: 1417 passed, 12 skipped, 47 xfailed (was 55; the 8 closed gaps). Zero failures.
- `tests/test_conformance.py`: the 8 `iters` cells now pass; neural three stay xfail.
- `mkdocs build --strict`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)