### PR TITLE
feat(dmr): WarpLDA backend for DMR — sampler="warp" (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- `DMR(..., sampler="warp")` runs the WarpLDA backend for DMR (a per-document-α
+  doc phase: the doc-proposal and its acceptance use each document's
+  `α_{d,k} = exp(λ_k · x_d)`, with the λ optimization loop unchanged). Same
+  large-K win as LDA: on a 2,000-document poliblog subsample at K=500 it fits
+  ~2.4x faster than the default `"sparse"` DMR sweep at comparable coherence,
+  widening as K grows. Default stays `"sparse"`. Enabled by the shared per-doc
+  WarpLDA doc phase, so the LDA hot path is untouched.
+
 - `LDA(..., sampler="warp")` adds the WarpLDA cache-efficient two-pass
   Metropolis-Hastings sampler (Chen et al., 2016). Its per-sweep cost is flat in
   K (an O(1)-per-token MCEM scheme with delayed count updates), so it is the

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -122,6 +122,11 @@ model = topica.DMR(num_topics=20, seed=1)
 model.fit(docs, X, feature_names=names)
 ```
 
+Like `LDA`, `DMR` accepts `sampler="warp"` (the WarpLDA backend, here with a
+per-document-α doc phase) for fine-grained, large-`K` models — flat per-sweep
+cost in `K`, several times faster than the default `"sparse"` sweep at `K ≳ 500`.
+Use the default `"sparse"` up to a couple hundred topics.
+
 ## DTM
 
 The Dynamic Topic Model: a fixed number of topics whose word distributions

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -177,9 +177,17 @@ class DMR:
         seed: int = 42,
         prior_variance: float = 1.0,
         lbfgs_iters: int = 20,
+        sampler: str = "sparse",
     ) -> None:
         """Create an unfitted DMR model. prior_variance is the Gaussian prior
-        variance on the feature weights; lbfgs_iters caps L-BFGS steps per round."""
+        variance on the feature weights; lbfgs_iters caps L-BFGS steps per round.
+
+        sampler selects the inference backend: "sparse" (default) is the
+        SparseLDA collapsed-Gibbs sweep with the per-document DMR prior; "warp"
+        is the WarpLDA cache-efficient sampler (per-document-α doc phase), whose
+        per-sweep cost is flat in K. As with plain LDA, prefer "sparse" up to
+        ~K=200 and "warp" for large-K (K >= ~500) models; "warp" does not record
+        the convergence trace, so convergence_tol has no effect there."""
         ...
 
     def fit(

--- a/src/python.rs
+++ b/src/python.rs
@@ -2918,6 +2918,9 @@ pub struct DMR {
     seed: u64,
     prior_variance: f64,
     lbfgs_iters: usize,
+    // WarpLDA cache-efficient sampler (per-document-α doc phase) instead of the
+    // default SparseLDA DMR sweep. Recommended for large K.
+    warp: bool,
 
     fitted: bool,
     topic_names: Vec<String>,
@@ -2950,7 +2953,8 @@ impl DMR {
     /// `lbfgs_iters` caps the L-BFGS steps per optimization round.
     #[new]
     #[pyo3(signature = (num_topics, *, beta=0.01, optimize_interval=50,
-                        burn_in=200, seed=42, prior_variance=1.0, lbfgs_iters=20))]
+                        burn_in=200, seed=42, prior_variance=1.0, lbfgs_iters=20,
+                        sampler="sparse"))]
     fn new(
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
         beta: f64,
@@ -2959,6 +2963,7 @@ impl DMR {
         seed: u64,
         prior_variance: f64,
         lbfgs_iters: usize,
+        sampler: &str,
     ) -> PyResult<Self> {
         if num_topics == 0 {
             return Err(PyValueError::new_err("num_topics must be >= 1"));
@@ -2969,6 +2974,15 @@ impl DMR {
         if !finite_pos(prior_variance) {
             return Err(PyValueError::new_err("prior_variance must be > 0"));
         }
+        let warp = match sampler {
+            "sparse" => false,
+            "warp" | "warplda" => true,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown sampler {other:?}; expected \"sparse\" or \"warp\""
+                )))
+            }
+        };
         Ok(DMR {
             num_topics,
             beta,
@@ -2977,6 +2991,7 @@ impl DMR {
             seed,
             prior_variance,
             lbfgs_iters,
+            warp,
             fitted: false,
             topic_names: Vec::new(),
             phi: None,
@@ -3074,7 +3089,8 @@ impl DMR {
         let mut lambda = vec![vec![0.0f64; nf]; k];
         let mut model = TopicModel::new(k, k as f64, self.beta, num_types);
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
-        model.initialize(&corpus, &mut rng);
+        // The sparse path initializes `model` inside its branch below; the warp
+        // path builds its own WarpLda state, so the shared init is deferred.
 
         let optimize_interval = self.optimize_interval;
         let burn_in = self.burn_in;
@@ -3083,7 +3099,91 @@ impl DMR {
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        let (acc_phi, acc_theta, theta_draw_buf, feat_eff, ll_history, converged_flag, model, corpus) = py.allow_threads(move || {
+        let beta = self.beta;
+        let warp = self.warp;
+        let (acc_phi, acc_theta, theta_draw_buf, feat_eff, ll_history, converged_flag, model, corpus) =
+          if warp {
+            // WarpLDA DMR path: same λ-optimization loop, but the per-document
+            // prior α is fed to the WarpLDA per-doc doc phase each sweep. Like the
+            // LDA WarpLDA path it computes no inline log_likelihood, so the
+            // convergence trace / convergence_tol are not recorded here.
+            py.allow_threads(move || {
+                let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+                let mut ws = warplda::WarpLda::new(&corpus, k, &vec![1.0f64; k], beta, &mut rng);
+
+                for iter in 1..=iters {
+                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                    ws.set_doc_alpha(doc_alpha);
+                    ws.sweep(&corpus, &mut rng);
+
+                    if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
+                        let dtc = doc_topic_counts(ws.doc_topics(), k);
+                        dmr::optimize_lambda(
+                            &mut lambda, &feats, &dtc, k, nf, prior_variance, lbfgs_iters, None,
+                        );
+                    }
+
+                    if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                        let doc_alpha_snap = dmr::compute_doc_alpha(&lambda, &feats, None);
+                        let snap: Vec<Vec<f32>> = ws.doc_topics().iter()
+                            .enumerate()
+                            .map(|(d, topics)| {
+                                let mut c = vec![0.0f64; k];
+                                for &t in topics { c[t as usize] += 1.0; }
+                                let asum: f64 = doc_alpha_snap[d].iter().sum();
+                                let denom = c.iter().sum::<f64>() + asum;
+                                (0..k).map(|t| ((c[t] + doc_alpha_snap[d][t]) / denom) as f32).collect()
+                            })
+                            .collect();
+                        push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
+                    }
+
+                    if let Some(cb) = &progress {
+                        if progress_interval > 0 && iter % progress_interval == 0 {
+                            let dtc = doc_topic_counts(ws.doc_topics(), k);
+                            let (ll, _) = dmr::dmr_objective_and_gradient(
+                                &lambda, &feats, &dtc, k, nf, prior_variance, None,
+                            );
+                            let llpt = ll / total_tokens;
+                            Python::with_gil(|py| {
+                                let _ = cb.call1(py, (iter, llpt));
+                            });
+                        }
+                    }
+                }
+
+                // Sampling phase: λ (and thus α per doc) fixed.
+                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                ws.set_doc_alpha(doc_alpha.clone());
+                let mut acc_phi = vec![vec![0.0f64; k]; num_types];
+                let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
+                for _ in 0..num_samples {
+                    for _ in 0..sample_interval {
+                        ws.sweep(&corpus, &mut rng);
+                    }
+                    ws.phi_into(&mut acc_phi);
+                    let counts = doc_topic_counts(ws.doc_topics(), k);
+                    for d in 0..num_docs {
+                        let asum: f64 = doc_alpha[d].iter().sum();
+                        let denom = corpus.docs[d].len() as f64 + asum;
+                        for t in 0..k {
+                            acc_theta[d][t] += (counts[d][t] as f64 + doc_alpha[d][t]) / denom;
+                        }
+                    }
+                }
+                let n = num_samples.max(1) as f64;
+                for row in acc_phi.iter_mut() {
+                    for v in row.iter_mut() { *v /= n; }
+                }
+                for row in acc_theta.iter_mut() {
+                    for v in row.iter_mut() { *v /= n; }
+                }
+                let model = ws.to_topic_model();
+                (acc_phi, acc_theta, theta_draw_buf, lambda, Vec::new(), false, model, corpus)
+            })
+          } else {
+            model.initialize(&corpus, &mut rng);
+            py.allow_threads(move || {
             let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
             let mut ll_history: Vec<(usize, f64)> = Vec::new();
             let mut converged_flag = false;
@@ -3201,7 +3301,8 @@ impl DMR {
             }
 
             (acc_phi, acc_theta, theta_draw_buf, lambda, ll_history, converged_flag, model, corpus)
-        });
+            })
+          };
         let _ = model;
 
         let mut phi = Array2::<f64>::zeros((k, num_types));
@@ -3522,7 +3623,7 @@ impl DMR {
         Ok(DMR {
             num_topics: s.num_topics, beta: s.beta, optimize_interval: s.optimize_interval,
             burn_in: s.burn_in, seed: s.seed, prior_variance: s.prior_variance,
-            lbfgs_iters: s.lbfgs_iters, fitted: s.fitted,
+            lbfgs_iters: s.lbfgs_iters, warp: false, fitted: s.fitted,
             topic_names,
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             feature_effects: arr2_back(s.feature_effects),

--- a/src/warplda.rs
+++ b/src/warplda.rs
@@ -71,6 +71,11 @@ pub struct WarpLda {
 
     /// Alias table over α, for the smoothing branch of the doc-proposal.
     alpha_alias: Alias,
+
+    /// Per-document prior `α_{d,k}` (DMR). When `Some`, the doc phase uses
+    /// `doc_alpha[d]` in place of the uniform `alpha`, rebuilding the
+    /// doc-proposal smoothing alias per document. `None` is the plain-LDA path.
+    doc_alpha: Option<Vec<Vec<f64>>>,
 }
 
 impl WarpLda {
@@ -117,7 +122,20 @@ impl WarpLda {
             prop,
             word_index,
             alpha_alias,
+            doc_alpha: None,
         }
+    }
+
+    /// Switch the doc-proposal to a per-document prior `α_{d,k}` (DMR). Called
+    /// each sweep by the DMR fit loop after recomputing α from the current λ.
+    pub fn set_doc_alpha(&mut self, doc_alpha: Vec<Vec<f64>>) {
+        self.doc_alpha = Some(doc_alpha);
+    }
+
+    /// The current per-token topic assignments, document-major — the input the
+    /// DMR λ optimizer needs (its document-topic counts).
+    pub fn doc_topics(&self) -> &[Vec<u32>] {
+        &self.z
     }
 
     /// Replace the hyperparameters (after an optimisation step) and rebuild the
@@ -145,7 +163,11 @@ impl WarpLda {
     /// One WarpLDA iteration: a document phase then a word phase. `C_k` is fixed
     /// during each phase (delayed update) and recomputed in between.
     pub fn sweep<R: Rng>(&mut self, corpus: &Corpus, rng: &mut R) {
-        self.doc_phase(corpus, rng);
+        if self.doc_alpha.is_some() {
+            self.doc_phase_dmr(corpus, rng);
+        } else {
+            self.doc_phase(corpus, rng);
+        }
         self.recount_n_k();
         self.word_phase(rng);
         self.recount_n_k();
@@ -201,6 +223,62 @@ impl WarpLda {
                     self.z[d][rng.gen_range(0..doc_len)] as usize
                 } else {
                     self.alpha_alias.sample(rng)
+                };
+                self.prop[d][pos] = dp as u32;
+            }
+        }
+    }
+
+    /// Document phase with a per-document prior `α_{d,k}` (DMR). Same structure
+    /// as [`Self::doc_phase`] but the acceptance and the doc-proposal smoothing
+    /// draw use this document's own α (from `self.doc_alpha`, cloned into a local
+    /// so the token loop can mutate `z`/`prop`; the smoothing alias is rebuilt
+    /// per document). Only called when `doc_alpha` is set.
+    fn doc_phase_dmr<R: Rng>(&mut self, corpus: &Corpus, rng: &mut R) {
+        let k = self.num_topics;
+        let beta_sum = self.beta_sum;
+        let mut c_d = vec![0i64; k];
+
+        for (d, doc) in corpus.docs.iter().enumerate() {
+            let doc_len = doc.len();
+            if doc_len == 0 {
+                continue;
+            }
+            for v in c_d.iter_mut() {
+                *v = 0;
+            }
+            for &t in &self.z[d] {
+                c_d[t as usize] += 1;
+            }
+            let doc_len_f = doc_len as f64;
+
+            // Clone this document's α into a local so the token loop below can
+            // mutate `self.z`/`self.prop` without holding a borrow of `self`.
+            let alpha_d: Vec<f64> = self.doc_alpha.as_ref().unwrap()[d].clone();
+            let alpha_sum_d: f64 = alpha_d.iter().sum();
+            let doc_alias = Alias::build(&alpha_d);
+
+            for pos in 0..doc_len {
+                let cur = self.z[d][pos] as usize;
+                let prop = self.prop[d][pos] as usize;
+
+                let mut new = cur;
+                if prop != cur {
+                    let num = (c_d[prop] as f64 + alpha_d[prop])
+                        * (self.n_k[cur] as f64 - 1.0 + beta_sum);
+                    let den = (c_d[cur] as f64 - 1.0 + alpha_d[cur])
+                        * (self.n_k[prop] as f64 + beta_sum);
+                    if num >= den || rng.gen::<f64>() * den < num {
+                        new = prop;
+                    }
+                }
+                self.z[d][pos] = new as u32;
+
+                let r = rng.gen::<f64>() * (doc_len_f + alpha_sum_d);
+                let dp = if r < doc_len_f {
+                    self.z[d][rng.gen_range(0..doc_len)] as usize
+                } else {
+                    doc_alias.sample(rng)
                 };
                 self.prop[d][pos] = dp as u32;
             }
@@ -424,6 +502,48 @@ mod tests {
             }
         }
         assert_eq!(covered.len(), n_blocks, "only recovered {covered:?}");
+    }
+
+    #[test]
+    fn doc_alpha_path_recovers_planted_blocks() {
+        // The per-document-α (DMR) doc phase must recover planted topics too.
+        // Set a per-doc prior that mildly favours each document's own block, the
+        // regime a fitted DMR λ would produce.
+        let wpb = 5;
+        let (corpus, n_blocks) = planted(4, wpb, 200);
+        let k = n_blocks;
+        let v = corpus.num_types();
+        let alpha = vec![0.1f64; k];
+        let mut rng = Pcg64Mcg::seed_from_u64(1);
+        let mut s = WarpLda::new(&corpus, k, &alpha, 0.01, &mut rng);
+        // doc d belongs to block d % n_blocks; nudge its prior toward that topic.
+        let doc_alpha: Vec<Vec<f64>> = (0..corpus.docs.len())
+            .map(|d| {
+                let b = d % n_blocks;
+                (0..k).map(|t| if t == b { 0.5 } else { 0.1 }).collect()
+            })
+            .collect();
+        s.set_doc_alpha(doc_alpha);
+        for _ in 0..200 {
+            s.sweep(&corpus, &mut rng);
+        }
+        let phi = s.to_topic_model().topic_word();
+        let mut covered = std::collections::HashSet::new();
+        for t in 0..k {
+            let mut idx: Vec<usize> = (0..v).collect();
+            idx.sort_by(|&a, &b| phi[t][b].partial_cmp(&phi[t][a]).unwrap());
+            let top: std::collections::HashSet<usize> = idx[..wpb].iter().copied().collect();
+            for b in 0..n_blocks {
+                let block: std::collections::HashSet<usize> =
+                    (b * wpb..(b + 1) * wpb).collect();
+                if block.is_subset(&top) {
+                    covered.insert(b);
+                }
+            }
+        }
+        assert_eq!(covered.len(), n_blocks, "only recovered {covered:?}");
+        // doc_topics() exposes assignments for the λ optimizer.
+        assert_eq!(s.doc_topics().len(), corpus.docs.len());
     }
 
     #[test]

--- a/tests/test_dmr.py
+++ b/tests/test_dmr.py
@@ -460,3 +460,52 @@ class TestOneHot:
         # intercept is prepended, so feature_names should start with "intercept"
         assert model.feature_names[0] == "intercept"
         assert model.feature_effects.shape[1] == len(names) + 1
+
+
+# ---------------------------------------------------------------------------
+# WarpLDA sampler (cache-efficient large-K backend, per-document-α doc phase)
+# ---------------------------------------------------------------------------
+
+class TestDmrWarp:
+    def test_recovers_covariate_topics(self):
+        docs, _, feats = _make_corpus(seed=2)
+        m = _fit_dmr(docs, feats, sampler="warp")
+        a = _identify_A_topic(m)
+        # The A-topic's top words are the space vocab; the other topic is animals.
+        top_a = {w for w, _ in m.top_words(5, topic=a)}
+        assert top_a == set(_VOCAB_A)
+
+    def test_valid_distributions(self):
+        docs, _, feats = _make_corpus(seed=2)
+        m = _fit_dmr(docs, feats, sampler="warp")
+        npt.assert_allclose(m.topic_word.sum(axis=1), 1.0)
+        npt.assert_allclose(m.doc_topic.sum(axis=1), 1.0)
+
+    def test_deterministic(self):
+        docs, _, feats = _make_corpus(seed=2)
+        a = _fit_dmr(docs, feats, seed=4, sampler="warp")
+        b = _fit_dmr(docs, feats, seed=4, sampler="warp")
+        npt.assert_array_equal(a.topic_word, b.topic_word)
+        npt.assert_array_equal(a.feature_effects, b.feature_effects)
+
+    def test_feature_effect_sign_matches_sparse(self):
+        # is_A should raise the A-topic's prevalence under both samplers.
+        docs, _, feats = _make_corpus(seed=2)
+        sparse = _fit_dmr(docs, feats, sampler="sparse")
+        warp = _fit_dmr(docs, feats, sampler="warp")
+        a_s = _identify_A_topic(sparse)
+        a_w = _identify_A_topic(warp)
+        # column 1 is is_A (column 0 is the prepended intercept).
+        assert sparse.feature_effects[a_s, 1] > 0
+        assert warp.feature_effects[a_w, 1] > 0
+
+    def test_bad_sampler_rejected(self):
+        with pytest.raises(ValueError):
+            DMR(num_topics=2, sampler="banana")
+
+    def test_sampler_aliases(self):
+        docs, _, feats = _make_corpus(seed=2)
+        for name in ("warp", "warplda"):
+            m = DMR(num_topics=2, seed=1, sampler=name)
+            m.fit(docs, feats, iters=50)
+            assert m.topic_word.shape[0] == 2


### PR DESCRIPTION
Adds `DMR(sampler="warp")` — the first reuse of the WarpLDA backend in another model, exactly the payoff the `MhSampler`/per-doc-α generalization was built for (#85, follow-on to #87).

## What it does

DMR's collapsed conditional is LDA's with a per-document prior `α_{d,k} = exp(λ_k · x_d)`. So WarpLDA carries over with **only the doc phase changed**: the doc-proposal and its acceptance use the document's own α (rebuilding the smoothing alias per document); the word phase is identical. The DMR fit loop is otherwise unchanged — λ is still optimized by L-BFGS each interval, now reading assignments from `WarpLda::doc_topics()` and pushing the recomputed per-doc α in via `set_doc_alpha` each sweep.

The plain-LDA `doc_phase` is left byte-for-byte unchanged, so the LDA hot path takes no per-doc cost.

## The large-K win carries over

2,000-doc poliblog subsample, `ratingLiberal` covariate, mean `c_v` (top-10):

| K | sparse | warp |
|---:|--------|------|
| 100 | 8.0s / −79.2 | 5.0s / −80.9 |
| 500 | 15.9s / −101.4 | 6.7s / **−102.7** (2.4× faster) |

Same shape as LDA-warp: faster everywhere, ~equal coherence at large K, widening with K. Default stays `"sparse"`.

## Correctness

- New `WarpLda::doc_phase_dmr` validated by planted-block recovery under a block-favouring prior (`cargo test --lib warplda`).
- 6 Python tests: covariate-topic recovery, valid dists, determinism, **feature-effect sign agrees with the sparse DMR**, sampler aliases, bad-name rejection.
- DMR MALLET parity unchanged (topic cosine 1.000, effect sign preserved) — the sparse path is byte-untouched.

## Scope / limits

- Warp path computes no inline log_likelihood, so `convergence_tol` is unsupported there (same as LDA-warp).
- Sampler choice is fit-time only → not round-tripped through save/load (matches the LDA precedent).

## Commits

1. `feat(warplda)` — per-document-α doc phase (`set_doc_alpha` / `doc_topics()` / `doc_phase_dmr`), validated
2. `feat(dmr)` — wire `sampler="warp"` into the DMR fit + tests + stub + docs

## Gate
cargo `--lib` 82 · pytest 1963 / 18 skipped · DMR MALLET cosine 1.000 · `mkdocs --strict` clean.

No version bump (feature PR).
