### PR TITLE
feat(sts): held-out transform + save/load + doc_names; register in conformance

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -624,6 +624,24 @@ class STS:
         (num_docs, 2*num_topics-1, 2*num_topics-1)."""
         ...
     @property
+    def doc_names(self) -> list[str]:
+        """Document labels (row order of doc_topic); default index strings."""
+        ...
+    def transform(
+        self, data: Corpus | Sequence[Sequence[str]]
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Infer topic prevalence theta for new documents by the Laplace E-step
+        against the fitted globals (kappa, m, Sigma) with a zero prior mean.
+        Out-of-vocabulary tokens are dropped. Returns (num_docs, num_topics)."""
+        ...
+    def save(self, path: str) -> None:
+        """Save the fitted model to path. Reload with STS.load."""
+        ...
+    @staticmethod
+    def load(path: str) -> STS:
+        """Load a model previously written by save."""
+        ...
+    @property
     def bound(self) -> float: ...
     @property
     def bound_history(self) -> list[float]: ...

--- a/python/topica/conformance.py
+++ b/python/topica/conformance.py
@@ -68,6 +68,7 @@ REGISTRY: list[tuple[str, object, str]] = [
     # logistic-normal (variational eta posterior)
     ("STM",          lambda: _topica.STM(2),                                     "logistic_normal"),
     ("CTM",          lambda: _topica.CTM(2),                                     "logistic_normal"),
+    ("STS",          lambda: _topica.STS(2),                                     "logistic_normal"),
     # neural / embedding-based — no theta posterior
     ("ETM",          lambda: _topica.ETM(2),                                     "none"),
     ("ProdLDA",      lambda: _topica.ProdLDA(2),                                 "none"),

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -114,16 +114,15 @@ pub struct RegistryEntry {
 ///
 /// `STM`/`CTM` and the `LDA`/`DMR`/`LabeledLDA` group share one backing struct
 /// (`CtmModel`, `TopicModel`) but are listed under their user-facing names to
-/// match the Python registry. `STS` is intentionally absent: it is logistic-
-/// normal at the Rust level (StsModel implements the trait) but is not yet in
-/// the Python `REGISTRY` pending its save/load/transform surface (issue #74
-/// follow-up). The embedding-cluster models (`BERTopic`, `Top2Vec`) carry a
-/// `topic_word`/`doc_topic` from their Rust struct and so participate here.
+/// match the Python registry. The embedding-cluster models (`BERTopic`,
+/// `Top2Vec`) carry a `topic_word`/`doc_topic` from their Rust struct and so
+/// participate here.
 #[allow(dead_code)]
 pub const RUST_ESTIMATORS: &[RegistryEntry] = &[
     // Logistic-normal variational (eta posterior).
     RegistryEntry { name: "STM", family: ModelFamily::LogisticNormal, exempt: &[] },
     RegistryEntry { name: "CTM", family: ModelFamily::LogisticNormal, exempt: &[] },
+    RegistryEntry { name: "STS", family: ModelFamily::LogisticNormal, exempt: &[] },
     // Collapsed-Gibbs / Dirichlet doc-topic posterior.
     RegistryEntry { name: "LDA", family: ModelFamily::Dirichlet, exempt: &[] },
     RegistryEntry { name: "DMR", family: ModelFamily::Dirichlet, exempt: &[] },
@@ -164,7 +163,7 @@ mod registry_tests {
                 assert!(METHODS.contains(&req), "{}: unknown exempt method {req:?}", e.name);
             }
         }
-        // Mirror of the Python REGISTRY size (20 user-facing models; STS pending).
-        assert_eq!(RUST_ESTIMATORS.len(), 20, "registry size drifted from the Python REGISTRY");
+        // Mirror of the Python REGISTRY size (21 user-facing models).
+        assert_eq!(RUST_ESTIMATORS.len(), 21, "registry size drifted from the Python REGISTRY");
     }
 }

