### PR TITLE
feat: theta_draws + doc_lengths on the rest of the Dirichlet family (conformance phase 5)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -193,6 +193,8 @@ class DMR:
         sample_interval: int = 25,
         progress: object | None = None,
         progress_interval: int = 50,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
     ) -> None:
         """Fit by collapsed Gibbs with the per-document Dirichlet prior
         alpha_{d,t} = exp(lambda_t . x_d). `features` is required: an (num_docs, F)
@@ -216,6 +218,17 @@ class DMR:
     def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
         """The baseline document-topic Dirichlet prior alpha, shape (num_topics,):
         exp(lambda_intercept), the per-topic prior at covariates = 0."""
+        ...
+
+    @property
+    def theta_draws(self) -> numpy.typing.NDArray[numpy.float32] | None:
+        """Thinned MCMC theta draws, shape (num_draws, num_docs, num_topics), float32,
+        or None when keep_theta_draws=False."""
+        ...
+
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Number of tokens in each training document."""
         ...
 
     @property
@@ -524,6 +537,8 @@ class HDP:
         *,
         iters: int = 150,
         report_interval: int = 0,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
     ) -> None:
         """Fit by `iters` Gibbs sweeps. The inferred K is then `num_topics`.
 
@@ -554,6 +569,16 @@ class HDP:
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]:
         """Document-topic matrix, shape (num_docs, num_topics); rows sum to 1."""
+        ...
+    @property
+    def theta_draws(self) -> numpy.typing.NDArray[numpy.float32] | None:
+        """Theta draws sampled from Dirichlet(njk[d]+alpha*beta[k]) after the chain
+        ends, shape (num_draws, num_docs, num_topics), or None when
+        keep_theta_draws=False."""
+        ...
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Number of tokens in each training document."""
         ...
     @property
     def num_topics(self) -> int:
@@ -692,6 +717,8 @@ class SupervisedLDA:
         *,
         iters: int = 25,
         var_iters: int = 15,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
     ) -> None:
         """Fit by variational EM. `y` is the per-document response (length =
         number of documents)."""
@@ -711,6 +738,15 @@ class SupervisedLDA:
     @property
     def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
         """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,)."""
+        ...
+    @property
+    def theta_draws(self) -> numpy.typing.NDArray[numpy.float32] | None:
+        """Theta draws sampled from Dirichlet(gamma_d) at fit end, shape
+        (num_draws, num_docs, num_topics), or None when keep_theta_draws=False."""
+        ...
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Number of tokens in each training document."""
         ...
     @property
     def coefficients(self) -> numpy.typing.NDArray[numpy.float64]:
@@ -786,6 +822,8 @@ class SAGE:
         sample_interval: int = 25,
         progress: Optional[object] = None,
         progress_interval: int = 50,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
     ) -> None:
         """Fit. groups is one group label per document (strings or ints);
         group_names fixes group order (default: sorted union)."""
@@ -811,6 +849,17 @@ class SAGE:
         """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,).
         SAGE's sparse additive parameterization is on the word side; the document
         side is an ordinary Dirichlet."""
+        ...
+
+    @property
+    def theta_draws(self) -> numpy.typing.NDArray[numpy.float32] | None:
+        """Thinned MCMC theta draws, shape (num_draws, num_docs, num_topics), float32,
+        or None when keep_theta_draws=False."""
+        ...
+
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Number of tokens in each training document."""
         ...
 
     @property
@@ -868,6 +917,8 @@ class LabeledLDA:
         sample_interval: int = 25,
         progress: Optional[object] = None,
         progress_interval: int = 50,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
     ) -> None:
         """Fit the model. labels is one label-list per document; the topic set is
         the union of all labels (or label_names, which fixes topic order). An
@@ -888,6 +939,17 @@ class LabeledLDA:
     @property
     def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
         """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,)."""
+        ...
+
+    @property
+    def theta_draws(self) -> numpy.typing.NDArray[numpy.float32] | None:
+        """Thinned MCMC theta draws, shape (num_draws, num_docs, num_topics), float32,
+        or None when keep_theta_draws=False."""
+        ...
+
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Number of tokens in each training document."""
         ...
 
     @property
@@ -1191,7 +1253,14 @@ class PT:
         beta: float = 0.01,
         seed: int = 42,
     ) -> None: ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 1000) -> None: ...
+    def fit(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iters: int = 1000,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
+    ) -> None: ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
@@ -1199,6 +1268,15 @@ class PT:
     @property
     def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
         """The symmetric document-topic Dirichlet prior alpha, shape (num_topics,)."""
