### PR TITLE
feat(lda): CVB0 deterministic inference backend — sampler="cvb0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- `LDA(..., sampler="cvb0")` adds collapsed variational Bayes, zeroth-order
+  (Asuncion et al. 2009) as a deterministic, non-MCMC inference backend for the
+  same LDA model. Each (document, word-type) cell keeps a soft topic
+  responsibility updated from expected counts, so a fit is exactly reproducible
+  for a seed and has no burn-in. It tends to give higher topic coherence than
+  the samplers, increasingly so at larger K (on a 2,000-document poliblog
+  subsample at K=100, mean c_v -68.5 vs -79.1 for `"sparse"`), at the cost of
+  O(K)-per-token compute, so it is slower, not faster (~47s vs ~10s at K=100).
+  Use it when topic quality matters more than fit time; it produces no MCMC
+  theta draws (`theta_draws` is None). Default stays `"sparse"`.
+
 - `SeededLDA(..., sampler="warp")` runs the WarpLDA backend (a seeded word phase:
   the word-proposal and its acceptance carry the asymmetric seed β
   `β_{k,w} = β + seed_weight·[w ∈ seeds_k]` and the per-topic normalizer

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -36,10 +36,10 @@ model.fit(docs, iters=1000)
 model.top_words(10)
 ```
 
-### Sampler choice: SparseLDA, WarpLDA, and LightLDA
+### Inference choice: SparseLDA, WarpLDA, LightLDA, and CVB0
 
-`LDA` ships three interchangeable samplers for the *same model*, selected with
-`sampler=`:
+`LDA` ships four interchangeable inference backends for the *same model*,
+selected with `sampler=`:
 
 - **`"sparse"`** (default) — MALLET's SparseLDA collapsed-Gibbs sampler,
   `O(K_d + K_w)` per token. Near-optimal for the topic counts typical of social
@@ -58,15 +58,30 @@ model.top_words(10)
   word/document proposal alias tables. Superseded by `"warp"`, which is faster
   and mixes better at the same `K`; retained for compatibility and as an
   independent cross-check.
+- **`"cvb0"`** — collapsed variational Bayes, zeroth-order
+  ([Asuncion et al. 2009](https://arxiv.org/abs/1205.2662)). A *deterministic*,
+  non-sampling backend: each (document, word-type) cell keeps a soft topic
+  responsibility updated from expected counts. It has no burn-in, is exactly
+  reproducible for a seed, and tends to give **higher topic coherence**,
+  increasingly so at larger `K` (on a 2,000-document corpus at `K = 100`, mean
+  `c_v` −68.5 against −79.1 for `"sparse"`). The catch is `O(K)`-per-token
+  compute, so it is **slower, not faster** (≈47s vs ≈10s at `K = 100`), and it
+  produces no MCMC `theta_draws`. Reach for it when topic quality matters more
+  than fit time.
 
 ```python
-# Fine-grained, large-K model: WarpLDA.
+# Fine-grained, large-K model, fast: WarpLDA.
 model = topica.LDA(num_topics=1000, seed=1, sampler="warp")
 model.fit(docs, iters=1000)
+
+# Highest-coherence topics, fit time not a constraint: CVB0.
+model = topica.LDA(num_topics=100, seed=1, sampler="cvb0")
+model.fit(docs, iters=300)
 ```
 
-All three target the same model. Use the default `"sparse"` up to a couple
-hundred topics; switch to `"warp"` for large-`K` (`K ≳ 500`) work.
+All four target the same model. Use the default `"sparse"` up to a couple
+hundred topics; `"warp"` for large-`K` (`K ≳ 500`) work where speed matters; and
+`"cvb0"` when you want the cleanest topics and can spend the compute.
 
 ## STM
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1262,12 +1262,14 @@ class LDA:
         SparseLDA collapsed Gibbs sampler; "lightlda" is the alias-table
         Metropolis-Hastings sampler of Yuan et al. (2015); "warp" is the
         cache-efficient two-pass MH sampler of Chen et al. (2016, WarpLDA),
-        whose per-sweep cost is flat in K. "sparse" is the best choice at the
-        topic counts typical of social-science work (K up to ~200). For
-        large-K, fine-grained models (K >= ~500) "warp" is the recommended
-        sampler: it is several times faster than "sparse" and both faster and
-        higher-coherence than "lightlda" there. mh_steps is the number of MH
-        proposals per token (lightlda only).
+        whose per-sweep cost is flat in K; "cvb0" is collapsed variational
+        Bayes, zeroth-order (Asuncion et al. 2009) -- deterministic, non-MCMC
+        inference that tends to give higher topic coherence at moderate-to-large
+        K, at the cost of O(K)-per-token compute (slower, not faster). "sparse"
+        is the best speed/quality default up to ~K=200; "warp" is the speed
+        choice for large K; "cvb0" is the quality choice when fit time is not the
+        constraint. CVB0 produces no MCMC theta draws (theta_draws is None).
+        mh_steps is the number of MH proposals per token (lightlda only).
 
         init selects the initial token-topic assignment: "random" (default,
         MALLET-compatible) draws each token's topic uniformly; "spectral" seeds

--- a/src/cvb0.rs
+++ b/src/cvb0.rs
@@ -1,0 +1,317 @@
+//! Collapsed Variational Bayes, zeroth-order (CVB0) inference for LDA
+//! (Asuncion, Welling, Smyth & Teh, *UAI* 2009, "On Smoothing and Inference for
+//! Topic Models").
+//!
+//! A deterministic alternative to collapsed Gibbs. Instead of a hard topic per
+//! token, each *(document, word-type)* cell keeps a soft responsibility vector
+//! `γ` over topics, updated from **expected** counts:
+//!
+//! ```text
+//! γ_{d,w,k} ∝ (E[n_dk]^{-dw} + α_k) · (E[n_wk]^{-dw} + β) / (E[n_k]^{-dw} + β̄)
+//! ```
+//!
+//! the same factored conditional as CGS, mean-field instead of sampled. So it is
+//! reproducible (no seed dependence beyond the initial γ), has no burn-in, and
+//! tends to match or beat CGS on held-out perplexity. The cost is `O(K)` per
+//! cell (γ is dense), so CVB0 does **not** have the sparse samplers' large-K
+//! speed; it competes on quality and determinism.
+//!
+//! Memory is kept to `O(#unique (doc,word) cells · K)` by sharing one γ across
+//! all tokens of the same word-type in a document (the standard efficient CVB0;
+//! those tokens have an identical conditional), rather than one γ per token.
+
+use rand::Rng;
+
+use crate::corpus::Corpus;
+use crate::model::TopicModel;
+
+/// A CVB0 inference engine over per-(document, word-type) responsibilities.
+pub struct Cvb0 {
+    pub num_topics: usize,
+    pub num_types: usize,
+    pub alpha: Vec<f64>,
+    pub alpha_sum: f64,
+    pub beta: f64,
+    pub beta_sum: f64,
+
+    /// `cells[d]` = the unique `(word_id, count)` pairs in document `d`.
+    cells: Vec<Vec<(u32, u32)>>,
+    /// `gamma[d][i]` = the length-`K` responsibility vector for cell `i` of doc `d`.
+    gamma: Vec<Vec<Vec<f64>>>,
+
+    /// Expected document-topic counts `E[n_dk]`.
+    n_dk: Vec<Vec<f64>>,
+    /// Expected word-topic counts `E[n_wk]`.
+    n_wk: Vec<Vec<f64>>,
+    /// Expected topic counts `E[n_k]`.
+    n_k: Vec<f64>,
+    /// Document lengths (token counts), for θ.
+    doc_len: Vec<f64>,
+}
+
+impl Cvb0 {
+    /// Initialize from `corpus` with a random γ per cell (the only stochastic
+    /// step; everything after is deterministic).
+    pub fn new<R: Rng>(
+        corpus: &Corpus,
+        num_topics: usize,
+        alpha: &[f64],
+        beta: f64,
+        rng: &mut R,
+    ) -> Cvb0 {
+        let num_types = corpus.num_types();
+        let beta_sum = beta * num_types as f64;
+        let alpha_sum: f64 = alpha.iter().sum();
+        let k = num_topics;
+
+        let mut n_dk = vec![vec![0.0f64; k]; corpus.docs.len()];
+        let mut n_wk = vec![vec![0.0f64; k]; num_types];
+        let mut n_k = vec![0.0f64; k];
+        let mut cells: Vec<Vec<(u32, u32)>> = Vec::with_capacity(corpus.docs.len());
+        let mut gamma: Vec<Vec<Vec<f64>>> = Vec::with_capacity(corpus.docs.len());
+        let mut doc_len = vec![0.0f64; corpus.docs.len()];
+
+        for (d, doc) in corpus.docs.iter().enumerate() {
+            // Collapse the document to unique (word, count) cells.
+            let mut counts: std::collections::HashMap<u32, u32> = std::collections::HashMap::new();
+            for &w in doc {
+                *counts.entry(w).or_insert(0) += 1;
+            }
+            doc_len[d] = doc.len() as f64;
+            let mut dcells: Vec<(u32, u32)> = counts.into_iter().collect();
+            dcells.sort_unstable(); // deterministic cell order
+            let mut dgamma: Vec<Vec<f64>> = Vec::with_capacity(dcells.len());
+
+            for &(w, c) in &dcells {
+                // Random initial responsibilities, normalized.
+                let mut g = vec![0.0f64; k];
+                let mut s = 0.0;
+                for x in g.iter_mut() {
+                    *x = rng.gen::<f64>() + 1e-6;
+                    s += *x;
+                }
+                let cf = c as f64;
+                for (t, x) in g.iter_mut().enumerate() {
+                    *x /= s;
+                    n_dk[d][t] += cf * *x;
+                    n_wk[w as usize][t] += cf * *x;
+                    n_k[t] += cf * *x;
+                }
+                dgamma.push(g);
+            }
+            cells.push(dcells);
+            gamma.push(dgamma);
+        }
+
+        Cvb0 {
+            num_topics: k,
+            num_types,
+            alpha: alpha.to_vec(),
+            alpha_sum,
+            beta,
+            beta_sum,
+            cells,
+            gamma,
+            n_dk,
+            n_wk,
+            n_k,
+            doc_len,
+        }
+    }
+
+    /// One deterministic CVB0 sweep over every cell. Returns the mean absolute
+    /// change in γ across all cells, a convergence signal (→ 0 as the
+    /// responsibilities settle), so the caller can early-stop.
+    pub fn sweep(&mut self) -> f64 {
+        let k = self.num_topics;
+        let beta = self.beta;
+        let beta_sum = self.beta_sum;
+        let uniform = 1.0 / k as f64;
+        let mut total_change = 0.0f64;
+        let mut n_cells = 0usize;
+        let mut old = vec![0.0f64; k];
+
+        for d in 0..self.cells.len() {
+            for i in 0..self.cells[d].len() {
+                let (w, c) = self.cells[d][i];
+                let (w, cf) = (w as usize, c as f64);
+
+                // Snapshot the old γ and remove this cell's mass (`-dw` counts).
+                for t in 0..k {
+                    let g = self.gamma[d][i][t];
+                    old[t] = g;
+                    self.n_dk[d][t] -= cf * g;
+                    self.n_wk[w][t] -= cf * g;
+                    self.n_k[t] -= cf * g;
+                }
+
+                // Recompute γ ∝ (n_dk+α)(n_wk+β)/(n_k+β̄).
+                let mut sum = 0.0f64;
+                for t in 0..k {
+                    let val = (self.n_dk[d][t] + self.alpha[t]) * (self.n_wk[w][t] + beta)
+                        / (self.n_k[t] + beta_sum);
+                    self.gamma[d][i][t] = if val > 0.0 { val } else { 0.0 };
+                    sum += self.gamma[d][i][t];
+                }
+
+                // Normalize, accumulate |Δγ|, and add the new mass back.
+                for t in 0..k {
+                    let new = if sum > 0.0 { self.gamma[d][i][t] / sum } else { uniform };
+                    self.gamma[d][i][t] = new;
+                    total_change += (new - old[t]).abs();
+                    self.n_dk[d][t] += cf * new;
+                    self.n_wk[w][t] += cf * new;
+                    self.n_k[t] += cf * new;
+                }
+                n_cells += 1;
+            }
+        }
+        if n_cells == 0 {
+            0.0
+        } else {
+            total_change / n_cells as f64
+        }
+    }
+
+    /// Smoothed topic-word φ `(E[n_wk]+β)/(E[n_k]+β̄)`, accumulated into
+    /// `acc[word][topic]` (matches the MH samplers' orientation).
+    pub fn phi_into(&self, acc: &mut [Vec<f64>]) {
+        for w in 0..self.num_types {
+            for t in 0..self.num_topics {
+                let denom = self.n_k[t] + self.beta_sum;
+                acc[w][t] += (self.n_wk[w][t] + self.beta) / denom;
+            }
+        }
+    }
+
+    /// Smoothed doc-topic θ `(E[n_dk]+α)/(n_d+α_sum)`, into `acc[doc][topic]`.
+    pub fn theta_into(&self, acc: &mut [Vec<f64>]) {
+        for d in 0..self.cells.len() {
+            let denom = self.doc_len[d] + self.alpha_sum;
+            for t in 0..self.num_topics {
+                acc[d][t] += (self.n_dk[d][t] + self.alpha[t]) / denom;
+            }
+        }
+    }
+
+    /// Pack into a [`TopicModel`] via the MAP hard assignment (argmax γ per
+    /// token) so the rest of the codebase (coherence, save/load, held-out
+    /// inference) is reused. The φ/θ point estimates above are the soft CVB0
+    /// solution and are what `fit` returns; this backs the archival/diagnostic
+    /// machinery that expects integer counts.
+    pub fn to_topic_model(&self, corpus: &Corpus) -> TopicModel {
+        let mut model =
+            TopicModel::new(self.num_topics, self.alpha_sum, self.beta, self.num_types);
+        model.alpha.copy_from_slice(&self.alpha);
+        model.alpha_sum = self.alpha_sum;
+        model.beta = self.beta;
+        model.beta_sum = self.beta_sum;
+
+        // Per-(doc,word) argmax topic; assign every token of that cell to it.
+        let doc_topics: Vec<Vec<u32>> = corpus
+            .docs
+            .iter()
+            .enumerate()
+            .map(|(d, doc)| {
+                // Map word -> argmax topic for this doc's cells.
+                let mut best: std::collections::HashMap<u32, u32> =
+                    std::collections::HashMap::new();
+                for (i, &(w, _)) in self.cells[d].iter().enumerate() {
+                    let g = &self.gamma[d][i];
+                    let mut bt = 0usize;
+                    for t in 1..self.num_topics {
+                        if g[t] > g[bt] {
+                            bt = t;
+                        }
+                    }
+                    best.insert(w, bt as u32);
+                }
+                doc.iter().map(|&w| best[&w]).collect()
+            })
+            .collect();
+        model.initialize_from_assignments(corpus, doc_topics);
+        model
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::corpus::Corpus;
+    use rand::SeedableRng;
+    use rand_pcg::Pcg64Mcg;
+
+    fn planted(n_blocks: usize, wpb: usize, n_docs: usize) -> (Corpus, usize) {
+        let v = n_blocks * wpb;
+        let docs: Vec<Vec<u32>> = (0..n_docs)
+            .map(|d| {
+                let b = d % n_blocks;
+                let block: Vec<u32> = (b * wpb..(b + 1) * wpb).map(|w| w as u32).collect();
+                let mut doc = block.clone();
+                doc.extend(block);
+                doc
+            })
+            .collect();
+        let corpus = Corpus {
+            id_to_word: (0..v).map(|i| format!("w{i}")).collect(),
+            doc_names: (0..n_docs).map(|i| format!("d{i}")).collect(),
+            doc_labels: vec![String::new(); n_docs],
+            doc_freqs: vec![0u32; v],
+            total_freqs: vec![0u32; v],
+            docs,
+        };
+        (corpus, n_blocks)
+    }
+
+    #[test]
+    fn recovers_planted_blocks() {
+        let wpb = 5;
+        let (corpus, n_blocks) = planted(4, wpb, 200);
+        let k = n_blocks;
+        let v = corpus.num_types();
+        let alpha = vec![0.1f64; k];
+        let mut rng = Pcg64Mcg::seed_from_u64(1);
+        let mut m = Cvb0::new(&corpus, k, &alpha, 0.01, &mut rng);
+        for _ in 0..100 {
+            m.sweep();
+        }
+        let mut phi = vec![vec![0.0f64; k]; v]; // [word][topic]
+        m.phi_into(&mut phi);
+        let mut covered = std::collections::HashSet::new();
+        for t in 0..k {
+            let mut idx: Vec<usize> = (0..v).collect();
+            idx.sort_by(|&a, &b| phi[b][t].partial_cmp(&phi[a][t]).unwrap());
+            let top: std::collections::HashSet<usize> = idx[..wpb].iter().copied().collect();
+            for b in 0..n_blocks {
+                let block: std::collections::HashSet<usize> = (b * wpb..(b + 1) * wpb).collect();
+                if block.is_subset(&top) {
+                    covered.insert(b);
+                }
+            }
+        }
+        assert_eq!(covered.len(), n_blocks, "only recovered {covered:?}");
+    }
+
+    #[test]
+    fn deterministic_for_seed() {
+        let (corpus, _) = planted(3, 4, 90);
+        let alpha = vec![0.1f64; 3];
+        let run = || {
+            let mut rng = Pcg64Mcg::seed_from_u64(7);
+            let mut m = Cvb0::new(&corpus, 3, &alpha, 0.01, &mut rng);
+            for _ in 0..40 {
+                m.sweep();
+            }
+            let mut th = vec![vec![0.0f64; 3]; corpus.docs.len()];
+            m.theta_into(&mut th);
+            th
+        };
+        let a = run();
+        let b = run();
+        for (ra, rb) in a.iter().zip(b.iter()) {
+            for (x, y) in ra.iter().zip(rb.iter()) {
+                assert!((x - y).abs() < 1e-12);
+            }
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ pub mod hdp;
 pub mod hlda;
 pub mod keyatm;
 pub mod labeled;
+pub mod cvb0;
 pub mod lightlda;
 pub mod mh;
 pub mod linalg;

--- a/src/python.rs
+++ b/src/python.rs
@@ -48,7 +48,7 @@ use regex::Regex;
 
 use crate::corpus::{self, InputFormat, LoadOptions};
 use crate::model::TopicModel;
-use crate::{coherence as coh, ctm, lightlda, optimize, output, sampler, spectral, sts, warplda};
+use crate::{coherence as coh, ctm, cvb0, lightlda, optimize, output, sampler, spectral, sts, warplda};
 
 // ---------------------------------------------------------------------------
 // Error helpers
@@ -755,6 +755,8 @@ pub struct LDA {
     light: bool,
     // WarpLDA cache-efficient two-pass MH sampler (mutually exclusive with light).
     warp: bool,
+    // CVB0 deterministic collapsed-variational inference (no MCMC draws).
+    cvb0: bool,
     mh_steps: usize,
     // MALLET's --use-symmetric-alpha: optimize only the alpha concentration,
     // keeping every alpha[t] equal, instead of learning the per-topic shape.
@@ -931,13 +933,14 @@ impl LDA {
                 ));
             }
         }
-        let (light, warp) = match sampler {
-            "sparse" | "mallet" => (false, false),
-            "lightlda" | "light" | "alias" => (true, false),
-            "warp" | "warplda" => (false, true),
+        let (light, warp, cvb0) = match sampler {
+            "sparse" | "mallet" => (false, false, false),
+            "lightlda" | "light" | "alias" => (true, false, false),
+            "warp" | "warplda" => (false, true, false),
+            "cvb0" | "cvb" => (false, false, true),
             other => {
                 return Err(PyValueError::new_err(format!(
-                    "unknown sampler {other:?}; expected \"sparse\", \"lightlda\", or \"warp\""
+                    "unknown sampler {other:?}; expected \"sparse\", \"lightlda\", \"warp\", or \"cvb0\""
                 )))
             }
         };
@@ -959,6 +962,7 @@ impl LDA {
             num_threads: num_threads.max(1),
             light,
             warp,
+            cvb0,
             mh_steps,
             use_symmetric_alpha,
             init_spectral,
@@ -1068,9 +1072,52 @@ impl LDA {
         let seed_base = self.seed;
         let light = self.light;
         let warp = self.warp;
+        let cvb0_flag = self.cvb0;
         let mh_steps = self.mh_steps;
         let beta = self.beta;
         let use_symmetric_alpha = self.use_symmetric_alpha;
+
+        // CVB0 path: deterministic collapsed-variational inference. No MCMC, so
+        // no θ-draws; convergence_tol early-stops on the mean |Δγ| per sweep.
+        if cvb0_flag {
+            let (acc_phi, acc_theta, ll_history, converged, model, corpus) =
+                py.allow_threads(move || {
+                    let alpha0 = vec![alpha_sum / num_topics as f64; num_topics];
+                    let mut cv = cvb0::Cvb0::new(&corpus, num_topics, &alpha0, beta, &mut rng);
+                    let mut ll_history: Vec<(usize, f64)> = Vec::new();
+                    let mut converged = false;
+                    for iter in 1..=iters {
+                        let change = cv.sweep();
+                        if let Some(cb) = &progress {
+                            if progress_interval > 0 && iter % progress_interval == 0 {
+                                let m = cv.to_topic_model(&corpus);
+                                let ll = output::model_log_likelihood(&m, &corpus) / total_tokens;
+                                Python::with_gil(|py| {
+                                    let _ = cb.call1(py, (iter, ll));
+                                });
+                            }
+                        }
+                        if check_every > 0 && iter % check_every == 0 {
+                            let m = cv.to_topic_model(&corpus);
+                            ll_history.push((iter, output::model_log_likelihood(&m, &corpus)));
+                        }
+                        if convergence_tol > 0.0 && change < convergence_tol {
+                            converged = true;
+                            break;
+                        }
+                    }
+                    let mut acc_phi = vec![vec![0.0f64; num_topics]; num_types];
+                    let mut acc_theta = vec![vec![0.0f64; num_topics]; num_docs];
+                    cv.phi_into(&mut acc_phi);
+                    cv.theta_into(&mut acc_theta);
+                    let model = cv.to_topic_model(&corpus);
+                    (acc_phi, acc_theta, ll_history, converged, model, corpus)
+                });
+            self.theta_draws = None;
+            self.finalize_fit(num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus,
+                ll_history, converged);
+            return Ok(());
+        }
 
         // Metropolis-Hastings backends (WarpLDA, LightLDA): each owns its dense
         // state and is driven through the shared `run_mh_training` loop, then
@@ -1605,6 +1652,7 @@ impl LDA {
             num_threads: 1,
             light: false,
             warp: false,
+            cvb0: false,
             mh_steps: 2,
             use_symmetric_alpha: false,
             init_spectral: false,
@@ -1996,7 +2044,7 @@ impl LDA {
         Ok(LDA {
             num_topics: s.num_topics, alpha_sum: s.alpha_sum, beta: s.beta,
             optimize_interval: s.optimize_interval, burn_in: s.burn_in, seed: s.seed,
-            num_threads: s.num_threads, light: false, warp: false, mh_steps: 2, fitted: s.fitted,
+            num_threads: s.num_threads, light: false, warp: false, cvb0: false, mh_steps: 2, fitted: s.fitted,
             use_symmetric_alpha: s.use_symmetric_alpha,
             init_spectral: s.init_spectral,
             topic_names,

--- a/tests/test_cvb0.py
+++ b/tests/test_cvb0.py
@@ -1,0 +1,93 @@
+"""CVB0 (collapsed variational Bayes, zeroth-order) inference for LDA, exposed
+as LDA(sampler="cvb0").
+
+CVB0 is a deterministic, non-sampling backend for the *same* LDA model: each
+(doc, word) cell keeps a soft topic responsibility updated from expected counts.
+These tests check it recovers known topics, produces valid distributions, is
+exactly reproducible for a seed, exposes no MCMC θ-draws (it is not a sampler),
+and supports the convergence-tol early stop.
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import topica
+
+PETS = ["cat", "dog", "fish", "pet", "paw", "tail"]
+SPACE = ["planet", "star", "moon", "sun", "orbit", "comet"]
+TWO_TOPIC_DOCS = [list(PETS)] * 40 + [list(SPACE)] * 40
+
+
+def _fit(docs, k=2, iters=200, **kw):
+    m = topica.LDA(k, seed=1, sampler="cvb0", optimize_interval=0, **kw)
+    m.fit(docs, iters=iters)
+    return m
+
+
+def test_recovers_two_topics():
+    m = _fit(TWO_TOPIC_DOCS)
+    sets = {frozenset(w for w, _ in ws) for ws in m.top_words(6)}
+    assert {frozenset(PETS), frozenset(SPACE)} == sets
+
+
+def test_valid_distributions():
+    m = _fit(TWO_TOPIC_DOCS)
+    npt.assert_allclose(m.topic_word.sum(axis=1), 1.0)
+    npt.assert_allclose(m.doc_topic.sum(axis=1), 1.0)
+    assert (m.topic_word >= 0).all() and (m.doc_topic >= 0).all()
+
+
+def test_deterministic_for_seed():
+    a = _fit(TWO_TOPIC_DOCS)
+    b = _fit(TWO_TOPIC_DOCS)
+    npt.assert_array_equal(a.topic_word, b.topic_word)
+    npt.assert_array_equal(a.doc_topic, b.doc_topic)
+
+
+def test_no_theta_draws():
+    # CVB0 is deterministic variational inference, not MCMC: no posterior draws.
+    m = _fit(TWO_TOPIC_DOCS)
+    assert m.theta_draws is None
+
+
+def test_convergence_tol_early_stops():
+    m = topica.LDA(2, seed=1, sampler="cvb0", optimize_interval=0)
+    m.fit(TWO_TOPIC_DOCS, iters=1000, convergence_tol=1e-4, check_every=5)
+    assert m.converged
+
+
+def test_aliases_and_bad_name():
+    for name in ("cvb0", "cvb"):
+        m = topica.LDA(2, seed=1, sampler=name)
+        m.fit(TWO_TOPIC_DOCS, iters=30)
+        assert m.topic_word.shape[0] == 2
+    with pytest.raises(ValueError):
+        topica.LDA(2, sampler="banana")
+
+
+def test_recovers_more_topics_at_larger_k():
+    n_blocks, wpb = 4, 5
+    vocab = [f"w{i}" for i in range(n_blocks * wpb)]
+    docs = []
+    for d in range(200):
+        b = d % n_blocks
+        block = vocab[b * wpb : (b + 1) * wpb]
+        docs.append(block + block)
+    m = _fit(docs, k=n_blocks, iters=150)
+    blocks = [set(vocab[b * wpb : (b + 1) * wpb]) for b in range(n_blocks)]
+    covered = set()
+    for t in range(m.num_topics):
+        top = {w for w, _ in m.top_words(wpb, topic=t)}
+        for bi, blk in enumerate(blocks):
+            if blk <= top:
+                covered.add(bi)
+    assert covered == set(range(n_blocks)), f"only recovered {covered}"
+
+
+def test_save_load_round_trip(tmp_path):
+    m = _fit(TWO_TOPIC_DOCS)
+    path = str(tmp_path / "cvb0.bin")
+    m.save(path)
+    reloaded = topica.LDA.load(path)
+    npt.assert_allclose(m.topic_word, reloaded.topic_word)


### PR DESCRIPTION
Adds `LDA(sampler="cvb0")` — collapsed variational Bayes, zeroth-order (Asuncion et al. 2009): a deterministic, non-MCMC inference backend for the same LDA model.

## What it is

Each (document, word-type) cell keeps a soft topic responsibility γ updated from *expected* counts: `γ_{dwk} ∝ (E[n_dk]+α)(E[n_wk]+β)/(E[n_k]+β̄)` — the same factored conditional as collapsed Gibbs, mean-field instead of sampled. No hard assignments, no burn-in, exactly reproducible per seed. Memory is held to O(unique (doc,word) cells · K) by sharing one γ across all tokens of a word-type in a document.

## A quality backend, not a speed one (honest framing)

On a 2,000-doc poliblog subsample, mean `c_v` (top-10), 300 iters:

| K | sparse | cvb0 |
|---:|--------|------|
| 20 | -57.6 / 7.8s | -60.0 / 9.3s |
| 50 | -64.4 / 8.7s | **-64.4** / 22.8s |
| 100 | -79.1 / 10.0s | **-68.5** / 47.0s |

CVB0's coherence advantage **grows with K** (tie at K=50, +10.6 at K=100), matching Asuncion et al. But it is O(K) per token, so it is **slower, not faster** — the opposite trade from WarpLDA. It's the choice when topic quality matters more than fit time.

Two corrections to the initial pitch, from measurement: it is *not* more seed-stable than Gibbs (random init → different variational optima; std 1.14 vs 0.41 across seeds), and it is slower. The real, measured win is **coherence at moderate-to-large K**.

## Integration

- New `src/cvb0.rs` (validated by planted-block recovery + exact determinism in `cargo test --lib`).
- Wired as `sampler="cvb0"` alongside `sparse`/`lightlda`/`warp`; deterministic, so `theta_draws` is None and `convergence_tol` early-stops on mean |Δγ|.
- `to_topic_model` via the argmax-γ assignment backs coherence/save/load/transform.

## Guarantees

- Default stays `"sparse"`; sparse path byte-unchanged (MALLET cosine 1.000).
- 8 Python tests (recovery, valid dists, exact determinism, no theta_draws, convergence_tol, aliases, large-K recovery, save/load).

## Gate
cargo `--lib` 85 · pytest 1977 / 18 skipped · MALLET cosine 1.000 · `mkdocs --strict` clean.

No version bump (feature PR).
