### PR TITLE
feat(seeded): WarpLDA backend for SeededLDA — sampler="warp" (#85)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- `SeededLDA(..., sampler="warp")` runs the WarpLDA backend (a seeded word phase:
+  the word-proposal and its acceptance carry the asymmetric seed β
+  `β_{k,w} = β + seed_weight·[w ∈ seeds_k]` and the per-topic normalizer
+  `β_sum_k`). SeededLDA's default sparse sweep scores all K topics per token, so
+  the win is even larger than for plain LDA: on a 2,000-document poliblog
+  subsample at K=500 the warp path fits in ~2.6s against ~111s for `"sparse"`
+  (~40x) at comparable coherence, and stays nearly flat in K. Default stays
+  `"sparse"`; `"warp"` does not yet support `doc_topic_prior`.
+
 - `DMR(..., sampler="warp")` runs the WarpLDA backend for DMR (a per-document-α
   doc phase: the doc-proposal and its acceptance use each document's
   `α_{d,k} = exp(λ_k · x_d)`, with the λ optimization loop unchanged). Same

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1822,7 +1822,15 @@ class SeededLDA:
         beta: float = 0.01,
         weight: float = 0.01,
         seed: int = 42,
-    ) -> None: ...
+        sampler: str = "sparse",
+    ) -> None:
+        """sampler selects the backend: "sparse" (default) is the seeded
+        collapsed-Gibbs sweep; "warp" is the WarpLDA cache-efficient sampler
+        (seeded word phase), whose per-sweep cost is flat in K. SeededLDA's
+        sparse sweep scores all K topics per token, so "warp" is dramatically
+        faster at large K (e.g. ~40x at K=500 on a 2,000-document corpus) at
+        comparable coherence. "warp" does not yet support doc_topic_prior."""
+        ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],