--- a/src/python.rs
+++ b/src/python.rs
@@ -221,6 +221,19 @@ struct StmState {
     #[serde(default)] topic_names: Vec<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
+struct StsState {
+    num_topics: usize, seed: u64, init_spectral: bool, fitted: bool,
+    beta: Option<Arr2>, theta: Option<Arr2>, sentiment: Option<Arr2>,
+    gamma: Option<Arr2>, eta_mean: Option<Arr2>, eta_cov: Option<Arr3>,
+    feature_names: Vec<String>,
+    kappa_t: Vec<Vec<f64>>, kappa_s: Vec<Vec<f64>>, mv: Vec<f64>, sigma: Vec<f64>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default = "nan")] bound: f64,
+    #[serde(default)] bound_history: Vec<f64>,
+    #[serde(default)] converged: bool,
+    #[serde(default)] topic_names: Vec<String>,
+}
+#[derive(serde::Serialize, serde::Deserialize)]
 struct HdpState {
     alpha: f64, gamma: f64, eta: f64, seed: u64, resample_conc: bool, fitted: bool,
     num_topics: usize, learned_alpha: f64, learned_gamma: f64,
@@ -6304,9 +6317,75 @@ impl STS {
         Ok(self.corpus.as_ref().unwrap().id_to_word.clone())
     }
 
+    /// Document labels (row order of :attr:`doc_topic`), default the document
+    /// indices as strings.
+    #[getter]
+    fn doc_names(&self) -> PyResult<Vec<String>> {
+        self.require_fitted()?;
+        Ok(self.corpus.as_ref().unwrap().doc_names.clone())
+    }
+
     #[getter]
     fn num_topics(&self) -> usize {
         self.num_topics
+    }
+
+    /// Infer topic prevalence θ for *new* documents by the Laplace E-step against
+    /// the fitted globals (κ, m, Σ) with a zero prior mean (held-out documents
+    /// carry no covariates). `data` is a :class:`Corpus` or `list[list[str]]`;
+    /// tokens outside the training vocabulary are dropped. Returns a
+    /// ``(num_docs, num_topics)`` array of prevalence proportions.
+    fn transform<'py>(
+        &self,
+        py: Python<'py>,
+        data: &Bound<'py, PyAny>,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        let docs = docs_to_ids(data, &self.corpus.as_ref().unwrap().id_to_word)?;
+        let theta = py.allow_threads(|| {
+            sts::sts_infer(&docs, &self.kappa_t, &self.kappa_s, &self.mv, &self.sigma, self.num_topics)
+        });
+        Ok(vecs_to_arr2(&theta).to_pyarray_bound(py))
+    }
+
+    /// Save the fitted model to `path`. Reload with :meth:`STS.load`.
+    fn save(&self, path: &str) -> PyResult<()> {
+        self.require_fitted()?;
+        write_state(path, &StsState {
+            num_topics: self.num_topics, seed: self.seed, init_spectral: self.init_spectral,
+            fitted: self.fitted,
+            beta: arr2_opt(&self.beta), theta: arr2_opt(&self.theta),
+            sentiment: arr2_opt(&self.sentiment), gamma: arr2_opt(&self.gamma),
+            eta_mean: arr2_opt(&self.eta_mean), eta_cov: arr3_opt(&self.eta_cov),
+            feature_names: self.feature_names.clone(),
+            kappa_t: self.kappa_t.clone(), kappa_s: self.kappa_s.clone(),
+            mv: self.mv.clone(), sigma: self.sigma.clone(),
+            corpus: self.corpus.clone(),
+            bound: self.bound, bound_history: self.bound_history.clone(),
+            converged: self.converged, topic_names: self.topic_names.clone(),
+        })
+    }
+
+    /// Load a model previously written by :meth:`save`.
+    #[staticmethod]
+    fn load(path: &str) -> PyResult<Self> {
+        let s: StsState = read_state(path)?;
+        let topic_names = if s.topic_names.is_empty() {
+            (0..s.num_topics).map(|i| format!("topic_{i}")).collect()
+        } else {
+            s.topic_names
+        };
+        Ok(STS {
+            num_topics: s.num_topics, seed: s.seed, init_spectral: s.init_spectral,
+            fitted: s.fitted, topic_names,
+            beta: arr2_back(s.beta), theta: arr2_back(s.theta),
+            sentiment: arr2_back(s.sentiment), gamma: arr2_back(s.gamma),
+            eta_mean: arr2_back(s.eta_mean), eta_cov: arr3_back(s.eta_cov),
+            feature_names: s.feature_names,
+            kappa_t: s.kappa_t, kappa_s: s.kappa_s, mv: s.mv, sigma: s.sigma,
+            corpus: s.corpus, bound: s.bound, bound_history: s.bound_history,
+            converged: s.converged,
+        })
     }
 
     /// Top `n` words per topic (or one topic) at neutral sentiment, as

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -378,6 +378,59 @@ impl LogisticNormalModel for StsModel {
 }
 
 
