### PR TITLE
feat(lda): opt-in spectral anchor-word init (better topics at large K)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Added
+
+- `LDA(..., init="spectral")` seeds the initial token-topic assignment from a
+  deterministic anchor-word topic-word matrix (the same spectral recovery STM
+  and CTM use) instead of a uniform random draw. It does not speed convergence,
+  but it improves topic coherence at larger K (a robust +2 to +3 mean-coherence
+  points across seeds at K=50 and K=100 on the poliblog corpus; a wash at small
+  K), the fine-grained regime where the sparse sampler already pays off. It
+  falls back to the random draw when the corpus is too small for anchor
+  recovery. The default stays `init="random"`, so MALLET byte-parity and
+  same-seed determinism are unchanged.
+
 ### Changed
 
 - The collapsed-Gibbs samplers (LDA, DMR, LabeledLDA, SeededLDA, KeyATM, PA, PT,

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1236,6 +1236,7 @@ class LDA:
         sampler: str = "sparse",
         mh_steps: int = 2,
         use_symmetric_alpha: bool = False,
+        init: str = "random",
     ) -> None:
         """Create an LDA model. alpha_sum defaults to num_topics if None.
 
@@ -1256,6 +1257,15 @@ class LDA:
         for the very-large-K / long-document regime; "sparse" is faster at the
         topic counts typical of social-science work. mh_steps is the number of
         MH proposals per token (alias sampler only).
+
+        init selects the initial token-topic assignment: "random" (default,
+        MALLET-compatible) draws each token's topic uniformly; "spectral" seeds
+        it from a deterministic anchor-word topic-word matrix (the same spectral
+        recovery STM/CTM use). Spectral init does not speed convergence, but it
+        improves topic coherence at larger K (roughly K >= 50; it is a wash at
+        small K) and falls back to the random draw when the corpus is too small
+        for anchor recovery. The default leaves the MALLET byte-parity and
+        same-seed determinism guarantees unchanged.
         """
         ...
 

--- a/src/model.rs
+++ b/src/model.rs
@@ -132,6 +132,87 @@ impl TopicModel {
         }
     }
 
