### PR TITLE
feat(dmr,seeded): CVB0 backend for DMR and SeededLDA — sampler="cvb0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- `DMR(..., sampler="cvb0")` and `SeededLDA(..., sampler="cvb0")` extend the CVB0
+  backend to those models — DMR with a per-document α (and the soft expected
+  counts `E[n_dk]` feeding the λ optimizer directly, a cleaner fit than the
+  hard-count sparse/warp paths), SeededLDA with the asymmetric seed β. Same
+  deterministic, higher-coherence-at-larger-K, no-`theta_draws` trade as LDA's
+  CVB0. Default stays `"sparse"`; the CVB0 SeededLDA path does not yet support
+  `doc_topic_prior`.
+
 - `LDA(..., sampler="cvb0")` adds collapsed variational Bayes, zeroth-order
   (Asuncion et al. 2009) as a deterministic, non-MCMC inference backend for the
   same LDA model. Each (document, word-type) cell keeps a soft topic

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -185,9 +185,12 @@ class DMR:
         sampler selects the inference backend: "sparse" (default) is the
         SparseLDA collapsed-Gibbs sweep with the per-document DMR prior; "warp"
         is the WarpLDA cache-efficient sampler (per-document-α doc phase), whose
-        per-sweep cost is flat in K. As with plain LDA, prefer "sparse" up to
-        ~K=200 and "warp" for large-K (K >= ~500) models; "warp" does not record
-        the convergence trace, so convergence_tol has no effect there."""
+        per-sweep cost is flat in K; "cvb0" is deterministic collapsed
+        variational Bayes (per-document α; the soft expected counts feed the λ
+        optimizer directly), the quality choice at the cost of O(K)-per-token
+        compute. As with plain LDA, prefer "sparse" up to ~K=200, "warp" for
+        large-K (K >= ~500); the "warp"/"cvb0" paths record no convergence
+        trace, so convergence_tol has no effect there."""
         ...
 
     def fit(
@@ -1828,10 +1831,12 @@ class SeededLDA:
     ) -> None:
         """sampler selects the backend: "sparse" (default) is the seeded
         collapsed-Gibbs sweep; "warp" is the WarpLDA cache-efficient sampler
-        (seeded word phase), whose per-sweep cost is flat in K. SeededLDA's
-        sparse sweep scores all K topics per token, so "warp" is dramatically
-        faster at large K (e.g. ~40x at K=500 on a 2,000-document corpus) at
-        comparable coherence. "warp" does not yet support doc_topic_prior."""
+        (seeded word phase), whose per-sweep cost is flat in K; "cvb0" is
+        deterministic collapsed variational Bayes (seeded β), the quality choice.
+        SeededLDA's sparse sweep scores all K topics per token, so "warp" is
+        dramatically faster at large K (e.g. ~40x at K=500 on a 2,000-document
+        corpus) at comparable coherence. The "warp" and "cvb0" paths do not yet
+        support doc_topic_prior."""
         ...
     def fit(
         self,

--- a/src/cvb0.rs
+++ b/src/cvb0.rs
@@ -47,6 +47,18 @@ pub struct Cvb0 {
     n_k: Vec<f64>,
     /// Document lengths (token counts), for θ.
     doc_len: Vec<f64>,
+
+    /// Per-document prior `α_{d,k}` (DMR). When `Some`, replaces the uniform α.
+    doc_alpha: Option<Vec<Vec<f64>>>,
+    /// Asymmetric β for SeededLDA (`β_{k,w}` and per-topic `β_sum_k`).
+    seed: Option<CvbSeedBeta>,
+}
+
+/// SeededLDA's asymmetric-β bookkeeping for CVB0 (mirrors the WarpLDA one).
+struct CvbSeedBeta {
+    seed_weight: f64,
+    beta_sum_k: Vec<f64>,
+    inv_seeds: Vec<Vec<u32>>,
 }
 
 impl Cvb0 {
@@ -116,7 +128,42 @@ impl Cvb0 {
             n_wk,
             n_k,
             doc_len,
+            doc_alpha: None,
+            seed: None,
         }
+    }
+
+    /// Use a per-document prior `α_{d,k}` (DMR); called each outer iteration
+    /// after recomputing α from the current λ.
+    pub fn set_doc_alpha(&mut self, doc_alpha: Vec<Vec<f64>>) {
+        self.doc_alpha = Some(doc_alpha);
+    }
+
+    /// Enable SeededLDA's asymmetric β. `seeds[k]` are the seed word-ids for
+    /// topic `k`, each gaining `seed_weight` in topic `k`.
+    pub fn set_seeds(&mut self, seeds: &[Vec<usize>], seed_weight: f64) {
+        let k = self.num_topics;
+        let v = self.num_types;
+        let mut beta_sum_k = vec![self.beta * v as f64; k];
+        let mut inv_seeds: Vec<Vec<u32>> = vec![Vec::new(); v];
+        for (t, ws) in seeds.iter().enumerate().take(k) {
+            beta_sum_k[t] += ws.len() as f64 * seed_weight;
+            for &w in ws {
+                if w < v {
+                    inv_seeds[w].push(t as u32);
+                }
+            }
+        }
+        for row in inv_seeds.iter_mut() {
+            row.sort_unstable();
+        }
+        self.seed = Some(CvbSeedBeta { seed_weight, beta_sum_k, inv_seeds });
+    }
+
+    /// Expected document-topic counts `E[n_dk]` — the soft input the DMR λ
+    /// optimizer consumes directly (it already takes `&[Vec<f64>]`).
+    pub fn doc_topic_expected(&self) -> &[Vec<f64>] {
+        &self.n_dk
     }
 
     /// One deterministic CVB0 sweep over every cell. Returns the mean absolute
@@ -145,13 +192,29 @@ impl Cvb0 {
                     self.n_k[t] -= cf * g;
                 }
 
-                // Recompute γ ∝ (n_dk+α)(n_wk+β)/(n_k+β̄).
+                // Recompute γ ∝ (n_dk+α_{d,k})(n_wk+β_{k,w})/(n_k+β_sum_k), with
+                // the per-document α (DMR) and asymmetric β (SeededLDA) folded in.
                 let mut sum = 0.0f64;
                 for t in 0..k {
-                    let val = (self.n_dk[d][t] + self.alpha[t]) * (self.n_wk[w][t] + beta)
-                        / (self.n_k[t] + beta_sum);
-                    self.gamma[d][i][t] = if val > 0.0 { val } else { 0.0 };
-                    sum += self.gamma[d][i][t];
+                    let a = match &self.doc_alpha {
+                        Some(da) => da[d][t],
+                        None => self.alpha[t],
+                    };
+                    let (bt, bsum) = match &self.seed {
+                        Some(s) => (
+                            if s.inv_seeds[w].binary_search(&(t as u32)).is_ok() {
+                                beta + s.seed_weight
+                            } else {
+                                beta
+                            },
+                            s.beta_sum_k[t],
+                        ),
+                        None => (beta, beta_sum),
+                    };
+                    let val = (self.n_dk[d][t] + a) * (self.n_wk[w][t] + bt) / (self.n_k[t] + bsum);
+                    let g = if val > 0.0 { val } else { 0.0 };
+                    self.gamma[d][i][t] = g;
+                    sum += g;
                 }
 
                 // Normalize, accumulate |Δγ|, and add the new mass back.
@@ -176,20 +239,67 @@ impl Cvb0 {
     /// Smoothed topic-word φ `(E[n_wk]+β)/(E[n_k]+β̄)`, accumulated into
     /// `acc[word][topic]` (matches the MH samplers' orientation).
     pub fn phi_into(&self, acc: &mut [Vec<f64>]) {
+        let beta = self.beta;
         for w in 0..self.num_types {
             for t in 0..self.num_topics {
-                let denom = self.n_k[t] + self.beta_sum;
-                acc[w][t] += (self.n_wk[w][t] + self.beta) / denom;
+                let (bt, bsum) = match &self.seed {
+                    Some(s) => (
+                        if s.inv_seeds[w].binary_search(&(t as u32)).is_ok() {
+                            beta + s.seed_weight
+                        } else {
+                            beta
+                        },
+                        s.beta_sum_k[t],
+                    ),
+                    None => (beta, self.beta_sum),
+                };
+                acc[w][t] += (self.n_wk[w][t] + bt) / (self.n_k[t] + bsum);
             }
         }
     }
 
-    /// Smoothed doc-topic θ `(E[n_dk]+α)/(n_d+α_sum)`, into `acc[doc][topic]`.
+    /// Smoothed topic-word matrix, shape `[topic][word]` (seeded-β aware) — the
+    /// topic-major orientation the SeededLDA output expects.
+    pub fn topic_word(&self) -> Vec<Vec<f64>> {
+        let beta = self.beta;
+        let mut phi = vec![vec![0.0f64; self.num_types]; self.num_topics];
+        for w in 0..self.num_types {
+            for t in 0..self.num_topics {
+                let (bt, bsum) = match &self.seed {
+                    Some(s) => (
+                        if s.inv_seeds[w].binary_search(&(t as u32)).is_ok() {
+                            beta + s.seed_weight
+                        } else {
+                            beta
+                        },
+                        s.beta_sum_k[t],
+                    ),
+                    None => (beta, self.beta_sum),
+                };
+                phi[t][w] = (self.n_wk[w][t] + bt) / (self.n_k[t] + bsum);
+            }
+        }
+        phi
+    }
+
+    /// Smoothed doc-topic θ matrix, shape `[doc][topic]` (per-document α).
+    pub fn doc_topic(&self) -> Vec<Vec<f64>> {
+        let mut th = vec![vec![0.0f64; self.num_topics]; self.cells.len()];
+        self.theta_into(&mut th);
+        th
+    }
+
+    /// Smoothed doc-topic θ `(E[n_dk]+α_{d,k})/(n_d+α_sum_d)`, into
+    /// `acc[doc][topic]` (per-document α for DMR).
     pub fn theta_into(&self, acc: &mut [Vec<f64>]) {
         for d in 0..self.cells.len() {
-            let denom = self.doc_len[d] + self.alpha_sum;
+            let (a_row, a_sum): (&[f64], f64) = match &self.doc_alpha {
+                Some(da) => (&da[d], da[d].iter().sum()),
+                None => (&self.alpha, self.alpha_sum),
+            };
+            let denom = self.doc_len[d] + a_sum;
             for t in 0..self.num_topics {
-                acc[d][t] += (self.n_dk[d][t] + self.alpha[t]) / denom;
+                acc[d][t] += (self.n_dk[d][t] + a_row[t]) / denom;
             }
         }
     }

--- a/src/python.rs
+++ b/src/python.rs
@@ -2969,6 +2969,8 @@ pub struct DMR {
     // WarpLDA cache-efficient sampler (per-document-α doc phase) instead of the
     // default SparseLDA DMR sweep. Recommended for large K.
     warp: bool,
+    // CVB0 deterministic collapsed-variational inference (per-document α).
+    cvb0: bool,
 
     fitted: bool,
     topic_names: Vec<String>,
@@ -3022,12 +3024,13 @@ impl DMR {
         if !finite_pos(prior_variance) {
             return Err(PyValueError::new_err("prior_variance must be > 0"));
         }
-        let warp = match sampler {
-            "sparse" => false,
-            "warp" | "warplda" => true,
+        let (warp, cvb0) = match sampler {
+            "sparse" => (false, false),
+            "warp" | "warplda" => (true, false),
+            "cvb0" | "cvb" => (false, true),
             other => {
                 return Err(PyValueError::new_err(format!(
-                    "unknown sampler {other:?}; expected \"sparse\" or \"warp\""
+                    "unknown sampler {other:?}; expected \"sparse\", \"warp\", or \"cvb0\""
                 )))
             }
         };
@@ -3040,6 +3043,7 @@ impl DMR {
             prior_variance,
             lbfgs_iters,
             warp,
+            cvb0,
             fitted: false,
             topic_names: Vec::new(),
             phi: None,
@@ -3149,8 +3153,34 @@ impl DMR {
 
         let beta = self.beta;
         let warp = self.warp;
+        let cvb0_flag = self.cvb0;
         let (acc_phi, acc_theta, theta_draw_buf, feat_eff, ll_history, converged_flag, model, corpus) =
-          if warp {
+          if cvb0_flag {
+            // CVB0 DMR: deterministic; per-document α is fed to the CVB0 sweep,
+            // and the soft expected counts E[n_dk] feed the λ optimizer directly.
+            // No MCMC, so no θ-draws and no convergence trace.
+            py.allow_threads(move || {
+                let alpha0 = vec![1.0f64; k];
+                let mut cv = cvb0::Cvb0::new(&corpus, k, &alpha0, beta, &mut rng);
+                for iter in 1..=iters {
+                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                    cv.set_doc_alpha(doc_alpha);
+                    cv.sweep();
+                    if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
+                        dmr::optimize_lambda(
+                            &mut lambda, &feats, cv.doc_topic_expected(), k, nf,
+                            prior_variance, lbfgs_iters, None,
+                        );
+                    }
+                }
+                let mut acc_phi = vec![vec![0.0f64; k]; num_types];
+                let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
+                cv.phi_into(&mut acc_phi);
+                cv.theta_into(&mut acc_theta);
+                let model = cv.to_topic_model(&corpus);
+                (acc_phi, acc_theta, Vec::new(), lambda, Vec::new(), false, model, corpus)
+            })
+          } else if warp {
             // WarpLDA DMR path: same λ-optimization loop, but the per-document
             // prior α is fed to the WarpLDA per-doc doc phase each sweep. Like the
             // LDA WarpLDA path it computes no inline log_likelihood, so the
@@ -3671,7 +3701,7 @@ impl DMR {
         Ok(DMR {
             num_topics: s.num_topics, beta: s.beta, optimize_interval: s.optimize_interval,
             burn_in: s.burn_in, seed: s.seed, prior_variance: s.prior_variance,
-            lbfgs_iters: s.lbfgs_iters, warp: false, fitted: s.fitted,
+            lbfgs_iters: s.lbfgs_iters, warp: false, cvb0: false, fitted: s.fitted,
             topic_names,
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             feature_effects: arr2_back(s.feature_effects),
@@ -8483,6 +8513,8 @@ pub struct SeededLDA {
     // WarpLDA cache-efficient sampler (seeded word phase) instead of the default
     // SparseLDA seeded sweep. Recommended for large K.
     warp: bool,
+    // CVB0 deterministic collapsed-variational inference (seeded β).
+    cvb0: bool,
     fitted: bool,
     topic_names: Vec<String>,
     phi: Option<Array2<f64>>,
@@ -8533,17 +8565,18 @@ impl SeededLDA {
         if names.len() + residual < 2 {
             return Err(PyValueError::new_err("need at least 2 topics (seeded + residual)"));
         }
-        let warp = match sampler {
-            "sparse" => false,
-            "warp" | "warplda" => true,
+        let (warp, cvb0) = match sampler {
+            "sparse" => (false, false),
+            "warp" | "warplda" => (true, false),
+            "cvb0" | "cvb" => (false, true),
             other => {
                 return Err(PyValueError::new_err(format!(
-                    "unknown sampler {other:?}; expected \"sparse\" or \"warp\""
+                    "unknown sampler {other:?}; expected \"sparse\", \"warp\", or \"cvb0\""
                 )))
             }
         };
         Ok(SeededLDA {
-            seed_names: names, seed_words: words, residual, alpha, beta, weight, seed, warp,
+            seed_names: names, seed_words: words, residual, alpha, beta, weight, seed, warp, cvb0,
             fitted: false, topic_names: Vec::new(), phi: None, theta: None,
             theta_draws: None, corpus: None,
             log_likelihood_history: Vec::new(), converged: false,
@@ -8621,6 +8654,38 @@ impl SeededLDA {
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, corpus.num_docs(), num_topics)?;
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+
+        if self.cvb0 {
+            // CVB0 seeded path: deterministic, asymmetric β via set_seeds. The
+            // per-document prior is not threaded through CVB0's θ output yet.
+            if doc_alpha.is_some() {
+                return Err(PyValueError::new_err(
+                    "sampler=\"cvb0\" does not support doc_topic_prior yet; use sampler=\"sparse\"",
+                ));
+            }
+            let (phi_tw, theta_dk, corpus) = py.allow_threads(move || {
+                let alpha0 = vec![alpha; num_topics];
+                let mut cv = cvb0::Cvb0::new(&corpus, num_topics, &alpha0, beta, &mut rng);
+                cv.set_seeds(&seeds, seed_weight);
+                for _ in 0..iters {
+                    cv.sweep();
+                }
+                (cv.topic_word(), cv.doc_topic(), corpus)
+            });
+            self.phi = Some(vecs_to_arr2(&phi_tw));
+            self.theta = Some(vecs_to_arr2(&theta_dk));
+            self.theta_draws = None;
+            let mut names = self.seed_names.clone();
+            for i in 0..self.residual {
+                names.push(format!("residual_{}", i + 1));
+            }
+            self.topic_names = names;
+            self.corpus = Some(corpus);
+            self.log_likelihood_history = Vec::new();
+            self.converged = false;
+            self.fitted = true;
+            return Ok(());
+        }
 
         if self.warp {
             // WarpLDA seeded path. The per-document prior (doc_topic_prior) is not
@@ -8806,7 +8871,7 @@ impl SeededLDA {
         Ok(SeededLDA {
             seed_names: Vec::new(), seed_words: Vec::new(),
             residual: s.num_topics.saturating_sub(s.topic_names.iter().filter(|n| !n.starts_with("residual_")).count()),
-            alpha: s.alpha, beta: s.beta, weight: s.weight, seed: s.seed, warp: false, fitted: s.fitted,
+            alpha: s.alpha, beta: s.beta, weight: s.weight, seed: s.seed, warp: false, cvb0: false, fitted: s.fitted,
             topic_names: s.topic_names, phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             theta_draws: None, corpus: s.corpus,
             log_likelihood_history: s.log_likelihood_history,

--- a/tests/test_dmr.py
+++ b/tests/test_dmr.py
@@ -509,3 +509,27 @@ class TestDmrWarp:
             m = DMR(num_topics=2, seed=1, sampler=name)
             m.fit(docs, feats, iters=50)
             assert m.topic_word.shape[0] == 2
+
+
+class TestDmrCvb0:
+    def test_recovers_and_valid(self):
+        docs, _, feats = _make_corpus(seed=2)
+        m = _fit_dmr(docs, feats, sampler="cvb0")
+        a = _identify_A_topic(m)
+        assert {w for w, _ in m.top_words(5, topic=a)} == set(_VOCAB_A)
+        npt.assert_allclose(m.topic_word.sum(axis=1), 1.0)
+        npt.assert_allclose(m.doc_topic.sum(axis=1), 1.0)
+
+    def test_deterministic_and_no_draws(self):
+        docs, _, feats = _make_corpus(seed=2)
+        a = _fit_dmr(docs, feats, seed=4, sampler="cvb0")
+        b = _fit_dmr(docs, feats, seed=4, sampler="cvb0")
+        npt.assert_array_equal(a.topic_word, b.topic_word)
+        assert a.theta_draws is None
+
+    def test_feature_effect_sign_matches_sparse(self):
+        docs, _, feats = _make_corpus(seed=2)
+        sparse = _fit_dmr(docs, feats, sampler="sparse")
+        cvb = _fit_dmr(docs, feats, sampler="cvb0")
+        assert sparse.feature_effects[_identify_A_topic(sparse), 1] > 0
+        assert cvb.feature_effects[_identify_A_topic(cvb), 1] > 0

--- a/tests/test_seeded_warp.py
+++ b/tests/test_seeded_warp.py
@@ -86,3 +86,32 @@ def test_doc_topic_prior_rejected_for_warp():
     m = topica.SeededLDA(_SEEDS, seed=1, sampler="warp")
     with pytest.raises(ValueError):
         m.fit(docs, iters=20, doc_topic_prior=prior)
+
+
+def _fit_cvb0(docs, iters=200, **kw):
+    m = topica.SeededLDA(_SEEDS, seed=1, sampler="cvb0", **kw)
+    m.fit(docs, iters=iters)
+    return m
+
+
+def test_cvb0_recovers_and_valid():
+    m = _fit_cvb0(_docs())
+    assert _recovered(m) == {0, 1, 2}
+    npt.assert_allclose(m.topic_word.sum(axis=1), 1.0)
+    npt.assert_allclose(m.doc_topic.sum(axis=1), 1.0)
+    assert m.topic_word.shape == (3, 12)
+
+
+def test_cvb0_deterministic_no_draws():
+    a = _fit_cvb0(_docs(), iters=120)
+    b = _fit_cvb0(_docs(), iters=120)
+    npt.assert_array_equal(a.topic_word, b.topic_word)
+    assert a.theta_draws is None
+
+
+def test_cvb0_rejects_doc_topic_prior():
+    docs = _docs(60)
+    prior = np.full((len(docs), 3), 0.1)
+    m = topica.SeededLDA(_SEEDS, seed=1, sampler="cvb0")
+    with pytest.raises(ValueError):
+        m.fit(docs, iters=20, doc_topic_prior=prior)


### PR DESCRIPTION
Extends the deterministic CVB0 backend to DMR and SeededLDA — the two clean reuses (#85).

The `Cvb0` engine gains an optional per-document α (DMR) and asymmetric seed β (SeededLDA), folded into the γ update / φ / θ via the same accessors as the WarpLDA generalizations; the plain-LDA path is numerically unchanged.

- **DMR(sampler="cvb0")** — per-document α_{d,k}=exp(λ·x_d) drives the γ update, and CVB0's soft expected counts `E[n_dk]` feed `dmr::optimize_lambda` **directly** (it already takes `&[Vec<f64>]`) — a cleaner fit than the hard-count sparse/warp paths.
- **SeededLDA(sampler="cvb0")** — asymmetric seed β in the γ update and the topic-word output.

Both deterministic (no `theta_draws`), same quality-for-speed trade as LDA's CVB0. Default stays `"sparse"`; the CVB0 SeededLDA path doesn't yet thread `doc_topic_prior`.

**Validated:** DMR covariate-effect sign matches the sparse fit; seeded recovery; determinism; valid distributions. 6 Python tests.

**Gate:** cargo 85 · pytest 1983/18 · MALLET cosine 1.000 (sparse paths byte-unchanged) · mkdocs --strict clean. No version bump.