### PR TITLE
feat: prep_documents + plot_removed with metadata re-alignment (closes #41)

### DIFF
--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -195,7 +195,7 @@ from .embedding import (  # noqa: E402
 from .preprocess import split_documents  # noqa: E402
 from .stopwords import ENGLISH_STOPWORDS  # noqa: E402
 from .phrases import learn_phrases, apply_phrases, add_ngrams, Phrases  # noqa: E402
-from .frames import from_dataframe, align  # noqa: E402
+from .frames import from_dataframe, align, prep_documents, plot_removed  # noqa: E402
 from .formulas import design_matrix  # noqa: E402
 
 __all__ = [
@@ -279,6 +279,8 @@ __all__ = [
     "ENGLISH_STOPWORDS",
     "from_dataframe",
     "align",
+    "prep_documents",
+    "plot_removed",
     "design_matrix",
     "summary",
     "diagnostics",

--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -8,6 +8,8 @@ prevalence regression. These helpers keep text and metadata bound together.
 
 from __future__ import annotations
 
+from typing import Sequence
+
 from . import Corpus, tokenize
 
 
@@ -83,6 +85,176 @@ def from_dataframe(
     else:
         corpus.metadata = df.iloc[idx][cols].reset_index(drop=True)
     return corpus
+
+
+def prep_documents(
+    corpus,
+    meta=None,
+    *,
+    lower_thresh=1,
+    upper_thresh=None,
+    rm_top=0,
+):
+    """Filter rare (and optionally common) vocabulary from a corpus while keeping
+    metadata row-aligned with the documents that survive.
+
+    This is topica's analogue of R ``stm``'s ``prepDocuments``. Terms that appear
+    in fewer than ``lower_thresh`` documents are dropped from the vocabulary; after
+    dropping, documents that become empty are removed. The ``meta`` frame is
+    subsetted to exactly the rows of the surviving documents, so the returned
+    corpus and metadata stay one-to-one and in the same order. Feeding the returned
+    meta straight into an STM prevalence design requires no further alignment.
+
+    Parameters
+    ----------
+    corpus : Corpus
+        A :class:`~topica.Corpus` built by :func:`~topica.Corpus.from_documents`
+        or :func:`~topica.from_dataframe`.  The corpus may already carry a
+        ``corpus.metadata`` attribute; if ``meta`` is also supplied, ``meta``
+        takes precedence and ``corpus.metadata`` is ignored.
+    meta : pandas.DataFrame, polars.DataFrame, sequence, or numpy.ndarray, optional
+        Per-document covariates, one entry per document in ``corpus`` (before this
+        call's filtering).  Accepts a pandas or Polars DataFrame, a numpy array,
+        or a plain list/sequence. When ``None``, ``corpus.metadata`` is used if
+        present; the returned metadata may then be ``None`` if neither is set.
+    lower_thresh : int, default 1
+        Minimum document frequency for a term to be kept.  Terms appearing in
+        fewer than ``lower_thresh`` documents are removed.  ``lower_thresh=1``
+        keeps all terms (no filtering); ``lower_thresh=2`` drops hapax legomena.
+    upper_thresh : int or None, default None
+        Maximum document frequency for a term to be kept.  Terms appearing in more
+        than ``upper_thresh`` documents are removed.  ``None`` disables the upper
+        bound.  Passed as ``rm_top`` is handled separately; ``upper_thresh`` is a
+        raw count ceiling.
+    rm_top : int, default 0
+        Number of the most-frequent terms to remove (regardless of count).
+        Mirrors :func:`~topica.Corpus.from_documents`'s ``rm_top`` parameter.
+
+    Returns
+    -------
+    filtered_corpus : Corpus
+        A new corpus with the rare-term vocabulary and empty documents removed.
+        ``filtered_corpus.kept_indices`` reports which of the *input corpus's*
+        document positions survived; ``filtered_corpus.doc_lengths`` is parallel to
+        the returned ``filtered_meta`` rows.
+    filtered_meta : same type as ``meta``, or None
+        The subset of ``meta`` (or ``corpus.metadata``) rows corresponding to the
+        surviving documents, in the same order.  Guaranteed
+        ``len(filtered_meta) == len(filtered_corpus.doc_lengths)`` when meta is not
+        None.
+    """
+    # Resolve which metadata to use
+    if meta is None:
+        meta = getattr(corpus, "metadata", None)
+
+    # Get the token-list representation of the current corpus
+    docs = corpus.documents()
+
+    # Compute max_doc_fraction from upper_thresh
+    n_docs = len(docs)
+    if upper_thresh is not None and n_docs > 0:
+        max_doc_fraction = upper_thresh / n_docs
+    else:
+        max_doc_fraction = 1.0
+
+    # Build a new corpus applying the frequency thresholds
+    filtered = Corpus.from_documents(
+        docs,
+        min_doc_freq=lower_thresh,
+        max_doc_fraction=max_doc_fraction,
+        rm_top=rm_top,
+    )
+
+    # filtered.kept_indices are positions into `docs` (= the input corpus docs).
+    # Subset meta to those positions.
+    idx = filtered.kept_indices
+    if meta is not None:
+        if hasattr(meta, "iloc"):  # pandas DataFrame / Series
+            filtered_meta = meta.iloc[idx].reset_index(drop=True)
+        elif _is_polars(meta):  # polars DataFrame / Series
+            filtered_meta = meta[list(idx)]
+        else:
+            try:
+                import numpy as np
+                if isinstance(meta, np.ndarray):
+                    filtered_meta = meta[idx]
+                else:
+                    filtered_meta = [meta[i] for i in idx]
+            except ImportError:
+                filtered_meta = [meta[i] for i in idx]
+        filtered.metadata = filtered_meta
+    else:
+        filtered_meta = None
+
+    return filtered, filtered_meta
+
+
+def plot_removed(corpus, thresholds, *, ax=None):
+    """Sweep document-frequency thresholds and plot how many documents and words
+    are removed at each level (R ``stm``'s ``plotRemoved``).
+
+    For each threshold value in ``thresholds``, :func:`prep_documents` is called
+    and the number of removed documents and removed vocabulary terms is recorded.
+    The result is a two-line chart that helps you choose a threshold: a very low
+    threshold removes few items; a high threshold may eliminate many documents whose
+    only terms are rare, which would corrupt a downstream covariate analysis.
+
+    Parameters
+    ----------
+    corpus : Corpus
+        The corpus to sweep. Passed unchanged to :func:`prep_documents` at each
+        threshold.
+    thresholds : sequence of int
+        Document-frequency thresholds to evaluate (x-axis). Typically a range
+        such as ``range(1, 10)``.
+    ax : matplotlib.axes.Axes, optional
+        Axes to draw into. When ``None`` a new figure is created.
+
+    Returns
+    -------
+    ax : matplotlib.axes.Axes
+        The primary axes (left y-axis = documents removed; right y-axis = words
+        removed).
+    """
+    try:
+        import matplotlib.pyplot as plt
+    except ImportError as e:  # pragma: no cover
+        raise ImportError(
+            "plot_removed needs matplotlib (pip install matplotlib)."
+        ) from e
+
+    thresholds = list(thresholds)
+    n_docs_orig = corpus.num_docs
+    n_words_orig = corpus.num_words
+
+    docs_removed = []
+    words_removed = []
+    for t in thresholds:
+        filtered, _ = prep_documents(corpus, lower_thresh=t)
+        docs_removed.append(n_docs_orig - filtered.num_docs)
+        words_removed.append(n_words_orig - filtered.num_words)
+
+    if ax is None:
+        _, ax = plt.subplots(figsize=(6, 4))
+
+    (line_docs,) = ax.plot(
+        thresholds, docs_removed, color="C0", marker="o", label="documents removed"
+    )
+    ax.set_xlabel("lower threshold (minimum document frequency)")
+    ax.set_ylabel("documents removed", color="C0")
+    ax.tick_params(axis="y", labelcolor="C0")
+
+    ax2 = ax.twinx()
+    (line_words,) = ax2.plot(
+        thresholds, words_removed, color="C1", marker="s", label="words removed"
+    )
+    ax2.set_ylabel("words removed", color="C1")
+    ax2.tick_params(axis="y", labelcolor="C1")
+
+    lines = [line_docs, line_words]
+    ax.legend(lines, [l.get_label() for l in lines], loc="upper left")
+    ax.figure.tight_layout()
+    return ax
 
 
 def align(x, corpus):

--- a/tests/test_prep_documents.py
+++ b/tests/test_prep_documents.py
@@ -1,0 +1,168 @@
+"""Tests for prep_documents and plot_removed (issue #41).
+
+prep_documents applies a document-frequency threshold AND keeps a metadata
+frame row-aligned through document removal. The alignment invariant is the
+key correctness property: len(meta) == len(corpus.doc_lengths) after the call,
+and the surviving metadata rows correspond to the surviving documents.
+"""
+
+import pytest
+
+import topica
+
+pd = pytest.importorskip("pandas")
+
+
+# ---------------------------------------------------------------------------
+# Corpus fixture
+# ---------------------------------------------------------------------------
+# Documents 1 ("zzz") and 3 ("qqq") appear only once, so lower_thresh=2 makes
+# them rare. After the vocabulary is pruned, docs 1 and 3 become empty and are
+# dropped.  The surviving documents are indices 0, 2, 4.
+DOCS = [
+    ["cat", "dog"],          # 0  — survives
+    ["zzz"],                 # 1  — "zzz" drops under thresh 2 → doc becomes empty
+    ["cat", "dog", "fish"],  # 2  — survives
+    ["qqq"],                 # 3  — "qqq" drops under thresh 2 → doc becomes empty
+    ["dog", "fish"],         # 4  — survives
+]
+
+META_DF = pd.DataFrame(
+    {
+        "year":  [2000, 2001, 2002, 2003, 2004],
+        "party": ["D",  "R",  "D",  "R",  "D"],
+    }
+)
+
+
+@pytest.fixture
+def base_corpus():
+    return topica.Corpus.from_documents(DOCS)
+
+
+# ---------------------------------------------------------------------------
+# prep_documents — core alignment guarantee
+# ---------------------------------------------------------------------------
+
+def test_prep_documents_drops_empty_docs(base_corpus):
+    """After applying lower_thresh=2, only 3 of 5 documents survive."""
+    fc, _ = topica.prep_documents(base_corpus, lower_thresh=2)
+    assert fc.num_docs == 3
+
+
+def test_prep_documents_metadata_row_count_equals_kept_docs(base_corpus):
+    """The alignment trap: meta rows must equal kept-doc count, not original count."""
+    fc, fmeta = topica.prep_documents(base_corpus, meta=META_DF, lower_thresh=2)
+    assert len(fmeta) == fc.num_docs
+    assert len(fmeta) == len(fc.doc_lengths)
+
+
+def test_prep_documents_metadata_values_follow_correct_rows(base_corpus):
+    """Surviving metadata rows correspond to the surviving documents (0, 2, 4)."""
+    fc, fmeta = topica.prep_documents(base_corpus, meta=META_DF, lower_thresh=2)
+    assert list(fmeta["year"]) == [2000, 2002, 2004]
+    assert list(fmeta["party"]) == ["D", "D", "D"]
+
+
+def test_prep_documents_index_reset_after_drop(base_corpus):
+    """Returned pandas metadata has a clean 0-based integer index."""
+    _, fmeta = topica.prep_documents(base_corpus, meta=META_DF, lower_thresh=2)
+    assert list(fmeta.index) == [0, 1, 2]
+
+
+def test_prep_documents_no_thresh_returns_all(base_corpus):
+    """lower_thresh=1 (the default) keeps everything."""
+    fc, fmeta = topica.prep_documents(base_corpus, meta=META_DF, lower_thresh=1)
+    assert fc.num_docs == 5
+    assert len(fmeta) == 5
+
+
+def test_prep_documents_returns_none_meta_when_no_meta(base_corpus):
+    """When neither meta kwarg nor corpus.metadata is set, second return is None."""
+    fc, fmeta = topica.prep_documents(base_corpus, lower_thresh=2)
+    assert fmeta is None
+    assert fc.num_docs == 3
+
+
+def test_prep_documents_uses_corpus_metadata_attribute(base_corpus):
+    """corpus.metadata is used when meta kwarg is omitted."""
+    base_corpus.metadata = META_DF
+    fc, fmeta = topica.prep_documents(base_corpus, lower_thresh=2)
+    assert len(fmeta) == 3
+    assert list(fmeta["year"]) == [2000, 2002, 2004]
+
+
+def test_prep_documents_kwarg_meta_overrides_corpus_metadata(base_corpus):
+    """Explicit meta= takes precedence over corpus.metadata."""
+    # Set corpus.metadata to something different
+    base_corpus.metadata = META_DF.assign(year=range(100, 105))
+    fc, fmeta = topica.prep_documents(base_corpus, meta=META_DF, lower_thresh=2)
+    assert list(fmeta["year"]) == [2000, 2002, 2004]
+
+
+def test_prep_documents_list_meta(base_corpus):
+    """Plain list metadata is aligned correctly."""
+    meta = ["a", "b", "c", "d", "e"]
+    _, fmeta = topica.prep_documents(base_corpus, meta=meta, lower_thresh=2)
+    assert fmeta == ["a", "c", "e"]
+
+
+# ---------------------------------------------------------------------------
+# prep_documents — composes with from_dataframe / align
+# ---------------------------------------------------------------------------
+
+def test_prep_documents_composes_with_from_dataframe():
+    """prep_documents works on a corpus built by from_dataframe."""
+    df = pd.DataFrame(
+        {
+            "text": ["cat dog", "zzz", "cat dog fish", "qqq", "dog fish"],
+            "year": [2000, 2001, 2002, 2003, 2004],
+        }
+    )
+    c = topica.from_dataframe(df, text_col="text")
+    fc, fmeta = topica.prep_documents(c, lower_thresh=2)
+    assert fc.num_docs == len(fmeta)
+
+
+def test_prep_documents_doc_lengths_aligned_with_meta(base_corpus):
+    """doc_lengths length equals metadata length after filtering."""
+    fc, fmeta = topica.prep_documents(base_corpus, meta=META_DF, lower_thresh=2)
+    assert len(fc.doc_lengths) == len(fmeta)
+
+
+# ---------------------------------------------------------------------------
+# prep_documents — upper_thresh
+# ---------------------------------------------------------------------------
+
+def test_prep_documents_upper_thresh_removes_common_terms(base_corpus):
+    """upper_thresh drops terms above the count ceiling, reducing vocabulary."""
+    fc_no_upper, _ = topica.prep_documents(base_corpus, lower_thresh=1)
+    # "dog" appears in docs 0, 2, 4 (3 out of 5). upper_thresh=2 removes it.
+    fc_upper, _ = topica.prep_documents(base_corpus, lower_thresh=1, upper_thresh=2)
+    assert fc_upper.num_words < fc_no_upper.num_words
+
+
+# ---------------------------------------------------------------------------
+# plot_removed
+# ---------------------------------------------------------------------------
+
+def test_plot_removed_returns_axes(base_corpus):
+    """plot_removed returns a matplotlib Axes."""
+    mpl = pytest.importorskip("matplotlib")
+    import matplotlib.pyplot as plt
+    plt.switch_backend("Agg")
+    ax = topica.plot_removed(base_corpus, thresholds=range(1, 4))
+    import matplotlib.axes
+    assert isinstance(ax, matplotlib.axes.Axes)
+    plt.close("all")
+
+
+def test_plot_removed_accepts_ax_argument(base_corpus):
+    """plot_removed draws into a provided Axes and returns it."""
+    mpl = pytest.importorskip("matplotlib")
+    import matplotlib.pyplot as plt
+    plt.switch_backend("Agg")
+    fig, ax = plt.subplots()
+    returned = topica.plot_removed(base_corpus, thresholds=[1, 2, 3], ax=ax)
+    assert returned is ax
+    plt.close("all")


### PR DESCRIPTION
Closes #41. `prep_documents(corpus, meta=, lower_thresh=, ...)` filters rare terms and returns the filtered corpus with a row-aligned metadata frame (drops metadata rows for emptied documents, via the corpus's `kept_indices`), closing the silent misalignment trap. `plot_removed(corpus, thresholds)` sweeps the threshold. Pure-Python on the existing Corpus infra; pandas/polars/list/ndarray metadata. 14 new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)