### PR TITLE
feat(labeled): CVB0 backend for LabeledLDA — sampler="cvb0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- `LabeledLDA(..., sampler="cvb0")` runs the CVB0 backend with the per-document
+  label set applied as a *mask* on the responsibilities (γ is zero off the
+  allowed topics). This is the supervised model WarpLDA could not serve — its
+  masked proposals would mix at a fraction of a percent — whereas masking is
+  free in CVB0: it enforces the supervised constraint exactly (zero θ off the
+  label set), deterministically, and tends to higher coherence. No MCMC
+  `theta_draws`. Default stays `"sparse"`.
+
 - `DMR(..., sampler="cvb0")` and `SeededLDA(..., sampler="cvb0")` extend the CVB0
   backend to those models — DMR with a per-document α (and the soft expected
   counts `E[n_dk]` feeding the λ optimizer directly, a cleaner fit than the

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1125,8 +1125,19 @@ class LabeledLDA:
     """Labeled LDA (Ramage et al. 2009): supervised topics constrained to each
     document's label set. The number of topics equals the number of labels."""
 
-    def __init__(self, *, alpha: float = 0.1, beta: float = 0.01, seed: int = 42) -> None:
-        """Create an unfitted model. alpha is the symmetric per-topic prior."""
+    def __init__(
+        self, *, alpha: float = 0.1, beta: float = 0.01, seed: int = 42,
+        sampler: str = "sparse",
+    ) -> None:
+        """Create an unfitted model. alpha is the symmetric per-topic prior.
+
+        sampler selects the backend: "sparse" (default) is the restricted
+        collapsed-Gibbs sweep; "cvb0" is deterministic collapsed variational
+        Bayes with the label set applied as a mask on the responsibilities (zero
+        off the allowed topics). CVB0 enforces the same supervised constraint
+        deterministically and tends to higher coherence; it produces no MCMC
+        theta_draws. (WarpLDA is not offered here: masked proposals mix poorly,
+        whereas masking is free in CVB0.)"""
         ...
 
     def fit(

--- a/src/cvb0.rs
+++ b/src/cvb0.rs
@@ -52,6 +52,10 @@ pub struct Cvb0 {
     doc_alpha: Option<Vec<Vec<f64>>>,
     /// Asymmetric β for SeededLDA (`β_{k,w}` and per-topic `β_sum_k`).
     seed: Option<CvbSeedBeta>,
+    /// Per-document allowed-topic sets (LabeledLDA). When `Some`, a document's
+    /// responsibilities are confined to `allowed[d]` (an empty set = all topics).
+    /// Masking is free in CVB0: γ is simply zero off the allowed set.
+    allowed: Option<Vec<Vec<usize>>>,
 }
 
 /// SeededLDA's asymmetric-β bookkeeping for CVB0 (mirrors the WarpLDA one).
@@ -130,7 +134,71 @@ impl Cvb0 {
             doc_len,
             doc_alpha: None,
             seed: None,
+            allowed: None,
         }
+    }
+
+    /// Recompute all expected counts from the current γ (used after a structural
+    /// change such as applying a topic mask).
+    fn rebuild_counts(&mut self) {
+        let k = self.num_topics;
+        for row in self.n_dk.iter_mut() {
+            for x in row.iter_mut() {
+                *x = 0.0;
+            }
+        }
+        for row in self.n_wk.iter_mut() {
+            for x in row.iter_mut() {
+                *x = 0.0;
+            }
+        }
+        for x in self.n_k.iter_mut() {
+            *x = 0.0;
+        }
+        for d in 0..self.cells.len() {
+            for (i, &(w, c)) in self.cells[d].iter().enumerate() {
+                let (w, cf) = (w as usize, c as f64);
+                for t in 0..k {
+                    let g = self.gamma[d][i][t];
+                    self.n_dk[d][t] += cf * g;
+                    self.n_wk[w][t] += cf * g;
+                    self.n_k[t] += cf * g;
+                }
+            }
+        }
+    }
+
+    /// Confine each document to its allowed topics (LabeledLDA). An empty
+    /// `allowed[d]` leaves that document unconstrained. Zeroes γ off the allowed
+    /// set, renormalizes, and rebuilds the expected counts.
+    pub fn set_allowed(&mut self, allowed: Vec<Vec<usize>>) {
+        let k = self.num_topics;
+        for d in 0..self.cells.len() {
+            if allowed[d].is_empty() {
+                continue;
+            }
+            for i in 0..self.cells[d].len() {
+                let g = &mut self.gamma[d][i];
+                for t in 0..k {
+                    if allowed[d].binary_search(&t).is_err() {
+                        g[t] = 0.0;
+                    }
+                }
+                let sum: f64 = g.iter().sum();
+                if sum > 0.0 {
+                    for x in g.iter_mut() {
+                        *x /= sum;
+                    }
+                } else {
+                    let u = 1.0 / allowed[d].len() as f64;
+                    for &t in &allowed[d] {
+                        g[t] = u;
+                    }
+                }
+            }
+        }
+        self.allowed = Some(allowed);
+        self.rebuild_counts();
     }
 
     /// Use a per-document prior `α_{d,k}` (DMR); called each outer iteration
@@ -173,18 +241,27 @@ impl Cvb0 {
         let k = self.num_topics;
         let beta = self.beta;
         let beta_sum = self.beta_sum;
-        let uniform = 1.0 / k as f64;
         let mut total_change = 0.0f64;
         let mut n_cells = 0usize;
         let mut old = vec![0.0f64; k];
+        let all_topics: Vec<usize> = (0..k).collect();
 
         for d in 0..self.cells.len() {
+            // The topic support for this document: its allowed set (LabeledLDA)
+            // or all topics. γ stays 0 off the support, so the loops touch only
+            // the supported topics.
+            let topics: &[usize] = match &self.allowed {
+                Some(al) if !al[d].is_empty() => al[d].as_slice(),
+                _ => all_topics.as_slice(),
+            };
+            let uniform = 1.0 / topics.len() as f64;
+
             for i in 0..self.cells[d].len() {
                 let (w, c) = self.cells[d][i];
                 let (w, cf) = (w as usize, c as f64);
 
                 // Snapshot the old γ and remove this cell's mass (`-dw` counts).
-                for t in 0..k {
+                for &t in topics {
                     let g = self.gamma[d][i][t];
                     old[t] = g;
                     self.n_dk[d][t] -= cf * g;
@@ -195,7 +272,7 @@ impl Cvb0 {
                 // Recompute γ ∝ (n_dk+α_{d,k})(n_wk+β_{k,w})/(n_k+β_sum_k), with
                 // the per-document α (DMR) and asymmetric β (SeededLDA) folded in.
                 let mut sum = 0.0f64;
-                for t in 0..k {
+                for &t in topics {
                     let a = match &self.doc_alpha {
                         Some(da) => da[d][t],
                         None => self.alpha[t],
@@ -218,7 +295,7 @@ impl Cvb0 {
                 }
 
                 // Normalize, accumulate |Δγ|, and add the new mass back.
-                for t in 0..k {
+                for &t in topics {
                     let new = if sum > 0.0 { self.gamma[d][i][t] / sum } else { uniform };
                     self.gamma[d][i][t] = new;
                     total_change += (new - old[t]).abs();
@@ -292,13 +369,21 @@ impl Cvb0 {
     /// Smoothed doc-topic θ `(E[n_dk]+α_{d,k})/(n_d+α_sum_d)`, into
     /// `acc[doc][topic]` (per-document α for DMR).
     pub fn theta_into(&self, acc: &mut [Vec<f64>]) {
+        let all_topics: Vec<usize> = (0..self.num_topics).collect();
         for d in 0..self.cells.len() {
-            let (a_row, a_sum): (&[f64], f64) = match &self.doc_alpha {
-                Some(da) => (&da[d], da[d].iter().sum()),
-                None => (&self.alpha, self.alpha_sum),
+            let a_row: &[f64] = match &self.doc_alpha {
+                Some(da) => &da[d],
+                None => &self.alpha,
             };
+            // Confine θ to the allowed topics (LabeledLDA): off the set it is 0,
+            // and the normalizer sums α over the allowed topics only.
+            let topics: &[usize] = match &self.allowed {
+                Some(al) if !al[d].is_empty() => al[d].as_slice(),
+                _ => all_topics.as_slice(),
+            };
+            let a_sum: f64 = topics.iter().map(|&t| a_row[t]).sum();
             let denom = self.doc_len[d] + a_sum;
-            for t in 0..self.num_topics {
+            for &t in topics {
                 acc[d][t] += (self.n_dk[d][t] + a_row[t]) / denom;
             }
         }
@@ -400,6 +485,37 @@ mod tests {
             }
         }
         assert_eq!(covered.len(), n_blocks, "only recovered {covered:?}");
+    }
+
+    #[test]
+    fn masked_path_respects_labels() {
+        // LabeledLDA-style: each doc may only use its own block's topic. After
+        // fitting, θ must put zero mass on disallowed topics, and each block's
+        // words must top its own topic.
+        let wpb = 5;
+        let (corpus, n_blocks) = planted(4, wpb, 200);
+        let k = n_blocks;
+        let alpha = vec![0.1f64; k];
+        let mut rng = Pcg64Mcg::seed_from_u64(1);
+        let mut m = Cvb0::new(&corpus, k, &alpha, 0.01, &mut rng);
+        // doc d (block d % n_blocks) is allowed only topic (d % n_blocks).
+        let allowed: Vec<Vec<usize>> =
+            (0..corpus.docs.len()).map(|d| vec![d % n_blocks]).collect();
+        m.set_allowed(allowed.clone());
+        for _ in 0..60 {
+            m.sweep();
+        }
+        let mut th = vec![vec![0.0f64; k]; corpus.docs.len()];
+        m.theta_into(&mut th);
+        for d in 0..corpus.docs.len() {
+            let b = d % n_blocks;
+            for t in 0..k {
+                if t != b {
+                    assert!(th[d][t].abs() < 1e-12, "doc {d} leaked mass to topic {t}");
+                }
+            }
+            assert!(th[d][b] > 0.5, "doc {d} not concentrated on its label");
+        }
     }
 
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -3731,6 +3731,9 @@ pub struct LabeledLDA {
     alpha: f64,
     beta: f64,
     seed: u64,
+    // CVB0 deterministic collapsed-variational inference (masked γ per document)
+    // instead of the default restricted SparseLDA sweep.
+    cvb0: bool,
 
     fitted: bool,
     num_topics: usize,
@@ -3761,18 +3764,28 @@ impl LabeledLDA {
     /// Create an unfitted model. `alpha` is the (symmetric) per-topic prior
     /// over a document's allowed topics.
     #[new]
-    #[pyo3(signature = (*, alpha=0.1, beta=0.01, seed=42))]
-    fn new(alpha: f64, beta: f64, seed: u64) -> PyResult<Self> {
+    #[pyo3(signature = (*, alpha=0.1, beta=0.01, seed=42, sampler="sparse"))]
+    fn new(alpha: f64, beta: f64, seed: u64, sampler: &str) -> PyResult<Self> {
         if !finite_pos(alpha) {
             return Err(PyValueError::new_err("alpha must be > 0"));
         }
         if !finite_pos(beta) {
             return Err(PyValueError::new_err("beta must be > 0"));
         }
+        let cvb0 = match sampler {
+            "sparse" => false,
+            "cvb0" | "cvb" => true,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown sampler {other:?}; expected \"sparse\" or \"cvb0\""
+                )))
+            }
+        };
         Ok(LabeledLDA {
             alpha,
             beta,
             seed,
+            cvb0,
             fitted: false,
             num_topics: 0,
             topic_names: Vec::new(),
@@ -3880,6 +3893,47 @@ impl LabeledLDA {
         let check_every_labeled = if check_every == 0 { 0 } else if convergence_tol > 0.0 { check_every.max(1) } else { check_every };
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
+
+        if self.cvb0 {
+            // CVB0 LabeledLDA: deterministic; the per-document label set masks the
+            // responsibilities (γ is zero off the allowed topics — free in CVB0,
+            // unlike a sampler's proposal rejection). No MCMC, so no θ-draws.
+            let beta = self.beta;
+            let alpha = self.alpha;
+            let (acc_phi, acc_theta, model, corpus) = py.allow_threads(move || {
+                let alpha0 = vec![alpha; k];
+                let mut cv = cvb0::Cvb0::new(&corpus, k, &alpha0, beta, &mut rng);
+                cv.set_allowed(allowed);
+                for _ in 0..iters {
+                    cv.sweep();
+                }
+                let mut acc_phi = vec![vec![0.0f64; k]; num_types];
+                let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
+                cv.phi_into(&mut acc_phi);
+                cv.theta_into(&mut acc_theta);
+                let model = cv.to_topic_model(&corpus);
+                (acc_phi, acc_theta, model, corpus)
+            });
+            let _ = &model; // packed CVB0 state (argmax γ) backs coherence/save
+            let mut phi = Array2::<f64>::zeros((k, num_types));
+            for (w, row) in acc_phi.iter().enumerate() {
+                for (t, &val) in row.iter().enumerate() {
+                    phi[[t, w]] = val;
+                }
+            }
+            let theta = vecs_to_arr2(&acc_theta);
+            self.num_topics = k;
+            self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+            self.label_vocab = label_vocab;
+            self.phi = Some(phi);
+            self.theta = Some(theta);
+            self.theta_draws = None;
+            self.corpus = Some(corpus);
+            self.log_likelihood_history = Vec::new();
+            self.converged = false;
+            self.fitted = true;
+            return Ok(());
+        }
 
         let (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, model, corpus) = py.allow_threads(move || {
             let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
@@ -4186,7 +4240,7 @@ impl LabeledLDA {
             s.topic_names
         };
         Ok(LabeledLDA {
-            alpha: s.alpha, beta: s.beta, seed: s.seed, fitted: s.fitted,
+            alpha: s.alpha, beta: s.beta, seed: s.seed, cvb0: false, fitted: s.fitted,
             num_topics: s.num_topics, topic_names,
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             label_vocab: s.label_vocab, corpus: s.corpus,

--- a/tests/test_labeled.py
+++ b/tests/test_labeled.py
@@ -383,3 +383,54 @@ class TestLabeledLDATopWordsAndCoherence:
     def test_coherence_values_nonpositive(self, fitted):
         c = fitted.coherence(n=5)
         assert (c <= 0).all()
+
+
+# ---------------------------------------------------------------------------
+# CVB0 backend (deterministic; the masked-γ inference warp could not do well)
+# ---------------------------------------------------------------------------
+
+class TestLabeledCvb0:
+    def _fit(self, seed=1, iters=300):
+        docs, labels = _make_corpus(seed=2)
+        m = LabeledLDA(alpha=0.1, seed=seed, sampler="cvb0")
+        m.fit(docs, labels, iters=iters)
+        return m, labels
+
+    def test_recovers_labels(self):
+        m, _ = self._fit()
+        label_to_idx = {lbl: i for i, lbl in enumerate(m.labels)}
+        for lbl, vocab_words in _VOCAB.items():
+            t = label_to_idx[lbl]
+            top4 = [w for w, _ in m.top_words(4, topic=t)]
+            assert sum(1 for w in top4 if w in vocab_words) >= 3
+
+    def test_mask_respected_exactly(self):
+        # The supervised constraint must hold under CVB0: zero θ off the label set.
+        m, labels = self._fit()
+        dt = m.doc_topic
+        label_to_idx = {lbl: i for i, lbl in enumerate(m.labels)}
+        for d, doc_labels in enumerate(labels):
+            allowed = {label_to_idx[l] for l in doc_labels}
+            for t in range(m.num_topics):
+                if t not in allowed:
+                    assert dt[d, t] < 1e-12
+
+    def test_valid_distributions_and_no_draws(self):
+        m, _ = self._fit()
+        npt.assert_allclose(m.topic_word.sum(axis=1), 1.0)
+        npt.assert_allclose(m.doc_topic.sum(axis=1), 1.0)
+        assert m.theta_draws is None
+
+    def test_deterministic(self):
+        a, _ = self._fit(seed=4, iters=120)
+        b, _ = self._fit(seed=4, iters=120)
+        npt.assert_array_equal(a.topic_word, b.topic_word)
+
+    def test_aliases_and_bad_name(self):
+        docs, labels = _make_corpus(seed=2)
+        for name in ("cvb0", "cvb"):
+            m = LabeledLDA(seed=1, sampler=name)
+            m.fit(docs, labels, iters=30)
+            assert m.num_topics == 3
+        with pytest.raises(ValueError):
+            LabeledLDA(sampler="banana")


### PR DESCRIPTION
Adds `LabeledLDA(sampler="cvb0")` — **the supervised model WarpLDA could not serve** (#85).

## Why CVB0 fits where warp didn't

LabeledLDA confines each document to its label's topics. A masked MH proposal lands in a doc's allowed set with probability ≈ |allowed|/K (≈0.5% at K=500), so WarpLDA would auto-reject ~99.5% of proposals and mix terribly. **Masking is free in CVB0**: a document's responsibilities are simply zero off its allowed topics. So CVB0 enforces the supervised constraint *exactly*, deterministically, at O(|allowed|) per cell.

## How

- The `Cvb0` engine gains an optional per-document allowed-topic mask: `set_allowed` zeroes γ off the allowed set, renormalizes, and rebuilds the expected counts; the sweep iterates only the allowed support; θ confines to it (denominator sums α over allowed topics).
- `LabeledLDA(sampler="cvb0")` builds a masked `Cvb0` and returns the soft φ/θ. **θ is exactly zero off each document's label set** (verified to 1e-12).
- Deterministic, no `theta_draws`. The plain/DMR/seeded CVB0 paths are numerically unchanged (`allowed=None`).

## Validated

- Rust masked-path test (zero off-label mass, concentrates on the label).
- 5 Python tests: label-vocab recovery, exact supervised mask, valid dists + no draws, determinism, aliases/bad-name.

## Gate
cargo 86 · pytest 1988/18 · **MALLET LabeledLDA cosine 1.000** (sparse path byte-unchanged) · mkdocs --strict clean. No version bump.

With this, the CVB0 backend covers LDA, DMR, SeededLDA, and LabeledLDA — and LabeledLDA is the one only CVB0 (not warp) could do.