### PR TITLE
fix: stop HDP topic-count runaway (#68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
-### Changed
+### Fixed
 
-- `HDP` default concentrations are now `alpha=0.1`, `gamma=0.1` (were `1.0`,
-  `1.0`), matching the reference HDP convention. The `1.0` defaults inferred far
-  too many topics on real corpora. This reduces the inferred topic count but does
-  not fully fix the underlying runaway-topic feedback over long runs, tracked in
-  #68.
+- `HDP` no longer runs away to hundreds of topics on real corpora (#68). The
+  concentration resampler was a positive-feedback loop: the Escobar-West update
+  draws `gamma` from `Gamma(a + K, ...)`, whose mean grows with the topic count
+  `K`, so more topics raised `gamma`, which created more topics, irreversibly
+  (K reached 774 with gamma at 102 over 800 sweeps on a 3,500-document corpus).
+  `resample_conc` now defaults to `False` (fixed concentrations give a stable,
+  reproducible topic count; `gamma` sets the granularity directly), and the
+  opt-in resampling path caps the concentrations so it stays bounded. Default
+  concentrations remain `alpha=0.1`, `gamma=0.1` (the reference convention).
 
 ## [0.15.0] - 2026-06-10
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -138,10 +138,16 @@ A nonparametric model that **infers** the number of topics rather than taking
 `K` as input. Useful as a sanity check on the `K` you chose elsewhere.
 
 ```python
-hdp = topica.HDP(eta=0.3, seed=1)
+hdp = topica.HDP(gamma=0.5, eta=0.3, seed=1)
 hdp.fit(docs, iters=300)
 print(hdp.num_topics, "topics inferred")
 ```
+
+`gamma` is the main lever on the inferred count: larger values discover more
+topics (the conservative default `0.1` lands near a handful, like the reference
+implementations). By default the concentrations are held fixed, which gives a
+stable, reproducible topic count; `resample_conc=True` lets the model adapt them
+to the data instead, useful for exploration but more liberal about adding topics.
 
 ## Guided topics
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -678,13 +678,15 @@ class HDP:
         gamma: float = 0.1,
         eta: float = 0.01,
         seed: int = 42,
-        resample_conc: bool = True,
+        resample_conc: bool = False,
     ) -> None:
-        """alpha/gamma are the document- and corpus-level DP concentrations
-        (initial values; resampled from the data when resample_conc=True, the
-        default). The defaults 0.1/0.1 match the reference HDP convention; gamma
-        is the dominant lever on the inferred topic count. eta is the topic-word
-        Dirichlet (base measure). alpha, gamma, eta must be > 0."""
+        """alpha/gamma are the document- and corpus-level DP concentrations.
+        gamma is the dominant lever on the inferred topic count (0.1 is
+        conservative; raise it for more topics). resample_conc defaults to False
+        (fixed concentrations -> a stable topic count); set it True to adapt the
+        concentrations to the data, which is now capped to avoid the runaway
+        topic count it used to cause (issue #68). eta is the topic-word Dirichlet
+        (base measure). alpha, gamma, eta must be > 0."""
         ...
 
     def fit(

--- a/src/hdp.rs
+++ b/src/hdp.rs
@@ -185,6 +185,16 @@ fn sample_index<R: Rng>(probs: &[f64], rng: &mut R) -> usize {
 // Sampler
 // ---------------------------------------------------------------------------
 
+/// Upper bound on a resampled DP concentration. The Escobar-West update for γ
+/// draws from `Gamma(a + K, b - log η)`, whose mean grows linearly with the
+/// topic count K; once K is large the rate term cannot pull γ back down, so γ
+/// and K reinforce each other without bound (issue #68: K ran to 774 with γ at
+/// 102). Healthy fits keep both concentrations in roughly `[0.05, 1.5]`, so this
+/// cap leaves normal adaptation untouched while preventing the runaway. It only
+/// matters when `resample_conc = true`; the default fits with fixed
+/// concentrations and never reaches it.
+const CONCENTRATION_MAX: f64 = 2.0;
+
 impl HdpModel {
     /// Drop any topic with no tokens, returning its stick mass to β_u and
     /// reindexing assignments/counts so topic indices stay contiguous.
@@ -260,7 +270,8 @@ impl HdpModel {
         let eta = sample_beta_dist(self.gamma + 1.0, m, rng).max(1e-12);
         let pi = (a + k - 1.0) / (a + k - 1.0 + m * (b - eta.ln()));
         let shape = if rng.gen::<f64>() < pi { a + k } else { a + k - 1.0 };
-        self.gamma = (sample_gamma(shape, rng) / (b - eta.ln())).max(1e-3);
+        self.gamma = (sample_gamma(shape, rng) / (b - eta.ln()))
+            .clamp(1e-3, CONCENTRATION_MAX);
     }
 
     /// Resample the document-level concentration α0 given per-document word
@@ -291,7 +302,7 @@ impl HdpModel {
             let shape = a + total_tables as f64 - sum_s;
             let rate = b - sum_log_w;
             if shape > 0.0 && rate > 0.0 {
-                self.alpha = (sample_gamma(shape, rng) / rate).max(1e-3);
+                self.alpha = (sample_gamma(shape, rng) / rate).clamp(1e-3, CONCENTRATION_MAX);
             }
         }
     }
@@ -527,6 +538,37 @@ mod tests {
         assert_eq!(trace.last().unwrap().1, model.num_topics());
         // The fit improves from the first recorded sweep to the last.
         assert!(trace.last().unwrap().2 > trace.first().unwrap().2);
+    }
+
+    #[test]
+    fn concentration_resampling_is_capped() {
+        // Issue #68: with many topics, the Escobar-West gamma update draws from
+        // Gamma(a+K, .) whose mean grows with K, so gamma (and K) ran away to the
+        // hundreds. Drive the resamplers from a large-K state and confirm both
+        // concentrations stay bounded by CONCENTRATION_MAX.
+        let k = 300usize;
+        let v = 50usize;
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let mut model = HdpModel {
+            num_types: v,
+            eta: 0.01,
+            alpha: 1.0,
+            gamma: 1.0,
+            nkw: vec![vec![1u32; v]; k],
+            nk: vec![v as u32; k],
+            beta: vec![1.0 / (k as f64 + 1.0); k],
+            beta_u: 1.0 / (k as f64 + 1.0),
+            z: Vec::new(),
+            njk: vec![(0..k).map(|t| (t % 3 + 1) as u32).collect(); 200],
+            trace: Vec::new(),
+        };
+        for _ in 0..50 {
+            let (m_total, t_j) = model.resample_beta(&mut rng);
+            model.resample_gamma(m_total, &mut rng);
+            model.resample_alpha(&t_j, &mut rng);
+            assert!(model.gamma <= CONCENTRATION_MAX + 1e-9, "gamma {} > cap", model.gamma);
+            assert!(model.alpha <= CONCENTRATION_MAX + 1e-9, "alpha {} > cap", model.alpha);
+        }
     }
 
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -6496,19 +6496,23 @@ impl HDP {
 
 #[pymethods]
 impl HDP {
-    /// Create an unfitted model. `alpha`/`gamma` are the initial document- and
+    /// Create an unfitted model. `alpha`/`gamma` are the document- and
     /// corpus-level DP concentrations; `eta` is the topic-word Dirichlet (base
-    /// measure). With `resample_conc=True` (default) `alpha`/`gamma` are
-    /// resampled each sweep and the given values are just starting points.
+    /// measure). `gamma` is the dominant lever on the inferred topic count:
+    /// larger values find more topics (`0.1` is conservative, like tomotopy's
+    /// default; raise it for finer granularity).
     ///
-    /// The defaults `alpha=0.1`, `gamma=0.1` match the reference HDP convention
-    /// (and tomotopy's). `gamma` is the dominant lever on the inferred topic
-    /// count; larger values find more topics. The earlier `1.0` defaults seeded
-    /// a runaway-topic regime, because the concentration resampler's gamma
-    /// posterior shape grows with the current topic count, so a high-K start
-    /// feeds a higher gamma and sustains it.
+    /// `resample_conc` controls whether `alpha`/`gamma` are resampled each sweep.
+    /// It defaults to ``False`` (fixed concentrations), which gives a stable,
+    /// reproducible topic count. Resampling (`resample_conc=True`) lets the model
+    /// adapt the concentrations to the data, but the corpus-level update is a
+    /// positive-feedback loop, more topics raise gamma, which creates more
+    /// topics, that ran the topic count away to the hundreds on real corpora
+    /// (issue #68). The resampled concentrations are now capped to keep that
+    /// bounded, but fixed concentrations remain the recommended default; set
+    /// `gamma` to choose the granularity directly.
     #[new]
-    #[pyo3(signature = (*, alpha=0.1, gamma=0.1, eta=0.01, seed=42, resample_conc=true))]
+    #[pyo3(signature = (*, alpha=0.1, gamma=0.1, eta=0.01, seed=42, resample_conc=false))]
     fn new(alpha: f64, gamma: f64, eta: f64, seed: u64, resample_conc: bool) -> PyResult<Self> {
         if !finite_pos(alpha) || !finite_pos(gamma) {
             return Err(PyValueError::new_err("alpha and gamma must be > 0"));


### PR DESCRIPTION
Closes #68.

## The bug
HDP's concentration resampler is a positive-feedback loop. The Escobar-West update draws the corpus-level concentration `gamma` from `Gamma(a + K, b - log eta)`, whose mean grows with the current topic count `K`. More topics → larger `gamma` → a larger leftover stick `beta_u` → more new topics. Past a threshold the rate term can no longer pull `gamma` back down (it would need `eta` < 1e-168), so the climb is **irreversible**.

Reproduced on a seeded 3,500-doc poliblog subsample (the issue's corpus), 800 sweeps, defaults:

| sweep | 100 | 200 | 300 | 400 | 500 | 600 | 700 | 800 |
|---|---|---|---|---|---|---|---|---|
| K | 3 | 6 | 11 | 31 | 70 | 177 | 379 | **774** |
| gamma | 0.5 | 0.6 | 0.7 | 2.7 | 7.2 | 18 | 47 | **102** |

Lowering the default concentrations (the earlier partial mitigation) only delayed onset, since resampling overwrites the start values on sweep 1.

## The fix
- **`resample_conc` now defaults to `False`.** Fixed concentrations give a stable, reproducible topic count — **K=2–3, stable across all 800 sweeps, and ~12× faster** (17s vs 199s, since it isn't sampling over hundreds of spurious topics). This matches the reference convention (tomotopy infers 2 on the same data). `gamma` is the granularity lever; raise it for more topics.
- **The opt-in resampling path caps the concentrations** at `CONCENTRATION_MAX = 2.0`. This leaves the healthy adaptation range (observed 0.05–1.5) untouched but bounds the runaway: same corpus, `resample_conc=True` now lands at **gamma ≤ 2.0, K = 82** (vs 102 / 774).
- New `concentration_resampling_is_capped` unit test drives the resamplers from a 300-topic state and asserts both concentrations stay bounded — it would fail pre-fix.

The planted-data recovery test (`resample_conc=True` on clean data) still recovers ~5 topics: the cap only binds on the pathological large-K path.

API note: this changes the `HDP(resample_conc=...)` default from `True` to `False`. The parameter and its meaning are unchanged; the new default is the safe, stable one. Docstring, `.pyi`, the models guide, and CHANGELOG are updated.

## Validation
- `cargo test --lib` 79 passed (incl. the new cap test + planted-5 recovery + determinism)
- `pytest tests/` 1943 passed, 18 skipped
- `mkdocs build --strict` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
