### PR TITLE
fix: search_k(held_out=Heldout) composes with make_heldout (closes #55)

### DIFF
--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -720,10 +720,32 @@ def search_k(
 
     Returns a list of dicts (one per K) with ``k``, ``coherence`` (mean UMass,
     so negative; the metric is named in ``coherence_metric`` since ``plot_report``
-    reports c_v on a different scale), ``exclusivity`` (mean top-word
-    exclusivity), and — for ``model="lda"`` with ``held_out`` — ``perplexity``
-    (held-out). The coherence/exclusivity trade-off is the signal: there is rarely
-    a single best K, so read it alongside interpretability (see the K guide).
+    reports c_v on a different scale), ``exclusivity`` (mean top-word exclusivity),
+    and — when ``held_out`` is supplied — a held-out quality metric.
+
+    Two held-out paths are supported, determined by the type of ``held_out``:
+
+    - **Heldout object** (from :func:`make_heldout`): scored with
+      :func:`eval_heldout`; results stored under ``"heldout_loglik"``
+      (``mean_per_doc_loglik``, higher / less negative is better). Use this
+      path for the standard within-corpus word-heldout diagnostic.
+    - **Corpus or token lists** (legacy): scored with :func:`perplexity`;
+      results stored under ``"perplexity"`` (lower is better). This is the
+      document-completion perplexity on a separate held-out set.
+
+    Parameters
+    ----------
+    docs : training documents (``list[list[str]]`` or a ``Corpus``).
+    ks : sequence of topic counts to scan.
+    model : ``"lda"`` (default) or ``"stm"``.
+    prevalence : covariate design matrix for ``model="stm"``; ignored otherwise.
+    held_out : optional held-out set. Pass a :class:`Heldout` (from
+        :func:`make_heldout`) or a separate corpus / token lists.
+    iters : training iterations per fit.
+    num_samples : Gibbs samples per fit (LDA only).
+    sample_interval : iterations between Gibbs samples (LDA only).
+    seed : RNG seed for every fit and transform call.
+    coherence_n : top-word count used for coherence and exclusivity.
     """
     from . import LDA, STM  # local import to avoid a cycle at module load
 
@@ -746,7 +768,11 @@ def search_k(
             "exclusivity": _mean_exclusivity(m.topic_word, coherence_n),
         }
         if held_out is not None:
-            row["perplexity"] = float(perplexity(m, held_out, seed=seed))
+            if isinstance(held_out, Heldout):
+                result = eval_heldout(m, held_out, seed=seed)
+                row["heldout_loglik"] = float(result.mean_per_doc_loglik)
+            else:
+                row["perplexity"] = float(perplexity(m, held_out, seed=seed))
         rows.append(row)
     return rows
 
@@ -758,8 +784,9 @@ def plot_search_k(rows, *, metrics=("coherence", "exclusivity"), ax=None):
     trade off, so the goal is a knee, not a maximum. Each metric gets its own
     y-axis (they live on different scales). ``rows`` is the list returned by
     :func:`search_k`; ``metrics`` selects which of its keys to draw (any of
-    ``"coherence"``, ``"exclusivity"``, ``"perplexity"``). Returns the primary
-    matplotlib ``Axes``. Requires matplotlib.
+    ``"coherence"``, ``"exclusivity"``, ``"perplexity"``, ``"heldout_loglik"``).
+    Only metrics present in the rows are drawn; absent keys are silently skipped.
+    Returns the primary matplotlib ``Axes``. Requires matplotlib.
     """
     try:
         import matplotlib.pyplot as plt

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -308,6 +308,117 @@ class TestSearchKHeldout:
 
 
 # ---------------------------------------------------------------------------
+# Issue #55: search_k(held_out=Heldout) used to raise TypeError
+# ---------------------------------------------------------------------------
+
+class TestSearchKWithHeldoutObject:
+    """Regression tests for the Heldout-dispatch bug in search_k (issue #55).
+
+    Before the fix, passing a Heldout dataclass as held_out raised
+    ``TypeError: 'list' object is not callable`` because search_k called
+    ``perplexity(m, held_out)`` which tried ``held_out.documents()`` — but
+    ``.documents`` on a Heldout is a plain list, not a method.
+    """
+
+    @pytest.fixture(scope="class")
+    def heldout_fixture(self):
+        rng = np.random.default_rng(0)
+        docs = [list(rng.choice(["alpha", "beta", "gamma", "delta"], size=12, replace=True))
+                for _ in range(30)]
+        ho = topica.make_heldout(docs, prop_docs=0.5, prop_words=0.5, seed=1)
+        prevalence = rng.normal(size=(len(docs), 1))
+        return docs, ho, prevalence
+
+    def test_lda_heldout_object_no_typeerror(self, heldout_fixture):
+        """search_k with a Heldout object must not raise TypeError."""
+        docs, ho, _ = heldout_fixture
+        rows = topica.search_k(ho.documents, [2], iters=80, held_out=ho, seed=0)
+        assert len(rows) == 1
+
+    def test_lda_heldout_object_uses_heldout_loglik_key(self, heldout_fixture):
+        """Heldout path stores the metric under 'heldout_loglik', not 'perplexity'."""
+        docs, ho, _ = heldout_fixture
+        rows = topica.search_k(ho.documents, [2], iters=80, held_out=ho, seed=0)
+        row = rows[0]
+        assert "heldout_loglik" in row, "expected 'heldout_loglik' key in result row"
+        assert "perplexity" not in row, "'perplexity' key must not appear for Heldout path"
+
+    def test_lda_heldout_loglik_is_finite_negative(self, heldout_fixture):
+        docs, ho, _ = heldout_fixture
+        rows = topica.search_k(ho.documents, [2], iters=80, held_out=ho, seed=0)
+        val = rows[0]["heldout_loglik"]
+        assert np.isfinite(val), f"heldout_loglik not finite: {val}"
+        assert val < 0.0, f"mean per-doc log-likelihood should be negative, got {val}"
+
+    def test_stm_heldout_object_no_typeerror(self, heldout_fixture):
+        """STM path also dispatches correctly through the Heldout branch."""
+        docs, ho, prevalence = heldout_fixture
+        rows = topica.search_k(
+            ho.documents, [2], model="stm", prevalence=prevalence,
+            iters=10, held_out=ho, seed=0,
+        )
+        assert len(rows) == 1
+        row = rows[0]
+        assert "heldout_loglik" in row
+        assert "perplexity" not in row
+        assert np.isfinite(row["heldout_loglik"])
+        assert row["heldout_loglik"] < 0.0
+
+    def test_multiple_ks_all_rows_have_heldout_loglik(self, heldout_fixture):
+        """Every row produced for different K values must carry the metric."""
+        docs, ho, _ = heldout_fixture
+        rows = topica.search_k(ho.documents, [2, 3], iters=50, held_out=ho, seed=0)
+        assert len(rows) == 2
+        for row in rows:
+            assert "heldout_loglik" in row
+            assert np.isfinite(row["heldout_loglik"])
+
+    def test_legacy_corpus_list_still_produces_perplexity(self, heldout_fixture):
+        """The legacy path (token lists, not Heldout) still yields 'perplexity'."""
+        docs, ho, _ = heldout_fixture
+        rng = np.random.default_rng(42)
+        held_docs = [list(rng.choice(["alpha", "beta", "gamma", "delta"], size=12, replace=True))
+                     for _ in range(8)]
+        rows = topica.search_k(docs, [2], iters=80, held_out=held_docs, seed=0)
+        row = rows[0]
+        assert "perplexity" in row
+        assert "heldout_loglik" not in row
+        assert np.isfinite(row["perplexity"])
+        assert row["perplexity"] > 1.0
+
+
+# ---------------------------------------------------------------------------
+# plot_search_k with heldout_loglik metric
+# ---------------------------------------------------------------------------
+
+def test_plot_search_k_accepts_heldout_loglik_metric():
+    """plot_search_k must plot 'heldout_loglik' rows without raising."""
+    mpl = pytest.importorskip("matplotlib")
+    mpl.use("Agg")
+
+    rows = [
+        {"k": 2, "coherence": -10.0, "exclusivity": 0.6, "heldout_loglik": -5.2},
+        {"k": 3, "coherence": -12.0, "exclusivity": 0.5, "heldout_loglik": -4.8},
+    ]
+    ax = topica.plot_search_k(rows, metrics=("coherence", "heldout_loglik"))
+    assert ax is not None
+
+
+def test_plot_search_k_mixed_rows_no_error():
+    """plot_search_k must silently skip metrics absent from all rows."""
+    mpl = pytest.importorskip("matplotlib")
+    mpl.use("Agg")
+
+    rows = [
+        {"k": 2, "coherence": -10.0, "exclusivity": 0.6},
+        {"k": 3, "coherence": -12.0, "exclusivity": 0.5},
+    ]
+    # asking for heldout_loglik when no row has it should raise (no metrics left)
+    with pytest.raises(ValueError):
+        topica.plot_search_k(rows, metrics=("heldout_loglik",))
+
+
+# ---------------------------------------------------------------------------
 # Optional: better-fit model should score higher held-out LL
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Closes #55. `search_k(ho.documents, ks, held_out=ho)` (with `ho = make_heldout(...)`) raised `TypeError: 'list' object is not callable` — `search_k` scored held-out via the legacy `perplexity()`, which calls `held_out.documents()` (a Corpus method), but `make_heldout` returns a `Heldout` whose `.documents` is a list attribute.

## Fix
`search_k` now dispatches on the held-out type: a `Heldout` is scored with `eval_heldout(m, held_out)` and reported as `heldout_loglik` (mean per-doc held-out log-likelihood, higher is better); a `Corpus`/token-list keeps the legacy `perplexity` path/key. The two are kept under distinct keys because they are opposite-direction, different-scale metrics. `plot_search_k` already handles arbitrary metric keys; its docstring lists `heldout_loglik`.

## Validation
- The exact issue repro now runs and returns a per-K `heldout_loglik`.
- New `TestSearchKWithHeldoutObject` (compose make_heldout -> search_k for LDA and STM; legacy path still yields `perplexity`) + plot tests. `tests/test_heldout.py` + `tests/test_plot_search_k.py`: 42 passed. Full suite: 1770 passed, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)