### PR TITLE
feat: held-out transform on KeyATM/SeededLDA/SAGE/PA/PT (conformance phase 6)

### DIFF
--- a/docs/contributing/estimator-contract.md
+++ b/docs/contributing/estimator-contract.md
@@ -64,10 +64,10 @@ def transform(self, docs) -> np.ndarray:  # shape (n_docs, K)
 `transform` infers the topic mixture for new documents (without updating the
 model). It is the basis for held-out perplexity, `eval_heldout`, and `search_k`.
 Only the models with no flat document-topic representation are structurally
-exempt: `HLDA` (a topic tree) and `DTM` (time-sliced). The keyword, seeded, and
-anchored Gibbs models (`KeyATM`, `SeededLDA`, `SAGE`, `PA`, `PT`) can infer a
-held-out theta from their fitted phi, so they are tracked in `KNOWN_GAPS` as
-work to do, not exempted.
+exempt: `HLDA` (a topic tree) and `DTM` (time-sliced). All five keyword,
+seeded, and anchored Gibbs models (`KeyATM`, `SeededLDA`, `SAGE`, `PA`, `PT`)
+implement `transform` by running collapsed Gibbs with the fitted phi held
+fixed.
 
 ### Tier 2 — family-specific attributes
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -895,6 +895,28 @@ class SAGE:
         ...
 
     def coherence(self, n: int = 10) -> numpy.typing.NDArray[numpy.float64]: ...
+
+    def transform(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iterations: int = 100,
+        burn_in: int = 10,
+        num_samples: int = 10,
+        sample_interval: int = 5,
+        seed: int | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Infer document-topic theta for new documents by collapsed Gibbs against
+        the fitted group-averaged topic-word matrix. The group-specific word
+        distributions are held fixed and averaged; no group covariate is needed for
+        held-out documents. Shape (num_new_docs, num_topics); rows sum to 1."""
+        ...
+
+    def save(self, path: str) -> None: ...
+    @staticmethod
+    def load(path: str) -> "SAGE": ...
+    @property
+    def doc_names(self) -> list[str]: ...
     def __repr__(self) -> str: ...
 
 
@@ -1292,6 +1314,21 @@ class PT:
         self, n: int = 10, *, topic: int | None = None
     ) -> list[tuple[str, float]] | list[list[tuple[str, float]]]: ...
     def coherence(self, n: int = 10) -> numpy.typing.NDArray[numpy.float64]: ...
+    def transform(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iterations: int = 100,
+        burn_in: int = 10,
+        num_samples: int = 10,
+        sample_interval: int = 5,
+        seed: int | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Infer document-topic theta for new documents by collapsed Gibbs against the
+        fitted topic-word matrix. The pseudo-document layer is a training-time device;
+        held-out documents infer theta over the K topics directly under the fitted phi.
+        Shape (num_new_docs, num_topics); rows sum to 1."""
+        ...
     def save(self, path: str) -> None: ...
     @staticmethod
     def load(path: str) -> "PT": ...
@@ -1425,6 +1462,20 @@ class PA:
         self, n: int = 10, *, topic: int | None = None
     ) -> list[tuple[str, float]] | list[list[tuple[str, float]]]: ...
     def coherence(self, n: int = 10) -> numpy.typing.NDArray[numpy.float64]: ...
