### PR TITLE
release: 0.15.0 — STM/keyATM parity completion + effect-estimation surface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,61 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.15.0] - 2026-06-10
+
+This release completes the structural-topic-model and keyATM drop-in parity work
+and rounds out the model-agnostic effect-estimation surface. It also moves the
+heavy CI (wheels, sdist) to release tags and builds the test job optimized, so a
+normal push runs only the fast test suite.
+
+### Added
+
+- `permutation_test(model, covariate, ...)` for a binary prevalence covariate: a
+  distribution-free check on whether a topic's prevalence differs across the two
+  groups, returning a `PermutationResult` per topic (#36).
+- `select_model` / `plot_models`: fit N models at a fixed K under different seeds
+  and pick the best by a held-out or coherence criterion, mirroring R `stm`'s
+  `selectModel`; returns a `SelectModelResult` (#37).
+- `prep_documents` / `plot_removed`: R `stm`-style preprocessing diagnostics that
+  report how many documents, words, and tokens each vocabulary threshold removes,
+  with metadata re-alignment via the `Corpus`'s kept indices (#41).
+- A uniform convergence interface on every iterative model: `model.fit_history`
+  (per-iteration `(iter, objective)`) and `model.converged`. The collapsed-Gibbs
+  models gained an opt-in early stop (`convergence_tol` / `check_every`, default
+  off so the full `iters` run is bit-for-bit unchanged); the variational models
+  trace and early-stop on the ELBO (#46).
+- `prevalence_ci(model, groups, ...)`: model-neutral per-group topic-prevalence
+  credible bands read directly from a model's posterior theta draws (the
+  draws-based companion to `by_strata`). `time_prevalence_ci(model, timestamps)`
+  is the dynamic-keyATM wrapper that pins the period order to `time_labels`, so
+  the dynamic time trend now carries the HMM posterior's own uncertainty rather
+  than a generic ribbon (#42).
+- Covariate-aware `stm.transform(model, docs, prevalence=/formula=/X=)`: held-out
+  topic inference that builds each new document's prior from its covariates and
+  the fitted `gamma` (`mu_d = X_d gamma`), matching R `stm`'s `fitNewDocuments`.
+  A model-neutral `align_corpus(new_docs, model)` maps new tokens onto the fitted
+  vocabulary (dropping out-of-vocabulary tokens) before transform (#39).
+- `STM.fit(gamma_prior="pooled"|"l1", gamma_enet=...)`: an L1/elastic-net prior on
+  the prevalence coefficients, fit by coordinate descent with an AIC-selected
+  penalty, for high-dimensional prevalence designs (a factor with many levels).
+  `"pooled"` (ridge, the default) is unchanged; `gamma_enet` is the elastic-net
+  mix (R `stm`'s `gamma.enet`) (#40).
+
+### Fixed
+
+- `search_k(held_out=...)` now composes with a `make_heldout` split: it dispatches
+  on the `Heldout` type and reports the held-out log-likelihood, instead of
+  raising a `TypeError` from the legacy perplexity path (#55).
+
+### Changed
+
+- CI: `build-wheels` and `sdist` run only on release tags (`v*`) and manual
+  dispatch, not on every push/PR; the wheels are consumed only by the release
+  job. The 3-platform test job still runs on every push/PR and now builds with
+  `--release` plus a cached Rust toolchain, cutting the test legs from roughly
+  twenty minutes to a few. Committed tests no longer assume a macOS-only
+  `/private/tmp`.
+
 ## [0.14.0] - 2026-06-10
 
 This release makes the estimator interface uniform across the whole library and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,7 +931,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.14.0"
+version = "0.15.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.14.0"
+version = "0.15.0"
 edition = "2021"
 
 [lib]

--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -61,6 +61,23 @@ and in the `topica.validation` module.
 
 ::: topica.topic_stability
 
+## Held-out likelihood
+
+Build a within-corpus word-heldout set — the analogue of R `stm`'s
+`make.heldout` — and score it under a fitted model to get document-completion
+log-likelihood.
+
+::: topica.make_heldout
+
+::: topica.eval_heldout
+
+## Estimator conformance
+
+Check any fitted model or model class against the topica estimator contract;
+returns a list of violation strings (empty means fully conformant).
+
+::: topica.check_conformance
+
 ## Reporting
 
 Model-neutral summaries that work on any fitted model.

--- a/docs/api/keyatm.md
+++ b/docs/api/keyatm.md
@@ -16,3 +16,10 @@ log-likelihood)` pairs (perplexity is `exp(-log_likelihood)`).
 ::: topica.keyatm.visualize_keywords
 
 ::: topica.keyatm.refine_keywords
+
+## Dynamic model: time-trend credible intervals
+
+Per-period topic prevalence with credible bands from the dynamic keyATM
+posterior's retained MCMC theta draws.
+
+::: topica.time_prevalence_ci

--- a/docs/api/keywords.md
+++ b/docs/api/keywords.md
@@ -14,6 +14,18 @@
 
 ::: topica.one_hot
 
+Prune rare (and optionally common) vocabulary from a corpus, keeping
+metadata row-aligned with the documents that survive — the analogue of R
+`stm`'s `prepDocuments`.
+
+::: topica.prep_documents
+
+Sweep document-frequency thresholds and visualize how many documents and
+vocabulary terms are removed at each level, to inform the choice of
+`lower_thresh`.
+
+::: topica.plot_removed
+
 ## DataFrames & metadata
 
 These accept pandas **or** Polars frames (and `align` also takes numpy arrays and

--- a/docs/api/stm.md
+++ b/docs/api/stm.md
@@ -17,3 +17,55 @@ post-hoc diagnostics (labeling, alignment, pyLDAvis, …) are on the
 ::: topica.stm.spline
 
 ::: topica.stm.interaction
+
+## Predicted prevalence
+
+Compute predicted topic prevalence at chosen covariate values, with
+simulation-based credible intervals — the model-agnostic counterpart of
+R `stm`'s `plot.estimateEffect`.
+
+::: topica.predicted_prevalence
+
+::: topica.PredictedPrevalence
+
+## Permutation test
+
+Distribution-free test of whether a binary prevalence covariate genuinely
+shifts topic prevalence, or whether the association could arise by chance.
+
+::: topica.permutation_test
+
+::: topica.PermutationResult
+
+## Per-group prevalence with credible bands
+
+Model-neutral per-group topic prevalence with posterior credible intervals
+drawn from the model's retained MCMC theta draws (or the logistic-normal
+posterior for STM/CTM).
+
+::: topica.prevalence_ci
+
+## Covariate-aware held-out inference
+
+Infer topic proportions for new documents using a fitted STM's prevalence
+model, setting the per-document prior from `mu_d = X_d gamma`.
+
+::: topica.stm.transform
+
+Map new token lists onto the fitted vocabulary before calling `transform`,
+dropping any out-of-vocabulary tokens.
+
+::: topica.align_corpus
+
+## Model selection at fixed K
+
+Run multiple initializations at a fixed K and compare candidates on the
+coherence-exclusivity frontier — the analogue of R `stm`'s `selectModel`.
+
+::: topica.select_model
+
+::: topica.SelectModelResult
+
+Visualize the coherence-versus-exclusivity scatter across candidate runs.
+
+::: topica.plot_models

--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -55,6 +55,76 @@ Build non-linear and interaction terms with `stm.spline` and `stm.interaction`.
 Full detail and the journal-grade treatment are in the
 [Publishing](../publishing/effects.md) track.
 
+## Predicted prevalence
+
+`topica.predicted_prevalence` computes predicted topic prevalence at chosen
+covariate values with simulation-based credible intervals — the direct
+counterpart of R `stm`'s `plot.estimateEffect`. Three modes mirror `stm`'s
+`method` argument:
+
+```python
+import topica
+
+# Point grid: predicted prevalence when party is "D" vs "R"
+pp = topica.predicted_prevalence(
+    model,
+    formula="~ party + year",
+    data=meta,
+    at={"party": ["D", "R"]},
+)
+for result in pp:
+    print(result.topic_name, result.estimate, result.ci_low, result.ci_high)
+
+# Continuous sweep: prevalence as year varies, other covariates at their means
+pp = topica.predicted_prevalence(
+    model, formula="~ party + year", data=meta,
+    continuous="year",
+)
+
+# Contrast: difference in prevalence between two covariate settings
+pp = topica.predicted_prevalence(
+    model, formula="~ party", data=meta,
+    contrast={"party": ["D", "R"]},
+)
+```
+
+## Permutation test for binary covariates
+
+`topica.permutation_test` assesses whether a binary covariate genuinely shifts
+topic prevalence, using permutation resampling rather than parametric
+assumptions:
+
+```python
+results = topica.permutation_test(
+    model, corpus=docs, covariate=treated,   # treated: 0/1 array
+    n_perm=100, seed=0,
+)
+for r in results:
+    print(f"Topic {r.topic_name}: observed={r.observed:.3f}  p={r.pvalue:.3f}")
+```
+
+Each `PermutationResult` carries the observed covariate effect, the full null
+distribution (`r.null`), and a two-sided p-value.
+
+## L1/elastic-net prior for high-dimensional designs
+
+When the prevalence design matrix has many columns (many dummies, interaction
+terms, or a wide feature matrix), add `gamma_prior="l1"` to `STM.fit` to
+penalize the prevalence coefficients:
+
+```python
+model = topica.STM(num_topics=20, seed=1)
+model.fit(
+    docs, prevalence=X, prevalence_names=names,
+    gamma_prior="l1",     # elastic-net with full L1 (lasso)
+    gamma_enet=1.0,       # alpha=1.0 is pure L1; 0 < alpha < 1 mixes L2
+)
+```
+
+The default `gamma_prior="pooled"` uses the OLS pooled regression from the
+original STM paper. Use `"l1"` when p (number of prevalence covariates)
+approaches or exceeds the number of documents.
+
 ## Choosing K for STM
 
 Use `search_k`, the coherence×exclusivity frontier, and an `HDP` sanity check.

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -80,6 +80,37 @@ topica.topic_stability([model_a, model_b], topn=10)       # cross-fit term overl
 topica.check_residuals(model, docs)                       # Taddy dispersion: is K too small?
 ```
 
+## Convergence
+
+Every iterative model exposes a uniform convergence interface. `model.fit_history`
+is a list of `(iteration, objective)` pairs — the ELBO/bound for variational
+models (STM, CTM, ProdLDA, ETM, FASTopic) and the per-token log-likelihood for
+collapsed-Gibbs models (LDA, keyATM, SeededLDA, …). `model.converged` is `True`
+if a tolerance criterion was met during `fit`, `False` if the model ran to the
+iteration cap, and `None` for models with no iterative objective (BERTopic,
+Top2Vec).
+
+```python
+model = topica.LDA(num_topics=20, seed=1)
+model.fit(docs, iters=500)
+
+model.converged        # True / False / None
+model.fit_history      # [(10, -7.43), (20, -7.31), ...]
+```
+
+On collapsed-Gibbs models you can enable early stopping by passing
+`convergence_tol` and `check_every` to `fit`:
+
+```python
+model.fit(docs, iters=1000, convergence_tol=1e-4, check_every=10)
+# stops as soon as the relative change in log-likelihood over one check
+# interval drops below 1e-4, rather than running all 1000 sweeps.
+```
+
+The cluster models (BERTopic, Top2Vec) and structurally non-iterative models
+(DTM, HLDA) return an empty `fit_history` and `converged` of `False` or `None`;
+they satisfy the contract without early-stop support.
+
 ## Visualization
 
 ```python

--- a/docs/guides/transform.md
+++ b/docs/guides/transform.md
@@ -40,3 +40,44 @@ theta = dmr.transform(new_docs, features=new_X)
 # STM variational inference (no Gibbs parameters needed):
 theta = stm_model.transform(new_docs)
 ```
+
+## Covariate-aware transform for STM
+
+When new documents carry prevalence covariates, use `topica.stm.transform`
+rather than the model method directly. It sets the per-document prior mean to
+`mu_d = X_d @ gamma`, which is R `stm`'s `fitNewDocuments` behavior:
+
+```python
+import topica
+
+# Via a raw covariate matrix (without the intercept column):
+theta = topica.stm.transform(stm_model, new_docs, prevalence=X_new)
+
+# Via a formula and a DataFrame of new-document covariates:
+theta = topica.stm.transform(
+    stm_model, new_docs,
+    formula="~ party + author",
+    data=new_meta_df,
+)
+```
+
+The `formula=` path encodes the design matrix using the same column encoding
+as at fit time, then prepends an intercept to match `gamma`. Formulas
+containing a `spline()` term are rejected here because the knots would be
+recomputed on the new documents rather than reused from the training data.
+Build the design matrix manually with `design_matrix_predict` using the
+fit-time knot context and pass it as `X=` instead.
+
+## Aligning vocabulary before transform
+
+New documents may contain tokens not seen at fit time. Use `align_corpus` to
+drop out-of-vocabulary tokens before passing the documents to `transform`:
+
+```python
+aligned = topica.align_corpus(new_docs, stm_model)
+theta = topica.stm.transform(stm_model, aligned, prevalence=X_new)
+```
+
+`align_corpus` works on any model that exposes a `vocabulary` attribute, so
+it also applies before `stm_model.transform(new_docs)` or any other
+transform call.

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -72,6 +72,53 @@ frontier = topica.quality_frontier(model, n=10)   # per-topic coherence & exclus
 DMR, CTM, STM, HDP, …) by inferring each held-out document's topic mixture from
 half its tokens and scoring the other half, so it is comparable across `K`.
 
+### Document-completion held-out log-likelihood
+
+`make_heldout` and `eval_heldout` implement R `stm`'s held-out word scoring
+rather than the standard perplexity split. We hold out a random fraction of
+words from a random fraction of documents, fit the model on the reduced corpus,
+then score the withheld words:
+
+```python
+import topica
+
+h = topica.make_heldout(corpus, prop_docs=0.5, prop_words=0.5, seed=0)
+model = topica.STM(num_topics=20, seed=1)
+model.fit(h.documents, prevalence=X)
+
+result = topica.eval_heldout(model, h)
+print(f"mean per-doc held-out log-likelihood: {result.mean_per_doc_loglik:.3f}")
+```
+
+Higher (less negative) values indicate better fit. This metric is comparable
+across values of K fit on the same `h.documents` corpus.
+
+### Best-of-N at fixed K
+
+Gibbs models and STM can land on different local optima from different starting
+values. `select_model` runs `runs` initializations at a fixed K and returns all
+fitted models with their coherence and exclusivity scores:
+
+```python
+result = topica.select_model(
+    docs, K=20,
+    runs=20,           # number of random initializations
+    model="stm",       # "lda" or "stm"
+    prevalence=X,      # required when model="stm"
+    fraction=0.5,      # keep only the top 50% after a short burn-in
+)
+# inspect the coherence-exclusivity frontier across all runs:
+topica.plot_models(result)
+
+# pick the run in the upper-right corner and use that model:
+best_idx = result.coherence.argmax()   # or use exclusivity, or visual inspection
+model = result.models[best_idx]
+```
+
+The `fraction` argument mirrors R `stm`'s "run briefly, keep the best ~20%"
+heuristic: a short burn-in filters out clearly poor starts before the full
+training runs.
+
 A nonparametric model is a useful sanity check on your choice: it *infers* a
 topic count rather than taking one.
 

--- a/docs/publishing/corpus.md
+++ b/docs/publishing/corpus.md
@@ -89,4 +89,33 @@ print(corpus.num_docs, corpus.num_words, corpus.total_tokens)
 Report the document count, vocabulary size, and token count *after* pruning.
 Those three numbers belong in your methods section.
 
+## Choosing vocabulary thresholds with prep_documents
+
+`topica.prep_documents` prunes a `Corpus` by document frequency — dropping
+terms that appear in fewer than `lower_thresh` documents — and keeps the
+metadata frame aligned with the surviving documents. This is the analogue of
+R `stm`'s `prepDocuments`:
+
+```python
+import topica
+
+corpus_pruned, meta_pruned = topica.prep_documents(
+    corpus, meta=meta_df,
+    lower_thresh=5,   # drop terms appearing in fewer than 5 docs
+    rm_top=20,        # also drop the 20 most frequent residual terms
+)
+```
+
+Before committing to a threshold, sweep a range and visualize how many
+documents and vocabulary terms each level removes:
+
+```python
+topica.plot_removed(corpus, thresholds=range(1, 15))
+```
+
+The chart shows two lines: documents removed (left axis) and vocabulary terms
+removed (right axis). A threshold that removes many documents will corrupt a
+downstream covariate analysis; aim for the elbow where vocabulary shrinks
+rapidly but document loss stays near zero.
+
 → Next: [Choose and justify K](choosing-k.md).

--- a/docs/replications/keyatm-dynamic.md
+++ b/docs/replications/keyatm-dynamic.md
@@ -109,6 +109,26 @@ Unions rise, and Criminal procedure and First amendment decline. `time_prevalenc
 gives the smoothed proportion per year and `time_state` the regime each year
 occupies.
 
+To add credible bands to the time-trend figure, use `topica.time_prevalence_ci`,
+which reads the credible interval directly from the retained MCMC theta draws
+(pass `keep_theta_draws=True` at fit, which is the default):
+
+```python
+import topica
+
+ci = topica.time_prevalence_ci(model, timestamps=years, ci=0.95)
+# ci["labels"]   — list of period labels aligned with model.time_labels
+# ci["mean"]     — (T, K) posterior mean prevalence per period
+# ci["ci_low"]   — (T, K) lower 2.5th-percentile credible bound
+# ci["ci_high"]  — (T, K) upper 97.5th-percentile credible bound
+```
+
+This differs from `topica.keyatm.by_strata`: `by_strata` widens a descriptive
+normal interval using Rubin's rules; `time_prevalence_ci` reads the band
+directly off the posterior draw stack, which gives the HMM's own uncertainty
+without a normal approximation. Use `time_prevalence_ci` for ribbon plots that
+claim to show posterior uncertainty.
+
 ## What differs
 
 Two differences are worth stating plainly. First, this is a single chain of 1,000

--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -265,8 +265,14 @@ topica.estimate_effect(m.doc_topic, X)   # ... and effect tool applies to m.
 \end{CodeInput}
 \end{CodeChunk}
 
-The built-in models are written to exactly this contract; the implementer's guide
-that ships with the package documents it for contributors.
+The built-in models are written to exactly this contract, and the contract is not
+left to convention. A machine-readable specification, \code{topica.check\_conformance},
+enumerates the attributes and methods every estimator must expose---the two
+matrices, the held-out \code{transform}, the per-iteration convergence trace, the
+family-specific posterior draws---and a parametrized test checks all of them on
+every continuous-integration run, so a model that drops part of the surface fails
+the suite rather than silently degrading the toolkit. The implementer's guide that
+ships with the package documents the contract for contributors.
 
 \subsection{Determinism as a constraint}
 
@@ -347,7 +353,9 @@ the SAGE mechanism, so the same topic can be worded differently across groups
 while its prevalence is regressed on metadata. The keyword-assisted model is also
 implemented in full, covering the base, covariate, and dynamic variants, the
 information-theoretic token weighting, and the change-point hidden Markov model
-\citep{chib1998changepoint} of the dynamic specification.
+\citep{chib1998changepoint} of the dynamic specification, whose smoothed time
+trend is reported with per-period credible bands drawn from the retained
+posterior rather than as a bare point estimate.
 
 %% ===========================================================================
 \section{A principled analysis workflow}\label{sec:workflow}
@@ -363,9 +371,11 @@ show where each one decides.
 
 The corpus fixes the scope of every later claim, so preprocessing is a
 substantive decision rather than a chore. \pkg{topica} provides the \code{Corpus}
-container and tokenization, phrase learning, and document-splitting tools, and the
-workflow documents every choice (stopwords, frequency thresholds, phrases) because
-the methods section has to report them.
+container and tokenization, phrase learning, and document-splitting tools, and
+\code{topica.prep\_documents} with \code{topica.plot\_removed} reports how many
+documents, words, and tokens each vocabulary threshold removes, so the pruning is
+quantified rather than guessed. The workflow documents every choice (stopwords,
+frequency thresholds, phrases) because the methods section has to report them.
 
 \subsection{Choose and justify the number of topics}
 
@@ -374,18 +384,27 @@ often get wrong, because the diagnostics tempt one to optimize it. $K$ is a
 research decision about granularity, not a hyperparameter to maximize: a model
 with fewer topics often scores higher on coherence while collapsing distinctions
 the researcher cares about. \code{topica.search\_k} fits a range of $K$ and
-reports coherence, exclusivity, and held-out perplexity for each, and
+reports coherence, exclusivity, and a held-out score for each; with
+\code{topica.make\_heldout} and \code{topica.eval\_heldout} that score is the
+document-completion held-out log-likelihood \pkg{stm} uses, available for every
+model that supports held-out inference rather than only \code{LDA}.
 \code{topica.quality\_frontier} plots the per-topic coherence-exclusivity
-trade-off. The honest procedure is to fit a small range around a theoretically
-plausible $K$, label the topics at each, count the uninterpretable ones, and let
-the researcher choose, reporting sensitivity to that choice.
+trade-off, and because a single fit of a non-convex model can land on a poor
+local optimum, \code{topica.select\_model} fits several models at a fixed $K$
+under different seeds and returns the most coherent. The honest procedure is to
+fit a small range around a theoretically plausible $K$, label the topics at each,
+count the uninterpretable ones, and let the researcher choose, reporting
+sensitivity to that choice.
 
 \subsection{Fit, read, and validate}
 
 Topics are read from several angles together, since top words alone underdetermine
 meaning: \code{label\_topics} reports the highest-probability, FREX
 \citep{bischof2012frex}, and lift words, and \code{find\_thoughts} returns the
-documents that load most heavily on a topic. Validation is not optional.
+documents that load most heavily on a topic. Every iterative model also exposes
+its convergence trace as \code{fit\_history} and a \code{converged} flag, so a fit
+that stopped at the iteration cap is not mistaken for one that met a tolerance.
+Validation is not optional.
 \code{topica.coherence} computes the windowed coherence measures
 \citep{lau2014coherence} in the core, \code{topica.exclusivity} and
 \code{topica.topic\_diversity} measure distinctness, \code{bootstrap\_stability}
@@ -414,10 +433,16 @@ effects = stm.estimate_effect(draws, X, feature_names=names, cluster=source_id)
 \end{CodeInput}
 \end{CodeChunk}
 
-The model-agnostic \code{topica.standard\_errors} extends this to any model and is
-explicit about the kind of uncertainty it reports. For a clustering of embeddings,
-which has no posterior over $\theta$, it declines to report confidence intervals
-and says so, rather than returning a number that looks like one.
+Beyond the coefficient table, \code{topica.predicted\_prevalence} reports predicted
+topic prevalence at chosen covariate values, with differences between settings and
+continuous prediction curves carried with simulation-based intervals---the
+quantity of interest \pkg{stm}'s \code{estimateEffect} plots---and
+\code{topica.permutation\_test} gives a distribution-free check of whether a
+topic's prevalence differs across a binary covariate. The model-agnostic
+\code{topica.standard\_errors} extends this to any model and is explicit about the
+kind of uncertainty it reports. For a clustering of embeddings, which has no
+posterior over $\theta$, it declines to report confidence intervals and says so,
+rather than returning a number that looks like one.
 
 \subsection{Visualization and reporting}
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.14.0"
+version = "0.15.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts 0.15.0. Closes the structural-topic-model and keyATM drop-in parity work (the #35-#46 set) and rounds out the model-agnostic effect-estimation surface, with the docs and paper updated to match.

## Added
- `permutation_test` for a binary prevalence covariate (#36)
- `select_model` / `plot_models` — best-of-N at fixed K (#37)
- `prep_documents` / `plot_removed` — stm-style preprocessing diagnostics (#41)
- Uniform convergence interface: `fit_history` + `converged` on every iterative model; opt-in `convergence_tol`/`check_every` early stop on the Gibbs models (#46)
- `prevalence_ci` (model-neutral per-group credible bands from posterior draws) + `time_prevalence_ci` (dynamic-keyATM wrapper) (#42)
- Covariate-aware `stm.transform` (`mu_d = X_d gamma`, R `fitNewDocuments`) + model-neutral `align_corpus` (#39)
- `STM.fit(gamma_prior="l1", gamma_enet=...)` — L1/elastic-net prevalence prior, AIC-selected, for high-dimensional designs; `"pooled"` default unchanged (#40)

## Fixed
- `search_k(held_out=...)` composes with `make_heldout` instead of raising (#55)

## Changed (CI)
- `build-wheels`/`sdist` gated to `v*` tags + manual dispatch; the test job builds `--release` with a cached toolchain (test legs ~21 min → ~5 min); committed tests no longer assume a macOS-only `/private/tmp`.

## Docs + paper
- API-reference directives for every new function; guide coverage for the covariate transform, predicted-prevalence / permutation test, held-out eval + select_model, prep_documents, the dynamic-keyATM bands, and the convergence interface.
- `paper/topica.tex` strengthened in six places (headline: the machine-checked conformance contract); verified compiling (18 pages).

## Validation
- `cargo test --lib`: 50 passed
- `pytest tests/`: 1882 passed, 18 skipped
- `mkdocs build --strict`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)