### PR TITLE
release: 0.14.0 — uniform estimator interface + predicted_prevalence / held-out

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,47 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.14.0] - 2026-06-10
+
+This release makes the estimator interface uniform across the whole library and
+adds two publication-grade quantities of interest. Every estimator now meets a
+documented contract, checked in CI.
+
+### Added
+
+- `predicted_prevalence(model, ...)`: predicted topic prevalence at chosen
+  covariate values, with difference contrasts and continuous prediction curves,
+  and simulation-based confidence intervals. Model-agnostic (STM, CTM, the
+  covariate keyATM, LDA, ...), built on the method-of-composition draws, so it is
+  the same call regardless of model family. A `viz.predicted_prevalence_plot`
+  renders the forest and curve figures (#35, #43).
+- `make_heldout` / `eval_heldout`: R `stm`-style document-completion held-out
+  log-likelihood, model-agnostic via each model's `transform`; `search_k` now
+  reports a held-out metric for STM/CTM, not only LDA (#38).
+- Estimator conformance facility: `topica.check_conformance(model)`, a
+  registry-driven `tests/test_conformance.py`, and a contributor contract at
+  `docs/contributing/estimator-contract.md`. New estimators that drop part of
+  the contract fail CI.
+- `theta_draws` and `doc_lengths` on the remaining Dirichlet models (DMR, SAGE,
+  PA, PT, HDP, LabeledLDA, SupervisedLDA), so `composition_theta`,
+  `standard_errors`, and `predicted_prevalence` work for them with no `corpus=`
+  re-thread. SupervisedLDA draws from its variational Dirichlet posterior.
+- Held-out `transform` on KeyATM, SeededLDA, SAGE, PA, and PT, so held-out
+  perplexity, `eval_heldout`, and out-of-sample inference now work for the
+  keyword, seeded, and anchored models.
+- Settable `topic_names` on every estimator (default `["topic_0", ...]`).
+- `coherence`, `save`/`load`, and `doc_names` on the neural and cluster models
+  (ETM, FASTopic, ProdLDA, BERTopic, Top2Vec) where they were missing.
+
+### Changed
+
+- **Breaking:** the fit iteration count is the canonical keyword `iters` on every
+  estimator (previously `iterations` for the collapsed-Gibbs models and
+  `em_iters` for the variational ones); `search_k` likewise takes `iters`. No
+  deprecation aliases.
+- **Breaking:** ETM, ProdLDA, and FASTopic take the training length as
+  `fit(iters=...)` rather than a constructor `epochs` / `em_iters` argument.
+
 ## [0.13.0] - 2026-06-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.13.0"
+version = "0.14.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.13.0"
+version = "0.14.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.13.0"
+version = "0.14.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Minor release bundling everything merged since 0.13.0.

## Headline
- **`predicted_prevalence`** (#35, #43) — predicted θ at covariate values, difference contrasts, continuous curves, with CIs; model-agnostic.
- **`make_heldout`/`eval_heldout`** (#38) — model-agnostic held-out document completion; `search_k` reports it for STM/CTM too.
- **Full estimator conformance** (#48–#53) — `topica.check_conformance` + a CI-enforced contract + contributor doc; `theta_draws`/`doc_lengths` and `transform` across the whole Dirichlet family; settable `topic_names`; `coherence`/`save`/`load`/`doc_names` on the neural/cluster models.

## Breaking changes (no aliases — sole user)
- The fit iteration keyword is now **`iters`** on every estimator (was `iterations`/`em_iters`); `search_k` likewise.
- ETM/ProdLDA/FASTopic take the training length as `fit(iters=...)`, not constructor `epochs`/`em_iters`.

See CHANGELOG for the full list.

## Validation
- Version bumped in Cargo.toml, Cargo.lock, pyproject.toml; wheel builds as 0.14.0.
- Full suite green (1578 passed); `tests/test_conformance.py` 0 xfailed (`KNOWN_GAPS` empty); `mkdocs build --strict` clean; `cargo test --lib` 49 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)