+/// Infer per-document prevalence θ (D×K) for *new* documents against fixed
+/// global parameters (κ_t, κ_s, m, Σ) by the same Laplace E-step used in fitting,
+/// with a zero prior mean (held-out documents carry no covariates). For each
+/// document the 2K-1 latent α = [α^(p), α^(s)] is found by the L-BFGS optimum of
+/// the per-document objective, then θ_d = softmax([α^(p)_d, 0]); the sentiment
+/// latent is inferred jointly but not returned. Empty documents (all tokens out
+/// of vocabulary) get a uniform θ. Document order is preserved, and the parallel
+/// inference is order-deterministic (one independent optimum per document).
+pub fn sts_infer(
+    docs: &[Vec<u32>],
+    kappa_t: &[Vec<f64>],
+    kappa_s: &[Vec<f64>],
+    mv: &[f64],
+    sigma: &[f64],
+    k: usize,
+) -> Vec<Vec<f64>> {
+    let n = 2 * k - 1;
+    let kappa = Kappa { kappa_t: kappa_t.to_vec(), kappa_s: kappa_s.to_vec() };
+    let siginv = spd_inverse(sigma, n).unwrap_or_else(|| {
+        let mut s = sigma.to_vec();
+        make_diagonally_dominant(&mut s, n);
+        spd_inverse(&s, n).unwrap()
+    });
+    let mu = vec![0.0f64; n];
+    let sparse: Vec<(Vec<usize>, Vec<f64>)> = docs.iter().map(|d| doc_sparse(d)).collect();
+    let inferred = crate::variational::laplace_estep(&sparse, |_di, words, counts| {
+        let a_hat = lbfgs_minimize(
+            vec![0.0f64; n],
+            |a| {
+                (
+                    -sts_lhood(a, &kappa, mv, words, counts, &mu, &siginv, k),
+                    sts_grad(a, &kappa, mv, words, counts, &mu, &siginv, k)
+                        .iter()
+                        .map(|g| -g)
+                        .collect(),
+                )
+            },
+            100,
+            7,
+            1e-5,
+        );
+        let e = expeta(&a_hat[..k - 1]);
+        let s: f64 = e.iter().sum();
+        e.iter().map(|x| x / s).collect::<Vec<f64>>()
+    });
+    // Reassemble in document order; empty docs (skipped by the driver) get uniform θ.
+    let mut out = vec![vec![1.0 / k as f64; k]; docs.len()];
+    for (di, theta) in inferred {
+        out[di] = theta;
+    }
+    out
+}
+
 /// A two-parameter Poisson regression `log E[y_g] = offset_g + a + b·z_g` fit by
 /// Newton's method with a small ridge. Returns `(a, b)` = `(κ^(t), κ^(s))` for one
 /// (word, topic). When the covariate `z` has no spread (or fewer than two groups)

--- a/tests/test_convergence_interface.py
+++ b/tests/test_convergence_interface.py
@@ -77,6 +77,12 @@ def _fit_model(name: str, factory):
         model.fit(_TOY, prevalence, iters=5)
         return model
 
+    # STS: requires a per-document sentiment_seed (the aggregation groups)
+    if name == "STS":
+        sent = [float(i % 3) for i in range(len(_TOY))]
+        model.fit(_TOY, sent, iters=5)
+        return model
+
     # ETM: requires positional word_embeddings and vocabulary
     if name == "ETM":
         import topica

