### PR TITLE
Ensemble topic modeling: combine runs into a reliable consensus

### DIFF
--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -61,6 +61,10 @@ and in the `topica.validation` module.
 
 ::: topica.topic_stability
 
+::: topica.ensemble
+
+::: topica.EnsembleResult
+
 ## Held-out likelihood
 
 Build a within-corpus word-heldout set — the analogue of R `stm`'s

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -80,6 +80,53 @@ topica.topic_stability([model_a, model_b], topn=10)       # cross-fit term overl
 topica.check_residuals(model, docs)                       # Taddy dispersion: is K too small?
 ```
 
+## Ensemble: combining runs
+
+A single fit is one draw from a noisy procedure. Change the seed and the topics
+move, sometimes a lot, and neural models are worse than classical ones (Hoyle et
+al. 2022). Rather than fit once and hope, or fit many and pick one with
+`select_model`, we can combine independent runs into a consensus that is more
+reliable than any single run. In Hoyle et al.'s experiments the ensemble beats the
+median run in 97% of settings and never loses to the worst.
+
+`ensemble` takes the runs (a list of fitted models, raw topic-word arrays, or a
+`select_model` result) and returns a consensus that behaves like a fitted model:
+it carries `topic_word`, `doc_topic`, and `vocabulary`, so it flows straight into
+`coherence`, the diagnostics, and the rest. Each consensus topic reports a
+`stability` score and a `reliable` flag, so a topic the runs do not actually agree
+on is marked rather than trusted.
+
+```python
+runs = topica.select_model(docs, K=20, runs=10)   # ten initializations
+cons = topica.ensemble(runs)                       # combine them
+
+cons.topic_word.shape       # (20, V)
+cons.stability              # per-topic agreement across runs, in [0, 1]
+cons.reliable               # per-topic: consistent AND well-supported?
+topica.coherence(cons, docs)
+```
+
+Three methods are available:
+
+- `method="cluster"` (default) reproduces Hoyle et al. (§6): pool the topics from
+  every run, measure a top-weighted rank distance between them that blends the
+  topic-word and document-topic views (`lambda_`), cluster the pool into K groups,
+  and average within each cluster. Clustering tolerates a topic that splits or
+  merges across runs, and flags a cluster that few runs supported.
+- `method="align"` is a lighter, fully deterministic alternative: match every
+  run's topics one-to-one to a reference run (Hungarian on the topic-word
+  distributions) and average the aligned topics.
+- `method="stable"` reimplements gensim's `EnsembleLda` (Brigl 2019). It does not
+  fix K: it finds dense, reproducible "cores" with Checkback DBSCAN and keeps only
+  the clusters with enough cores as stable topics, discarding the rest as noise.
+  Use it to let the data decide how many topics are reproducible. It is validated
+  against gensim to floating-point precision.
+
+```python
+topica.ensemble(runs, method="align")                  # reference matching
+topica.ensemble(runs, method="stable", eps=0.1)        # discover stable topics
+```
+
 ## Convergence
 
 Every iterative model exposes a uniform convergence interface. `model.fit_history`

--- a/parity/ensemblelda_gensim_compare.py
+++ b/parity/ensemblelda_gensim_compare.py
@@ -1,0 +1,112 @@
+"""Cross-implementation validation: topica's ``ensemble(method="stable")`` vs
+gensim's ``EnsembleLda`` (Brigl 2019).
+
+The "stable" method is a numpy-native reimplementation of gensim's CBDBSCAN
+stable-topic procedure: pool the topics from every run, compute an asymmetric
+masked-cosine distance between them, run Checkback DBSCAN to find dense cores, and
+keep the clusters with enough cores as stable topics (averaging their members).
+
+Unlike the R parity checks, gensim is a Python package, so the comparison is exact
+rather than statistical: we drive *both* implementations from the SAME pooled
+topic-term array (so no LDA training noise enters) and check that they agree on (1)
+the asymmetric distance matrix, and (2) the resulting stable topics. They should
+match to floating-point precision.
+
+Skips (exit 0) if gensim is unavailable. Run directly:
+
+    python parity/ensemblelda_gensim_compare.py
+"""
+
+from __future__ import annotations
+
+import sys
+
+import numpy as np
+
+
+def gensim_available():
+    try:
+        import gensim.models.ensemblelda  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _synthetic_ttda(m=5, K=4, V=30, seed=0):
+    """A pooled topic-term array with clean cluster structure: K disjoint-block
+    prototypes, lightly perturbed in each of m runs. Rows are normalized."""
+    rng = np.random.default_rng(seed)
+    protos = np.zeros((K, V))
+    for k in range(K):
+        protos[k, k * (V // K):(k + 1) * (V // K)] = 1.0
+    protos /= protos.sum(1, keepdims=True)
+    runs = []
+    for _ in range(m):
+        b = protos + rng.normal(0, 0.01, protos.shape)
+        b = np.clip(b, 1e-6, None)
+        b /= b.sum(1, keepdims=True)
+        runs.append(b)
+    return runs
+
+
+def _gensim_stable(ttda, eps, min_samples, min_cores):
+    """Run gensim's own clustering pipeline on a fixed ttda and return its stable
+    topics — the reference output."""
+    from gensim.models.ensemblelda import (
+        CBDBSCAN, _aggregate_topics, _calculate_asymmetric_distance_matrix_chunk,
+        _group_by_labels, _is_valid_core, _validate_clusters, mass_masking,
+    )
+
+    D = _calculate_asymmetric_distance_matrix_chunk(ttda, ttda, 0, mass_masking, 0.95)
+    cb = CBDBSCAN(eps=eps, min_samples=min_samples)
+    cb.fit(D)
+    clusters = _aggregate_topics(_group_by_labels(cb.results))
+    valid = {c.label for c in _validate_clusters(clusters, min_cores)}
+    for t in cb.results:
+        t.valid_neighboring_labels = {lbl for lbl in t.neighboring_labels if lbl in valid}
+    mask = np.vectorize(_is_valid_core)(cb.results)
+    labels = np.array([t.label for t in cb.results])[mask]
+    stable = np.vstack([ttda[mask][labels == lbl].mean(0) for lbl in np.unique(labels)])
+    return D, stable
+
+
+def main():
+    if not gensim_available():
+        print("gensim not available; skipping EnsembleLda parity check.")
+        return 0
+
+    import topica
+    from topica.ensemble import _asymmetric_distance
+
+    m, K = 5, 4
+    runs = _synthetic_ttda(m=m, K=K)
+    ttda = np.vstack(runs)
+    eps = 0.1
+    min_samples = int(m / 2)
+    min_cores = min(3, max(1, int(m / 4 + 1)))
+
+    D_gensim, stable_gensim = _gensim_stable(ttda, eps, min_samples, min_cores)
+    D_topica = _asymmetric_distance(ttda, "mass", 0.95)
+    res = topica.ensemble(
+        runs, method="stable", eps=eps, min_samples=min_samples,
+        min_cores=min_cores, masking="mass", masking_threshold=0.95,
+    )
+
+    d_err = float(np.abs(D_gensim - D_topica).max())
+    print(f"asymmetric distance matrix: max abs diff = {d_err:.2e}")
+    assert d_err < 1e-9, "asymmetric distance matrices disagree"
+
+    print(f"stable topic count: gensim={stable_gensim.shape[0]} topica={res.topic_word.shape[0]}")
+    assert stable_gensim.shape[0] == res.topic_word.shape[0] == K, "stable topic count mismatch"
+
+    pairs = topica.align_topics(stable_gensim, res.topic_word, metric="cosine")
+    t_err = max(d for _, _, d in pairs)
+    print(f"stable topics: max aligned cosine distance = {t_err:.2e}")
+    assert t_err < 1e-9, "stable topics disagree"
+
+    print("OK: topica ensemble(method='stable') matches gensim EnsembleLda.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -165,6 +165,7 @@ from .validation import (  # noqa: E402  general, model-agnostic post-hoc analys
     align_topics,
     topic_stability,
 )
+from .ensemble import ensemble, EnsembleResult  # noqa: E402  (consensus across runs)
 from .analysis import (  # noqa: E402  (model-neutral fitted-model analysis surface)
     topic_info,
     topic_sizes,
@@ -255,6 +256,8 @@ __all__ = [
     "check_residuals",
     "align_topics",
     "topic_stability",
+    "ensemble",
+    "EnsembleResult",
     "find_thoughts_html",
     "quality_frontier",
     "bootstrap_stability",

--- a/python/topica/ensemble.py
+++ b/python/topica/ensemble.py
@@ -1,0 +1,771 @@
+"""Ensemble topic modeling: combine several independent fits into one consensus.
+
+A single topic-model fit is a draw from a noisy procedure — change the seed or a
+hyperparameter and the topics shift, sometimes a lot (Hoyle et al. 2022, "Are
+Neural Topic Models Broken?"). Combining several independent runs is more reliable
+than any one run: across Hoyle et al.'s experiments the ensemble improves on the
+median run in 97% of contexts and never loses to the worst. This module builds
+that consensus.
+
+It is the natural follow-on to :func:`~topica.select_model`, which fits N runs at a
+fixed K. Instead of *picking* the best run with ``plot_models``, ``ensemble``
+*combines* all of them.
+
+Three methods are available:
+
+``method="cluster"`` (default) reproduces Hoyle et al. §6. Pool the topics from
+every run (m runs of K topics each give m·K topics), measure the pairwise distance
+between them — a blend ``lambda_·D(topic-word) + (1-lambda_)·D(doc-topic)`` using a
+top-weighted rank distance (Rank-Biased Overlap, or average Jaccard) — cluster the
+pooled topics into K groups, and take the element-wise mean within each cluster.
+Clustering does not force a one-to-one match, so a topic that splits or merges
+across runs is handled naturally, and a cluster only a few runs contributed to is
+flagged as low-support.
+
+``method="align"`` is a lighter, fully deterministic alternative (the Miller &
+McCoy 2017 / Mäntylä et al. 2018 lineage): align every run's topics one-to-one to
+a single reference run (Hungarian matching on the topic-word distributions) and
+average the aligned topics. No clustering, no Θ, no λ.
+
+``method="stable"`` reimplements gensim's ``EnsembleLda`` (Brigl 2019). It does not
+fix K: it pools the topics, measures an asymmetric masked-cosine distance between
+them, runs Checkback DBSCAN (CBDBSCAN) to find dense, reproducible "cores", and
+keeps only the clusters with enough cores as *stable topics* (averaging their
+members). Unstable topics — those that do not recur densely across runs — are
+discarded as noise rather than averaged in, so the number of consensus topics is
+discovered from the data. Validated against gensim in ``parity/``.
+
+The result duck-types as a fitted model for the model-neutral analysis surface (it
+exposes ``topic_word``, ``doc_topic``, and ``vocabulary``), so the consensus flows
+straight into :func:`~topica.coherence`, the diagnostics, and the rest. Each
+ensemble topic carries a ``stability`` score and a ``reliable`` flag, so a
+consensus topic the individual runs do not actually agree on is marked, not
+silently trusted.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass, field
+
+import numpy as np
+
+# A topic is "reliable" when it is both internally consistent (its members agree)
+# and well-supported (enough runs found it). Same alignment threshold as the
+# bootstrap path in effects.py, so a reliable topic means the same thing across the
+# library.
+_MIN_STABILITY = 0.5
+_MIN_SUPPORT = 0.5     # cluster: fraction of runs that must back a topic
+_MIN_MARGIN = 0.1      # align: how much the best match must beat the next-best
+_RBO_P = 0.9  # Rank-Biased Overlap persistence; ~0.9 weights roughly the top ten.
+
+
+@dataclass
+class EnsembleResult:
+    """Consensus of several topic-model fits, returned by :func:`ensemble`.
+
+    Exposes ``topic_word``, ``doc_topic``, and ``vocabulary`` so it can be passed
+    wherever a fitted model is accepted by the model-neutral analysis functions
+    (:func:`~topica.coherence`, the diagnostics surface, :func:`~topica.align_topics`).
+
+    Attributes
+    ----------
+    topic_word : ``(K, V)`` averaged, row-normalized topic-word matrix.
+    doc_topic : ``(D, K)`` averaged document-topic matrix, or ``None`` when the
+        runs were not fit on the same documents in the same order.
+    vocabulary : the shared vocabulary, or ``None`` when raw arrays were passed.
+    stability : ``(K,)`` per-topic consistency in ``[0, 1]``. For ``"cluster"`` and
+        ``"stable"`` it is one minus the mean pairwise distance among the run
+        topics that formed the cluster; for ``"align"`` it is the mean top-word
+        Jaccard with the matched run topics. 1.0 means every run produced the same
+        topic.
+    support : ``(K,)`` how well-backed each topic is. For ``"cluster"`` and
+        ``"stable"`` it is the fraction of runs that contributed a topic to the
+        cluster (1.0 = all runs found it); for ``"align"`` it is the match margin
+        over the next-best run topic. A small value means few runs really support
+        the topic.
+    reliable : ``(K,)`` bool — ``stability >= 0.5`` *and* well-supported. An
+        unreliable topic is a consensus the individual runs do not agree on; treat
+        it with suspicion. (``"stable"`` topics are reproducible by construction,
+        so this is usually all ``True``.)
+    agreement : scalar mean of ``stability`` — an overall "how reproducible is this
+        K?" number (``nan`` if ``"stable"`` found no topics).
+    method : ``"cluster"``, ``"align"``, or ``"stable"``.
+    cluster_sizes : ``(K,)`` number of run topics in each cluster (``"cluster"``
+        and ``"stable"``; ``None`` for ``"align"``).
+    reference : index of the reference run (``"align"`` only; ``None`` for
+        ``"cluster"``).
+    n_runs : number of fits combined.
+    runs : the input fits, in the order given.
+    """
+
+    topic_word: np.ndarray
+    doc_topic: np.ndarray | None
+    vocabulary: list | None
+    stability: np.ndarray
+    support: np.ndarray
+    reliable: np.ndarray
+    agreement: float
+    method: str
+    cluster_sizes: np.ndarray | None
+    reference: int | None
+    n_runs: int
+    runs: list = field(repr=False)
+
+    def __repr__(self):  # noqa: D105
+        K = self.topic_word.shape[0]
+        return (
+            f"EnsembleResult(method={self.method!r}, n_runs={self.n_runs}, K={K}, "
+            f"agreement={self.agreement:.3f}, reliable={int(np.sum(self.reliable))}/{K})"
+        )
+
+    def top_words(self, n=10):
+        """Top-`n` ``(term, probability)`` pairs per ensemble topic, matching the
+        fitted-model contract so the result drops into the analysis surface. The
+        term is a word when a vocabulary is known, else the integer term index."""
+        phi = self.topic_word
+        vocab = list(self.vocabulary) if self.vocabulary is not None else None
+        out = []
+        for t in range(phi.shape[0]):
+            idx = np.argsort(phi[t])[::-1][:n]
+            out.append([((vocab[i] if vocab is not None else int(i)), float(phi[t, i])) for i in idx])
+        return out
+
+
+# ---------------------------------------------------------------------------
+# Shared plumbing
+# ---------------------------------------------------------------------------
+
+def _coerce_runs(runs):
+    """Accept a list of fits, or a ``SelectModelResult`` (use its ``.models``)."""
+    models = getattr(runs, "models", None)
+    if models is not None:
+        runs = models
+    runs = list(runs)
+    if len(runs) < 2:
+        raise ValueError("need at least two runs to form an ensemble")
+    return runs
+
+
+def _gather(runs):
+    """Topic-word arrays, optional document-topic arrays, and the vocabulary.
+
+    Returns ``(betas, thetas, vocab, K, V)``. ``thetas`` is ``None`` unless every
+    run exposes a document-topic matrix of the same shape — the only case in which
+    averaging per-document proportions across runs is meaningful."""
+    from .coherence import _as_doc_topic, _as_topic_word
+
+    betas = [_as_topic_word(r) for r in runs]
+    K, V = betas[0].shape
+    for b in betas:
+        if b.shape != (K, V):
+            raise ValueError(
+                f"all runs must share the same shape (K, V); got {betas[0].shape} and {b.shape}"
+            )
+
+    vocab = getattr(runs[0], "vocabulary", None)
+    if vocab is not None:
+        vocab = list(vocab)
+
+    # Only fitted models carry a distinct document-topic matrix. A raw (K, V)
+    # array has none — _as_doc_topic would pass the array straight through and we
+    # would mistake the topic-word matrix for Θ — so require an actual attribute.
+    thetas = None
+    if all(hasattr(r, "doc_topic") and not isinstance(r, np.ndarray) for r in runs):
+        try:
+            cand = [_as_doc_topic(r) for r in runs]
+            if all(t.shape == cand[0].shape and t.shape[1] == K for t in cand):
+                thetas = cand
+        except (AttributeError, TypeError, ValueError):
+            thetas = None
+
+    return betas, thetas, vocab, K, V
+
+
+def _normalize_weights(weights, n):
+    if weights is None:
+        return np.full(n, 1.0 / n)
+    w = np.asarray(weights, dtype=np.float64)
+    if w.shape != (n,):
+        raise ValueError(f"weights must have length {n}, got shape {w.shape}")
+    if np.any(w < 0):
+        raise ValueError("weights must be non-negative")
+    total = w.sum()
+    if total <= 0:
+        raise ValueError("weights must not be all zero")
+    return w / total
+
+
+def _ranked(vectors, topn):
+    """Per-row ranked top-`topn` index lists (descending by value)."""
+    return [list(np.argsort(v)[::-1][:topn]) for v in vectors]
+
+
+def _rbo(a, b, p=_RBO_P):
+    """Rank-Biased Overlap (Webber et al. 2010), extrapolated, on two equal-depth
+    ranked lists. Top-weighted: early-rank agreement counts most. Returns a
+    similarity in ``(0, 1]`` (1 = identical ordering)."""
+    k = max(len(a), len(b))
+    if k == 0:
+        return 1.0
+    s = 0.0
+    x_d = 0
+    for d in range(1, k + 1):
+        x_d = len(set(a[:d]) & set(b[:d]))
+        s += (x_d / d) * (p ** d)
+    return (x_d / k) * (p ** k) + ((1.0 - p) / p) * s
+
+
+def _avg_jaccard(a, b):
+    """Average Jaccard overlap across prefix depths (Greene et al. 2014). Returns a
+    similarity in ``[0, 1]``."""
+    k = max(len(a), len(b))
+    if k == 0:
+        return 1.0
+    s = 0.0
+    for d in range(1, k + 1):
+        A, B = set(a[:d]), set(b[:d])
+        u = A | B
+        s += (len(A & B) / len(u)) if u else 0.0
+    return s / k
+
+
+def _rank_distance(ranked, distance):
+    """Pairwise distance matrix among ranked lists, using a top-weighted rank
+    similarity (1 - similarity)."""
+    sim = {"rbo": _rbo, "jaccard": _avg_jaccard}[distance]
+    n = len(ranked)
+    D = np.zeros((n, n))
+    for i in range(n):
+        for j in range(i + 1, n):
+            D[i, j] = D[j, i] = 1.0 - sim(ranked[i], ranked[j])
+    return D
+
+
+# ---------------------------------------------------------------------------
+# method="cluster" — Hoyle et al. 2022, §6
+# ---------------------------------------------------------------------------
+
+def _agglomerative(D, k):
+    """Average-linkage agglomerative clustering on a precomputed distance matrix.
+    Returns a length-T label array with ``k`` clusters. Deterministic. Hand-rolled
+    (numpy only) to keep the library free of a scipy/scikit dependency; the inner
+    loop is vectorized, so it is fine for the m·K topics a topic-model ensemble
+    produces (cost grows with that total, so very large run counts are slow)."""
+    T = D.shape[0]
+    if k >= T:
+        return np.arange(T)
+    D = D.astype(float).copy()
+    np.fill_diagonal(D, np.inf)
+    sizes = np.ones(T)
+    alive = np.ones(T, dtype=bool)
+    members = [[i] for i in range(T)]
+    n_active = T
+    while n_active > k:
+        i, j = divmod(int(np.argmin(D)), T)
+        ni, nj = sizes[i], sizes[j]
+        merged = (ni * D[i] + nj * D[j]) / (ni + nj)  # Lance-Williams average linkage
+        merged[~alive] = np.inf
+        merged[i] = np.inf
+        D[i, :] = merged
+        D[:, i] = merged
+        D[j, :] = np.inf
+        D[:, j] = np.inf
+        alive[j] = False
+        sizes[i] = ni + nj
+        members[i] += members[j]
+        members[j] = []
+        n_active -= 1
+    labels = np.empty(T, dtype=int)
+    for ci, i in enumerate(np.flatnonzero(alive)):
+        for m in members[i]:
+            labels[m] = ci
+    return labels
+
+
+def _ensemble_cluster(runs, betas, thetas, vocab, K, V, *,
+                      num_topics, lambda_, distance, topn, weights):
+    m = len(runs)
+    nc = K if num_topics is None else int(num_topics)
+    if nc < 1:
+        raise ValueError(f"num_topics must be a positive integer, got {num_topics!r}")
+
+    # Pool every run's topics: one row of the concatenated B̄, one column of Θ̄ each.
+    all_beta = np.vstack(betas)                       # (m*K, V)
+    run_of = np.repeat(np.arange(m), K)               # which run each pooled topic came from
+    w = _normalize_weights(weights, m)
+
+    # Each pooled topic also carries its document-topic column, used both for the
+    # blended distance and for the averaged Θ output.
+    all_theta = np.hstack(thetas).T if thetas is not None else None  # (m*K, D)
+
+    D = _rank_distance(_ranked(all_beta, topn), distance)
+    lam = float(lambda_)
+    if all_theta is not None and lam < 1.0:
+        D_theta = _rank_distance(_ranked(all_theta, topn), distance)
+        D = lam * D + (1.0 - lam) * D_theta
+    elif lam < 1.0:
+        warnings.warn(
+            "runs do not share a document set, so the document-topic distance is "
+            "unavailable; using topic-word distance only (lambda_=1).",
+            stacklevel=3,
+        )
+        lam = 1.0
+
+    labels = _agglomerative(D, nc)
+
+    rows_beta, rows_theta = [], [] if thetas is not None else None
+    stability, support, sizes = [], [], []
+    for c in range(labels.max() + 1):
+        members = np.flatnonzero(labels == c)
+        wm = w[run_of[members]]
+        wm = wm / wm.sum()
+        rows_beta.append(np.average(all_beta[members], axis=0, weights=wm))
+        if thetas is not None:
+            rows_theta.append(np.average(all_theta[members], axis=0, weights=wm))
+        # Internal consistency: 1 - mean pairwise distance among members.
+        if len(members) > 1:
+            sub = D[np.ix_(members, members)]
+            stab = 1.0 - sub[np.triu_indices(len(members), 1)].mean()
+        else:
+            stab = 1.0
+        stability.append(float(stab))
+        support.append(len(np.unique(run_of[members])) / m)
+        sizes.append(len(members))
+
+    beta_bar = np.vstack(rows_beta)
+    stability = np.array(stability)
+    support = np.array(support)
+    sizes = np.array(sizes, dtype=int)
+
+    # Order topics by how well-backed they are (support, then consistency), so the
+    # most trustworthy consensus topics come first.
+    order = np.lexsort((-stability, -support))
+    beta_bar = beta_bar[order]
+    beta_bar = beta_bar / np.clip(beta_bar.sum(axis=1, keepdims=True), 1e-300, None)
+    theta_bar = None
+    if thetas is not None:
+        theta_bar = np.vstack(rows_theta)[order].T  # back to (D, K)
+        theta_bar = theta_bar / np.clip(theta_bar.sum(axis=1, keepdims=True), 1e-300, None)
+
+    stability, support, sizes = stability[order], support[order], sizes[order]
+    reliable = (stability >= _MIN_STABILITY) & (support >= _MIN_SUPPORT)
+    return EnsembleResult(
+        topic_word=beta_bar, doc_topic=theta_bar, vocabulary=vocab,
+        stability=stability, support=support, reliable=reliable,
+        agreement=float(np.mean(stability)), method="cluster",
+        cluster_sizes=sizes, reference=None, n_runs=m, runs=runs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# method="align" — reference matching (Miller & McCoy 2017; Mäntylä et al. 2018)
+# ---------------------------------------------------------------------------
+
+def _top_sets(beta, topn):
+    """Per-topic set of top-`topn` term indices (vocabulary-independent)."""
+    return [set(np.argsort(beta[t])[::-1][:topn].tolist()) for t in range(beta.shape[0])]
+
+
+def _align_cost(ref, other, metric):
+    from .validation import align_topics
+
+    pairs = align_topics(ref, other, metric=metric)
+    return float(np.mean([d for _, _, d in pairs])) if pairs else float("inf")
+
+
+def _choose_reference(betas, reference, metric):
+    n = len(betas)
+    if reference == "first":
+        return 0
+    if isinstance(reference, (int, np.integer)) and not isinstance(reference, bool):
+        if not 0 <= reference < n:
+            raise ValueError(f"reference index {reference} out of range for {n} runs")
+        return int(reference)
+    if reference != "medoid":
+        raise ValueError("reference must be 'medoid', 'first', or a run index")
+    cost = np.zeros((n, n))
+    for a in range(n):
+        for b in range(n):
+            if a != b:
+                cost[a, b] = _align_cost(betas[a], betas[b], metric)
+    return int(np.argmin(cost.sum(axis=1)))
+
+
+def _perm_to_ref(ref, beta, metric):
+    from .validation import align_topics
+
+    pairs = align_topics(ref, beta, metric=metric)
+    perm = [0] * len(pairs)
+    for i, j, _ in pairs:
+        perm[i] = j
+    return perm
+
+
+def _reliability_from_perm(ref_sets, run_sets, perm):
+    """Per-reference-topic Jaccard quality and ambiguity margin under a fixed
+    permutation (mirrors effects._match_to_reference, but honors the externally
+    chosen alignment so reported quality matches the averaged topics)."""
+    k, kb = len(ref_sets), len(run_sets)
+    jac = np.zeros((k, kb))
+    for i, rs in enumerate(ref_sets):
+        for j, bs in enumerate(run_sets):
+            union = rs | bs
+            jac[i, j] = (len(rs & bs) / len(union)) if union else 0.0
+    quality, margin = np.zeros(k), np.zeros(k)
+    for i in range(k):
+        j = perm[i]
+        quality[i] = jac[i, j]
+        margin[i] = jac[i, j] - float(np.max(np.delete(jac[i], j))) if kb > 1 else jac[i, j]
+    return quality, margin
+
+
+def _ensemble_align(runs, betas, thetas, vocab, K, V, *,
+                    reference, metric, topn, weights):
+    n = len(runs)
+    ref_idx = _choose_reference(betas, reference, metric)
+    ref = betas[ref_idx]
+    ref_sets = _top_sets(ref, topn)
+    w = _normalize_weights(weights, n)
+
+    aligned_betas = np.empty((n, K, V))
+    aligned_thetas = np.empty((n, *thetas[0].shape)) if thetas is not None else None
+    qualities = np.zeros((n, K))
+    margins = np.zeros((n, K))
+    for r in range(n):
+        perm = _perm_to_ref(ref, betas[r], metric)
+        aligned_betas[r] = betas[r][perm]
+        if thetas is not None:
+            aligned_thetas[r] = thetas[r][:, perm]
+        qualities[r], margins[r] = _reliability_from_perm(ref_sets, _top_sets(betas[r], topn), perm)
+
+    beta_bar = np.tensordot(w, aligned_betas, axes=1)
+    beta_bar = beta_bar / np.clip(beta_bar.sum(axis=1, keepdims=True), 1e-300, None)
+    theta_bar = None
+    if aligned_thetas is not None:
+        theta_bar = np.tensordot(w, aligned_thetas, axes=1)
+        theta_bar = theta_bar / np.clip(theta_bar.sum(axis=1, keepdims=True), 1e-300, None)
+
+    stability = np.tensordot(w, qualities, axes=1)
+    support = np.tensordot(w, margins, axes=1)
+    reliable = (stability >= _MIN_STABILITY) & (support >= _MIN_MARGIN)
+    return EnsembleResult(
+        topic_word=beta_bar, doc_topic=theta_bar, vocabulary=vocab,
+        stability=stability, support=support, reliable=reliable,
+        agreement=float(np.mean(stability)), method="align",
+        cluster_sizes=None, reference=ref_idx, n_runs=n, runs=runs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# method="stable" — gensim's EnsembleLda (Brigl 2019): CBDBSCAN stable cores
+# ---------------------------------------------------------------------------
+# Reimplemented numpy-native and validated against gensim in parity/. Constants
+# and defaults mirror gensim.models.ensemblelda so the two agree on identical
+# input.
+
+_COSINE_SKIP = 0.05  # gensim's _COSINE_DISTANCE_CALCULATION_THRESHOLD
+
+
+def _mass_mask(a, threshold):
+    """Smallest set of top terms whose cumulative mass reaches ``threshold``
+    (gensim ``mass_masking``)."""
+    if threshold is None:
+        threshold = 0.95
+    sorted_a = np.sort(a)[::-1]
+    keep = sorted_a.cumsum() < threshold
+    if not keep.any():  # a single term already exceeds the threshold
+        return a >= sorted_a[0]
+    return a >= sorted_a[keep][-1]
+
+
+def _rank_mask(a, threshold):
+    """Top ``threshold`` fraction of terms by rank (gensim ``rank_masking``)."""
+    if threshold is None:
+        threshold = 0.11
+    cut = int(len(a) * threshold)
+    return a > np.sort(a)[::-1][cut]
+
+
+def _cosine_distance(u, v):
+    nu = np.linalg.norm(u)
+    nv = np.linalg.norm(v)
+    if nu == 0.0 or nv == 0.0:
+        return 1.0
+    return 1.0 - float(np.dot(u, v) / (nu * nv))
+
+
+def _asymmetric_distance(ttda, masking, threshold):
+    """Asymmetric masked-cosine distance between every pair of pooled topics, per
+    gensim. Topic ``i``'s mask selects its own high-mass terms; the distance to
+    ``j`` is the cosine distance restricted to those terms (so it measures whether
+    ``i`` is contained in ``j``)."""
+    mask_fn = {"mass": _mass_mask, "rank": _rank_mask}[masking]
+    T = len(ttda)
+    D = np.ones((T, T))
+    for i in range(T):
+        mask = mask_fn(ttda[i], threshold)
+        a = ttda[i][mask]
+        for j in range(T):
+            if i == j:
+                D[i, j] = 0.0
+                continue
+            b = ttda[j][mask]
+            D[i, j] = 1.0 if b.sum() <= _COSINE_SKIP else _cosine_distance(a, b)
+    return D
+
+
+class _CBDBSCANTopic:
+    __slots__ = ("is_core", "label", "neighboring_labels", "valid_neighboring_labels")
+
+    def __init__(self):
+        self.is_core = False
+        self.label = None
+        self.neighboring_labels = set()
+        self.valid_neighboring_labels = set()
+
+
+def _cbdbscan(D, eps, min_samples):
+    """Checkback DBSCAN (Brigl 2019). Faithful port of gensim's ``CBDBSCAN.fit``:
+    grows clusters from the densest topics outward, and the checkback step starts a
+    new cluster when a candidate is too far from its parent's neighborhood (<25%
+    close), keeping clusters compact. Returns a list of per-topic results."""
+    import sys
+
+    T = D.shape[0]
+    results = [_CBDBSCANTopic() for _ in range(T)]
+    A = D.copy()
+    np.fill_diagonal(A, 1.0)
+
+    ordered = [i for _, i in sorted((A[i].min(), i) for i in range(T))]
+    state = {"next_label": 0}
+
+    def scan_topic(topic_index, current_label=None, parent_neighbors=None):
+        neighbors = [j for _, j in sorted((A[topic_index][j], j) for j in range(T)) if A[topic_index][j] < eps]
+        if len(neighbors) >= min_samples:
+            results[topic_index].is_core = True
+            if current_label is None:
+                current_label = state["next_label"]
+                state["next_label"] += 1
+            else:
+                close = A[topic_index][parent_neighbors] < eps
+                if close.mean() < 0.25:
+                    current_label = state["next_label"]
+                    state["next_label"] += 1
+            results[topic_index].label = current_label
+            for nb in neighbors:
+                if results[nb].label is None:
+                    ordered.remove(nb)
+                    scan_topic(nb, current_label, neighbors + [topic_index])
+                results[nb].neighboring_labels.add(current_label)
+        else:
+            results[topic_index].label = current_label if current_label is not None else -1
+
+    old_limit = sys.getrecursionlimit()
+    sys.setrecursionlimit(max(old_limit, T * 2 + 100))
+    try:
+        while ordered:
+            scan_topic(ordered.pop(0))
+    finally:
+        sys.setrecursionlimit(old_limit)
+    return results
+
+
+def _stable_labels(results, num_models, min_cores):
+    """Apply gensim's cluster validation to CBDBSCAN results and return the set of
+    labels that form stable topics. Mirrors ``_aggregate_topics`` /
+    ``_validate_clusters`` / ``_is_valid_core``."""
+    # Group cores by label; collect each core's neighboring-label set per cluster.
+    by_label = {}
+    for t in results:
+        if t.is_core:
+            by_label.setdefault(t.label, []).append(t)
+
+    clusters = []
+    for label, topics in by_label.items():
+        nbls = [set(t.neighboring_labels) for t in topics if t.neighboring_labels]
+        clusters.append({
+            "label": label,
+            "num_cores": len(topics),
+            "max_nbl": max((len(t.neighboring_labels) for t in topics), default=0),
+            "neighboring_labels": nbls,
+        })
+
+    def remove_label(label):
+        for c in clusters:
+            for s in c["neighboring_labels"]:
+                s.discard(label)
+
+    clusters.sort(key=lambda c: (c["max_nbl"], c["num_cores"], c["label"]))
+    for c in clusters:
+        c["valid"] = None
+        if c["num_cores"] < min_cores:
+            c["valid"] = False
+            remove_label(c["label"])
+    for c in clusters:
+        if c["valid"] is None:
+            isolated = sum(s == {c["label"]} for s in c["neighboring_labels"])
+            if isolated >= min_cores:
+                c["valid"] = True
+            else:
+                c["valid"] = False
+                remove_label(c["label"])
+
+    return {c["label"] for c in clusters if c["valid"]}
+
+
+def _ensemble_stable(runs, betas, thetas, vocab, K, V, *,
+                     eps, min_samples, min_cores, masking, masking_threshold):
+    m = len(runs)
+    if min_samples is None:
+        min_samples = int(m / 2)
+    if min_cores is None:
+        min_cores = min(3, max(1, int(m / 4 + 1)))
+    elif min_cores == 0:
+        min_cores = 1
+    if masking not in ("mass", "rank"):
+        raise ValueError("masking must be 'mass' or 'rank'")
+
+    ttda = np.vstack(betas)                     # (m*K, V), rows already normalized
+    run_of = np.repeat(np.arange(m), K)
+    all_theta = np.hstack(thetas).T if thetas is not None else None
+
+    D = _asymmetric_distance(ttda, masking, masking_threshold)
+    results = _cbdbscan(D, eps, min_samples)
+    stable = _stable_labels(results, m, min_cores)
+
+    for t in results:
+        t.valid_neighboring_labels = {lbl for lbl in t.neighboring_labels if lbl in stable}
+    valid = np.array([t.is_core and t.valid_neighboring_labels == {t.label} for t in results])
+    labels = np.array([t.label for t in results])
+
+    rows_beta, rows_theta = [], [] if all_theta is not None else None
+    stability, support, sizes = [], [], []
+    for lbl in sorted(set(labels[valid].tolist())):
+        members = np.flatnonzero(valid & (labels == lbl))
+        rows_beta.append(ttda[members].mean(axis=0))
+        if all_theta is not None:
+            rows_theta.append(all_theta[members].mean(axis=0))
+        if len(members) > 1:
+            sub = D[np.ix_(members, members)]
+            stab = 1.0 - sub[~np.eye(len(members), dtype=bool)].mean()
+        else:
+            stab = 1.0
+        stability.append(float(stab))
+        support.append(len(np.unique(run_of[members])) / m)
+        sizes.append(len(members))
+
+    if not rows_beta:
+        warnings.warn(
+            "no stable topic was detected; try a larger eps, more runs, or a lower "
+            "min_cores. Returning an empty ensemble.",
+            stacklevel=3,
+        )
+        empty = np.empty((0, V))
+        return EnsembleResult(
+            topic_word=empty, doc_topic=None, vocabulary=vocab,
+            stability=np.empty(0), support=np.empty(0), reliable=np.empty(0, bool),
+            agreement=float("nan"), method="stable",
+            cluster_sizes=np.empty(0, int), reference=None, n_runs=m, runs=runs,
+        )
+
+    beta_bar = np.vstack(rows_beta)
+    beta_bar = beta_bar / np.clip(beta_bar.sum(axis=1, keepdims=True), 1e-300, None)
+    theta_bar = None
+    if rows_theta is not None:
+        theta_bar = np.vstack(rows_theta).T
+        theta_bar = theta_bar / np.clip(theta_bar.sum(axis=1, keepdims=True), 1e-300, None)
+
+    stability = np.array(stability)
+    support = np.array(support)
+    sizes = np.array(sizes, dtype=int)
+    reliable = (stability >= _MIN_STABILITY) & (support >= _MIN_SUPPORT)
+    return EnsembleResult(
+        topic_word=beta_bar, doc_topic=theta_bar, vocabulary=vocab,
+        stability=stability, support=support, reliable=reliable,
+        agreement=float(np.mean(stability)), method="stable",
+        cluster_sizes=sizes, reference=None, n_runs=m, runs=runs,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public entry point
+# ---------------------------------------------------------------------------
+
+def ensemble(runs, *, method="cluster", num_topics=None, lambda_=0.5,
+             distance="rbo", topn=10, reference="medoid", metric="cosine",
+             weights=None, eps=0.1, min_samples=None, min_cores=None,
+             masking="mass", masking_threshold=None):
+    """Combine several topic-model fits into one consensus model.
+
+    The consensus is more reliable than any single run — it beats the median run
+    and rarely loses to the best (Hoyle et al. 2022). This is the natural
+    follow-on to :func:`~topica.select_model`: fit N runs, then combine them here
+    instead of picking one.
+
+    Parameters
+    ----------
+    runs : a list of fitted models (or ``(K, V)`` topic-word arrays sharing a
+        vocabulary), or a :class:`~topica.validation.SelectModelResult`. All runs
+        must share the same K and vocabulary.
+    method : ``"cluster"`` (default) reproduces Hoyle et al. §6 — pool the topics
+        from all runs, cluster them, and average within each cluster. ``"align"``
+        matches every run's topics to one reference run and averages the aligned
+        topics (simpler, deterministic, no document-topic distance).
+    num_topics : number of consensus topics for ``"cluster"`` (default: the runs'
+        K). Ignored by ``"align"`` (which always returns K).
+    lambda_ : ``"cluster"`` only — weight on the topic-word distance when pooling
+        topics; ``1 - lambda_`` weights the document-topic distance. Falls back to
+        ``1.0`` when the runs were not fit on the same documents.
+    distance : ``"cluster"`` only — the top-weighted rank distance between topics:
+        ``"rbo"`` (Rank-Biased Overlap, default) or ``"jaccard"`` (average Jaccard).
+    topn : top-word (and top-document) count for the distances and diagnostics.
+    reference : ``"align"`` only — which run anchors the matching. ``"medoid"``
+        (default) picks the run that aligns most cheaply to all others; ``"first"``
+        uses run 0; an int uses that run.
+    metric : ``"align"`` only — topic-word distance for the matching, ``"cosine"``
+        (default) or ``"js"``.
+    weights : optional per-run weights (length ``n_runs``) for a weighted average —
+        e.g. down-weight low-coherence runs. ``None`` (default) weights equally.
+        Used by ``"cluster"`` and ``"align"``.
+    eps, min_samples, min_cores, masking, masking_threshold : ``"stable"`` only —
+        the gensim ``EnsembleLda`` knobs. ``eps`` (default 0.1) is the CBDBSCAN
+        neighbor radius; ``min_samples`` (default ``int(n_runs/2)``) the neighbors
+        needed to be a core; ``min_cores`` (default ``min(3, n_runs//4 + 1)``) the
+        cores a cluster needs to count as a stable topic; ``masking`` is ``"mass"``
+        (default) or ``"rank"`` and ``masking_threshold`` its cutoff (gensim
+        defaults 0.95 / 0.11). A larger ``eps`` or smaller ``min_cores`` yields more
+        (looser) stable topics.
+
+    Returns
+    -------
+    An :class:`EnsembleResult`. It exposes ``topic_word``, ``doc_topic``, and
+    ``vocabulary``, so it passes straight into :func:`~topica.coherence`, the
+    diagnostics, and other model-neutral analyses. Per-topic ``stability`` and
+    ``reliable`` flags mark consensus topics the individual runs do not agree on.
+    """
+    runs = _coerce_runs(runs)
+    betas, thetas, vocab, K, V = _gather(runs)
+
+    if method == "cluster":
+        if distance not in ("rbo", "jaccard"):
+            raise ValueError("distance must be 'rbo' or 'jaccard'")
+        if not 0.0 <= lambda_ <= 1.0:
+            raise ValueError(f"lambda_ must be in [0, 1], got {lambda_!r}")
+        return _ensemble_cluster(
+            runs, betas, thetas, vocab, K, V,
+            num_topics=num_topics, lambda_=lambda_, distance=distance,
+            topn=topn, weights=weights,
+        )
+    if method == "align":
+        return _ensemble_align(
+            runs, betas, thetas, vocab, K, V,
+            reference=reference, metric=metric, topn=topn, weights=weights,
+        )
+    if method == "stable":
+        return _ensemble_stable(
+            runs, betas, thetas, vocab, K, V,
+            eps=eps, min_samples=min_samples, min_cores=min_cores,
+            masking=masking, masking_threshold=masking_threshold,
+        )
+    raise ValueError("method must be 'cluster', 'align', or 'stable'")

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -1,0 +1,309 @@
+"""Ensemble topic modeling: combine independent fits into a consensus.
+
+The central claim (Hoyle et al. 2022, §6) is that pooling topics across runs and
+clustering them yields a consensus more reliable than any single run — it beats the
+median run and rarely loses to the best. The default ``method="cluster"``
+reproduces that procedure; ``method="align"`` is the lighter reference-matching
+alternative. Most tests work on hand-built topic-word arrays so the ground truth is
+known exactly; a couple exercise the real fitted-model path end to end.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+
+def _sharp_topics(blocks, V, rng, peak=0.7):
+    """K topic-word rows, each concentrating ``peak`` mass on a disjoint block of
+    terms and spreading the rest uniformly. ``blocks`` is a list of index lists."""
+    K = len(blocks)
+    beta = np.full((K, V), (1.0 - peak) / V)
+    for k, idx in enumerate(blocks):
+        beta[k, idx] += peak / len(idx)
+    beta /= beta.sum(axis=1, keepdims=True)
+    return beta
+
+
+def _noisy_run(beta_true, rng, noise, permute=True):
+    """A noisy, possibly topic-reordered copy of ``beta_true``."""
+    b = beta_true + rng.normal(0, noise, size=beta_true.shape)
+    b = np.clip(b, 1e-6, None)
+    b /= b.sum(axis=1, keepdims=True)
+    if permute:
+        b = b[rng.permutation(beta_true.shape[0])]
+    return b
+
+
+def _aligned_error(beta_true, mat):
+    """Mean per-topic L1 distance after Hungarian alignment to the truth."""
+    pairs = topica.align_topics(beta_true, mat, metric="cosine")
+    return float(np.mean([np.abs(beta_true[i] - mat[j]).sum() for i, j, _ in pairs]))
+
+
+class TestClusterMethod:
+    """The default method: Hoyle et al. §6 — pool, cluster, average per cluster."""
+
+    def test_identical_runs_recover_the_topics(self):
+        rng = np.random.default_rng(0)
+        beta = _sharp_topics([[0, 1], [2, 3], [4, 5]], 8, rng)
+        res = topica.ensemble([beta, beta.copy(), beta.copy()], topn=2, lambda_=1.0)
+        assert res.method == "cluster"
+        assert res.topic_word.shape == beta.shape
+        # Each consensus topic equals one input topic (order may differ).
+        for _, _, dist in topica.align_topics(beta, res.topic_word):
+            assert dist < 1e-9
+        np.testing.assert_allclose(res.stability, 1.0)
+        np.testing.assert_allclose(res.support, 1.0)
+        assert res.reliable.all()
+        np.testing.assert_array_equal(res.cluster_sizes, [3, 3, 3])
+
+    def test_ensemble_beats_median_run(self):
+        # The Hoyle claim in miniature: the clustered average is closer to the
+        # truth than the median individual run.
+        rng = np.random.default_rng(7)
+        V = 24
+        blocks = [list(range(0, 6)), list(range(6, 12)), list(range(12, 18)), list(range(18, 24))]
+        beta_true = _sharp_topics(blocks, V, rng, peak=0.6)
+        runs = [_noisy_run(beta_true, rng, noise=0.04) for _ in range(15)]
+
+        res = topica.ensemble(runs, topn=6, lambda_=1.0)
+        ens_err = _aligned_error(beta_true, res.topic_word)
+        run_errs = sorted(_aligned_error(beta_true, r) for r in runs)
+        median_err = run_errs[len(run_errs) // 2]
+        assert ens_err < median_err
+
+    def test_unstable_topic_is_flagged(self):
+        # Two topics are identical across runs; a third shares only its top word and
+        # is otherwise random each run. Its cluster is high-support (every run
+        # contributes) but low-stability, so it is marked unreliable.
+        rng = np.random.default_rng(3)
+        V = 18
+        A = _sharp_topics([[0, 1, 2]], V, rng, peak=0.8)[0]
+        B = _sharp_topics([[3, 4, 5]], V, rng, peak=0.8)[0]
+        runs = []
+        for _ in range(6):
+            r1, r2 = rng.choice(range(7, V), size=2, replace=False)
+            wild = np.full(V, 0.01)
+            wild[6], wild[r1], wild[r2] = 0.5, 0.2, 0.2
+            wild /= wild.sum()
+            runs.append(np.vstack([A, B, wild]))
+        res = topica.ensemble(runs, topn=3, lambda_=1.0)
+        assert int(res.reliable.sum()) == 2
+        assert res.stability.min() < 0.5
+        # The unstable topic is still high-support: every run fed it a topic.
+        assert res.support.min() == pytest.approx(1.0)
+
+    def test_jaccard_distance_also_works(self):
+        rng = np.random.default_rng(1)
+        beta = _sharp_topics([[0, 1], [2, 3], [4, 5]], 8, rng)
+        res = topica.ensemble([beta, beta.copy()], distance="jaccard", topn=2, lambda_=1.0)
+        assert res.reliable.all()
+
+
+class TestAlignMethod:
+    """The retained reference-matching alternative: deterministic, exact."""
+
+    def test_identical_runs_reproduce_input(self):
+        rng = np.random.default_rng(0)
+        beta = _sharp_topics([[0, 1], [2, 3], [4, 5]], 8, rng)
+        res = topica.ensemble([beta, beta.copy()], method="align", topn=2)
+        assert res.method == "align"
+        np.testing.assert_allclose(res.topic_word, beta, atol=1e-9)
+        np.testing.assert_allclose(res.stability, 1.0)
+        assert res.reliable.all()
+        assert res.reference in (0, 1)
+
+    def test_recovers_topic_permutation(self):
+        rng = np.random.default_rng(1)
+        beta = _sharp_topics([[0, 1], [2, 3], [4, 5]], 8, rng)
+        shuffled = beta[[2, 0, 1]]  # same topics, different order
+        res = topica.ensemble([beta, shuffled], method="align", reference="first", topn=2)
+        np.testing.assert_allclose(res.topic_word, beta, atol=1e-9)
+
+    def test_weights_average_is_weighted(self):
+        a = np.array([[0.9, 0.1], [0.1, 0.9]])
+        b = np.array([[0.5, 0.5], [0.5, 0.5]])
+        res = topica.ensemble([a, b], method="align", reference="first", weights=[0.75, 0.25])
+        expected = 0.75 * a + 0.25 * b
+        expected /= expected.sum(axis=1, keepdims=True)
+        np.testing.assert_allclose(res.topic_word, expected, atol=1e-9)
+
+
+class TestStableMethod:
+    """gensim EnsembleLda port: discover stable topics, discard noise (no K)."""
+
+    def _clean_runs(self, m=5, K=4, V=30, noise=0.01, seed=0):
+        rng = np.random.default_rng(seed)
+        protos = np.zeros((K, V))
+        for k in range(K):
+            protos[k, k * (V // K):(k + 1) * (V // K)] = 1.0
+        protos /= protos.sum(1, keepdims=True)
+        runs = []
+        for _ in range(m):
+            b = protos + rng.normal(0, noise, protos.shape)
+            b = np.clip(b, 1e-6, None)
+            b /= b.sum(1, keepdims=True)
+            runs.append(b)
+        return runs, protos
+
+    def test_discovers_the_stable_topics(self):
+        runs, protos = self._clean_runs()
+        res = topica.ensemble(runs, method="stable")
+        assert res.method == "stable"
+        # Four reproducible prototypes -> four stable topics, each recovered.
+        assert res.topic_word.shape[0] == 4
+        for _, _, dist in topica.align_topics(protos, res.topic_word):
+            assert dist < 5e-3
+        assert res.reliable.all()
+        np.testing.assert_allclose(res.support, 1.0)
+
+    def test_unstable_topics_are_dropped(self):
+        # Three stable prototypes plus, in each run, one purely random topic. The
+        # random topics do not recur, so they form no core and are discarded — the
+        # ensemble keeps only the three stable topics, not 4.
+        rng = np.random.default_rng(2)
+        m, V = 6, 30
+        protos = np.zeros((3, V))
+        for k in range(3):
+            protos[k, k * 8:(k + 1) * 8] = 1.0
+        protos /= protos.sum(1, keepdims=True)
+        runs = []
+        for _ in range(m):
+            junk = rng.random(V)
+            junk /= junk.sum()
+            b = np.vstack([protos + rng.normal(0, 0.01, protos.shape), junk])
+            b = np.clip(b, 1e-6, None)
+            b /= b.sum(1, keepdims=True)
+            runs.append(b)
+        res = topica.ensemble(runs, method="stable")
+        assert res.topic_word.shape[0] == 3
+
+    def test_no_stable_topic_warns_and_returns_empty(self):
+        # Every topic in every run is random noise: nothing recurs, so no stable
+        # topic exists.
+        rng = np.random.default_rng(5)
+        runs = []
+        for _ in range(4):
+            b = rng.random((3, 20))
+            b /= b.sum(1, keepdims=True)
+            runs.append(b)
+        with pytest.warns(UserWarning, match="no stable topic"):
+            res = topica.ensemble(runs, method="stable", eps=0.05)
+        assert res.topic_word.shape == (0, 20)
+        assert np.isnan(res.agreement)
+
+    def test_bad_masking_rejected(self):
+        runs, _ = self._clean_runs()
+        with pytest.raises(ValueError, match="masking must be"):
+            topica.ensemble(runs, method="stable", masking="soft")
+
+
+class TestApiSurface:
+    def test_accepts_select_model_result(self):
+        runs = [np.eye(3)[[0, 1, 2]] + 0.01, np.eye(3)[[1, 0, 2]] + 0.01]
+        runs = [r / r.sum(axis=1, keepdims=True) for r in runs]
+
+        class _FakeSelect:
+            models = runs
+
+        res = topica.ensemble(_FakeSelect(), lambda_=1.0)
+        assert res.n_runs == 2
+
+    def test_top_words_pairs_use_indices_without_vocab(self):
+        rng = np.random.default_rng(0)
+        beta = _sharp_topics([[0, 1], [5, 6]], 8, rng)
+        res = topica.ensemble([beta, beta.copy()], topn=2, lambda_=1.0)
+        tw = res.top_words(2)  # list of [(term, prob), ...] per topic; terms are ints
+        terms = {t for t, _ in tw[0]}
+        assert terms == {0, 1} or terms == {5, 6}
+        assert all(isinstance(p, float) for _, p in tw[0])
+
+    def test_repr_reports_method_and_reliability(self):
+        rng = np.random.default_rng(0)
+        beta = _sharp_topics([[0, 1], [2, 3]], 6, rng)
+        res = topica.ensemble([beta, beta.copy()], topn=2, lambda_=1.0)
+        r = repr(res)
+        assert "method='cluster'" in r
+        assert "reliable=2/2" in r
+
+    def test_missing_doc_topic_warns_and_falls_back(self):
+        rng = np.random.default_rng(0)
+        beta = _sharp_topics([[0, 1], [2, 3]], 6, rng)
+        with pytest.warns(UserWarning, match="document-topic distance is"):
+            topica.ensemble([beta, beta.copy()], topn=2, lambda_=0.5)
+
+
+class TestErrors:
+    def test_single_run_rejected(self):
+        with pytest.raises(ValueError, match="at least two runs"):
+            topica.ensemble([np.eye(3)])
+
+    def test_shape_mismatch_rejected(self):
+        with pytest.raises(ValueError, match="same shape"):
+            topica.ensemble([np.ones((3, 5)), np.ones((3, 6))], lambda_=1.0)
+
+    def test_bad_method_rejected(self):
+        b = np.ones((2, 4)) / 4
+        with pytest.raises(ValueError, match="method must be"):
+            topica.ensemble([b, b], method="magic", lambda_=1.0)
+
+    def test_bad_distance_rejected(self):
+        b = np.ones((2, 4)) / 4
+        with pytest.raises(ValueError, match="distance must be"):
+            topica.ensemble([b, b], distance="euclidean", lambda_=1.0)
+
+    def test_bad_lambda_rejected(self):
+        b = np.ones((2, 4)) / 4
+        with pytest.raises(ValueError, match="lambda_"):
+            topica.ensemble([b, b], lambda_=2.0)
+
+    def test_bad_reference_rejected(self):
+        b = np.ones((2, 4)) / 4
+        with pytest.raises(ValueError, match="reference"):
+            topica.ensemble([b, b], method="align", reference="best")
+        with pytest.raises(ValueError, match="out of range"):
+            topica.ensemble([b, b], method="align", reference=5)
+
+    def test_bad_weights_rejected(self):
+        b = np.ones((2, 4)) / 4
+        with pytest.raises(ValueError, match="length"):
+            topica.ensemble([b, b], method="align", weights=[1.0])
+        with pytest.raises(ValueError, match="non-negative"):
+            topica.ensemble([b, b], method="align", weights=[-1.0, 2.0])
+
+
+class TestFittedModels:
+    """End-to-end on real LDA fits: doc-topic averaging and the analysis surface."""
+
+    def _runs(self, n=4):
+        rng = np.random.default_rng(0)
+        A = ["cat", "dog", "pet", "kitten", "puppy", "vet"]
+        B = ["star", "moon", "sky", "sun", "comet", "orbit"]
+        docs = []
+        for _ in range(80):
+            v = A if rng.random() < 0.5 else B
+            docs.append([v[int(rng.integers(len(v)))] for _ in range(10)])
+        runs = []
+        for s in range(n):
+            m = topica.LDA(num_topics=2, seed=s + 1)
+            m.fit(docs, iters=300)
+            runs.append(m)
+        return runs, docs
+
+    def test_doc_topic_averaged_for_same_docs(self):
+        runs, docs = self._runs()
+        res = topica.ensemble(runs)  # default cluster, lambda_=0.5 uses theta
+        assert res.doc_topic is not None
+        assert res.doc_topic.shape == (len(docs), 2)
+        np.testing.assert_allclose(res.doc_topic.sum(axis=1), 1.0, atol=1e-6)
+        assert res.vocabulary is not None
+
+    def test_result_flows_into_coherence(self):
+        runs, docs = self._runs()
+        res = topica.ensemble(runs)
+        # The ensemble duck-types as a model: the model-neutral coherence surface
+        # accepts it directly.
+        cv = topica.coherence(res, docs, coherence_type="c_v", topn=5)
+        assert np.asarray(cv).shape == (2,)
+        assert np.all(np.isfinite(cv))


### PR DESCRIPTION
## What

Adds `topica.ensemble(runs, method=...)` — combine several independent topic-model fits into a consensus that is more reliable than any single run (Hoyle et al. 2022, *Are Neural Topic Models Broken?*). It is the natural step after `select_model`: instead of fitting N runs and *picking* one with `plot_models`, *combine* them all.

The result (`EnsembleResult`) duck-types as a fitted model — it exposes `topic_word`, `doc_topic`, `vocabulary`, and `top_words()`, so it flows straight into `coherence`, the diagnostics, and `align_topics`. Each consensus topic carries a `stability` score and a `reliable` flag, so a topic the runs do not actually agree on is marked rather than silently trusted.

## Three methods

| Method | Source | Topic count | Validation |
|---|---|---|---|
| `cluster` (default) | Hoyle et al. 2022 §6 — pool topics, blend a top-weighted rank distance over topic-word + doc-topic (`lambda_`), cluster into K, average per cluster | fixed K | synthetic ground truth (beats the median run) |
| `align` | Miller & McCoy 2017 — Hungarian-match each run to a reference, average | fixed K | exact-recovery tests |
| `stable` | numpy-native reimplementation of gensim's `EnsembleLda` (Brigl 2019) — CBDBSCAN stable cores | **auto-discovered** | **matches gensim to ~2e-16** |

`stable` does not fix K: it finds dense, reproducible cores with Checkback DBSCAN and keeps only the clusters with enough cores as stable topics, discarding the rest as noise.

## Validation

- `tests/test_ensemble.py` — 24 tests: the Hoyle "beats the median run" claim on synthetic data, permutation recovery, unstable-topic flagging, stable-topic discovery + noise rejection, the error surface, and end-to-end on real LDA fits.
- `parity/ensemblelda_gensim_compare.py` — drives topica and gensim from the *same* pooled topics; the asymmetric masked-cosine distance matrix and the resulting stable topics match gensim to floating-point precision. Skips cleanly when gensim is absent (CI-safe), per the `parity/` convention.
- Docs: a section in `guides/diagnostics.md` plus API entries; `mkdocs build --strict` clean.
- Full suite: **1906 passed, 18 skipped**.

## Notes

- **Pure Python, no Rust changes** — no rebuild required.
- No version bump (feature PR).
- The `cluster` method's agglomerative step is O(T³) in the pooled topic count T = runs×K — fine for typical sizes (T up to ~1000), not yet optimized for very large ensembles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)