+    def transform(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iterations: int = 100,
+        burn_in: int = 10,
+        num_samples: int = 10,
+        sample_interval: int = 5,
+        seed: int | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Infer sub-topic proportions for new documents by collapsed Gibbs against the
+        fitted sub-topic-word matrix. Projects onto the num_sub sub-topics, marginalizing
+        the super-topic layer. Shape (num_new_docs, num_sub); rows sum to 1."""
+        ...
     def save(self, path: str) -> None: ...
     @staticmethod
     def load(path: str) -> "PA": ...
@@ -1541,6 +1592,21 @@ class SeededLDA:
         self, n: int = 10, *, topic: int | None = None
     ) -> list[tuple[str, float]] | list[list[tuple[str, float]]]: ...
     def coherence(self, n: int = 10) -> numpy.typing.NDArray[numpy.float64]: ...
+    def transform(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iterations: int = 100,
+        burn_in: int = 10,
+        num_samples: int = 10,
+        sample_interval: int = 5,
+        seed: int | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Infer document-topic theta for new documents by collapsed Gibbs against the
+        fitted topic-word matrix. The seed-word boost is baked into the fitted phi;
+        new documents infer theta under those distributions without re-estimating the
+        seed prior. Shape (num_new_docs, num_topics); rows sum to 1."""
+        ...
     def save(self, path: str) -> None: ...
     @staticmethod
     def load(path: str) -> "SeededLDA": ...
@@ -2056,6 +2122,22 @@ class KeyATM:
         self, n: int = 10, *, topic: int | None = None
     ) -> list[tuple[str, float]] | list[list[tuple[str, float]]]: ...
     def coherence(self, n: int = 10) -> numpy.typing.NDArray[numpy.float64]: ...
