### PR TITLE
feat(keyatm): CVB0 backend for the base model — sampler="cvb0"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- `KeyATM(..., sampler="cvb0")` adds a CVB0 backend for the base keyATM model:
+  deterministic collapsed-variational inference over the (topic, keyword-switch)
+  states, with a soft responsibility per (document, word) cell that mirrors the
+  Gibbs conditional (token-weighting included). It is an **opt-in, non-R-parity**
+  estimator (a different inference method, so it does not reproduce R keyATM),
+  restricted to the base model — it errors with covariates, timestamps, or a
+  prior_offset, which stay Gibbs-only — and produces no MCMC `theta_draws`. Use
+  it when reproducibility/quality matters more than R-faithfulness. Default stays
+  `"sparse"`.
+
 - `LabeledLDA(..., sampler="cvb0")` runs the CVB0 backend with the per-document
   label set applied as a *mask* on the responsibilities (γ is zero off the
   allowed topics). This is the supervised model WarpLDA could not serve — its

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2330,12 +2330,21 @@ class KeyATM:
         gamma2: float = 1.0,
         seed: int = 42,
         estimate_alpha: bool = True,
+        sampler: str = "sparse",
     ) -> None:
         """estimate_alpha (default True, matching R keyATM) slice-samples an
         asymmetric document-topic prior alpha each sweep. Set it False for a
         fixed symmetric alpha: a faster fit (it skips the dominant non-sweep
         cost) at the price of the R-matching asymmetric prior. The base model
-        only; the covariate and dynamic models always learn their priors."""
+        only; the covariate and dynamic models always learn their priors.
+
+        sampler selects inference: "sparse" (default) is the collapsed-Gibbs
+        sampler validated against R keyATM; "cvb0" is deterministic collapsed
+        variational Bayes over the (topic, keyword-switch) states. CVB0 is an
+        opt-in alternative for the base model only (it errors with covariates,
+        timestamps, or a prior_offset) and does NOT preserve R-parity -- it is a
+        different, deterministic estimator with no MCMC theta_draws, useful when
+        you want reproducibility/quality over R-faithfulness."""
         ...
     @staticmethod
     def weighted_lda(

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -1129,6 +1129,176 @@ fn init_state<R: Rng>(
     (model, assignments, ki)
 }
 
+/// CVB0 (collapsed variational Bayes, zeroth-order) inference for the **base**
+/// keyATM model — a deterministic alternative to the Gibbs sampler.
+///
+/// Each (document, word-type) cell keeps a soft responsibility over the
+/// (topic, switch) states the Gibbs sampler draws from: `s=0` for every topic,
+/// plus `s=1` for each keyword topic that lists the word. The responsibilities
+/// are updated from the expected counts using the very same conditional as
+/// [`resample_token_inner`] (mass-weighted by the token weights), so it reuses
+/// keyATM's count tables and [`KeyAtmModel`] output methods unchanged.
+///
+/// This is **not** the R-keyATM estimator: it is a deterministic, non-sampling
+/// backend (optional `sampler="cvb0"`), so it does not preserve R-parity. It
+/// uses a fixed symmetric `alpha` (no slice sampling) and does not cover the
+/// covariate or dynamic variants.
+#[allow(clippy::too_many_arguments)]
+pub fn fit_keyatm_cvb0<R: Rng>(
+    docs: &[Vec<u32>],
+    num_types: usize,
+    num_topics: usize,
+    keywords: &[Vec<usize>],
+    alpha: f64,
+    beta: f64,
+    beta_key: f64,
+    gamma1: f64,
+    gamma2: f64,
+    iters: usize,
+    weights: WeightScheme,
+    rng: &mut R,
+) -> KeyAtmModel {
+    assert_eq!(keywords.len(), num_topics, "keywords length must equal num_topics");
+    let (mut model, _assign, ki) = init_state(
+        docs, num_types, num_topics, keywords, alpha, beta, beta_key, gamma1, gamma2, weights, rng,
+    );
+    let k = num_topics;
+    let num_kw = model.num_keyword_topics;
+    let v_beta = num_types as f64 * beta;
+
+    // Cells: per doc, unique (word, weighted mass = Σ token weights of that word).
+    let cells: Vec<Vec<(u32, f64)>> = docs
+        .iter()
+        .map(|doc| {
+            let mut m: std::collections::HashMap<u32, f64> = std::collections::HashMap::new();
+            for &w in doc {
+                *m.entry(w).or_insert(0.0) += model.vocab_weights[w as usize];
+            }
+            let mut c: Vec<(u32, f64)> = m.into_iter().collect();
+            c.sort_by_key(|&(w, _)| w);
+            c
+        })
+        .collect();
+
+    // γ per cell: g0[k] over s=0 (length K) and g1 over s=1 (parallel to
+    // ki.by_word[w]). Random init, normalized, then build the expected counts.
+    for row in model.ndk.iter_mut() {
+        row.iter_mut().for_each(|x| *x = 0.0);
+    }
+    model.nkw.iter_mut().for_each(|r| r.iter_mut().for_each(|x| *x = 0.0));
+    model.nkx.iter_mut().for_each(|r| r.iter_mut().for_each(|x| *x = 0.0));
+    model.nk0.iter_mut().for_each(|x| *x = 0.0);
+    model.nk1.iter_mut().for_each(|x| *x = 0.0);
+
+    let mut g0: Vec<Vec<Vec<f64>>> = Vec::with_capacity(docs.len());
+    let mut g1: Vec<Vec<Vec<f64>>> = Vec::with_capacity(docs.len());
+    for (d, dcells) in cells.iter().enumerate() {
+        let mut dg0 = Vec::with_capacity(dcells.len());
+        let mut dg1 = Vec::with_capacity(dcells.len());
+        for &(w, mass) in dcells {
+            let kw = &ki.by_word[w as usize];
+            let mut a0 = vec![0.0f64; k];
+            let mut a1 = vec![0.0f64; kw.len()];
+            let mut sum = 0.0;
+            for x in a0.iter_mut() {
+                *x = rng.gen::<f64>() + 1e-6;
+                sum += *x;
+            }
+            for x in a1.iter_mut() {
+                *x = rng.gen::<f64>() + 1e-6;
+                sum += *x;
+            }
+            for (t, x) in a0.iter_mut().enumerate() {
+                *x /= sum;
+                model.ndk[d][t] += mass * *x;
+                model.nkw[t][w as usize] += mass * *x;
+                model.nk0[t] += mass * *x;
+            }
+            for (idx, &(t, j)) in kw.iter().enumerate() {
+                a1[idx] /= sum;
+                model.ndk[d][t] += mass * a1[idx];
+                model.nkx[t][j] += mass * a1[idx];
+                model.nk1[t] += mass * a1[idx];
+            }
+            dg0.push(a0);
+            dg1.push(a1);
+        }
+        g0.push(dg0);
+        g1.push(dg1);
+    }
+
+    // Sweeps: mirror resample_token_inner softly per cell.
+    for _ in 0..iters {
+        for (d, dcells) in cells.iter().enumerate() {
+            for (ci, &(w, mass)) in dcells.iter().enumerate() {
+                let w = w as usize;
+                let kw = &ki.by_word[w];
+
+                // Remove this cell's mass (the `-dw` expected counts).
+                for t in 0..k {
+                    let c = mass * g0[d][ci][t];
+                    model.ndk[d][t] -= c;
+                    model.nkw[t][w] -= c;
+                    model.nk0[t] -= c;
+                }
+                for (idx, &(t, j)) in kw.iter().enumerate() {
+                    let c = mass * g1[d][ci][idx];
+                    model.ndk[d][t] -= c;
+                    model.nkx[t][j] -= c;
+                    model.nk1[t] -= c;
+                }
+
+                // Recompute the (topic, switch) responsibilities.
+                let mut sum = 0.0f64;
+                for t in 0..k {
+                    let ndk_val = model.ndk[d][t] + alpha;
+                    let reg = (model.nkw[t][w] + beta) / (v_beta + model.nk0[t]);
+                    let sw0 = if t < num_kw {
+                        (gamma2 + model.nk0[t]) / (gamma1 + gamma2 + model.nk0[t] + model.nk1[t])
+                    } else {
+                        1.0
+                    };
+                    let val = ndk_val * reg * sw0;
+                    let val = if val > 0.0 { val } else { 0.0 };
+                    g0[d][ci][t] = val;
+                    sum += val;
+                }
+                for (idx, &(t, j)) in kw.iter().enumerate() {
+                    let ndk_val = model.ndk[d][t] + alpha;
+                    let lk = model.l[t] as f64;
+                    let key = (model.nkx[t][j] + beta_key) / (lk * beta_key + model.nk1[t]);
+                    let sw1 = (gamma1 + model.nk1[t])
+                        / (gamma1 + gamma2 + model.nk0[t] + model.nk1[t]);
+                    let val = ndk_val * key * sw1;
+                    let val = if val > 0.0 { val } else { 0.0 };
+                    g1[d][ci][idx] = val;
+                    sum += val;
+                }
+
+                // Normalize and add the new mass back.
+                let inv = if sum > 0.0 { 1.0 / sum } else { 0.0 };
+                for t in 0..k {
+                    let g = g0[d][ci][t] * inv;
+                    g0[d][ci][t] = g;
+                    let c = mass * g;
+                    model.ndk[d][t] += c;
+                    model.nkw[t][w] += c;
+                    model.nk0[t] += c;
+                }
+                for (idx, &(t, j)) in kw.iter().enumerate() {
+                    let g = g1[d][ci][idx] * inv;
+                    g1[d][ci][idx] = g;
+                    let c = mass * g;
+                    model.ndk[d][t] += c;
+                    model.nkx[t][j] += c;
+                    model.nk1[t] += c;
+                }
+            }
+        }
+    }
+    model
+}
+
 /// Whether to record the predictive log-likelihood at 1-based sweep `iter`.
 /// Records every `interval` sweeps (and always the final one) so the trace
 /// ends at the model's returned state; `interval == 0` disables tracing.
@@ -1749,6 +1919,60 @@ mod tests {
             1,
             "topic 1 (keyword=block B) should be dominated by block B words"
         );
+    }
+
+    #[test]
+    fn cvb0_keywords_steer_topics() {
+        // The CVB0 backend must steer keyword topics the same way as Gibbs.
+        let block_size = 10usize;
+        let num_blocks = 3usize;
+        let v = num_blocks * block_size;
+        let mut docs: Vec<Vec<u32>> = Vec::new();
+        for b in 0..num_blocks {
+            let offset = b * block_size;
+            for d in 0..100usize {
+                let mut doc: Vec<u32> =
+                    (0..5).map(|i| (offset + (i + d) % block_size) as u32).collect();
+                doc.push(((b + 1) % num_blocks * block_size + d % block_size) as u32);
+                docs.push(doc);
+            }
+        }
+        let keywords: Vec<Vec<usize>> = vec![vec![0, 1], vec![10, 11], vec![]];
+        let mut rng = ChaCha8Rng::seed_from_u64(42);
+        let model = fit_keyatm_cvb0(
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 100, WeightScheme::None, &mut rng,
+        );
+        let dominant_block = |k: usize| -> usize {
+            let phi = model.topic_word(k);
+            (0..num_blocks)
+                .max_by(|&ba, &bb| {
+                    let sa: f64 = (0..block_size).map(|i| phi[ba * block_size + i]).sum();
+                    let sb: f64 = (0..block_size).map(|i| phi[bb * block_size + i]).sum();
+                    sa.partial_cmp(&sb).unwrap()
+                })
+                .unwrap()
+        };
+        assert_eq!(dominant_block(0), 0, "cvb0 topic 0 should be block A");
+        assert_eq!(dominant_block(1), 1, "cvb0 topic 1 should be block B");
+    }
+
+    #[test]
+    fn cvb0_deterministic_for_seed() {
+        let docs: Vec<Vec<u32>> = (0..60)
+            .map(|d| (0..6).map(|i| ((i + d) % 12) as u32).collect())
+            .collect();
+        let keywords: Vec<Vec<usize>> = vec![vec![0], vec![6], vec![]];
+        let run = || {
+            let mut rng = ChaCha8Rng::seed_from_u64(7);
+            fit_keyatm_cvb0(&docs, 12, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, WeightScheme::None, &mut rng)
+                .doc_topic()
+        };
+        let (a, b) = (run(), run());
+        for (ra, rb) in a.iter().zip(b.iter()) {
+            for (x, y) in ra.iter().zip(rb.iter()) {
+                assert!((x - y).abs() < 1e-12);
+            }
+        }
     }
 
     /// Every `keyword_rate()` value must lie in [0, 1], and regular topics

--- a/src/python.rs
+++ b/src/python.rs
@@ -11244,6 +11244,9 @@ pub struct KeyATM {
     gamma2: f64,
     seed: u64,
     estimate_alpha: bool,
+    // CVB0 deterministic collapsed-variational inference for the base model
+    // (optional, non-R-parity; covariate/dynamic variants stay Gibbs-only).
+    cvb0: bool,
     fitted: bool,
     topic_names: Vec<String>,
     keyword_rate: Vec<f64>,
@@ -11295,7 +11298,7 @@ impl KeyATM {
     /// `beta`/`beta_keyword` are the regular and keyword topic-word smoothing, and
     /// `gamma1`/`gamma2` the Beta prior on the keyword-vs-regular switch.
     #[new]
-    #[pyo3(signature = (keywords, *, num_topics=None, alpha=None, beta=0.01, beta_keyword=0.1, gamma1=1.0, gamma2=1.0, seed=42, estimate_alpha=true))]
+    #[pyo3(signature = (keywords, *, num_topics=None, alpha=None, beta=0.01, beta_keyword=0.1, gamma1=1.0, gamma2=1.0, seed=42, estimate_alpha=true, sampler="sparse"))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         keywords: &Bound<'_, PyDict>,
@@ -11307,6 +11310,7 @@ impl KeyATM {
         gamma2: f64,
         seed: u64,
         estimate_alpha: bool,
+        sampler: &str,
     ) -> PyResult<Self> {
         let (names, words) = parse_seed_dict(keywords)?;
         let k = num_topics.unwrap_or(names.len());
@@ -11323,9 +11327,18 @@ impl KeyATM {
         if !finite_pos(alpha) || !finite_pos(beta) || !finite_pos(beta_keyword) || !finite_pos(gamma1) || !finite_pos(gamma2) {
             return Err(PyValueError::new_err("alpha, beta, beta_keyword, gamma1, gamma2 must be > 0"));
         }
+        let cvb0 = match sampler {
+            "sparse" => false,
+            "cvb0" | "cvb" => true,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown sampler {other:?}; expected \"sparse\" or \"cvb0\""
+                )))
+            }
+        };
         Ok(KeyATM {
             key_names: names, keywords: words, num_topics: k, alpha, beta, beta_keyword,
-            gamma1, gamma2, seed, estimate_alpha, fitted: false, topic_names: Vec::new(),
+            gamma1, gamma2, seed, estimate_alpha, cvb0, fitted: false, topic_names: Vec::new(),
             keyword_rate: Vec::new(), phi: None, theta: None, corpus: None,
             feature_effects: None, feature_names: Vec::new(),
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
@@ -11353,6 +11366,7 @@ impl KeyATM {
         Ok(KeyATM {
             key_names: Vec::new(), keywords: Vec::new(), num_topics, alpha, beta,
             beta_keyword: 0.1, gamma1: 1.0, gamma2: 1.0, seed, estimate_alpha: true,
+            cvb0: false,
             fitted: false,
             topic_names: Vec::new(), keyword_rate: Vec::new(), phi: None, theta: None,
             corpus: None, feature_effects: None, feature_names: Vec::new(),
@@ -11469,6 +11483,14 @@ impl KeyATM {
         } else {
             report_interval
         };
+
+        // The CVB0 backend covers only the base model.
+        if self.cvb0 && (timestamps.is_some() || covariates.is_some() || prior_offset.is_some()) {
+            return Err(PyValueError::new_err(
+                "sampler=\"cvb0\" supports only the base keyATM (no timestamps, covariates, or prior_offset)",
+            ));
+        }
+        let cvb0 = self.cvb0;
 
         // --- Dynamic model: timestamps drive a change-point HMM on prevalence. ---
         if let Some(ts) = timestamps {
@@ -11619,6 +11641,10 @@ impl KeyATM {
                     beta, beta_key, g1, g2, iters, optimize_interval, burn_in,
                     prior_variance, lbfgs_iters, ll_interval, weight_scheme, nthreads,
                     offset.as_deref(), draws_opts, &mut rng,
+                ),
+                None if cvb0 => keyatm::fit_keyatm_cvb0(
+                    &corpus.docs, num_types, num_topics, &keys, alpha, beta, beta_key, g1, g2,
+                    iters, weight_scheme, &mut rng,
                 ),
                 None => keyatm::fit_keyatm(
                     &corpus.docs, num_types, num_topics, &keys, alpha, beta, beta_key, g1, g2,
@@ -11875,7 +11901,7 @@ impl KeyATM {
         Ok(KeyATM {
             key_names: Vec::new(), keywords: Vec::new(), num_topics: s.num_topics,
             alpha: s.alpha, beta: s.beta, beta_keyword: s.beta_keyword, gamma1: s.gamma1,
-            gamma2: s.gamma2, seed: s.seed, estimate_alpha: true, fitted: s.fitted,
+            gamma2: s.gamma2, seed: s.seed, estimate_alpha: true, cvb0: false, fitted: s.fitted,
             topic_names: s.topic_names,
             keyword_rate: s.keyword_rate, phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             corpus: s.corpus, feature_effects: None, feature_names: Vec::new(),

--- a/tests/test_keyatm_cvb0.py
+++ b/tests/test_keyatm_cvb0.py
@@ -1,0 +1,94 @@
+"""CVB0 backend for the base keyATM model (sampler="cvb0").
+
+CVB0 is a deterministic, non-MCMC alternative to keyATM's collapsed-Gibbs
+sampler: each (document, word) cell keeps a soft responsibility over the
+(topic, keyword-switch) states. It is *not* the R-keyATM estimator (it does not
+preserve R-parity), so it is an opt-in backend; these tests check it recovers a
+keyword topic, produces valid outputs, is deterministic, and is restricted to
+the base model (covariate/dynamic variants stay Gibbs-only).
+"""
+
+import numpy as np
+import numpy.testing as npt
+import pytest
+
+import topica
+
+_BS, _NB = 10, 3  # block size, num blocks
+
+
+def _corpus():
+    docs = []
+    for b in range(_NB):
+        for d in range(100):
+            doc = [(b * _BS + (i + d) % _BS) for i in range(5)]
+            doc.append(((b + 1) % _NB) * _BS + d % _BS)  # one noise token
+            docs.append([f"w{x}" for x in doc])
+    keywords = {"A": ["w0", "w1"], "B": ["w10", "w11"]}
+    return docs, keywords
+
+
+def _fit(sampler="cvb0", seed=42, iters=150, **kw):
+    docs, keywords = _corpus()
+    m = topica.KeyATM(keywords, num_topics=3, beta=0.1, beta_keyword=0.5, seed=seed,
+                      sampler=sampler, **kw)
+    m.fit(docs, iters=iters)
+    return m
+
+
+def test_recovers_keyword_topic():
+    # Topic 0's keyword set is block A (words w0..w9); its regular distribution
+    # should be dominated by block-A words.
+    m = _fit()
+    vocab = m.vocabulary
+    block_a = sum(m.topic_word[0][vocab.index(f"w{i}")] for i in range(_BS) if f"w{i}" in vocab)
+    assert block_a > 0.5
+
+
+def test_valid_distributions_and_no_draws():
+    m = _fit()
+    npt.assert_allclose(m.topic_word.sum(axis=1), 1.0)
+    npt.assert_allclose(m.doc_topic.sum(axis=1), 1.0)
+    assert m.theta_draws is None
+    assert len(m.keyword_rate) == 3
+
+
+def test_deterministic():
+    a = _fit(seed=4, iters=80)
+    b = _fit(seed=4, iters=80)
+    npt.assert_array_equal(a.topic_word, b.topic_word)
+    npt.assert_array_equal(a.doc_topic, b.doc_topic)
+
+
+def test_matches_gibbs_topic_structure():
+    # CVB0 is a different estimator, but on the same corpus it should land each
+    # keyword topic on the same block as the Gibbs sampler (the dominant block
+    # per topic agrees).
+    docs, _ = _corpus()
+    vocab_blocks = lambda m: [
+        int(np.argmax([
+            sum(m.topic_word[k][m.vocabulary.index(f"w{b*_BS+i}")]
+                for i in range(_BS) if f"w{b*_BS+i}" in m.vocabulary)
+            for b in range(_NB)
+        ]))
+        for k in range(2)
+    ]
+    assert vocab_blocks(_fit("sparse")) == vocab_blocks(_fit("cvb0"))
+
+
+def test_aliases_and_bad_name():
+    for name in ("cvb0", "cvb"):
+        m = _fit(sampler=name, iters=20)
+        assert m.num_topics == 3
+    with pytest.raises(ValueError):
+        topica.KeyATM({"A": ["w0"]}, num_topics=2, sampler="banana")
+
+
+def test_cvb0_rejects_covariate_and_dynamic():
+    docs, keywords = _corpus()
+    m = topica.KeyATM(keywords, num_topics=3, seed=1, sampler="cvb0")
+    with pytest.raises(ValueError):
+        m.fit(docs, iters=10, covariates=np.ones((len(docs), 1)))
+    m2 = topica.KeyATM(keywords, num_topics=3, seed=1, sampler="cvb0")
+    with pytest.raises(ValueError):
+        m2.fit(docs, iters=10, timestamps=list(range(len(docs))))


### PR DESCRIPTION
Adds `KeyATM(sampler="cvb0")` — deterministic CVB0 inference for the **base** keyATM (#85). The most involved backend: it runs over the **(topic, keyword-switch)** state space, not just topics.

## How

Each (document, word-type) cell keeps a soft responsibility over the states the Gibbs sampler draws from — `s=0` for every topic, plus `s=1` for each keyword topic that lists the word — updated from keyATM's five expected-count tables (`ndk/nkw/nk0/nkx/nk1`) using the **same conditional as `resample_token_inner`**, with the token weights folded into each cell's mass. It populates a `KeyAtmModel` with the soft counts, so the φ/θ/π output methods are reused unchanged.

## Honest scope

- **Opt-in, non-R-parity.** It's a *different* (deterministic) estimator, so it does not reproduce R keyATM — keyATM's whole identity is R-faithfulness, so this is never the default.
- **Base model only.** Errors with covariates, timestamps, or a prior_offset (those stay Gibbs-only). Fixed symmetric α, no MCMC `theta_draws`.
- Use it when reproducibility/quality matters more than R-faithfulness.

## Validated

- Rust: CVB0 steers keyword topics like Gibbs; deterministic.
- 6 Python tests: keyword-topic recovery, valid dists + no draws, determinism, **dominant-block agreement with the Gibbs fit**, aliases, and covariate/dynamic rejection.
- The Gibbs keyATM path is byte-unchanged (all existing keyatm tests pass).

## Gate
cargo 88 · pytest 1994/18 · MALLET cosine 1.000 · mkdocs --strict clean. No version bump.