+        ...
+    @property
+    def theta_draws(self) -> numpy.typing.NDArray[numpy.float32] | None:
+        """Thinned MCMC theta draws, shape (num_draws, num_docs, num_topics), float32,
+        or None when keep_theta_draws=False."""
+        ...
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Number of tokens in each training document."""
         ...
     @property
     def num_topics(self) -> int: ...
@@ -1298,7 +1376,14 @@ class PA:
         beta: float = 0.01,
         seed: int = 42,
     ) -> None: ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 1000) -> None: ...
+    def fit(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iters: int = 1000,
+        keep_theta_draws: bool = True,
+        num_theta_draws: int = 25,
+    ) -> None: ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]:
         """Sub-topic word matrix, shape (num_sub, num_words); rows sum to 1."""
@@ -1310,6 +1395,15 @@ class PA:
     @property
     def alpha(self) -> numpy.typing.NDArray[numpy.float64]:
         """The symmetric sub-topic Dirichlet prior alpha, shape (num_sub,)."""
+        ...
+    @property
+    def theta_draws(self) -> numpy.typing.NDArray[numpy.float32] | None:
+        """Thinned MCMC theta draws (sub-topic proportions), shape
+        (num_draws, num_docs, num_sub), or None when keep_theta_draws=False."""
+        ...
+    @property
+    def doc_lengths(self) -> list[int]:
+        """Number of tokens in each training document."""
         ...
     @property
     def super_sub(self) -> numpy.typing.NDArray[numpy.float64]:

--- a/python/topica/conformance.py
+++ b/python/topica/conformance.py
@@ -203,21 +203,6 @@ KNOWN_GAPS: dict[tuple[str, str], str] = {
     ("PA",           "transform"): "phase 6: add transform (sub-topic held-out inference)",
     ("PT",           "transform"): "phase 6: add transform (pseudo-topic held-out inference)",
 
-    # --- Phase 5: add theta_draws + doc_lengths to remaining Gibbs models ---
-    ("DMR",          "theta_draws"):    "phase 5: add theta_draws to DMR (retained MCMC draws)",
-    ("DMR",          "doc_lengths"):    "phase 5: add doc_lengths to DMR",
-    ("SAGE",         "theta_draws"):    "phase 5: add theta_draws to SAGE",
-    ("SAGE",         "doc_lengths"):    "phase 5: add doc_lengths to SAGE",
-    ("PA",           "theta_draws"):    "phase 5: add theta_draws to PA",
-    ("PA",           "doc_lengths"):    "phase 5: add doc_lengths to PA",
-    ("PT",           "theta_draws"):    "phase 5: add theta_draws to PT",
-    ("PT",           "doc_lengths"):    "phase 5: add doc_lengths to PT",
-    ("HDP",          "theta_draws"):    "phase 5: add theta_draws to HDP",
-    ("HDP",          "doc_lengths"):    "phase 5: add doc_lengths to HDP",
-    ("LabeledLDA",   "theta_draws"):    "phase 5: add theta_draws to LabeledLDA",
-    ("LabeledLDA",   "doc_lengths"):    "phase 5: add doc_lengths to LabeledLDA",
-    ("SupervisedLDA","theta_draws"):    "phase 5: add theta_draws to SupervisedLDA",
-    ("SupervisedLDA","doc_lengths"):    "phase 5: add doc_lengths to SupervisedLDA",
 }
 
 # ---------------------------------------------------------------------------

--- a/src/hdp.rs
+++ b/src/hdp.rs
@@ -123,7 +123,7 @@ fn sample_normal<R: Rng>(rng: &mut R) -> f64 {
 }
 
 /// Gamma(shape, 1) variate (Marsaglia & Tsang; boosted for shape < 1).
-fn sample_gamma<R: Rng>(shape: f64, rng: &mut R) -> f64 {
+pub fn sample_gamma<R: Rng>(shape: f64, rng: &mut R) -> f64 {
     if shape < 1.0 {
         let g = sample_gamma(shape + 1.0, rng);
         let u: f64 = rng.gen::<f64>().max(1e-300);

--- a/src/pa.rs
+++ b/src/pa.rs
@@ -260,71 +260,13 @@ pub fn fit_pam<R: Rng>(
     iters: usize,
     rng: &mut R,
 ) -> PamModel {
-    let d = docs.len();
-    // Break the super-topic label symmetry with a structured prior: super-topic
-    // `s` is seeded to mildly prefer the contiguous slice of sub-topics around
-    // `s·K/S`. This only biases *which super-topic owns which sub-topic slots* —
-    // the sub-topic ↔ vocabulary mapping is still learned from the data, and the
-    // asymmetric-α re-estimate is free to move the preference. Without some such
-    // break the two super-topics are a priori exchangeable and never specialize.
-    let alpha_sk: Vec<Vec<f64>> = (0..num_super)
-        .map(|s| {
-            (0..num_sub)
-                .map(|k| {
-                    let owner = (k * num_super) / num_sub; // which super-topic "owns" sub k
-                    if owner == s { alpha * 5.0 } else { alpha }
-                })
-                .collect()
-        })
-        .collect();
-    let mut model = PamModel {
-        num_types,
-        num_super,
-        num_sub,
-        alpha,
-        beta,
-        alpha_sk,
-        nkw: vec![vec![0u32; num_types]; num_sub],
-        nk: vec![0u32; num_sub],
-        nds: vec![vec![0u32; num_super]; d],
-        ndsk: vec![vec![vec![0u32; num_sub]; num_super]; d],
-        zs: docs.iter().map(|doc| vec![0usize; doc.len()]).collect(),
-        zk: docs.iter().map(|doc| vec![0usize; doc.len()]).collect(),
-        theta_draws: Vec::new(),
-    };
-
-    // Initialization. Each *document* is assigned a single random super-topic for
-    // all of its tokens (committed-document init), while sub-topics are random per
-    // token. Committing a document to one super-topic at the start gives the
-    // super-topic layer something to specialize on; the Gibbs sweeps and the
-    // asymmetric-α estimate then sort out which super-topic owns which sub-topics.
-    for (di, doc) in docs.iter().enumerate() {
-        let s = (rng.gen::<f64>() * num_super as f64) as usize % num_super;
-        for (i, &w) in doc.iter().enumerate() {
-            let w = w as usize;
-            let sub = (rng.gen::<f64>() * num_sub as f64) as usize % num_sub;
-            model.nds[di][s] += 1;
-            model.ndsk[di][s][sub] += 1;
-            model.nkw[sub][w] += 1;
-            model.nk[sub] += 1;
-            model.zs[di][i] = s;
-            model.zk[di][i] = sub;
-        }
-    }
-
-    // Burn in with the structured prior fixed so the super-topics lock onto a
-    // stable, consistent labeling first; only then start sharpening each α_s
-    // toward the grouping the data has settled into (running the adaptive update
-    // from iteration 0 would merely reinforce the random initial labeling).
-    let adapt_after = iters - iters / 4;
-    for it in 0..iters {
-        model.sweep(docs, rng);
-        if it >= adapt_after {
-            model.estimate_alpha_sk();
-        }
-    }
-
-    model
+    // Plain fit is the draw-collecting fit with collection disabled, so the
+    // sampler lives in exactly one place (see `fit_pam_with_draws`).
+    fit_pam_with_draws(
+        docs, num_types, num_super, num_sub, alpha, beta, iters,
+        crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
+        rng,
+    )
 }
 
 /// Fit a PAM with thinned θ snapshots (sub-topic proportions, marginalized over
@@ -345,6 +287,12 @@ pub fn fit_pam_with_draws<R: Rng>(
     let d = docs.len();
     let k = num_sub;
 
+    // Break the super-topic label symmetry with a structured prior: super-topic
+    // `s` mildly prefers the contiguous slice of sub-topics around `s·K/S`. This
+    // only biases which super-topic owns which sub-topic slots; the sub-topic to
+    // vocabulary mapping is still learned, and the asymmetric-alpha re-estimate
+    // can move the preference. Without it the super-topics stay exchangeable and
+    // never specialize.
     let alpha_sk: Vec<Vec<f64>> = (0..num_super)
         .map(|s| {
             (0..num_sub)

--- a/src/pa.rs
+++ b/src/pa.rs
@@ -65,6 +65,9 @@ pub struct PamModel {
     pub ndsk: Vec<Vec<Vec<u32>>>, // D × S × K  doc ↦ (super, sub) counts
     pub zs: Vec<Vec<usize>>, // per-document token super-topic assignments
     pub zk: Vec<Vec<usize>>, // per-document token sub-topic assignments
+    /// Thinned θ draws (num_draws, D, K): sub-topic proportions marginalized
+    /// over super-topics at each snapshot. Empty when draw_cap=0.
+    pub theta_draws: Vec<Vec<Vec<f32>>>,
 }
 
 impl PamModel {
@@ -287,6 +290,7 @@ pub fn fit_pam<R: Rng>(
         ndsk: vec![vec![vec![0u32; num_sub]; num_super]; d],
         zs: docs.iter().map(|doc| vec![0usize; doc.len()]).collect(),
         zk: docs.iter().map(|doc| vec![0usize; doc.len()]).collect(),
+        theta_draws: Vec::new(),
     };
 
     // Initialization. Each *document* is assigned a single random super-topic for
@@ -317,6 +321,93 @@ pub fn fit_pam<R: Rng>(
         model.sweep(docs, rng);
         if it >= adapt_after {
             model.estimate_alpha_sk();
+        }
+    }
+
+    model
+}
+
+/// Fit a PAM with thinned θ snapshots (sub-topic proportions, marginalized over
+/// super-topics) collected every `thin` sweeps, ring-buffered to `cap` draws.
+/// `cap=0` disables collection entirely.
+#[allow(clippy::too_many_arguments)]
+pub fn fit_pam_with_draws<R: Rng>(
+    docs: &[Vec<u32>],
+    num_types: usize,
+    num_super: usize,
+    num_sub: usize,
+    alpha: f64,
+    beta: f64,
+    iters: usize,
+    opts: crate::keyatm::ThetaDrawOpts,
+    rng: &mut R,
+) -> PamModel {
+    let d = docs.len();
+    let k = num_sub;
+
+    let alpha_sk: Vec<Vec<f64>> = (0..num_super)
+        .map(|s| {
+            (0..num_sub)
+                .map(|kk| {
+                    let owner = (kk * num_super) / num_sub;
+                    if owner == s { alpha * 5.0 } else { alpha }
+                })
+                .collect()
+        })
+        .collect();
+    let mut model = PamModel {
+        num_types,
+        num_super,
+        num_sub,
+        alpha,
+        beta,
+        alpha_sk,
+        nkw: vec![vec![0u32; num_types]; num_sub],
+        nk: vec![0u32; num_sub],
+        nds: vec![vec![0u32; num_super]; d],
+        ndsk: vec![vec![vec![0u32; num_sub]; num_super]; d],
+        zs: docs.iter().map(|doc| vec![0usize; doc.len()]).collect(),
+        zk: docs.iter().map(|doc| vec![0usize; doc.len()]).collect(),
+        theta_draws: Vec::new(),
+    };
+
+    for (di, doc) in docs.iter().enumerate() {
+        let s = (rng.gen::<f64>() * num_super as f64) as usize % num_super;
+        for (i, &w) in doc.iter().enumerate() {
+            let w = w as usize;
+            let sub = (rng.gen::<f64>() * num_sub as f64) as usize % num_sub;
+            model.nds[di][s] += 1;
+            model.ndsk[di][s][sub] += 1;
+            model.nkw[sub][w] += 1;
+            model.nk[sub] += 1;
+            model.zs[di][i] = s;
+            model.zk[di][i] = sub;
+        }
+    }
+
+    let adapt_after = iters - iters / 4;
+    for it in 0..iters {
+        model.sweep(docs, rng);
+        if it >= adapt_after {
+            model.estimate_alpha_sk();
+        }
+        let iter = it + 1;
+        if opts.thin > 0 && iter % opts.thin == 0 {
+            let snap: Vec<Vec<f32>> = model.ndsk.iter().map(|doc| {
+                let mut row = vec![0.0f64; k];
+                for sub in 0..k {
+                    let total: u32 = (0..model.num_super).map(|s| doc[s][sub]).sum();
+                    row[sub] = total as f64 + model.alpha;
+                }
+                let s: f64 = row.iter().sum();
+                row.iter().map(|&x| (if s > 0.0 { x / s } else { 1.0 / k as f64 }) as f32).collect()
+            }).collect();
+            if model.theta_draws.len() < opts.cap {
+                model.theta_draws.push(snap);
+            } else {
+                model.theta_draws.remove(0);
+                model.theta_draws.push(snap);
+            }
         }
     }
 

--- a/src/pt.rs
+++ b/src/pt.rs
@@ -64,6 +64,9 @@ pub struct PtmModel {
     pub l: Vec<usize>,
     /// z[d][i]: topic assignment for each token
     pub z: Vec<Vec<usize>>,
+    /// Thinned θ draws (num_draws, D, K): each doc inherits its pseudo-doc's
+    /// Dirichlet-smoothed distribution at each snapshot. Empty when draw_cap=0.
+    pub theta_draws: Vec<Vec<Vec<f32>>>,
 }
 
 impl PtmModel {
@@ -294,10 +297,91 @@ pub fn fit_ptm<R: Rng>(
         np,
         l,
         z,
+        theta_draws: Vec::new(),
     };
 
     for _ in 0..iters {
         model.sweep(docs, rng);
+    }
+
+    model
+}
+
+/// Fit a PTM with thinned θ snapshots collected every `thin` sweeps (ring-buffered
+/// to `cap` total draws). `cap=0` disables collection entirely.
+#[allow(clippy::too_many_arguments)]
+pub fn fit_ptm_with_draws<R: Rng>(
+    docs: &[Vec<u32>],
+    num_types: usize,
+    num_topics: usize,
+    num_pseudo: usize,
+    alpha: f64,
+    beta: f64,
+    iters: usize,
+    opts: crate::keyatm::ThetaDrawOpts,
+    rng: &mut R,
+) -> PtmModel {
+    let d_count = docs.len();
+    let k = num_topics;
+    let p = num_pseudo;
+    let v = num_types;
+
+    let l: Vec<usize> = (0..d_count).map(|_| (rng.gen::<f64>() * p as f64) as usize % p).collect();
+    let z: Vec<Vec<usize>> = docs
+        .iter()
+        .map(|doc| {
+            doc.iter()
+                .map(|_| (rng.gen::<f64>() * k as f64) as usize % k)
+                .collect()
+        })
+        .collect();
+
+    let mut nkw = vec![vec![0u32; v]; k];
+    let mut nk = vec![0u32; k];
+    let mut npk = vec![vec![0u32; k]; p];
+    let mut np = vec![0u32; p];
+
+    for (d, doc) in docs.iter().enumerate() {
+        let pd = l[d];
+        for (i, &w) in doc.iter().enumerate() {
+            let kk = z[d][i];
+            nkw[kk][w as usize] += 1;
+            nk[kk] += 1;
+            npk[pd][kk] += 1;
+            np[pd] += 1;
+        }
+    }
+
+    let mut model = PtmModel {
+        num_types: v,
+        num_topics: k,
+        num_pseudo: p,
+        alpha,
+        beta,
+        nkw,
+        nk,
+        npk,
+        np,
+        l,
+        z,
+        theta_draws: Vec::new(),
+    };
+
+    for iter in 1..=iters {
+        model.sweep(docs, rng);
+        if opts.thin > 0 && iter % opts.thin == 0 {
+            let snap: Vec<Vec<f32>> = model.l.iter().map(|&pd| {
+                let denom = model.np[pd] as f64 + k as f64 * model.alpha;
+                (0..k).map(|kk| ((model.npk[pd][kk] as f64 + model.alpha) / denom) as f32).collect()
+            }).collect();
+            if model.theta_draws.len() < opts.cap {
+                model.theta_draws.push(snap);
+            } else {
+                // ring-buffer: pop oldest, push newest
+                model.theta_draws.remove(0);
+                model.theta_draws.push(snap);
+            }
+        }
     }
 
     model

--- a/src/pt.rs
+++ b/src/pt.rs
@@ -252,59 +252,13 @@ pub fn fit_ptm<R: Rng>(
     iters: usize,
     rng: &mut R,
 ) -> PtmModel {
-    let d_count = docs.len();
-    let k = num_topics;
-    let p = num_pseudo;
-    let v = num_types;
-
-    // --- Initialisation ---
-    // Each document is assigned to a random pseudo-doc; each token to a random topic.
-    let l: Vec<usize> = (0..d_count).map(|_| (rng.gen::<f64>() * p as f64) as usize % p).collect();
-    let z: Vec<Vec<usize>> = docs
-        .iter()
-        .map(|doc| {
-            doc.iter()
-                .map(|_| (rng.gen::<f64>() * k as f64) as usize % k)
-                .collect()
-        })
-        .collect();
-
-    let mut nkw = vec![vec![0u32; v]; k];
-    let mut nk = vec![0u32; k];
-    let mut npk = vec![vec![0u32; k]; p];
-    let mut np = vec![0u32; p];
-
-    for (d, doc) in docs.iter().enumerate() {
-        let pd = l[d];
-        for (i, &w) in doc.iter().enumerate() {
-            let kk = z[d][i];
-            nkw[kk][w as usize] += 1;
-            nk[kk] += 1;
-            npk[pd][kk] += 1;
-            np[pd] += 1;
-        }
-    }
-
-    let mut model = PtmModel {
-        num_types: v,
-        num_topics: k,
-        num_pseudo: p,
-        alpha,
-        beta,
-        nkw,
-        nk,
-        npk,
-        np,
-        l,
-        z,
-        theta_draws: Vec::new(),
-    };
-
-    for _ in 0..iters {
-        model.sweep(docs, rng);
-    }
-
-    model
+    // Plain fit is the draw-collecting fit with collection disabled, so the
+    // sampler lives in exactly one place (see `fit_ptm_with_draws`).
+    fit_ptm_with_draws(
+        docs, num_types, num_topics, num_pseudo, alpha, beta, iters,
+        crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
+        rng,
+    )
 }
 
 /// Fit a PTM with thinned θ snapshots collected every `thin` sweeps (ring-buffered

--- a/src/python.rs
+++ b/src/python.rs
@@ -2709,6 +2709,9 @@ pub struct DMR {
     topic_names: Vec<String>,
     phi: Option<Array2<f64>>,            // (num_topics, num_words)
     theta: Option<Array2<f64>>,          // (num_docs, num_topics)
+    // Thinned MCMC θ snapshots (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Feeds composition_theta's cross-sweep uncertainty.
+    theta_draws: Option<Array3<f32>>,
     feature_effects: Option<Array2<f64>>, // (num_topics, num_features)
     feature_names: Vec<String>,
     corpus: Option<corpus::Corpus>,
@@ -2762,6 +2765,7 @@ impl DMR {
             topic_names: Vec::new(),
             phi: None,
             theta: None,
+            theta_draws: None,
             feature_effects: None,
             feature_names: Vec::new(),
             corpus: None,
@@ -2773,7 +2777,8 @@ impl DMR {
     /// intercept column is prepended automatically). `feature_names` (length F)
     /// names the columns; an "intercept" name is prepended.
     #[pyo3(signature = (data, features, *, feature_names=None, iters=1000,
-                        num_samples=5, sample_interval=25, progress=None, progress_interval=50))]
+                        num_samples=5, sample_interval=25, progress=None, progress_interval=50,
+                        keep_theta_draws=true, num_theta_draws=25))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -2786,6 +2791,8 @@ impl DMR {
         sample_interval: usize,
         progress: Option<PyObject>,
         progress_interval: usize,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -2852,8 +2859,11 @@ impl DMR {
         let burn_in = self.burn_in;
         let prior_variance = self.prior_variance;
         let lbfgs_iters = self.lbfgs_iters;
+        let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        let (acc_phi, acc_theta, feat_eff, model, corpus) = py.allow_threads(move || {
+        let (acc_phi, acc_theta, theta_draw_buf, feat_eff, model, corpus) = py.allow_threads(move || {
+            let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
             for iter in 1..=iters {
                 let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
                 dmr::run_sweep_dmr(
@@ -2875,6 +2885,22 @@ impl DMR {
                     dmr::optimize_lambda(
                         &mut lambda, &feats, &dtc, k, nf, prior_variance, lbfgs_iters, None,
                     );
+                }
+
+                // Snapshot θ = (n_dk + α_dk) / (N_d + Σα_d) every thin sweeps.
+                if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                    let doc_alpha_snap = dmr::compute_doc_alpha(&lambda, &feats, None);
+                    let snap: Vec<Vec<f32>> = model.doc_topics.iter()
+                        .enumerate()
+                        .map(|(d, topics)| {
+                            let mut c = vec![0.0f64; k];
+                            for &t in topics { c[t as usize] += 1.0; }
+                            let asum: f64 = doc_alpha_snap[d].iter().sum();
+                            let denom = c.iter().sum::<f64>() + asum;
+                            (0..k).map(|t| ((c[t] + doc_alpha_snap[d][t]) / denom) as f32).collect()
+                        })
+                        .collect();
+                    push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
                 }
 
                 if let Some(cb) = &progress {
@@ -2936,7 +2962,7 @@ impl DMR {
                 }
             }
 
-            (acc_phi, acc_theta, lambda, model, corpus)
+            (acc_phi, acc_theta, theta_draw_buf, lambda, model, corpus)
         });
         let _ = model;
 
@@ -2962,6 +2988,7 @@ impl DMR {
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         self.phi = Some(phi);
         self.theta = Some(theta);
+        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
         self.feature_effects = Some(fe);
         self.feature_names = names;
         self.corpus = Some(corpus);
@@ -2981,6 +3008,26 @@ impl DMR {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+
+    /// Thinned MCMC θ draws, shape ``(num_draws, num_docs, num_topics)``, or
+    /// ``None`` when fit with ``keep_theta_draws=False``. These are real
+    /// cross-sweep posterior samples; :func:`topica.composition_theta` prefers
+    /// them over the within-document Dirichlet approximation.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
+    }
+
+    /// Per-document token counts (length D), in :attr:`doc_topic` row order.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
     }
 
     /// The baseline document-topic Dirichlet prior α, shape ``(num_topics,)``:
@@ -3222,6 +3269,7 @@ impl DMR {
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             feature_effects: arr2_back(s.feature_effects),
             feature_names: s.feature_names, corpus: s.corpus,
+            theta_draws: None,
         })
     }
 
@@ -3252,6 +3300,9 @@ pub struct LabeledLDA {
     theta: Option<Array2<f64>>,
     label_vocab: Vec<String>,
     corpus: Option<corpus::Corpus>,
+    // Thinned MCMC θ snapshots (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Feeds composition_theta's cross-sweep uncertainty.
+    theta_draws: Option<Array3<f32>>,
 }
 
 impl LabeledLDA {
@@ -3288,6 +3339,7 @@ impl LabeledLDA {
             theta: None,
             label_vocab: Vec::new(),
             corpus: None,
+            theta_draws: None,
         })
     }
 
@@ -3296,7 +3348,8 @@ impl LabeledLDA {
     /// the union of all labels (or `label_names`, which also fixes topic order).
     /// An empty label list leaves that document unconstrained.
     #[pyo3(signature = (data, labels, *, label_names=None, iters=1000,
-                        num_samples=5, sample_interval=25, progress=None, progress_interval=50))]
+                        num_samples=5, sample_interval=25, progress=None, progress_interval=50,
+                        keep_theta_draws=true, num_theta_draws=25))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -3309,6 +3362,8 @@ impl LabeledLDA {
         sample_interval: usize,
         progress: Option<PyObject>,
         progress_interval: usize,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -3373,9 +3428,29 @@ impl LabeledLDA {
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         labeled::initialize_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
 
-        let (acc_phi, acc_theta, model, corpus) = py.allow_threads(move || {
+        let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
+
+        let (acc_phi, acc_theta, theta_draw_buf, model, corpus) = py.allow_threads(move || {
+            let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+            let all_topics: Vec<usize> = (0..k).collect();
+
             for iter in 1..=iters {
                 labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
+                if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                    let counts = doc_topic_counts(&model.doc_topics, k);
+                    let snap: Vec<Vec<f32>> = (0..num_docs).map(|d| {
+                        let allow: &[usize] = if allowed[d].is_empty() { &all_topics } else { &allowed[d] };
+                        let asum: f64 = allow.iter().map(|&t| model.alpha[t]).sum();
+                        let denom = corpus.docs[d].len() as f64 + asum;
+                        let mut row = vec![0.0f32; k];
+                        for &t in allow {
+                            row[t] = ((counts[d][t] as f64 + model.alpha[t]) / denom) as f32;
+                        }
+                        row
+                    }).collect();
+                    push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
+                }
                 if let Some(cb) = &progress {
                     if progress_interval > 0 && iter % progress_interval == 0 {
                         let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
@@ -3386,7 +3461,6 @@ impl LabeledLDA {
                 }
             }
 
-            let all_topics: Vec<usize> = (0..k).collect();
             let mut acc_phi = vec![vec![0.0f64; k]; num_types];
             let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
             for _ in 0..num_samples {
@@ -3420,7 +3494,7 @@ impl LabeledLDA {
                     *v /= n;
                 }
             }
-            (acc_phi, acc_theta, model, corpus)
+            (acc_phi, acc_theta, theta_draw_buf, model, corpus)
         });
         let _ = model;
 
@@ -3437,6 +3511,7 @@ impl LabeledLDA {
             }
         }
 
+        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
         self.num_topics = k;
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         self.phi = Some(phi);
@@ -3469,6 +3544,22 @@ impl LabeledLDA {
     fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         Ok(Array1::from(vec![self.alpha; self.num_topics]).to_pyarray_bound(py))
+    }
+
+    /// Thinned MCMC θ snapshots, shape ``(num_draws, num_docs, num_topics)``,
+    /// dtype ``float32``. ``None`` when fit with ``keep_theta_draws=False``. These
+    /// are real cross-sweep draws; use them with
+    /// :func:`topica.effects.composition_theta` for uncertainty quantification.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
+    }
+
+    /// Number of tokens in each training document, shape ``(num_docs,)``.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
     }
 
     /// The label name for each topic, in topic (column) order.
@@ -3616,6 +3707,7 @@ impl LabeledLDA {
             num_topics: s.num_topics, topic_names,
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             label_vocab: s.label_vocab, corpus: s.corpus,
+            theta_draws: None,
         })
     }
 
@@ -3665,6 +3757,9 @@ pub struct SAGE {
     theta: Option<Array2<f64>>,
     group_names: Vec<String>,
     corpus: Option<corpus::Corpus>,
+    // Thinned MCMC θ snapshots (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Feeds composition_theta's cross-sweep uncertainty.
+    theta_draws: Option<Array3<f32>>,
 }
 
 impl SAGE {
@@ -3731,6 +3826,7 @@ impl SAGE {
             theta: None,
             group_names: Vec::new(),
             corpus: None,
+            theta_draws: None,
         })
     }
 
@@ -3738,7 +3834,8 @@ impl SAGE {
     /// `groups` is a per-document group label (strings or ints), one per
     /// document. `group_names` fixes the group order (defaults to sorted union).
     #[pyo3(signature = (data, groups, *, group_names=None, iters=1000,
-                        num_samples=5, sample_interval=25, progress=None, progress_interval=50))]
+                        num_samples=5, sample_interval=25, progress=None, progress_interval=50,
+                        keep_theta_draws=true, num_theta_draws=25))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -3751,6 +3848,8 @@ impl SAGE {
         sample_interval: usize,
         progress: Option<PyObject>,
         progress_interval: usize,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -3814,11 +3913,24 @@ impl SAGE {
         let burn_in = self.burn_in;
         let lbfgs_iters = self.lbfgs_iters;
 
-        let (beta, acc_theta, corpus) = py.allow_threads(move || {
+        let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
+
+        let (beta, acc_theta, theta_draw_buf, corpus) = py.allow_threads(move || {
+            let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+
             for iter in 1..=iters {
                 sage::run_sweep_sage(&mut model, &corpus.docs, &groups_idx, &mut rng);
                 if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                     sage::optimize_kappa(&mut model, lbfgs_iters);
+                }
+                if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                    let counts = doc_topic_counts(&model.doc_topics, k);
+                    let snap: Vec<Vec<f32>> = (0..num_docs).map(|d| {
+                        let denom = corpus.docs[d].len() as f64 + alpha_sum;
+                        (0..k).map(|t| ((counts[d][t] as f64 + alpha) / denom) as f32).collect()
+                    }).collect();
+                    push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
                 }
                 if let Some(cb) = &progress {
                     if progress_interval > 0 && iter % progress_interval == 0 {
@@ -3860,7 +3972,7 @@ impl SAGE {
                     *v /= n;
                 }
             }
-            (model.beta.clone(), acc_theta, corpus)
+            (model.beta.clone(), acc_theta, theta_draw_buf, corpus)
         });
 
         let mut theta = Array2::<f64>::zeros((num_docs, k));
@@ -3870,6 +3982,7 @@ impl SAGE {
             }
         }
 
+        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         self.num_groups = group_n;
         self.beta = beta;
@@ -3921,6 +4034,22 @@ impl SAGE {
     fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         Ok(Array1::from(vec![self.alpha; self.num_topics]).to_pyarray_bound(py))
+    }
+
+    /// Thinned MCMC θ snapshots, shape ``(num_draws, num_docs, num_topics)``,
+    /// dtype ``float32``. ``None`` when fit with ``keep_theta_draws=False``. These
+    /// are real cross-sweep draws; use them with
+    /// :func:`topica.effects.composition_theta` for uncertainty quantification.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
+    }
+
+    /// Number of tokens in each training document, shape ``(num_docs,)``.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
     }
 
     /// Group names, in the index order used by :attr:`topic_word`'s second axis.
@@ -4083,6 +4212,7 @@ impl SAGE {
             lbfgs_iters: s.lbfgs_iters, fitted: s.fitted, num_groups: s.num_groups,
             topic_names,
             beta: s.beta, theta: arr2_back(s.theta), group_names: s.group_names, corpus: s.corpus,
+            theta_draws: None,
         })
     }
 
@@ -5384,6 +5514,11 @@ pub struct HDP {
     corpus: Option<corpus::Corpus>,
     // Discovery/convergence trace: (iteration, num_topics, log-likelihood, alpha, gamma).
     trace: Vec<(usize, usize, f64, f64, f64)>,
+    // Thinned θ draws (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Because HDP's K varies during training, these draws
+    // are sampled from the final Dirichlet posterior Dirichlet(njk[d]+alpha*beta[k])
+    // after the Gibbs chain ends, using the stabilized topic count.
+    theta_draws: Option<Array3<f32>>,
 }
 
 impl HDP {
@@ -5426,18 +5561,22 @@ impl HDP {
             theta: None,
             corpus: None,
             trace: Vec::new(),
+            theta_draws: None,
         })
     }
 
     /// Fit by Gibbs sampling for `iters` sweeps. `data` is a :class:`Corpus` or
     /// `list[list[str]]`. The inferred topic count is available as `num_topics`.
-    #[pyo3(signature = (data, *, iters=150, report_interval=0))]
+    #[pyo3(signature = (data, *, iters=150, report_interval=0,
+                        keep_theta_draws=true, num_theta_draws=25))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
         report_interval: usize,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -5451,11 +5590,16 @@ impl HDP {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
 
+        let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (alpha, gamma, eta, conc) = (self.alpha, self.gamma, self.eta, self.resample_conc);
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         // 0 = auto: ~50 evenly spaced trace points across the run.
         let ll_interval = if report_interval == 0 { (iters / 50).max(1) } else { report_interval };
+
+        // HDP's K varies during training, so theta_draws are sampled from the final
+        // Dirichlet posterior Dirichlet(njk[d]+alpha*beta[k]) after the chain ends.
+        let draw_cap = if keep_theta_draws { num_theta_draws } else { 0 };
 
         let (model, corpus) = py.allow_threads(move || {
             let m = hdp::fit_hdp(
@@ -5465,6 +5609,8 @@ impl HDP {
         });
 
         let k = model.num_topics();
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
+
         let tw = model.topic_word();
         let mut beta = Array2::<f64>::zeros((k, num_types));
         for (t, row) in tw.iter().enumerate() {
@@ -5480,6 +5626,29 @@ impl HDP {
             }
         }
 
+        // Draw from Dirichlet(njk[d] + alpha*beta[k]) for each draw request.
+        let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+        if draw_cap > 0 {
+            let mut draw_rng = ChaCha8Rng::seed_from_u64(self.seed.wrapping_add(1));
+            for _ in 0..draw_cap {
+                let snap: Vec<Vec<f32>> = model.njk.iter().map(|counts| {
+                    let mut gammas: Vec<f64> = (0..k)
+                        .map(|t| {
+                            let shape = counts[t] as f64 + model.alpha * model.beta[t];
+                            hdp::sample_gamma(shape.max(1e-12), &mut draw_rng)
+                        })
+                        .collect();
+                    let s: f64 = gammas.iter().sum();
+                    if s > 0.0 {
+                        for g in gammas.iter_mut() { *g /= s; }
+                    }
+                    gammas.iter().map(|&g| g as f32).collect()
+                }).collect();
+                theta_draw_buf.push(snap);
+            }
+        }
+
+        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
         self.num_topics = k;
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         self.learned_alpha = model.alpha;
@@ -5550,6 +5719,22 @@ impl HDP {
     #[getter]
     fn gamma(&self) -> f64 {
         self.learned_gamma
+    }
+
+    /// Thinned θ draws, shape ``(num_draws, num_docs, num_topics)``, dtype
+    /// ``float32``. ``None`` when fit with ``keep_theta_draws=False``. Because
+    /// HDP's K changes during training, these draws are sampled from the final
+    /// Dirichlet posterior after the Gibbs chain ends.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
+    }
+
+    /// Number of tokens in each training document, shape ``(num_docs,)``.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
     }
 
     #[getter]
@@ -5684,6 +5869,7 @@ impl HDP {
             learned_alpha: s.learned_alpha, learned_gamma: s.learned_gamma,
             beta: arr2_back(s.beta), theta: arr2_back(s.theta), corpus: s.corpus,
             trace: s.trace,
+            theta_draws: None,
         })
     }
 
@@ -6067,6 +6253,9 @@ pub struct SupervisedLDA {
     theta: Option<Array2<f64>>, // D × K
     log_beta: Option<Vec<Vec<f64>>>,
     corpus: Option<corpus::Corpus>,
+    // Thinned θ draws (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Each draw samples from Dirichlet(gamma_d).
+    theta_draws: Option<Array3<f32>>,
 }
 
 impl SupervisedLDA {
@@ -6104,12 +6293,14 @@ impl SupervisedLDA {
             theta: None,
             log_beta: None,
             corpus: None,
+            theta_draws: None,
         })
     }
 
     /// Fit by variational EM. `data` is a :class:`Corpus` or `list[list[str]]`;
     /// `y` is the per-document real-valued response (length = number of docs).
-    #[pyo3(signature = (data, y, *, iters=25, var_iters=15))]
+    #[pyo3(signature = (data, y, *, iters=25, var_iters=15,
+                        keep_theta_draws=true, num_theta_draws=25))]
     fn fit(
         &mut self,
         py: Python<'_>,
@@ -6117,6 +6308,8 @@ impl SupervisedLDA {
         y: Vec<f64>,
         iters: usize,
         var_iters: usize,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -6137,8 +6330,13 @@ impl SupervisedLDA {
             )));
         }
 
+        let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (k, alpha) = (self.num_topics, self.alpha);
+
+        let draw_cap = if keep_theta_draws { num_theta_draws } else { 0 };
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
+
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
 
         let (model, corpus) = py.allow_threads(move || {
@@ -6160,6 +6358,24 @@ impl SupervisedLDA {
                 theta[[di, t]] = val;
             }
         }
+
+        // Draw from Dirichlet(gamma_d) for each requested draw.
+        let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+        if draw_cap > 0 {
+            let mut draw_rng = ChaCha8Rng::seed_from_u64(self.seed.wrapping_add(1));
+            for _ in 0..draw_cap {
+                let snap: Vec<Vec<f32>> = model.gamma.iter().map(|gd| {
+                    let mut gammas: Vec<f64> = gd.iter()
+                        .map(|&g| hdp::sample_gamma(g.max(1e-12), &mut draw_rng))
+                        .collect();
+                    let s: f64 = gammas.iter().sum();
+                    if s > 0.0 { for x in gammas.iter_mut() { *x /= s; } }
+                    gammas.iter().map(|&g| g as f32).collect()
+                }).collect();
+                theta_draw_buf.push(snap);
+            }
+        }
+        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
 
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         self.sigma2 = model.sigma2;
@@ -6237,6 +6453,21 @@ impl SupervisedLDA {
     fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         Ok(Array1::from(vec![self.alpha; self.num_topics]).to_pyarray_bound(py))
+    }
+
+    /// Thinned θ draws, shape ``(num_draws, num_docs, num_topics)``, dtype
+    /// ``float32``. ``None`` when fit with ``keep_theta_draws=False``. Each draw
+    /// samples from the variational posterior Dirichlet(γ_d).
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
+    }
+
+    /// Number of tokens in each training document, shape ``(num_docs,)``.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
     }
 
     /// Regression coefficients η, shape ``(num_topics,)`` — how each topic moves
@@ -6387,6 +6618,7 @@ impl SupervisedLDA {
             topic_names,
             sigma2: s.sigma2, eta: arr1_back(s.eta), beta: arr2_back(s.beta),
             theta: arr2_back(s.theta), log_beta: s.log_beta, corpus: s.corpus,
+            theta_draws: None,
         })
     }
 
@@ -6415,6 +6647,9 @@ pub struct PT {
     phi: Option<Array2<f64>>,
     theta: Option<Array2<f64>>,
     corpus: Option<corpus::Corpus>,
+    // Thinned MCMC θ snapshots (num_draws, num_docs, num_topics), f32; None when
+    // keep_theta_draws=False. Each doc inherits its pseudo-doc's topic distribution.
+    theta_draws: Option<Array3<f32>>,
 }
 
 impl PT {
@@ -6446,12 +6681,20 @@ impl PT {
         Ok(PT {
             num_topics, num_pseudo, alpha, beta, seed,
             fitted: false, topic_names: Vec::new(), phi: None, theta: None, corpus: None,
+            theta_draws: None,
         })
     }
 
     /// Fit by collapsed Gibbs sampling for `iters` sweeps.
-    #[pyo3(signature = (data, *, iters=1000))]
-    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>, iters: usize) -> PyResult<()> {
+    #[pyo3(signature = (data, *, iters=1000, keep_theta_draws=true, num_theta_draws=25))]
+    fn fit(
+        &mut self,
+        py: Python<'_>,
+        data: &Bound<'_, PyAny>,
+        iters: usize,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
+    ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -6463,13 +6706,21 @@ impl PT {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (k, p, a, b) = (self.num_topics, self.num_pseudo, self.alpha, self.beta);
+
+        let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
+
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let (model, corpus) = py.allow_threads(move || {
-            let m = pt::fit_ptm(&corpus.docs, num_types, k, p, a, b, iters, &mut rng);
+            let m = pt::fit_ptm_with_draws(
+                &corpus.docs, num_types, k, p, a, b, iters, draws_opts, &mut rng,
+            );
             (m, corpus)
         });
+        self.theta_draws = draws_to_array3(&model.theta_draws, num_docs, k, None);
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         self.phi = Some(vecs_to_arr2(&model.topic_word()));
         self.theta = Some(vecs_to_arr2(&model.doc_topic()));
@@ -6495,6 +6746,18 @@ impl PT {
     fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         Ok(Array1::from(vec![self.alpha; self.num_topics]).to_pyarray_bound(py))
+    }
+    /// Thinned MCMC θ snapshots, shape ``(num_draws, num_docs, num_topics)``,
+    /// dtype ``float32``. ``None`` when fit with ``keep_theta_draws=False``.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
+    }
+    /// Number of tokens in each training document, shape ``(num_docs,)``.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
     }
     #[getter]
     fn num_topics(&self) -> usize {
@@ -6566,6 +6829,7 @@ impl PT {
             seed: s.seed, fitted: s.fitted, topic_names,
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             corpus: s.corpus,
+            theta_draws: None,
         })
     }
 
@@ -9477,6 +9741,9 @@ pub struct PA {
     theta: Option<Array2<f64>>,     // num_docs × num_sub
     super_sub: Option<Array2<f64>>, // num_super × num_sub
     corpus: Option<corpus::Corpus>,
+    // Thinned MCMC θ snapshots (num_draws, num_docs, num_sub), f32; None when
+    // keep_theta_draws=False. Sub-topic proportions marginalized over super-topics.
+    theta_draws: Option<Array3<f32>>,
 }
 
 impl PA {
@@ -9506,12 +9773,20 @@ impl PA {
             num_super, num_sub, alpha, beta, seed,
             fitted: false, topic_names: Vec::new(),
             phi: None, theta: None, super_sub: None, corpus: None,
+            theta_draws: None,
         })
     }
 
     /// Fit by collapsed Gibbs sampling for `iters` sweeps.
-    #[pyo3(signature = (data, *, iters=1000))]
-    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>, iters: usize) -> PyResult<()> {
+    #[pyo3(signature = (data, *, iters=1000, keep_theta_draws=true, num_theta_draws=25))]
+    fn fit(
+        &mut self,
+        py: Python<'_>,
+        data: &Bound<'_, PyAny>,
+        iters: usize,
+        keep_theta_draws: bool,
+        num_theta_draws: usize,
+    ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -9523,13 +9798,19 @@ impl PA {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (s, k, a, b) = (self.num_super, self.num_sub, self.alpha, self.beta);
+
+        let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
+        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
+
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let (model, corpus) = py.allow_threads(move || {
-            let m = pa::fit_pam(&corpus.docs, num_types, s, k, a, b, iters, &mut rng);
+            let m = pa::fit_pam_with_draws(&corpus.docs, num_types, s, k, a, b, iters, draws_opts, &mut rng);
             (m, corpus)
         });
+        self.theta_draws = draws_to_array3(&model.theta_draws, num_docs, k, None);
         self.phi = Some(vecs_to_arr2(&model.topic_word()));
         self.theta = Some(vecs_to_arr2(&model.doc_topic()));
         self.super_sub = Some(vecs_to_arr2(&model.super_sub()));
@@ -9558,6 +9839,18 @@ impl PA {
     fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         Ok(Array1::from(vec![self.alpha; self.num_sub]).to_pyarray_bound(py))
+    }
+    /// Thinned MCMC θ snapshots, shape ``(num_draws, num_docs, num_sub)``,
+    /// dtype ``float32``. ``None`` when fit with ``keep_theta_draws=False``.
+    #[getter]
+    fn theta_draws<'py>(&self, py: Python<'py>) -> Option<Bound<'py, PyArray3<f32>>> {
+        self.theta_draws.as_ref().map(|a| a.to_pyarray_bound(py))
+    }
+    /// Number of tokens in each training document, shape ``(num_docs,)``.
+    #[getter]
+    fn doc_lengths(&self) -> PyResult<Vec<usize>> {
+        self.require_fitted()?;
+        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
     }
     /// Super-topic → sub-topic association, shape ``(num_super, num_sub)``; row s
     /// shows which sub-topics super-topic s groups together (the correlations).
@@ -9643,6 +9936,7 @@ impl PA {
             seed: s.seed, fitted: s.fitted, topic_names,
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             super_sub: arr2_back(s.super_sub), corpus: s.corpus,
+            theta_draws: None,
         })
     }
 

--- a/tests/test_phase5_theta_draws.py
+++ b/tests/test_phase5_theta_draws.py
@@ -1,0 +1,364 @@
+"""Phase 5: theta_draws and doc_lengths on the remaining Dirichlet-family models.
+
+Covers DMR, SAGE, LabeledLDA, HDP, PT, PA, and SupervisedLDA.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+from topica.effects import composition_theta
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+def _toy_docs(n=60, vocab=16, lo=8, hi=18, seed=7):
+    rng = np.random.default_rng(seed)
+    words = [f"w{i}" for i in range(vocab)]
+    return [list(rng.choice(words, size=int(rng.integers(lo, hi)))) for _ in range(n)]
+
+
+def _toy_corpus(seed=7):
+    return topica.Corpus.from_documents(_toy_docs(seed=seed))
+
+
+# ---------------------------------------------------------------------------
+# DMR
+# ---------------------------------------------------------------------------
+
+def _fit_dmr(corpus, *, keep_theta_draws=True, num_theta_draws=10):
+    n = corpus.num_docs
+    rng = np.random.default_rng(0)
+    features = rng.standard_normal((n, 2)).tolist()
+    m = topica.DMR(num_topics=4, seed=1)
+    m.fit(corpus, features, iters=120,
+          keep_theta_draws=keep_theta_draws, num_theta_draws=num_theta_draws)
+    return m
+
+
+class TestDMR:
+    def test_theta_draws_shape(self):
+        corpus = _toy_corpus()
+        m = _fit_dmr(corpus, num_theta_draws=8)
+        td = np.asarray(m.theta_draws)
+        d, k = np.asarray(m.doc_topic).shape
+        assert td.shape == (8, d, k)
+        assert td.dtype == np.float32
+
+    def test_theta_draws_rows_sum_to_one(self):
+        corpus = _toy_corpus()
+        m = _fit_dmr(corpus, num_theta_draws=5)
+        td = np.asarray(m.theta_draws)
+        row_sums = td.sum(axis=2)
+        np.testing.assert_allclose(row_sums, np.ones_like(row_sums), atol=1e-5)
+
+    def test_theta_draws_vary_across_draws(self):
+        corpus = _toy_corpus()
+        m = _fit_dmr(corpus, num_theta_draws=10)
+        td = np.asarray(m.theta_draws)
+        assert td.std() > 1e-4
+
+    def test_keep_false_returns_none(self):
+        corpus = _toy_corpus()
+        m = _fit_dmr(corpus, keep_theta_draws=False)
+        assert m.theta_draws is None
+
+    def test_doc_lengths_shape(self):
+        corpus = _toy_corpus()
+        m = _fit_dmr(corpus)
+        dl = m.doc_lengths
+        assert len(dl) == corpus.num_docs
+        assert all(n > 0 for n in dl)
+
+    def test_composition_theta_works(self):
+        corpus = _toy_corpus()
+        m = _fit_dmr(corpus, num_theta_draws=5)
+        out = composition_theta(m, corpus, nsims=3)
+        assert out.shape == (3, corpus.num_docs, np.asarray(m.doc_topic).shape[1])
+
+
+# ---------------------------------------------------------------------------
+# SAGE
+# ---------------------------------------------------------------------------
+
+def _fit_sage(corpus, *, keep_theta_draws=True, num_theta_draws=10):
+    n = corpus.num_docs
+    groups = ["a" if i < n // 2 else "b" for i in range(n)]
+    m = topica.SAGE(num_topics=4, seed=1)
+    m.fit(corpus, groups, iters=120,
+          keep_theta_draws=keep_theta_draws, num_theta_draws=num_theta_draws)
+    return m
+
+
+class TestSAGE:
+    def test_theta_draws_shape(self):
+        corpus = _toy_corpus()
+        m = _fit_sage(corpus, num_theta_draws=8)
+        td = np.asarray(m.theta_draws)
+        d, k = np.asarray(m.doc_topic).shape
+        assert td.shape == (8, d, k)
+        assert td.dtype == np.float32
+
+    def test_theta_draws_rows_sum_to_one(self):
+        corpus = _toy_corpus()
+        m = _fit_sage(corpus, num_theta_draws=5)
+        td = np.asarray(m.theta_draws)
+        row_sums = td.sum(axis=2)
+        np.testing.assert_allclose(row_sums, np.ones_like(row_sums), atol=1e-5)
+
+    def test_keep_false_returns_none(self):
+        corpus = _toy_corpus()
+        m = _fit_sage(corpus, keep_theta_draws=False)
+        assert m.theta_draws is None
+
+    def test_doc_lengths(self):
+        corpus = _toy_corpus()
+        m = _fit_sage(corpus)
+        dl = m.doc_lengths
+        assert len(dl) == corpus.num_docs
+        assert all(n > 0 for n in dl)
+
+    def test_composition_theta_works(self):
+        corpus = _toy_corpus()
+        m = _fit_sage(corpus, num_theta_draws=5)
+        out = composition_theta(m, corpus, nsims=3)
+        assert out.shape == (3, corpus.num_docs, np.asarray(m.doc_topic).shape[1])
+
+
+# ---------------------------------------------------------------------------
+# LabeledLDA
+# ---------------------------------------------------------------------------
+
+def _fit_labeled(corpus, *, keep_theta_draws=True, num_theta_draws=10):
+    n = corpus.num_docs
+    labels = [["topic_a"] if i % 3 != 0 else ["topic_b"] for i in range(n)]
+    m = topica.LabeledLDA(alpha=0.1, beta=0.01, seed=1)
+    m.fit(corpus, labels, iters=120,
+          keep_theta_draws=keep_theta_draws, num_theta_draws=num_theta_draws)
+    return m
+
+
+class TestLabeledLDA:
+    def test_theta_draws_shape(self):
+        corpus = _toy_corpus()
+        m = _fit_labeled(corpus, num_theta_draws=8)
+        td = np.asarray(m.theta_draws)
+        d, k = np.asarray(m.doc_topic).shape
+        assert td.shape == (8, d, k)
+        assert td.dtype == np.float32
+
+    def test_theta_draws_rows_sum_to_one(self):
+        corpus = _toy_corpus()
+        m = _fit_labeled(corpus, num_theta_draws=5)
+        td = np.asarray(m.theta_draws)
+        row_sums = td.sum(axis=2)
+        np.testing.assert_allclose(row_sums, np.ones_like(row_sums), atol=1e-5)
+
+    def test_keep_false_returns_none(self):
+        corpus = _toy_corpus()
+        m = _fit_labeled(corpus, keep_theta_draws=False)
+        assert m.theta_draws is None
+
+    def test_doc_lengths(self):
+        corpus = _toy_corpus()
+        m = _fit_labeled(corpus)
+        dl = m.doc_lengths
+        assert len(dl) == corpus.num_docs
+        assert all(n > 0 for n in dl)
+
+    def test_composition_theta_works(self):
+        corpus = _toy_corpus()
+        m = _fit_labeled(corpus, num_theta_draws=5)
+        out = composition_theta(m, corpus, nsims=3)
+        assert out.shape == (3, corpus.num_docs, np.asarray(m.doc_topic).shape[1])
+
+
+# ---------------------------------------------------------------------------
+# HDP
+# ---------------------------------------------------------------------------
+
+def _fit_hdp(corpus, *, keep_theta_draws=True, num_theta_draws=10):
+    m = topica.HDP(seed=1)
+    m.fit(corpus, iters=80,
+          keep_theta_draws=keep_theta_draws, num_theta_draws=num_theta_draws)
+    return m
+
+
+class TestHDP:
+    def test_theta_draws_shape(self):
+        corpus = _toy_corpus()
+        m = _fit_hdp(corpus, num_theta_draws=8)
+        assert m.theta_draws is not None
+        td = np.asarray(m.theta_draws)
+        k = m.num_topics
+        d = np.asarray(m.doc_topic).shape[0]
+        assert td.shape == (8, d, k)
+        assert td.dtype == np.float32
+
+    def test_theta_draws_rows_sum_to_one(self):
+        corpus = _toy_corpus()
+        m = _fit_hdp(corpus, num_theta_draws=5)
+        td = np.asarray(m.theta_draws)
+        row_sums = td.sum(axis=2)
+        np.testing.assert_allclose(row_sums, np.ones_like(row_sums), atol=1e-5)
+
+    def test_keep_false_returns_none(self):
+        corpus = _toy_corpus()
+        m = _fit_hdp(corpus, keep_theta_draws=False)
+        assert m.theta_draws is None
+
+    def test_doc_lengths(self):
+        corpus = _toy_corpus()
+        m = _fit_hdp(corpus)
+        dl = m.doc_lengths
+        assert len(dl) == corpus.num_docs
+        assert all(n > 0 for n in dl)
+
+    def test_self_sufficient_for_composition(self):
+        corpus = _toy_corpus()
+        m = _fit_hdp(corpus, num_theta_draws=5)
+        out = composition_theta(m, corpus, nsims=3)
+        assert out.shape == (3, corpus.num_docs, np.asarray(m.doc_topic).shape[1])
+
+
+# ---------------------------------------------------------------------------
+# PT (Pseudo-document Topic Model)
+# ---------------------------------------------------------------------------
+
+def _fit_pt(corpus, *, keep_theta_draws=True, num_theta_draws=10):
+    m = topica.PT(num_topics=4, num_pseudo=20, seed=1)
+    m.fit(corpus, iters=200,
+          keep_theta_draws=keep_theta_draws, num_theta_draws=num_theta_draws)
+    return m
+
+
+class TestPT:
+    def test_theta_draws_shape(self):
+        corpus = _toy_corpus()
+        m = _fit_pt(corpus, num_theta_draws=8)
+        td = np.asarray(m.theta_draws)
+        d, k = np.asarray(m.doc_topic).shape
+        assert td.shape == (8, d, k)
+        assert td.dtype == np.float32
+
+    def test_theta_draws_rows_sum_to_one(self):
+        corpus = _toy_corpus()
+        m = _fit_pt(corpus, num_theta_draws=5)
+        td = np.asarray(m.theta_draws)
+        row_sums = td.sum(axis=2)
+        np.testing.assert_allclose(row_sums, np.ones_like(row_sums), atol=1e-5)
+
+    def test_keep_false_returns_none(self):
+        corpus = _toy_corpus()
+        m = _fit_pt(corpus, keep_theta_draws=False)
+        assert m.theta_draws is None
+
+    def test_doc_lengths(self):
+        corpus = _toy_corpus()
+        m = _fit_pt(corpus)
+        dl = m.doc_lengths
+        assert len(dl) == corpus.num_docs
+        assert all(n > 0 for n in dl)
+
+    def test_composition_theta_works(self):
+        corpus = _toy_corpus()
+        m = _fit_pt(corpus, num_theta_draws=5)
+        out = composition_theta(m, corpus, nsims=3)
+        assert out.shape == (3, corpus.num_docs, np.asarray(m.doc_topic).shape[1])
+
+
+# ---------------------------------------------------------------------------
+# PA (Pachinko Allocation Model)
+# ---------------------------------------------------------------------------
+
+def _fit_pa(corpus, *, keep_theta_draws=True, num_theta_draws=10):
+    m = topica.PA(num_super=2, num_sub=4, seed=1)
+    m.fit(corpus, iters=300,
+          keep_theta_draws=keep_theta_draws, num_theta_draws=num_theta_draws)
+    return m
+
+
+class TestPA:
+    def test_theta_draws_shape(self):
+        corpus = _toy_corpus()
+        m = _fit_pa(corpus, num_theta_draws=8)
+        td = np.asarray(m.theta_draws)
+        d, k = np.asarray(m.doc_topic).shape
+        assert td.shape == (8, d, k)
+        assert td.dtype == np.float32
+
+    def test_theta_draws_rows_sum_to_one(self):
+        corpus = _toy_corpus()
+        m = _fit_pa(corpus, num_theta_draws=5)
+        td = np.asarray(m.theta_draws)
+        row_sums = td.sum(axis=2)
+        np.testing.assert_allclose(row_sums, np.ones_like(row_sums), atol=1e-5)
+
+    def test_keep_false_returns_none(self):
+        corpus = _toy_corpus()
+        m = _fit_pa(corpus, keep_theta_draws=False)
+        assert m.theta_draws is None
+
+    def test_doc_lengths(self):
+        corpus = _toy_corpus()
+        m = _fit_pa(corpus)
+        dl = m.doc_lengths
+        assert len(dl) == corpus.num_docs
+        assert all(n > 0 for n in dl)
+
+    def test_composition_theta_works(self):
+        corpus = _toy_corpus()
+        m = _fit_pa(corpus, num_theta_draws=5)
+        out = composition_theta(m, corpus, nsims=3)
+        assert out.shape == (3, corpus.num_docs, np.asarray(m.doc_topic).shape[1])
+
+
+# ---------------------------------------------------------------------------
+# SupervisedLDA
+# ---------------------------------------------------------------------------
+
+def _fit_slda(corpus, *, keep_theta_draws=True, num_theta_draws=10):
+    n = corpus.num_docs
+    rng = np.random.default_rng(42)
+    y = rng.standard_normal(n).tolist()
+    m = topica.SupervisedLDA(num_topics=4, seed=1)
+    m.fit(corpus, y, iters=15,
+          keep_theta_draws=keep_theta_draws, num_theta_draws=num_theta_draws)
+    return m
+
+
+class TestSupervisedLDA:
+    def test_theta_draws_shape(self):
+        corpus = _toy_corpus()
+        m = _fit_slda(corpus, num_theta_draws=8)
+        td = np.asarray(m.theta_draws)
+        d, k = np.asarray(m.doc_topic).shape
+        assert td.shape == (8, d, k)
+        assert td.dtype == np.float32
+
+    def test_theta_draws_rows_sum_to_one(self):
+        corpus = _toy_corpus()
+        m = _fit_slda(corpus, num_theta_draws=5)
+        td = np.asarray(m.theta_draws)
+        row_sums = td.sum(axis=2)
+        np.testing.assert_allclose(row_sums, np.ones_like(row_sums), atol=1e-5)
+
+    def test_keep_false_returns_none(self):
+        corpus = _toy_corpus()
+        m = _fit_slda(corpus, keep_theta_draws=False)
+        assert m.theta_draws is None
+
+    def test_doc_lengths(self):
+        corpus = _toy_corpus()
+        m = _fit_slda(corpus)
+        dl = m.doc_lengths
+        assert len(dl) == corpus.num_docs
+        assert all(n > 0 for n in dl)
+
+    def test_composition_theta_works(self):
+        corpus = _toy_corpus()
+        m = _fit_slda(corpus, num_theta_draws=5)
+        out = composition_theta(m, corpus, nsims=3)
+        assert out.shape == (3, corpus.num_docs, np.asarray(m.doc_topic).shape[1])

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -157,11 +157,11 @@ def test_composition_self_sufficient_for_gibbs_and_rejects_embedding():
     prev = topica.standard_errors(m, of="prevalence", nsims=10)  # no corpus needed
     assert len(prev) == 2
 
-    # HDP is Dirichlet-family but does not retain lengths, so it still needs one.
+    # HDP now retains doc_lengths, so it is also self-sufficient (phase 5).
     hdp = topica.HDP(seed=1)
     hdp.fit(corpus, iters=120)
-    with pytest.raises(ValueError, match="corpus"):
-        topica.standard_errors(hdp, of="prevalence", nsims=10)
+    prev_hdp = topica.standard_errors(hdp, of="prevalence", nsims=5)
+    assert len(prev_hdp) == hdp.num_topics
 
     bert = topica.BERTopic(min_cluster_size=5)
     with pytest.raises(ValueError, match="bootstrap"):


### PR DESCRIPTION
Phase 5 of the estimator-conformance program. Adds `theta_draws` and `doc_lengths` to the remaining Dirichlet-family estimators, so `composition_theta` / `standard_errors` / `predicted_prevalence` now work for them with no `corpus=` re-thread.

## What changed
- **6 collapsed-Gibbs models** (DMR, SAGE, PA, PT, HDP, LabeledLDA): thinned MCMC θ snapshots via the #31 `ThetaDrawOpts` ring-buffer, each snapshot computed to match that model's own `doc_topic` normalization (PA marginalizes over super-topics; HDP uses its discovered K; LabeledLDA restricts to label sets; etc.). `keep_theta_draws`/`num_theta_draws` fit kwargs; `theta_draws` `(S,D,K)` getter; `doc_lengths` getter from the retained corpus.
- **SupervisedLDA** (variational EM, not Gibbs): `theta_draws` are draws from the per-document variational Dirichlet posterior `Dirichlet(gamma_d)` — the honest analog of the Gibbs models' cross-sweep snapshots. `doc_lengths` likewise.
- `conformance.py`: the 14 `theta_draws`/`doc_lengths` gaps removed from `KNOWN_GAPS`. Stub + `test_phase5_theta_draws.py` (36 tests). The `test_standard_errors` HDP case flips from "needs corpus" to self-sufficient (it now retains both).

## Review fix included
The agent first added `fit_pam_with_draws`/`fit_ptm_with_draws` as parallel copies of the existing samplers. Collapsed `fit_pam`/`fit_ptm` into thin delegations to the `_with_draws` variants (collection disabled), so each sampler lives in one place; `cargo test` confirms the delegated path is behavior-identical.

## Validation
- `cargo test --lib`: 49 passed. Rebuilt with `maturin develop --release`.
- Full suite: 1518 passed, 12 skipped, 20 xfailed (was 34; 14 closed).
- Smoke-checked PA/HDP/SupervisedLDA: draws sum to 1, non-zero cross-draw variance, `composition_theta` works with no corpus, `doc_lengths` matches.
- `tests/test_conformance.py` 14 cells now pass; `mkdocs build --strict` clean.

Conformance now: **20 gaps left** (Phase 4 neural members, Phase 6 transform, Phase 2b neural iters).

🤖 Generated with [Claude Code](https://claude.com/claude-code)