--- a/tests/test_sts.py
+++ b/tests/test_sts.py
@@ -103,6 +103,45 @@ class TestAnalysisSurface:
         assert m.sentiment.shape == (len(docs), 2)
 
 
+class TestPersistenceAndTransform:
+    def test_doc_names(self):
+        docs, sent_seed, prev, _ = _planted()
+        m = topica.STS(num_topics=2, seed=1)
+        m.fit(docs, sentiment_seed=sent_seed, prevalence=prev, iters=15)
+        assert m.doc_names == [f"doc_{i}" for i in range(len(docs))]
+
+    def test_transform_shape_and_normalization(self):
+        docs, sent_seed, prev, _ = _planted()
+        m = topica.STS(num_topics=2, seed=1)
+        m.fit(docs, sentiment_seed=sent_seed, prevalence=prev, iters=20)
+        held = [A[:4], B[:4], ["???", "out-of-vocab"]]
+        th = m.transform(held)
+        assert th.shape == (3, 2)
+        np.testing.assert_allclose(th.sum(axis=1), 1.0, atol=1e-9)
+        # an all-OOV document falls back to a uniform prevalence
+        np.testing.assert_allclose(th[2], [0.5, 0.5], atol=1e-9)
+        # a clearly topic-A document leans to the topic that owns the A block
+        a_top = max(range(2), key=lambda t: th[0, t])
+        b_top = max(range(2), key=lambda t: th[1, t])
+        assert a_top != b_top
+
+    def test_save_load_round_trip(self, tmp_path):
+        docs, sent_seed, prev, _ = _planted()
+        m = topica.STS(num_topics=2, seed=1)
+        m.fit(docs, sentiment_seed=sent_seed, prevalence=prev, iters=20)
+        p = str(tmp_path / "model.sts")
+        m.save(p)
+        m2 = topica.STS.load(p)
+        for attr in ("topic_word", "doc_topic", "sentiment", "eta_mean", "eta_cov"):
+            np.testing.assert_array_equal(
+                np.asarray(getattr(m, attr)), np.asarray(getattr(m2, attr))
+            )
+        assert m2.prevalence_effects.shape == m.prevalence_effects.shape
+        # the reloaded model transforms identically
+        held = [A[:4], B[:4]]
+        np.testing.assert_allclose(m2.transform(held), m.transform(held), atol=1e-12)
+
+
 class TestErrors:
     def test_num_topics_too_small(self):
         with pytest.raises(ValueError):


### PR DESCRIPTION
Completes STS's estimator surface — the follow-up flagged during #74 (PR #79). STS shipped without `save`/`load`/`transform`/`doc_names`, so it was the one logistic-normal model absent from the conformance registry. This closes that gap and registers it.

## What changed
- **`transform(docs)`** — held-out inference. A new `sts::sts_infer` runs the same Laplace E-step used in fitting against the fixed globals (κ, m, Σ) with a zero prior mean, one independent optimum per document, and returns prevalence θ = softmax([α^(p), 0]). Parallel and document-order-deterministic via `variational::laplace_estep`; an all-out-of-vocabulary document falls back to uniform θ.
- **`save` / `load`** — a new `StsState` serde struct + `write_state`/`read_state`, mirroring `CtmState`/`StmState`. κ_t/κ_s/m/Σ are carried so a reloaded model `transform`s identically.
- **`doc_names`** getter.
- `.pyi` stub updated for all four; **STS added to `conformance.py::REGISTRY`** (`logistic_normal`) and to the Rust `RUST_ESTIMATORS` table (size 20 → 21). `test_convergence_interface._fit_model` gains an STS branch (STS needs a per-document `sentiment_seed`).

STS now passes the full Tier-0 / Tier-1 / Tier-2 contract.

## Validation
- `cargo test --lib` 78 passed
- `pytest tests/` **1943 passed, 18 skipped** (+26: STS now exercised by the conformance and convergence-interface registries)
- `mkdocs build --strict` clean
- New tests: `transform` shape/normalization incl. the OOV uniform fallback; a `save`/`load` round-trip that reproduces `topic_word`/`doc_topic`/`sentiment`/`eta_mean`/`eta_cov` and `transform`.

Additive only; no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