--- a/src/python.rs
+++ b/src/python.rs
@@ -8432,6 +8432,9 @@ pub struct SeededLDA {
     beta: f64,
     weight: f64,
     seed: u64,
+    // WarpLDA cache-efficient sampler (seeded word phase) instead of the default
+    // SparseLDA seeded sweep. Recommended for large K.
+    warp: bool,
     fitted: bool,
     topic_names: Vec<String>,
     phi: Option<Array2<f64>>,
@@ -8464,7 +8467,8 @@ impl SeededLDA {
     /// matching the seededlda package) scales the seed prior. `alpha` is the
     /// per-topic Dirichlet, `beta` the base topic-word smoothing.
     #[new]
-    #[pyo3(signature = (seed_words, *, residual=0, alpha=0.1, beta=0.01, weight=0.01, seed=42))]
+    #[pyo3(signature = (seed_words, *, residual=0, alpha=0.1, beta=0.01, weight=0.01, seed=42,
+                        sampler="sparse"))]
     fn new(
         seed_words: &Bound<'_, PyDict>,
         residual: usize,
@@ -8472,6 +8476,7 @@ impl SeededLDA {
         beta: f64,
         weight: f64,
         seed: u64,
+        sampler: &str,
     ) -> PyResult<Self> {
         let (names, words) = parse_seed_dict(seed_words)?;
         if !finite_pos(alpha) || !finite_pos(beta) {
@@ -8480,8 +8485,17 @@ impl SeededLDA {
         if names.len() + residual < 2 {
             return Err(PyValueError::new_err("need at least 2 topics (seeded + residual)"));
         }
+        let warp = match sampler {
+            "sparse" => false,
+            "warp" | "warplda" => true,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown sampler {other:?}; expected \"sparse\" or \"warp\""
+                )))
+            }
+        };
         Ok(SeededLDA {
-            seed_names: names, seed_words: words, residual, alpha, beta, weight, seed,
+            seed_names: names, seed_words: words, residual, alpha, beta, weight, seed, warp,
             fitted: false, topic_names: Vec::new(), phi: None, theta: None,
             theta_draws: None, corpus: None,
             log_likelihood_history: Vec::new(), converged: false,
@@ -8559,6 +8573,52 @@ impl SeededLDA {
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, corpus.num_docs(), num_topics)?;
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+
+        if self.warp {
+            // WarpLDA seeded path. The per-document prior (doc_topic_prior) is not
+            // yet wired through the warp θ output, so require the symmetric case.
+            if doc_alpha.is_some() {
+                return Err(PyValueError::new_err(
+                    "sampler=\"warp\" does not support doc_topic_prior yet; use sampler=\"sparse\"",
+                ));
+            }
+            let num_docs = corpus.num_docs();
+            let (phi_tw, theta_dk, theta_draw_buf, corpus) = py.allow_threads(move || {
+                let alpha0 = vec![alpha; num_topics];
+                let mut ws = warplda::WarpLda::new(&corpus, num_topics, &alpha0, beta, &mut rng);
+                ws.set_seeds(&seeds, seed_weight);
+                let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+                for iter in 1..=iters {
+                    ws.sweep(&corpus, &mut rng);
+                    if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                        let mut tmp = vec![vec![0.0f64; num_topics]; num_docs];
+                        ws.theta_into(&corpus, &mut tmp);
+                        let snap = tmp.iter()
+                            .map(|r| r.iter().map(|&v| v as f32).collect())
+                            .collect();
+                        push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
+                    }
+                }
+                let phi_tw = ws.topic_word();
+                let mut theta_dk = vec![vec![0.0f64; num_topics]; num_docs];
+                ws.theta_into(&corpus, &mut theta_dk);
+                (phi_tw, theta_dk, theta_draw_buf, corpus)
+            });
+            self.phi = Some(vecs_to_arr2(&phi_tw));
+            self.theta = Some(vecs_to_arr2(&theta_dk));
+            self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
+            let mut names = self.seed_names.clone();
+            for i in 0..self.residual {
+                names.push(format!("residual_{}", i + 1));
+            }
+            self.topic_names = names;
+            self.corpus = Some(corpus);
+            self.log_likelihood_history = Vec::new();
+            self.converged = false;
+            self.fitted = true;
+            return Ok(());
+        }
+
         let (model, ll_history, converged, corpus) = py.allow_threads(move || {
             let (m, ll, conv) = seeded::fit_seeded_lda(
                 &corpus.docs, num_types, num_topics, &seeds, alpha, beta, seed_weight, doc_alpha,
@@ -8698,7 +8758,7 @@ impl SeededLDA {
         Ok(SeededLDA {
             seed_names: Vec::new(), seed_words: Vec::new(),
             residual: s.num_topics.saturating_sub(s.topic_names.iter().filter(|n| !n.starts_with("residual_")).count()),
-            alpha: s.alpha, beta: s.beta, weight: s.weight, seed: s.seed, fitted: s.fitted,
+            alpha: s.alpha, beta: s.beta, weight: s.weight, seed: s.seed, warp: false, fitted: s.fitted,
             topic_names: s.topic_names, phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             theta_draws: None, corpus: s.corpus,
             log_likelihood_history: s.log_likelihood_history,

--- a/src/warplda.rs
+++ b/src/warplda.rs
@@ -76,6 +76,22 @@ pub struct WarpLda {
     /// `doc_alpha[d]` in place of the uniform `alpha`, rebuilding the
     /// doc-proposal smoothing alias per document. `None` is the plain-LDA path.
     doc_alpha: Option<Vec<Vec<f64>>>,
+
+    /// Asymmetric β for SeededLDA. When `Some`, a seed word gets an extra
+    /// `seed_weight` pseudocount in each topic it seeds, so β and its per-topic
+    /// sum become topic/word dependent (see [`Self::beta_at`] /
+    /// [`Self::beta_sum_at`]). `None` is the plain symmetric-β path.
+    seed: Option<SeedBeta>,
+}
+
+/// SeededLDA's asymmetric-β bookkeeping: `β_{k,w} = β + seed_weight·[w ∈ seeds[k]]`
+/// and `β_sum_k = V·β + |seeds[k]|·seed_weight`.
+struct SeedBeta {
+    seed_weight: f64,
+    /// Per-topic β normalizer `β_sum_k`.
+    beta_sum_k: Vec<f64>,
+    /// `inv_seeds[w]` = the (sorted) topics that word `w` seeds.
+    inv_seeds: Vec<Vec<u32>>,
 }
 
 impl WarpLda {
@@ -123,6 +139,7 @@ impl WarpLda {
             word_index,
             alpha_alias,
             doc_alpha: None,
+            seed: None,
         }
     }
 
@@ -130,6 +147,47 @@ impl WarpLda {
     /// each sweep by the DMR fit loop after recomputing α from the current λ.
     pub fn set_doc_alpha(&mut self, doc_alpha: Vec<Vec<f64>>) {
         self.doc_alpha = Some(doc_alpha);
+    }
+
+    /// Enable SeededLDA's asymmetric β. `seeds[k]` is the list of seed word-ids
+    /// for topic `k`; each gets an extra `seed_weight` pseudocount in topic `k`.
+    pub fn set_seeds(&mut self, seeds: &[Vec<usize>], seed_weight: f64) {
+        let k = self.num_topics;
+        let v = self.num_types;
+        let mut beta_sum_k = vec![self.beta * v as f64; k];
+        let mut inv_seeds: Vec<Vec<u32>> = vec![Vec::new(); v];
+        for (t, ws) in seeds.iter().enumerate().take(k) {
+            beta_sum_k[t] += ws.len() as f64 * seed_weight;
+            for &w in ws {
+                if w < v {
+                    inv_seeds[w].push(t as u32);
+                }
+            }
+        }
+        for row in inv_seeds.iter_mut() {
+            row.sort_unstable();
+        }
+        self.seed = Some(SeedBeta { seed_weight, beta_sum_k, inv_seeds });
+    }
+
+    /// β_{k,w}: the base β plus the seed boost when word `w` seeds topic `k`.
+    #[inline]
+    fn beta_at(&self, k: usize, w: usize) -> f64 {
+        match &self.seed {
+            Some(s) if s.inv_seeds[w].binary_search(&(k as u32)).is_ok() => {
+                self.beta + s.seed_weight
+            }
+            _ => self.beta,
+        }
+    }
+
+    /// β_sum_k: the per-topic β normalizer (uniform `beta_sum` when unseeded).
+    #[inline]
+    fn beta_sum_at(&self, k: usize) -> f64 {
+        match &self.seed {
+            Some(s) => s.beta_sum_k[k],
+            None => self.beta_sum,
+        }
     }
 
     /// The current per-token topic assignments, document-major — the input the
@@ -169,7 +227,11 @@ impl WarpLda {
             self.doc_phase(corpus, rng);
         }
         self.recount_n_k();
-        self.word_phase(rng);
+        if self.seed.is_some() {
+            self.word_phase_seeded(rng);
+        } else {
+            self.word_phase(rng);
+        }
         self.recount_n_k();
     }
 
@@ -178,7 +240,6 @@ impl WarpLda {
     /// only the current document's `C_d` row is randomly accessed.
     fn doc_phase<R: Rng>(&mut self, corpus: &Corpus, rng: &mut R) {
         let k = self.num_topics;
-        let beta_sum = self.beta_sum;
         let mut c_d = vec![0i64; k];
 
         for (d, doc) in corpus.docs.iter().enumerate() {
@@ -206,9 +267,9 @@ impl WarpLda {
                 let mut new = cur;
                 if prop != cur {
                     let num = (c_d[prop] as f64 + self.alpha[prop])
-                        * (self.n_k[cur] as f64 - 1.0 + beta_sum);
+                        * (self.n_k[cur] as f64 - 1.0 + self.beta_sum_at(cur));
                     let den = (c_d[cur] as f64 - 1.0 + self.alpha[cur])
-                        * (self.n_k[prop] as f64 + beta_sum);
+                        * (self.n_k[prop] as f64 + self.beta_sum_at(prop));
                     if num >= den || rng.gen::<f64>() * den < num {
                         new = prop;
                     }
@@ -236,7 +297,6 @@ impl WarpLda {
     /// per document). Only called when `doc_alpha` is set.
     fn doc_phase_dmr<R: Rng>(&mut self, corpus: &Corpus, rng: &mut R) {
         let k = self.num_topics;
-        let beta_sum = self.beta_sum;
         let mut c_d = vec![0i64; k];
 
         for (d, doc) in corpus.docs.iter().enumerate() {
@@ -265,9 +325,9 @@ impl WarpLda {
                 let mut new = cur;
                 if prop != cur {
                     let num = (c_d[prop] as f64 + alpha_d[prop])
-                        * (self.n_k[cur] as f64 - 1.0 + beta_sum);
+                        * (self.n_k[cur] as f64 - 1.0 + self.beta_sum_at(cur));
                     let den = (c_d[cur] as f64 - 1.0 + alpha_d[cur])
-                        * (self.n_k[prop] as f64 + beta_sum);
+                        * (self.n_k[prop] as f64 + self.beta_sum_at(prop));
                     if num >= den || rng.gen::<f64>() * den < num {
                         new = prop;
                     }
@@ -346,7 +406,102 @@ impl WarpLda {
         }
     }
 
-    /// Accumulate a smoothed φ snapshot `(C_wk+β)/(C_k+β̄)` into `acc[word][topic]`.
+    /// Word phase with SeededLDA's asymmetric β. Same structure as
+    /// [`Self::word_phase`] but `β_{k,w}` carries the seed boost and the
+    /// normalizer is the per-topic `β_sum_k`. Only called when `seed` is set.
+    fn word_phase_seeded<R: Rng>(&mut self, rng: &mut R) {
+        let k = self.num_topics;
+        let beta = self.beta;
+        let kbeta = k as f64 * beta;
+        // Borrow the seed bookkeeping for the whole pass: disjoint from the
+        // z/prop/word_index fields the token loop touches.
+        let seed = self.seed.as_ref().unwrap();
+        let seed_weight = seed.seed_weight;
+        let mut c_w = vec![0i64; k];
+
+        for w in 0..self.num_types {
+            let toks = &self.word_index[w];
+            let n_w = toks.len();
+            if n_w == 0 {
+                continue;
+            }
+            for v in c_w.iter_mut() {
+                *v = 0;
+            }
+            for &(d, pos) in toks {
+                c_w[self.z[d as usize][pos as usize] as usize] += 1;
+            }
+            let n_w_f = n_w as f64;
+            let inv_w = &seed.inv_seeds[w];
+            // β_{k,w} = β + seed_weight·[k seeds w]; Σ_k β_{k,w} = Kβ + |inv_w|·sw.
+            let bt = |t: usize| -> f64 {
+                if inv_w.binary_search(&(t as u32)).is_ok() {
+                    beta + seed_weight
+                } else {
+                    beta
+                }
+            };
+            let sum_beta_w = kbeta + inv_w.len() as f64 * seed_weight;
+
+            for &(d, pos) in toks {
+                let (d, pos) = (d as usize, pos as usize);
+                let cur = self.z[d][pos] as usize;
+                let prop = self.prop[d][pos] as usize;
+
+                let mut new = cur;
+                if prop != cur {
+                    let num = (c_w[prop] as f64 + bt(prop))
+                        * (self.n_k[cur] as f64 - 1.0 + seed.beta_sum_k[cur]);
+                    let den = (c_w[cur] as f64 - 1.0 + bt(cur))
+                        * (self.n_k[prop] as f64 + seed.beta_sum_k[prop]);
+                    if num >= den || rng.gen::<f64>() * den < num {
+                        new = prop;
+                    }
+                }
+                self.z[d][pos] = new as u32;
+
+                // Word-proposal q_w(k) ∝ C_wk + β_{k,w}: with prob ∝ n_w copy a
+                // random token-of-w's topic; else draw from β_{k,w} (uniform with
+                // prob ∝ Kβ, else a random topic that w seeds).
+                let r = rng.gen::<f64>() * (n_w_f + sum_beta_w);
+                let wp = if r < n_w_f {
+                    let (rd, rp) = toks[rng.gen_range(0..n_w)];
+                    self.z[rd as usize][rp as usize] as usize
+                } else if (r - n_w_f) < kbeta || inv_w.is_empty() {
+                    rng.gen_range(0..k)
+                } else {
+                    inv_w[rng.gen_range(0..inv_w.len())] as usize
+                };
+                self.prop[d][pos] = wp as u32;
+            }
+        }
+    }
+
+    /// Smoothed topic-word matrix `(C_wk+β_{k,w})/(C_k+β_sum_k)`, shape
+    /// `[topic][word]` (seeded-β aware). Used by the SeededLDA warp path, whose
+    /// output orientation is topic-major.
+    pub fn topic_word(&self) -> Vec<Vec<f64>> {
+        let k = self.num_topics;
+        let v = self.num_types;
+        let mut c_w = vec![0i64; k];
+        let mut phi = vec![vec![0.0f64; v]; k];
+        for w in 0..v {
+            for x in c_w.iter_mut() {
+                *x = 0;
+            }
+            for &(d, pos) in &self.word_index[w] {
+                c_w[self.z[d as usize][pos as usize] as usize] += 1;
+            }
+            for t in 0..k {
+                phi[t][w] =
+                    (c_w[t] as f64 + self.beta_at(t, w)) / (self.n_k[t] as f64 + self.beta_sum_at(t));
+            }
+        }
+        phi
+    }
+
+    /// Accumulate a smoothed φ snapshot `(C_wk+β_{k,w})/(C_k+β_sum_k)` into
+    /// `acc[word][topic]`.
     pub fn phi_into(&self, acc: &mut [Vec<f64>]) {
         // Rebuild the word-topic counts from the assignments (not stored densely).
         let k = self.num_topics;
@@ -359,8 +514,8 @@ impl WarpLda {
                 c_w[self.z[d as usize][pos as usize] as usize] += 1;
             }
             for t in 0..k {
-                let denom = self.n_k[t] as f64 + self.beta_sum;
-                acc[w][t] += (c_w[t] as f64 + self.beta) / denom;
+                let denom = self.n_k[t] as f64 + self.beta_sum_at(t);
+                acc[w][t] += (c_w[t] as f64 + self.beta_at(t, w)) / denom;
             }
         }
     }
@@ -544,6 +699,40 @@ mod tests {
         assert_eq!(covered.len(), n_blocks, "only recovered {covered:?}");
         // doc_topics() exposes assignments for the λ optimizer.
         assert_eq!(s.doc_topics().len(), corpus.docs.len());
+    }
+
+    #[test]
+    fn seeded_path_recovers_planted_blocks() {
+        // Seed each block's first word into its topic; the seeded word phase must
+        // still recover every block (and respect the asymmetric β).
+        let wpb = 5;
+        let (corpus, n_blocks) = planted(4, wpb, 200);
+        let k = n_blocks;
+        let v = corpus.num_types();
+        let alpha = vec![0.1f64; k];
+        let mut rng = Pcg64Mcg::seed_from_u64(1);
+        let mut s = WarpLda::new(&corpus, k, &alpha, 0.01, &mut rng);
+        // seeds[t] = the first word id of block t.
+        let seeds: Vec<Vec<usize>> = (0..k).map(|t| vec![t * wpb]).collect();
+        s.set_seeds(&seeds, 50.0);
+        for _ in 0..200 {
+            s.sweep(&corpus, &mut rng);
+        }
+        let phi = s.to_topic_model().topic_word();
+        let mut covered = std::collections::HashSet::new();
+        for t in 0..k {
+            let mut idx: Vec<usize> = (0..v).collect();
+            idx.sort_by(|&a, &b| phi[t][b].partial_cmp(&phi[t][a]).unwrap());
+            let top: std::collections::HashSet<usize> = idx[..wpb].iter().copied().collect();
+            for b in 0..n_blocks {
+                let block: std::collections::HashSet<usize> =
+                    (b * wpb..(b + 1) * wpb).collect();
+                if block.is_subset(&top) {
+                    covered.insert(b);
+                }
+            }
+        }
+        assert_eq!(covered.len(), n_blocks, "only recovered {covered:?}");
     }
 
     #[test]

--- a/tests/test_seeded_warp.py
+++ b/tests/test_seeded_warp.py
@@ -1,0 +1,88 @@
+"""WarpLDA backend for SeededLDA (sampler="warp").
+
+SeededLDA's default sparse sweep scores all K topics per token (its asymmetric
+β is not sparsity-aware), so it scales poorly in K; the WarpLDA backend (seeded
+word phase) is O(1) per token and flat in K. These tests check the warp path
+recovers seeded topics, produces valid distributions, is deterministic, honours
+the seeds, and rejects the unsupported doc_topic_prior combination.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import topica
+
+_BLOCKS = [["a", "b", "c", "d"], ["e", "f", "g", "h"], ["i", "j", "k", "l"]]
+_SEEDS = {"t0": ["a"], "t1": ["e"], "t2": ["i"]}
+
+
+def _docs(n=180):
+    return [_BLOCKS[d % 3] + _BLOCKS[d % 3] for d in range(n)]
+
+
+def _fit(docs, iters=300, **kw):
+    m = topica.SeededLDA(_SEEDS, seed=1, sampler="warp", **kw)
+    m.fit(docs, iters=iters)
+    return m
+
+
+def _recovered(m):
+    bsets = [set(b) for b in _BLOCKS]
+    covered = set()
+    for t in range(m.num_topics):
+        top = {w for w, _ in m.top_words(4, topic=t)}
+        for bi, bs in enumerate(bsets):
+            if bs <= top:
+                covered.add(bi)
+    return covered
+
+
+def test_recovers_seeded_blocks():
+    m = _fit(_docs())
+    assert _recovered(m) == {0, 1, 2}
+
+
+def test_valid_distributions():
+    m = _fit(_docs())
+    npt.assert_allclose(m.topic_word.sum(axis=1), 1.0)
+    npt.assert_allclose(m.doc_topic.sum(axis=1), 1.0)
+    assert m.topic_word.shape == (3, 12)
+
+
+def test_deterministic():
+    a = _fit(_docs(), iters=120)
+    b = _fit(_docs(), iters=120)
+    npt.assert_array_equal(a.topic_word, b.topic_word)
+
+
+def test_seed_word_lands_on_its_topic():
+    # Each seed word should be most probable in (or strongly associated with) its
+    # own seeded topic: the topic whose top words are that seed's block.
+    m = _fit(_docs())
+    vocab = m.vocabulary
+    tw = m.topic_word
+    for ti, (_, words) in enumerate(_SEEDS.items()):
+        seed_w = words[0]
+        # the topic where this seed word is most probable
+        best_t = int(np.argmax(tw[:, vocab.index(seed_w)]))
+        block = set(_BLOCKS[ti])
+        top = {w for w, _ in m.top_words(4, topic=best_t)}
+        assert block <= top
+
+
+def test_aliases_and_bad_name():
+    for name in ("warp", "warplda"):
+        m = topica.SeededLDA(_SEEDS, seed=1, sampler=name)
+        m.fit(_docs(60), iters=40)
+        assert m.topic_word.shape[0] == 3
+    with pytest.raises(ValueError):
+        topica.SeededLDA(_SEEDS, sampler="banana")
+
+
+def test_doc_topic_prior_rejected_for_warp():
+    docs = _docs(60)
+    prior = np.full((len(docs), 3), 0.1)
+    m = topica.SeededLDA(_SEEDS, seed=1, sampler="warp")
+    with pytest.raises(ValueError):
+        m.fit(docs, iters=20, doc_topic_prior=prior)


### PR DESCRIPTION
Adds `SeededLDA(sampler="warp")` — the WarpLDA backend generalized to SeededLDA's asymmetric β. Follow-on to #87/#88 (#85).

## The biggest warp win yet

SeededLDA's default sparse sweep scores **all K topics per token** (its asymmetric seed-β is not sparsity-aware), so it scales O(K) per token. WarpLDA is O(1) and flat in K, so the gap is huge. 2,000-doc poliblog subsample, mean `c_v` (top-10):

| K | sparse | warp |
|---:|--------|------|
| 100 | 25.0s / −66.4 | 2.4s / −68.0 (**10× faster**) |
| 500 | 111.3s / −85.3 | 2.6s / **−84.8** (**~40× faster**) |

warp stays nearly flat (2.4→2.6s) while sparse explodes (25→111s).

## How

WarpLDA's word phase now handles per-(topic,word) `β_{k,w} = β + seed_weight·[w∈seeds_k]` and a per-topic normalizer `β_sum_k`:

- A new optional `SeedBeta` on `WarpLda`, accessed via inline `beta_at(k,w)` / `beta_sum_at(k)` that **collapse to the scalar β for the unseeded path** — so LDA/DMR output is numerically identical (MALLET cosine 1.000 preserved, 65 LDA+DMR warp tests still pass).
- A `word_phase_seeded` (seeded β in the acceptance + word-proposal); the plain `word_phase` is byte-unchanged, so the LDA hot path is untouched.
- `set_seeds` + a seeded-aware `topic_word()` (topic-major) for the SeededLDA output.

## Scope / limits

- Default stays `"sparse"`.
- The warp path doesn't yet thread `doc_topic_prior` through its θ output, so it errors when both are passed (documented).

## Correctness

- Rust: seeded planted-block recovery under an asymmetric prior (`cargo test --lib warplda`).
- 6 Python tests: seeded recovery, valid dists, determinism, **seed words land on their topics**, aliases / bad-name, doc_topic_prior rejected.

## Commits
1. `feat(seeded)` — seeded word phase + SeededLDA wiring (single commit)

## Gate
cargo `--lib` 83 · pytest 1969 / 18 skipped · MALLET cosine 1.000 · `mkdocs --strict` clean.

No version bump (feature PR).