+    def transform(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iterations: int = 100,
+        burn_in: int = 10,
+        num_samples: int = 10,
+        sample_interval: int = 5,
+        seed: int | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Infer document-topic theta for new documents by collapsed Gibbs against the
+        fitted effective topic-word matrix. The effective P(w|topic) already marginalizes
+        over the keyword switch; held-out inference does not re-estimate the switch for
+        new tokens. Uses the estimated asymmetric alpha when available. Shape
+        (num_new_docs, num_topics); rows sum to 1."""
+        ...
     def save(self, path: str) -> None: ...
     @staticmethod
     def load(path: str) -> "KeyATM": ...

--- a/python/topica/conformance.py
+++ b/python/topica/conformance.py
@@ -193,16 +193,6 @@ KNOWN_GAPS: dict[tuple[str, str], str] = {
     ("BERTopic",     "coherence"):  "phase 4: add coherence method to BERTopic (UMass over top words)",
     ("Top2Vec",      "coherence"):  "phase 4: add coherence method to Top2Vec (UMass over top words)",
 
-    # --- Phase 6: held-out transform for the remaining generative models ---
-    # All five are fittable Dirichlet models whose held-out theta can be inferred
-    # with the fitted phi (Gibbs inference for the keyword/seeded/pseudo models;
-    # a baseline, covariate-free projection for SAGE's sparse-additive phi).
-    ("KeyATM",       "transform"): "phase 6: add transform (Gibbs held-out inference with fitted phi)",
-    ("SeededLDA",    "transform"): "phase 6: add transform (Gibbs held-out inference with fitted phi)",
-    ("SAGE",         "transform"): "phase 6: add transform (baseline, covariate-free projection)",
-    ("PA",           "transform"): "phase 6: add transform (sub-topic held-out inference)",
-    ("PT",           "transform"): "phase 6: add transform (pseudo-topic held-out inference)",
-
 }
 
 # ---------------------------------------------------------------------------

--- a/src/python.rs
+++ b/src/python.rs
@@ -4216,6 +4216,37 @@ impl SAGE {
         })
     }
 
+    /// Infer document-topic distributions for new, unseen documents under the
+    /// fitted model (sklearn-style ``transform``). Holds the fitted
+    /// group-averaged topic-word distributions fixed and runs collapsed Gibbs
+    /// to infer θ for each document. Returns shape
+    /// ``(num_new_docs, num_topics)`` with rows summing to 1.
+    ///
+    /// **Approximation:** held-out inference uses the group-averaged
+    /// topic-word matrix (the marginal over groups) and does not condition on
+    /// a group covariate for new documents. This is a baseline projection;
+    /// the group-specific word distributions are a training-time device and
+    /// cannot be recovered for documents whose group label is unknown.
+    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None))]
+    fn transform<'py>(
+        &self,
+        py: Python<'py>,
+        data: &Bound<'py, PyAny>,
+        iterations: usize,
+        burn_in: usize,
+        num_samples: usize,
+        sample_interval: usize,
+        seed: Option<u64>,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
+        let phi = self.topic_marginal();
+        let alpha = vec![self.alpha; self.num_topics];
+        transform_gibbs(py, data, id_to_word, &phi, &alpha, iterations, burn_in,
+                        num_samples, sample_interval, seed.unwrap_or(self.seed))
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "SAGE(num_topics={}, num_groups={}, fitted={})",
@@ -6833,6 +6864,36 @@ impl PT {
         })
     }
 
+    /// Infer document-topic distributions for new, unseen documents under the
+    /// fitted model (sklearn-style ``transform``). Holds the fitted topic-word
+    /// distributions fixed and runs collapsed Gibbs to infer θ for each
+    /// document. Returns shape ``(num_new_docs, num_topics)`` with rows
+    /// summing to 1.
+    ///
+    /// **Approximation:** the pseudo-document layer is a training-time
+    /// aggregation device. Held-out documents infer θ over the K topics
+    /// directly under the fitted topic-word matrix, without pseudo-document
+    /// assignment.
+    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None))]
+    fn transform<'py>(
+        &self,
+        py: Python<'py>,
+        data: &Bound<'py, PyAny>,
+        iterations: usize,
+        burn_in: usize,
+        num_samples: usize,
+        sample_interval: usize,
+        seed: Option<u64>,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
+        let phi = self.phi.as_ref().unwrap();
+        let alpha = vec![self.alpha; self.num_topics];
+        transform_gibbs(py, data, id_to_word, phi, &alpha, iterations, burn_in,
+                        num_samples, sample_interval, seed.unwrap_or(self.seed))
+    }
+
     fn __repr__(&self) -> String {
         format!("PT(num_topics={}, num_pseudo={}, fitted={})", self.num_topics, self.num_pseudo, self.fitted)
     }
@@ -7376,6 +7437,36 @@ impl SeededLDA {
             topic_names: s.topic_names, phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             theta_draws: None, corpus: s.corpus,
         })
+    }
+
+    /// Infer document-topic distributions for new, unseen documents under the
+    /// fitted model (sklearn-style ``transform``). Holds the fitted topic-word
+    /// distributions fixed and runs collapsed Gibbs to infer θ for each
+    /// document. Returns shape ``(num_new_docs, num_topics)`` with rows
+    /// summing to 1.
+    ///
+    /// **Approximation:** the seed-word boost is baked into the fitted
+    /// topic-word matrix. New documents infer θ under those distributions
+    /// without re-estimating the seed prior.
+    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None))]
+    fn transform<'py>(
+        &self,
+        py: Python<'py>,
+        data: &Bound<'py, PyAny>,
+        iterations: usize,
+        burn_in: usize,
+        num_samples: usize,
+        sample_interval: usize,
+        seed: Option<u64>,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
+        let phi = self.phi.as_ref().unwrap();
+        let k = self.num_topics_val();
+        let alpha = vec![self.alpha; k];
+        transform_gibbs(py, data, id_to_word, phi, &alpha, iterations, burn_in,
+                        num_samples, sample_interval, seed.unwrap_or(self.seed))
     }
 
     fn __repr__(&self) -> String {
@@ -9715,6 +9806,40 @@ impl KeyATM {
         })
     }
 
+    /// Infer document-topic distributions for new, unseen documents under the
+    /// fitted model (sklearn-style ``transform``). Holds the fitted effective
+    /// topic-word distributions fixed and runs collapsed Gibbs to infer θ for
+    /// each document. Returns shape ``(num_new_docs, num_topics)`` with rows
+    /// summing to 1.
+    ///
+    /// **Approximation:** held-out inference uses the fitted effective P(w |
+    /// topic), which already marginalizes over the keyword switch, and the
+    /// estimated asymmetric document-topic prior α (falling back to the
+    /// symmetric base value when α was not estimated). The keyword switch
+    /// variable is not re-estimated for new tokens.
+    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None))]
+    fn transform<'py>(
+        &self,
+        py: Python<'py>,
+        data: &Bound<'py, PyAny>,
+        iterations: usize,
+        burn_in: usize,
+        num_samples: usize,
+        sample_interval: usize,
+        seed: Option<u64>,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
+        let phi = self.phi.as_ref().unwrap();
+        let alpha: Vec<f64> = match &self.alpha_vec {
+            Some(v) => v.clone(),
+            None => vec![self.alpha; self.num_topics],
+        };
+        transform_gibbs(py, data, id_to_word, phi, &alpha, iterations, burn_in,
+                        num_samples, sample_interval, seed.unwrap_or(self.seed))
+    }
+
     fn __repr__(&self) -> String {
         format!("KeyATM(keyword_topics={}, num_topics={}, fitted={})", self.key_names.len(), self.num_topics, self.fitted)
     }
@@ -9938,6 +10063,36 @@ impl PA {
             super_sub: arr2_back(s.super_sub), corpus: s.corpus,
             theta_draws: None,
         })
+    }
+
+    /// Infer sub-topic proportions for new, unseen documents under the fitted
+    /// model (sklearn-style ``transform``). Holds the fitted sub-topic–word
+    /// distributions fixed and runs collapsed Gibbs to infer θ over the
+    /// ``num_sub`` sub-topics for each document. Returns shape
+    /// ``(num_new_docs, num_sub)`` with rows summing to 1.
+    ///
+    /// **Approximation:** held-out inference projects directly onto the
+    /// fitted sub-topics, marginalizing the super-topic layer. The
+    /// super-topic assignments are a training-time device and are not
+    /// re-estimated for new documents.
+    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None))]
+    fn transform<'py>(
+        &self,
+        py: Python<'py>,
+        data: &Bound<'py, PyAny>,
+        iterations: usize,
+        burn_in: usize,
+        num_samples: usize,
+        sample_interval: usize,
+        seed: Option<u64>,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
+        let phi = self.phi.as_ref().unwrap();
+        let alpha = vec![self.alpha; self.num_sub];
+        transform_gibbs(py, data, id_to_word, phi, &alpha, iterations, burn_in,
+                        num_samples, sample_interval, seed.unwrap_or(self.seed))
     }
 
     fn __repr__(&self) -> String {

--- a/tests/test_phase6_transform.py
+++ b/tests/test_phase6_transform.py
@@ -1,0 +1,241 @@
+"""Phase 6: held-out transform for KeyATM, SeededLDA, SAGE, PA, PT.
+
+Tests that each model's transform:
+- returns (n, K) array with rows summing to ~1
+- K equals num_topics (num_sub for PA)
+- drops OOV tokens silently
+- a document with no in-vocabulary tokens returns a valid prior row
+- is deterministic given the same seed
+
+Payoff: topica.perplexity and topica.eval_heldout now work for KeyATM and
+SeededLDA (they previously raised "no transform").
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+# ---------------------------------------------------------------------------
+# Shared tiny corpus
+# ---------------------------------------------------------------------------
+DOCS = [
+    ["cat", "cat", "dog", "pet", "animal"],
+    ["dog", "dog", "cat", "pet", "walk"],
+    ["code", "python", "rust", "program", "software"],
+    ["python", "code", "rust", "software", "compile"],
+    ["cat", "dog", "code", "python", "pet"],
+    ["animal", "walk", "rust", "program", "compile"],
+    ["cat", "animal", "pet", "dog", "walk"],
+    ["code", "software", "program", "rust", "python"],
+]
+
+HELD_OUT = [
+    ["cat", "pet", "animal"],
+    ["code", "python", "software"],
+    ["unknown_word_xyz", "another_oov"],  # all OOV
+    ["cat", "code"],
+]
+
+
+def _rows_sum_to_one(arr, atol=1e-6):
+    return np.allclose(arr.sum(axis=1), 1.0, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# KeyATM
+# ---------------------------------------------------------------------------
+
+class TestKeyATMTransform:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = topica.KeyATM({"animals": ["cat", "dog"], "tech": ["code", "python"]},
+                          num_topics=2, seed=7)
+        m.fit(DOCS, iters=50)
+        return m
+
+    def test_shape(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert out.shape == (len(HELD_OUT), model.num_topics)
+
+    def test_rows_sum_to_one(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert _rows_sum_to_one(out)
+
+    def test_oov_only_doc_is_valid(self, model):
+        """A document with no in-vocabulary tokens gets the prior row (sums to 1)."""
+        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+                              num_samples=5, sample_interval=2, seed=0)
+        assert out.shape == (1, model.num_topics)
+        assert _rows_sum_to_one(out)
+
+    def test_deterministic(self, model):
+        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        a = model.transform(HELD_OUT, **kw)
+        b = model.transform(HELD_OUT, **kw)
+        np.testing.assert_array_equal(a, b)
+
+    def test_perplexity_works(self, model):
+        pp = topica.perplexity(model, HELD_OUT[:2], seed=0)
+        assert np.isfinite(pp) and pp > 0
+
+    def test_eval_heldout_works(self, model):
+        heldout = topica.make_heldout(DOCS, seed=1)
+        m2 = topica.KeyATM({"animals": ["cat", "dog"], "tech": ["code", "python"]},
+                           num_topics=2, seed=7)
+        m2.fit(heldout.documents, iters=50)
+        result = topica.eval_heldout(m2, heldout, seed=0)
+        assert np.isfinite(result.mean_per_doc_loglik)
+
+
+# ---------------------------------------------------------------------------
+# SeededLDA
+# ---------------------------------------------------------------------------
+
+class TestSeededLDATransform:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = topica.SeededLDA({"animals": ["cat", "dog"], "tech": ["code", "python"]},
+                             seed=7)
+        m.fit(DOCS, iters=50)
+        return m
+
+    def test_shape(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert out.shape == (len(HELD_OUT), model.num_topics)
+
+    def test_rows_sum_to_one(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert _rows_sum_to_one(out)
+
+    def test_oov_only_doc_is_valid(self, model):
+        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+                              num_samples=5, sample_interval=2, seed=0)
+        assert out.shape == (1, model.num_topics)
+        assert _rows_sum_to_one(out)
+
+    def test_deterministic(self, model):
+        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        a = model.transform(HELD_OUT, **kw)
+        b = model.transform(HELD_OUT, **kw)
+        np.testing.assert_array_equal(a, b)
+
+    def test_perplexity_works(self, model):
+        pp = topica.perplexity(model, HELD_OUT[:2], seed=0)
+        assert np.isfinite(pp) and pp > 0
+
+    def test_eval_heldout_works(self, model):
+        heldout = topica.make_heldout(DOCS, seed=1)
+        m2 = topica.SeededLDA({"animals": ["cat", "dog"], "tech": ["code", "python"]},
+                               seed=7)
+        m2.fit(heldout.documents, iters=50)
+        result = topica.eval_heldout(m2, heldout, seed=0)
+        assert np.isfinite(result.mean_per_doc_loglik)
+
+
+# ---------------------------------------------------------------------------
+# SAGE
+# ---------------------------------------------------------------------------
+
+class TestSAGETransform:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = topica.SAGE(2, seed=7)
+        groups = ["a", "b", "a", "b", "a", "b", "a", "b"]
+        m.fit(DOCS, groups, iters=50)
+        return m
+
+    def test_shape(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert out.shape == (len(HELD_OUT), model.num_topics)
+
+    def test_rows_sum_to_one(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert _rows_sum_to_one(out)
+
+    def test_oov_only_doc_is_valid(self, model):
+        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+                              num_samples=5, sample_interval=2, seed=0)
+        assert out.shape == (1, model.num_topics)
+        assert _rows_sum_to_one(out)
+
+    def test_deterministic(self, model):
+        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        a = model.transform(HELD_OUT, **kw)
+        b = model.transform(HELD_OUT, **kw)
+        np.testing.assert_array_equal(a, b)
+
+
+# ---------------------------------------------------------------------------
+# PA
+# ---------------------------------------------------------------------------
+
+class TestPATransform:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = topica.PA(num_super=2, num_sub=3, seed=7)
+        m.fit(DOCS, iters=50)
+        return m
+
+    def test_shape_is_num_sub(self, model):
+        """PA transform returns (n, num_sub), not (n, num_super)."""
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert out.shape == (len(HELD_OUT), model.num_sub)
+
+    def test_rows_sum_to_one(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert _rows_sum_to_one(out)
+
+    def test_oov_only_doc_is_valid(self, model):
+        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+                              num_samples=5, sample_interval=2, seed=0)
+        assert out.shape == (1, model.num_sub)
+        assert _rows_sum_to_one(out)
+
+    def test_deterministic(self, model):
+        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        a = model.transform(HELD_OUT, **kw)
+        b = model.transform(HELD_OUT, **kw)
+        np.testing.assert_array_equal(a, b)
+
+
+# ---------------------------------------------------------------------------
+# PT
+# ---------------------------------------------------------------------------
+
+class TestPTTransform:
+    @pytest.fixture(scope="class")
+    def model(self):
+        m = topica.PT(num_topics=2, num_pseudo=4, seed=7)
+        m.fit(DOCS, iters=50)
+        return m
+
+    def test_shape(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert out.shape == (len(HELD_OUT), model.num_topics)
+
+    def test_rows_sum_to_one(self, model):
+        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+                              sample_interval=2, seed=0)
+        assert _rows_sum_to_one(out)
+
+    def test_oov_only_doc_is_valid(self, model):
+        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+                              num_samples=5, sample_interval=2, seed=0)
+        assert out.shape == (1, model.num_topics)
+        assert _rows_sum_to_one(out)
+
+    def test_deterministic(self, model):
+        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        a = model.transform(HELD_OUT, **kw)
+        b = model.transform(HELD_OUT, **kw)
+        np.testing.assert_array_equal(a, b)


### PR DESCRIPTION
Phase 6 of the estimator-conformance program, and the close of the original motivating gap: the keyword/seeded/anchored Dirichlet models could not do held-out inference. They now implement `transform`.

## What changed
Added `transform(data, *, iterations=100, burn_in=10, num_samples=10, sample_interval=5, seed=None) -> (n, K)` to **KeyATM, SeededLDA, SAGE, PA, PT**, each reusing the existing `transform_gibbs` helper (per-doc collapsed Gibbs holding the fitted phi fixed):
- **KeyATM** — effective P(w|topic) (keyword switch already marginalized); estimated/symmetric alpha.
- **SeededLDA** — fitted phi (seed boost baked in); symmetric alpha.
- **SAGE** — group-averaged topic-word via the existing `topic_marginal()`; baseline (covariate-free) projection.
- **PT** — fitted phi; pseudo-document layer is training-only.
- **PA** — projects onto the fitted sub-topics (returns `(n, num_sub)`), marginalizing the super-topic layer.

Each docstring states its held-out approximation honestly.

## Payoff (loop closed)
`topica.perplexity` and `topica.eval_heldout` now run for KeyATM and SeededLDA (they previously raised "no transform"). `composition_theta`/`predicted_prevalence` already worked via Phase 5 draws; these five are now fully usable in every held-out / uncertainty facility.

## Conformance
- 5 `transform` gaps removed from `KNOWN_GAPS`; contract doc updated (only HLDA and DTM remain structurally transform-exempt).
- Stub updated. `tests/test_phase6_transform.py`: shapes/row-sums/determinism for all 5 + perplexity/eval_heldout payoff for KeyATM/SeededLDA.

## Validation
- `cargo test --lib`: 49 passed. Full suite: 1547 passed, 12 skipped, 15 xfailed (was 20; 5 closed). `tests/test_conformance.py` 5 cells now pass. `mkdocs build --strict` clean.

Conformance now: **15 gaps left** — Phase 4 (neural/cluster `coherence`/`save`/`load`/`doc_names`) and Phase 2b (neural `iters`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)