+    /// Anchor-word / spectral initialization: seed each token's topic by
+    /// sampling from the categorical p(t | w) ∝ β[t][w], where `beta` is the
+    /// K×V topic-word matrix from [`crate::spectral::spectral_init`]. This
+    /// biases the starting state toward the recovered anchor structure while
+    /// keeping the assignment stochastic, so within-document mixing is
+    /// preserved and the sampler is not pinned to a degenerate start. Any word
+    /// whose β column carries no mass falls back to a uniform draw.
+    ///
+    /// Deterministic given `rng`. Equivalent in every other respect to
+    /// [`Self::initialize`] (same count-table sizing and accumulation); only
+    /// the initial topic draw differs.
+    pub fn initialize_spectral<R: Rng>(
+        &mut self,
+        corpus: &Corpus,
+        beta: &[Vec<f64>],
+        rng: &mut R,
+    ) {
+        let k = self.num_topics;
+
+        let mut type_totals = vec![0usize; self.num_types];
+        for doc in &corpus.docs {
+            for &word_id in doc {
+                type_totals[word_id as usize] += 1;
+            }
+        }
+        self.type_topic_counts = type_totals
+            .iter()
+            .map(|&total| vec![0u32; self.num_topics.min(total)])
+            .collect();
+
+        // Per-word cumulative topic weights from the β columns (one length-k
+        // prefix sum per word type). The last entry is the column's total mass;
+        // a (near-)zero total marks a word we sample uniformly instead.
+        let mut col_cum: Vec<Vec<f64>> = Vec::with_capacity(self.num_types);
+        for w in 0..self.num_types {
+            let mut cum = Vec::with_capacity(k);
+            let mut s = 0.0f64;
+            for t in 0..k {
+                s += beta[t][w].max(0.0);
+                cum.push(s);
+            }
+            col_cum.push(cum);
+        }
+
+        self.doc_topics = corpus
+            .docs
+            .iter()
+            .map(|doc| {
+                doc.iter()
+                    .map(|&w| {
+                        let cum = &col_cum[w as usize];
+                        let total = cum[k - 1];
+                        if total <= 0.0 {
+                            return rng.gen_range(0..k) as u32;
+                        }
+                        let u = rng.gen::<f64>() * total;
+                        // First topic whose prefix sum exceeds u.
+                        let mut t = 0usize;
+                        while t + 1 < k && cum[t] <= u {
+                            t += 1;
+                        }
+                        t as u32
+                    })
+                    .collect()
+            })
+            .collect();
+
+        let assignments: Vec<(usize, usize)> = corpus
+            .docs
+            .iter()
+            .zip(self.doc_topics.iter())
+            .flat_map(|(doc, topics)| {
+                doc.iter().map(|&w| w as usize).zip(topics.iter().map(|&t| t as usize))
+            })
+            .collect();
+        for (word_id, topic) in assignments {
+            self.tokens_per_topic[topic] += 1;
+            self.increment_type_topic(word_id, topic);
+        }
+    }
+
     /// Increment the count for (word_id, topic) in type_topic_counts,
     /// maintaining descending sort.
     pub fn increment_type_topic(&mut self, word_id: usize, topic: usize) {

--- a/src/python.rs
+++ b/src/python.rs
@@ -48,7 +48,7 @@ use regex::Regex;
 
 use crate::corpus::{self, InputFormat, LoadOptions};
 use crate::model::TopicModel;
-use crate::{coherence as coh, ctm, lightlda, optimize, output, sampler, sts};
+use crate::{coherence as coh, ctm, lightlda, optimize, output, sampler, spectral, sts};
 
 // ---------------------------------------------------------------------------
 // Error helpers
@@ -161,6 +161,7 @@ struct LdaState {
     #[serde(default)] topic_names: Vec<String>,
     #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
     #[serde(default)] converged: bool,
+    #[serde(default)] init_spectral: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct DmrState {
@@ -756,6 +757,10 @@ pub struct LDA {
     // MALLET's --use-symmetric-alpha: optimize only the alpha concentration,
     // keeping every alpha[t] equal, instead of learning the per-topic shape.
     use_symmetric_alpha: bool,
+    // Seed the initial token→topic assignment from a spectral anchor-word β
+    // instead of a uniform random draw. Opt-in (default random) so the MALLET
+    // byte-parity guarantee and existing determinism baselines are unchanged.
+    init_spectral: bool,
 
     // Populated after fit().
     fitted: bool,
@@ -895,7 +900,8 @@ impl LDA {
     #[new]
     #[pyo3(signature = (num_topics, *, alpha_sum=None, beta=0.01,
                         optimize_interval=50, burn_in=200, seed=42, num_threads=1,
-                        sampler="sparse", mh_steps=2, use_symmetric_alpha=false))]
+                        sampler="sparse", mh_steps=2, use_symmetric_alpha=false,
+                        init="random"))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
@@ -908,6 +914,7 @@ impl LDA {
         sampler: &str,
         mh_steps: usize,
         use_symmetric_alpha: bool,
+        init: &str,
     ) -> PyResult<Self> {
         if num_topics == 0 {
             return Err(PyValueError::new_err("num_topics must be >= 1"));
@@ -934,6 +941,11 @@ impl LDA {
         if light && mh_steps == 0 {
             return Err(PyValueError::new_err("mh_steps must be >= 1 for the lightlda sampler"));
         }
+        let init_spectral = match init {
+            "spectral" => true,
+            "random" => false,
+            _ => return Err(PyValueError::new_err("init must be 'spectral' or 'random'")),
+        };
         Ok(LDA {
             num_topics,
             alpha_sum,
@@ -945,6 +957,7 @@ impl LDA {
             light,
             mh_steps,
             use_symmetric_alpha,
+            init_spectral,
             fitted: false,
             topic_names: Vec::new(),
             phi: None,
@@ -1034,7 +1047,16 @@ impl LDA {
 
         let mut model = TopicModel::new(num_topics, alpha_sum, self.beta, num_types);
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
-        model.initialize(&corpus, &mut rng);
+        // Spectral anchor-word init is opt-in; it falls back to the random draw
+        // when the corpus is too small for anchor recovery (spectral_init -> None).
+        if self.init_spectral {
+            match spectral::spectral_init(&corpus.docs, num_topics, num_types) {
+                Some(beta) => model.initialize_spectral(&corpus, &beta, &mut rng),
+                None => model.initialize(&corpus, &mut rng),
+            }
+        } else {
+            model.initialize(&corpus, &mut rng);
+        }
 
         let optimize_interval = self.optimize_interval;
         let burn_in = self.burn_in;
@@ -1615,6 +1637,7 @@ impl LDA {
             light: false,
             mh_steps: 2,
             use_symmetric_alpha: false,
+            init_spectral: false,
             fitted: true,
             topic_names: (0..num_topics).map(|i| format!("topic_{i}")).collect(),
             phi: Some(phi),
@@ -1987,6 +2010,7 @@ impl LDA {
             topic_names: self.topic_names.clone(),
             log_likelihood_history: self.log_likelihood_history.clone(),
             converged: self.converged,
+            init_spectral: self.init_spectral,
         })
     }
 
@@ -2004,6 +2028,7 @@ impl LDA {
             optimize_interval: s.optimize_interval, burn_in: s.burn_in, seed: s.seed,
             num_threads: s.num_threads, light: false, mh_steps: 2, fitted: s.fitted,
             use_symmetric_alpha: s.use_symmetric_alpha,
+            init_spectral: s.init_spectral,
             topic_names,
             phi: arr2_back(s.phi), theta: arr2_back(s.theta), theta_draws: None,
             model: s.model, corpus: s.corpus,

--- a/tests/test_lda.py
+++ b/tests/test_lda.py
@@ -252,3 +252,82 @@ class TestSaveFiles:
         for line in path.read_text().splitlines()[1:5]:
             parts = line.split("\t")
             assert len(parts) >= 2
+
+
+# ---------------------------------------------------------------------------
+# Spectral (anchor-word) initialization
+# ---------------------------------------------------------------------------
+
+def _planted_blocks(n_blocks=4, words_per_block=5, n_docs=200):
+    """One disjoint vocabulary block per topic; each doc draws from one block."""
+    vocab = [f"w{i}" for i in range(n_blocks * words_per_block)]
+    docs = []
+    for d in range(n_docs):
+        b = d % n_blocks
+        block = vocab[b * words_per_block : (b + 1) * words_per_block]
+        docs.append(block + block)
+    return docs, n_blocks, words_per_block
+
+
+class TestSpectralInit:
+    def test_default_is_random(self):
+        # The default leaves the MALLET-compatible random init in place, so an
+        # explicit init="random" reproduces it bit-for-bit.
+        docs, k, _ = _planted_blocks()
+        m_default = LDA(k, seed=3)
+        m_default.fit(docs, iters=80)
+        m_random = LDA(k, seed=3, init="random")
+        m_random.fit(docs, iters=80)
+        npt.assert_array_equal(m_default.topic_word, m_random.topic_word)
+
+    def test_bad_init_rejected(self):
+        with pytest.raises(ValueError):
+            LDA(2, init="banana")
+
+    def test_spectral_runs_and_is_well_formed(self):
+        docs, k, _ = _planted_blocks()
+        m = LDA(k, seed=1, init="spectral")
+        m.fit(docs, iters=120)
+        assert m.topic_word.shape == (k, len(m.vocabulary))
+        npt.assert_allclose(m.topic_word.sum(axis=1), 1.0, atol=1e-9)
+        npt.assert_allclose(m.doc_topic.sum(axis=1), 1.0, atol=1e-9)
+
+    def test_spectral_is_deterministic_for_seed(self):
+        docs, k, _ = _planted_blocks()
+        a = LDA(k, seed=7, init="spectral")
+        a.fit(docs, iters=80)
+        b = LDA(k, seed=7, init="spectral")
+        b.fit(docs, iters=80)
+        npt.assert_array_equal(a.topic_word, b.topic_word)
+
+    def test_spectral_recovers_planted_blocks(self):
+        docs, k, wpb = _planted_blocks()
+        m = LDA(k, seed=1, init="spectral")
+        m.fit(docs, iters=200)
+        vocab = [f"w{i}" for i in range(k * wpb)]
+        blocks = [set(vocab[b * wpb : (b + 1) * wpb]) for b in range(k)]
+        covered = set()
+        for t in range(k):
+            top = {w for w, _ in m.top_words(wpb, topic=t)}
+            for bi, blk in enumerate(blocks):
+                if blk <= top:
+                    covered.add(bi)
+        assert covered == set(range(k)), f"only recovered {covered}"
+
+    def test_spectral_falls_back_on_tiny_corpus(self):
+        # Fewer word types than topics: spectral_init returns None and the fit
+        # falls back to the random draw rather than erroring.
+        docs = [["a", "b"], ["a", "b"], ["b", "a"]]
+        m = LDA(5, seed=1, init="spectral")
+        m.fit(docs, iters=20)
+        assert m.num_topics == 5
+        assert m.topic_word.shape[1] == len(m.vocabulary)
+
+    def test_spectral_survives_save_load(self, tmp_path):
+        docs, k, _ = _planted_blocks()
+        m = LDA(k, seed=1, init="spectral")
+        m.fit(docs, iters=80)
+        path = str(tmp_path / "lda_spec.bin")
+        m.save(path)
+        reloaded = LDA.load(path)
+        npt.assert_array_equal(reloaded.topic_word, m.topic_word)


### PR DESCRIPTION
Adds an opt-in `LDA(..., init="spectral")` that seeds the initial token-topic assignment from a deterministic anchor-word topic-word matrix (the same `spectral::spectral_init` recovery STM/CTM use) instead of a uniform random draw. From #85 (perf roadmap, lever 1).

## The honest result: a quality lever, not a speed one

#85 framed this as a *time-to-quality* idea (fewer iterations to converge). **The experiment did not bear that out** — spectral init adds ~1s of upfront anchor recovery and does not cut sweeps-to-converge. But it does deliver a robust **topic-quality** win at larger K, which is the regime topica's sparse sampler already targets:

Mean coherence (`c_v`-style, n=10), 2,000-doc poliblog subsample, 200 iters, reference time:

| K | random (mean over seeds) | spectral | delta | spectral wins |
|---|---|---|---|---|
| 20 | — | — | noisy | ~wash (split across seeds) |
| 50 | -66.72 | -63.94 | **+2.78** | 4/4 seeds |
| 100 | -78.85 | -76.65 | **+2.20** | 4/4 seeds |

Consistent +2 to +3 coherence points at K≥50 across every seed; a wash at K=20. The docstring and CHANGELOG say exactly this — no speed claim.

## Design

- `TopicModel::initialize_spectral` samples each token's topic from the categorical `p(t|w) ∝ β[t][w]`, biasing the start toward the anchor structure while staying stochastic (within-document mixing preserved; no degenerate pinning where every occurrence of a word collapses to one topic).
- Falls back to the random draw when the corpus is too small for anchor recovery (`spectral_init -> None`).
- `init_spectral` is threaded through the constructor, the serialized state (`#[serde(default)]` = false, so models saved before this change still load), and the type stub.

## Guarantees preserved

- **Default stays `init="random"`** → MALLET byte-parity (`parity/mallet_parity.py`: LDA cosine **1.000**) and same-seed determinism unchanged.
- Seven tests: well-formedness, same-seed determinism, planted-block recovery, tiny-corpus fallback, save/load roundtrip, and that the default reproduces `init="random"` bit-for-bit.

## Gate

- `cargo test --lib` — 79 passed
- full pytest — 1950 passed / 18 skipped (7 new)
- `mkdocs build --strict` — clean
- MALLET parity — cosine 1.000

No version bump (feature PR).
