### PR TITLE
keyATM opt-in convergence_tol early-stop; finish #46 Part B docs (#95)

### DIFF
--- a/docs/api/keyatm.md
+++ b/docs/api/keyatm.md
@@ -7,7 +7,13 @@ effects, …) are model-agnostic and work on a fitted `KeyATM` directly: see the
 
 The fitted model also exposes the convergence trace keyATM's `plot_modelfit`
 reports, as `KeyATM.log_likelihood_history` — a list of `(iteration, per-token
-log-likelihood)` pairs (perplexity is `exp(-log_likelihood)`).
+log-likelihood)` pairs (perplexity is `exp(-log_likelihood)`). The same trace is
+available in the cross-model form as `KeyATM.fit_history`. Passing
+`convergence_tol` to `fit` (default `0.0`, disabled) opts into early stopping on
+that trace: the Gibbs run halts once the relative change in the recorded
+log-likelihood drops below the tolerance, and `KeyATM.converged` reports whether
+it did. The base, covariate, and dynamic Gibbs backends support it; the CVB0
+backend (`sampler="cvb0"`) keeps no trace and never early-stops.
 
 ::: topica.keyatm.top_topics
 

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -154,9 +154,32 @@ model.fit(docs, iters=1000, convergence_tol=1e-4, check_every=10)
 # interval drops below 1e-4, rather than running all 1000 sweeps.
 ```
 
+keyATM takes `convergence_tol` the same way, but its check cadence is the
+`report_interval` it already uses for the `model_fit` trace (not a separate
+`check_every`).
+
+### Defaults, and why
+
+The defaults follow each family's reference implementation rather than a tuned
+guess:
+
+- **Variational EM (STM, CTM, STS)** stop automatically when the relative change
+  in the variational bound falls below `em_tol`, default `1e-5` — the same
+  criterion and value as R `stm`'s `emtol` ([Roberts, Stewart & Tingley
+  2019](https://doi.org/10.18637/jss.v091.i02)).
+- **Collapsed-Gibbs samplers (LDA, keyATM, DMR, SeededLDA, …)** default to
+  `convergence_tol=0.0` (no early stop): a fixed number of sweeps is the field
+  convention, following MALLET and Griffiths & Steyvers (2004), and keeps the
+  retained θ-draw thinning (`thin = iters / num_theta_draws`) well defined.
+  Setting `convergence_tol > 0` opts into log-likelihood-plateau early stopping
+  without changing the default fit.
+
 The cluster models (BERTopic, Top2Vec) and structurally non-iterative models
 (DTM, HLDA) return an empty `fit_history` and `converged` of `False` or `None`;
-they satisfy the contract without early-stop support.
+they satisfy the contract without early-stop support. HDP and GSDMM record a
+`fit_history` but never early-stop (`converged` stays `False`): they *discover*
+their topic and cluster counts, so a log-likelihood plateau is not a convergence
+signal.
 
 ## Visualization
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -298,11 +298,14 @@ class DMR:
 
     @property
     def fit_history(self) -> list[tuple[int, float]]:
-        """Per-iteration trace. Empty until issue #46 part B wires the trace."""
+        """Per-iteration ``(iteration, objective)`` trace recorded every
+        ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
     def converged(self) -> bool:
-        """Always False; no early-stop criterion yet."""
+        """True if fit early-stopped because the relative change in the objective
+        fell below ``convergence_tol``; False when the full ``iters`` ran (the
+        default, opt-in early stopping)."""
         ...
     def __repr__(self) -> str: ...
 
@@ -990,11 +993,14 @@ class SupervisedLDA:
         ...
     @property
     def fit_history(self) -> list[tuple[int, float]]:
-        """Per-iteration trace. Empty until issue #46 part B wires the trace."""
+        """Per-iteration ``(iteration, objective)`` trace recorded every
+        ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
     def converged(self) -> bool:
-        """Always False; no early-stop criterion yet."""
+        """True if fit early-stopped because the relative change in the objective
+        fell below ``convergence_tol``; False when the full ``iters`` ran (the
+        default, opt-in early stopping)."""
         ...
     def __repr__(self) -> str: ...
 
@@ -1124,11 +1130,14 @@ class SAGE:
     def doc_names(self) -> list[str]: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]:
-        """Per-iteration trace. Empty until issue #46 part B wires the trace."""
+        """Per-iteration ``(iteration, objective)`` trace recorded every
+        ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
     def converged(self) -> bool:
-        """Always False; no early-stop criterion yet."""
+        """True if fit early-stopped because the relative change in the objective
+        fell below ``convergence_tol``; False when the full ``iters`` ran (the
+        default, opt-in early stopping)."""
         ...
     def __repr__(self) -> str: ...
 
@@ -1245,11 +1254,14 @@ class LabeledLDA:
 
     @property
     def fit_history(self) -> list[tuple[int, float]]:
-        """Per-iteration trace. Empty until issue #46 part B wires the trace."""
+        """Per-iteration ``(iteration, objective)`` trace recorded every
+        ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
     def converged(self) -> bool:
-        """Always False; no early-stop criterion yet."""
+        """True if fit early-stopped because the relative change in the objective
+        fell below ``convergence_tol``; False when the full ``iters`` ran (the
+        default, opt-in early stopping)."""
         ...
     def __repr__(self) -> str: ...
 
@@ -1603,11 +1615,14 @@ class PT:
     def load(path: str) -> "PT": ...
     @property
     def fit_history(self) -> list[tuple[int, float]]:
-        """Per-iteration trace. Empty until issue #46 part B wires the trace."""
+        """Per-iteration ``(iteration, objective)`` trace recorded every
+        ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
     def converged(self) -> bool:
-        """Always False; no early-stop criterion yet."""
+        """True if fit early-stopped because the relative change in the objective
+        fell below ``convergence_tol``; False when the full ``iters`` ran (the
+        default, opt-in early stopping)."""
         ...
     def __repr__(self) -> str: ...
 
@@ -1766,11 +1781,14 @@ class PA:
     def load(path: str) -> "PA": ...
     @property
     def fit_history(self) -> list[tuple[int, float]]:
-        """Per-iteration trace. Empty until issue #46 part B wires the trace."""
+        """Per-iteration ``(iteration, objective)`` trace recorded every
+        ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
     def converged(self) -> bool:
-        """Always False; no early-stop criterion yet."""
+        """True if fit early-stopped because the relative change in the objective
+        fell below ``convergence_tol``; False when the full ``iters`` ran (the
+        default, opt-in early stopping)."""
         ...
     def __repr__(self) -> str: ...
 
@@ -1866,9 +1884,18 @@ class SeededLDA:
         data: Corpus | Sequence[Sequence[str]],
         *,
         iters: int = 2000,
+        doc_topic_prior: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
         keep_theta_draws: bool = True,
         num_theta_draws: int = 25,
-    ) -> None: ...
+        convergence_tol: float = 0.0,
+        check_every: int = 10,
+    ) -> None:
+        """Fit the seeded model. `convergence_tol` (default 0.0, disabled) enables
+        opt-in log-likelihood early stopping on the default ("sparse") sampler,
+        recording the `fit_history` trace every `check_every` sweeps; the "cvb0"
+        and "warp" backends ignore both (no per-iteration trace, `converged`
+        stays False)."""
+        ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
@@ -1923,11 +1950,14 @@ class SeededLDA:
     def load(path: str) -> "SeededLDA": ...
     @property
     def fit_history(self) -> list[tuple[int, float]]:
-        """Per-iteration trace. Empty until issue #46 part B wires the trace."""
+        """Per-iteration ``(iteration, objective)`` trace recorded every
+        ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
     def converged(self) -> bool:
-        """Always False; no early-stop criterion yet."""
+        """True if fit early-stopped because the relative change in the objective
+        fell below ``convergence_tol``; False when the full ``iters`` ran (the
+        default, opt-in early stopping)."""
         ...
     def __repr__(self) -> str: ...
 
@@ -2388,6 +2418,7 @@ class KeyATM:
         report_interval: int = 0,
         keep_theta_draws: bool = True,
         num_theta_draws: int = 25,
+        convergence_tol: float = 0.0,
     ) -> None:
         """Fit by collapsed Gibbs. Pass `covariates` (num_docs x F) for the
         covariate keyATM: the document-topic prior becomes a DMR,
@@ -2408,7 +2439,15 @@ class KeyATM:
         `report_interval` sets how often model_fit is recorded for
         `log_likelihood_history` (keyATM's model_fit / plot_modelfit): 0
         (default) records ~50 evenly spaced points across the run; a positive
-        value records every that-many sweeps."""
+        value records every that-many sweeps.
+
+        `convergence_tol` (default 0.0, disabled) enables opt-in early stopping
+        on the recorded model_fit trace: the Gibbs sweep stops once the relative
+        change in the log-likelihood between two recorded points falls below the
+        tolerance, setting `converged` to True (the relative-bound criterion R
+        stm uses; 0.0 runs the full `iters`, the field convention for collapsed
+        samplers). Applies to the base/covariate/dynamic Gibbs backends; ignored
+        by the CVB0 backend, which keeps no trace."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...
@@ -2524,6 +2563,8 @@ class KeyATM:
         ...
     @property
     def converged(self) -> bool:
-        """Always False; KeyATM has no early-stop criterion."""
+        """True if the Gibbs run early-stopped because the relative change in the
+        recorded model_fit log-likelihood fell below `convergence_tol`; False when
+        the full `iters` ran (the default; always False for the CVB0 backend)."""
         ...
     def __repr__(self) -> str: ...

--- a/python/topica/conformance.py
+++ b/python/topica/conformance.py
@@ -177,12 +177,15 @@ EXEMPT: dict[tuple[str, str], str] = {
 # ---------------------------------------------------------------------------
 # Key: (model_name, requirement)   Value: phase note
 #
-# Issue #46 Part B: DMR, SeededLDA, LabeledLDA, SAGE, SupervisedLDA, PA, PT
-# return an empty fit_history (no per-iteration trace wired yet) and
-# converged=False (no early-stop).  The conformance check here is class-level
-# (hasattr), which passes because the attribute exists.  The per-iteration
-# trace quality is verified in tests/test_convergence_interface.py, which
-# marks those seven models xfail until part B ships.
+# Issue #46 (both parts) and #95 have shipped: every iterative model records a
+# real per-iteration fit_history and exposes a converged flag, and the whole
+# collapsed-Gibbs family (LDA, DMR, SeededLDA, LabeledLDA, SAGE, SupervisedLDA,
+# PA, PT, keyATM) supports opt-in convergence_tol early-stopping.  Per-iteration
+# trace quality and early-stop semantics are verified in
+# tests/test_convergence_interface.py.  No known convergence gaps remain; HDP and
+# GSDMM intentionally never early-stop (they discover topic/cluster counts, so a
+# log-likelihood plateau is not a convergence signal — see that test's
+# _CONVERGED_FALSE_ALWAYS set).
 
 KNOWN_GAPS: dict[tuple[str, str], str] = {}
 

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -192,6 +192,12 @@ pub struct KeyAtmModel {
     /// keyword-free model or when tracing is disabled.
     #[serde(default)]
     pub pi_history: Vec<(usize, Vec<f64>)>,
+    /// Whether the Gibbs run stopped early because the relative change in the
+    /// recorded `model_fit` log-likelihood fell below `convergence_tol` (opt-in;
+    /// `false` when the full `iters` sweeps ran, the default). Mirrors the LDA
+    /// family's `converged` flag.
+    #[serde(default)]
+    pub converged: bool,
     /// Thinned MCMC θ snapshots (issue #31): the last `num_theta_draws` per-doc
     /// topic distributions taken every `thin` sweeps of the fit loop, stored as
     /// f32 to halve the (S × D × K) footprint. Real cross-sweep posterior draws
@@ -495,7 +501,7 @@ impl Estimator for KeyAtmModel {
     fn fit_history(&self) -> Vec<(usize, f64)> {
         self.log_likelihood_history.iter().map(|&(i, ll, _)| (i, ll)).collect()
     }
-    fn converged(&self) -> Option<bool> { None }
+    fn converged(&self) -> Option<bool> { Some(self.converged) }
     fn model_family(&self) -> ModelFamily { ModelFamily::Dirichlet }
 }
 
@@ -961,6 +967,7 @@ pub fn fit_keyatm<R: Rng>(
     weights: WeightScheme,
     num_threads: usize,
     draws: ThetaDrawOpts,
+    convergence_tol: f64,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(
@@ -1019,6 +1026,11 @@ pub fn fit_keyatm<R: Rng>(
             }
             if num_keyword_topics > 0 {
                 model.pi_history.push((it + 1, model.keyword_rate()));
+            }
+            if ll_converged(&model.log_likelihood_history, convergence_tol) {
+                model.converged = true;
+                model.alpha_vec = Some(alpha_vec.clone());
+                break;
             }
         }
     }
@@ -1124,6 +1136,7 @@ fn init_state<R: Rng>(
         log_likelihood_history: Vec::new(),
         alpha_history: Vec::new(),
         pi_history: Vec::new(),
+        converged: false,
         theta_draws: Vec::new(),
     };
     (model, assignments, ki)
@@ -1307,6 +1320,21 @@ fn record_ll(iter: usize, interval: usize, iters: usize) -> bool {
     interval > 0 && (iter % interval == 0 || iter == iters)
 }
 
+/// Opt-in early-stop test on keyATM's recorded `model_fit` trace: `true` once the
+/// last two recorded log-likelihoods differ by less than `tol` in relative terms.
+/// `tol <= 0` disables it (the default), so the full `iters` sweeps run. Mirrors
+/// the relative-bound criterion the LDA family and R `stm` use; the trace cadence
+/// (`ll_interval`) sets the comparison window.
+#[inline]
+fn ll_converged(history: &[(usize, f64, f64)], tol: f64) -> bool {
+    if tol <= 0.0 || history.len() < 2 {
+        return false;
+    }
+    let cur = history[history.len() - 1].1;
+    let prev = history[history.len() - 2].1;
+    (cur - prev).abs() / (prev.abs() + 1e-12) < tol
+}
+
 /// Thinned θ-draw retention schedule (issue #31): snapshot every `thin` sweeps
 /// and keep the last `cap` on a ring buffer, so the kept draws are the converged
 /// tail of the chain. `cap == 0` disables collection.
@@ -1384,6 +1412,7 @@ pub fn fit_keyatm_cov<R: Rng>(
     num_threads: usize,
     offset: Option<&[Vec<f64>]>,
     draws: ThetaDrawOpts,
+    convergence_tol: f64,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(keywords.len(), num_topics, "keywords length must equal num_topics");
@@ -1434,6 +1463,10 @@ pub fn fit_keyatm_cov<R: Rng>(
                 .log_likelihood_history
                 .push((it + 1, model.model_loglik(), model.perplexity()));
             model.pi_history.push((it + 1, model.keyword_rate()));
+            if ll_converged(&model.log_likelihood_history, convergence_tol) {
+                model.converged = true;
+                break;
+            }
         }
     }
 
@@ -1596,6 +1629,7 @@ pub fn fit_keyatm_dynamic<R: Rng>(
     weights: WeightScheme,
     num_threads: usize,
     draws: ThetaDrawOpts,
+    convergence_tol: f64,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(keywords.len(), num_topics, "keywords length must equal num_topics");
@@ -1821,6 +1855,10 @@ pub fn fit_keyatm_dynamic<R: Rng>(
                 .log_likelihood_history
                 .push((it + 1, model.model_loglik(), model.perplexity()));
             model.pi_history.push((it + 1, model.keyword_rate()));
+            if ll_converged(&model.log_likelihood_history, convergence_tol) {
+                model.converged = true;
+                break;
+            }
         }
     }
 
@@ -1892,7 +1930,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 200, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 200, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
         );
 
         // Helper: block with max probability mass in topic_word(k).
@@ -1993,7 +2031,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let model = fit_keyatm(
-            &docs, v, 4, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 50, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
+            &docs, v, 4, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 50, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
         );
 
         let rates = model.keyword_rate();
@@ -2029,7 +2067,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(123);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.5, 0.1, 0.5, 1.0, 1.0, 30, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
+            &docs, v, 3, &keywords, 0.5, 0.1, 0.5, 1.0, 1.0, 30, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
         );
 
         let d = docs.len();
@@ -2087,7 +2125,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let model = fit_keyatm_dynamic(
             &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0,
-            2.0, 1.0, 300, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
+            2.0, 1.0, 300, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
         );
 
         let dyn_ = model.dynamic.as_ref().expect("dynamic state present");
@@ -2121,10 +2159,10 @@ mod tests {
         let mut r1 = ChaCha8Rng::seed_from_u64(9);
         let mut r2 = ChaCha8Rng::seed_from_u64(9);
         let m1 = fit_keyatm_dynamic(
-            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut r1,
+            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut r1,
         );
         let m2 = fit_keyatm_dynamic(
-            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut r2,
+            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut r2,
         );
         assert_eq!(
             m1.dynamic.as_ref().unwrap().r_est,
@@ -2150,8 +2188,8 @@ mod tests {
         let mut r1 = ChaCha8Rng::seed_from_u64(77);
         let mut r2 = ChaCha8Rng::seed_from_u64(77);
 
-        let m1 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut r1);
-        let m2 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut r2);
+        let m1 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut r1);
+        let m2 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut r2);
 
         assert_eq!(
             m1.topic_word_all(),
@@ -2181,7 +2219,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(3);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 10, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 10, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
         );
         let h = &model.log_likelihood_history;
         // iters=60, interval=10 -> sweeps 10,20,30,40,50,60.
@@ -2197,7 +2235,7 @@ mod tests {
         // interval 0 disables tracing.
         let mut rng2 = ChaCha8Rng::seed_from_u64(3);
         let none = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng2,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng2,
         );
         assert!(none.log_likelihood_history.is_empty());
     }
@@ -2212,7 +2250,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(77);
         let m = fit_keyatm(
             &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true,
-            WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), &mut rng,
+            WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/src/python.rs
+++ b/src/python.rs
@@ -289,6 +289,7 @@ struct KeyAtmState {
     seed: u64, fitted: bool, topic_names: Vec<String>, keyword_rate: Vec<f64>,
     phi: Option<Arr2>, theta: Option<Arr2>, corpus: Option<corpus::Corpus>,
     #[serde(default)] log_likelihood_history: Vec<(usize, f64, f64)>,
+    #[serde(default)] converged: bool,
     #[serde(default)] alpha_history: Vec<(usize, Vec<f64>)>,
     #[serde(default)] pi_history: Vec<(usize, Vec<f64>)>,
     #[serde(default)] alpha_vec: Option<Vec<f64>>,
@@ -11293,6 +11294,8 @@ pub struct KeyATM {
     transition_matrix: Option<Array2<f64>>,
     // Convergence trace: (iteration, log-likelihood, perplexity) — keyATM's model_fit.
     log_likelihood_history: Vec<(usize, f64, f64)>,
+    // Whether the Gibbs run early-stopped on convergence_tol (opt-in; false by default).
+    converged: bool,
     // (iteration, alpha vector) and (iteration, pi vector) — plot_alpha / plot_pi.
     alpha_history: Vec<(usize, Vec<f64>)>,
     pi_history: Vec<(usize, Vec<f64>)>,
@@ -11370,7 +11373,7 @@ impl KeyATM {
             keyword_rate: Vec::new(), phi: None, theta: None, corpus: None,
             feature_effects: None, feature_names: Vec::new(),
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
-            transition_matrix: None, log_likelihood_history: Vec::new(),
+            transition_matrix: None, log_likelihood_history: Vec::new(), converged: false,
             alpha_history: Vec::new(), pi_history: Vec::new(), alpha_vec: None,
             theta_draws: None,
         })
@@ -11399,7 +11402,7 @@ impl KeyATM {
             topic_names: Vec::new(), keyword_rate: Vec::new(), phi: None, theta: None,
             corpus: None, feature_effects: None, feature_names: Vec::new(),
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
-            transition_matrix: None, log_likelihood_history: Vec::new(),
+            transition_matrix: None, log_likelihood_history: Vec::new(), converged: false,
             alpha_history: Vec::new(), pi_history: Vec::new(), alpha_vec: None,
             theta_draws: None,
         })
@@ -11425,7 +11428,7 @@ impl KeyATM {
                         timestamps=None, num_states=5, weights="information-theory",
                         num_threads=1, optimize_interval=50, burn_in=200, prior_variance=1.0,
                         lbfgs_iters=20, report_interval=0, prior_offset=None,
-                        keep_theta_draws=true, num_theta_draws=25))]
+                        keep_theta_draws=true, num_theta_draws=25, convergence_tol=0.0_f64))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -11446,6 +11449,7 @@ impl KeyATM {
         prior_offset: Option<&Bound<'_, PyAny>>,
         keep_theta_draws: bool,
         num_theta_draws: usize,
+        convergence_tol: f64,
     ) -> PyResult<()> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -11553,7 +11557,7 @@ impl KeyATM {
                     &sorted_docs, num_types, num_topics, &keys, &sorted_time, num_states,
                     beta, beta_key, g1, g2,
                     1.0, 1.0, 2.0, 1.0, // keyATM α-prior defaults: eta_1, eta_2, eta_1_reg, eta_2_reg
-                    iters, ll_interval, weight_scheme, nthreads, draws_opts, &mut rng,
+                    iters, ll_interval, weight_scheme, nthreads, draws_opts, convergence_tol, &mut rng,
                 )
             });
 
@@ -11575,6 +11579,7 @@ impl KeyATM {
                 self.transition_matrix = Some(vecs_to_arr2(&d.p_est));
             }
             self.log_likelihood_history = model.log_likelihood_history.clone();
+            self.converged = model.converged;
             self.alpha_history = model.alpha_history.clone();
             self.pi_history = model.pi_history.clone();
             self.alpha_vec = model.alpha_vec.clone();
@@ -11668,7 +11673,7 @@ impl KeyATM {
                     &corpus.docs, num_types, num_topics, &keys, f, f[0].len(),
                     beta, beta_key, g1, g2, iters, optimize_interval, burn_in,
                     prior_variance, lbfgs_iters, ll_interval, weight_scheme, nthreads,
-                    offset.as_deref(), draws_opts, &mut rng,
+                    offset.as_deref(), draws_opts, convergence_tol, &mut rng,
                 ),
                 None if cvb0 => keyatm::fit_keyatm_cvb0(
                     &corpus.docs, num_types, num_topics, &keys, alpha, beta, beta_key, g1, g2,
@@ -11676,7 +11681,7 @@ impl KeyATM {
                 ),
                 None => keyatm::fit_keyatm(
                     &corpus.docs, num_types, num_topics, &keys, alpha, beta, beta_key, g1, g2,
-                    iters, ll_interval, estimate_alpha, weight_scheme, nthreads, draws_opts, &mut rng,
+                    iters, ll_interval, estimate_alpha, weight_scheme, nthreads, draws_opts, convergence_tol, &mut rng,
                 ),
             };
             (m, corpus)
@@ -11687,6 +11692,7 @@ impl KeyATM {
             draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
         self.keyword_rate = model.keyword_rate();
         self.log_likelihood_history = model.log_likelihood_history.clone();
+        self.converged = model.converged;
         self.alpha_history = model.alpha_history.clone();
         self.pi_history = model.pi_history.clone();
         self.alpha_vec = model.alpha_vec.clone();
@@ -11835,11 +11841,14 @@ impl KeyATM {
             .collect())
     }
 
-    /// KeyATM does not implement an early-stop criterion; always ``False``.
+    /// ``True`` if the Gibbs run early-stopped because the relative change in the
+    /// recorded ``model_fit`` log-likelihood fell below ``convergence_tol``;
+    /// ``False`` when the full ``iters`` sweeps ran (the default, and always for
+    /// the CVB0 backend, which keeps no trace).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
-        Ok(false)
+        Ok(self.converged)
     }
 
     /// Trace of the estimated document-topic prior α as ``(iteration, alpha)``
@@ -11917,6 +11926,7 @@ impl KeyATM {
             keyword_rate: self.keyword_rate.clone(), phi: arr2_opt(&self.phi),
             theta: arr2_opt(&self.theta), corpus: self.corpus.clone(),
             log_likelihood_history: self.log_likelihood_history.clone(),
+            converged: self.converged,
             alpha_history: self.alpha_history.clone(),
             pi_history: self.pi_history.clone(),
             alpha_vec: self.alpha_vec.clone(),
@@ -11935,6 +11945,7 @@ impl KeyATM {
             corpus: s.corpus, feature_effects: None, feature_names: Vec::new(),
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
             transition_matrix: None, log_likelihood_history: s.log_likelihood_history,
+            converged: s.converged,
             alpha_history: s.alpha_history, pi_history: s.pi_history,
             alpha_vec: s.alpha_vec, theta_draws: None,
         })

--- a/tests/test_convergence_interface.py
+++ b/tests/test_convergence_interface.py
@@ -27,9 +27,11 @@ _TOY    = [list(_ANIMAL) for _ in range(15)] + [list(_SPACE) for _ in range(15)]
 # Cluster models: fit_history == [] and converged is None by design (not a gap).
 _CLUSTER_MODELS = {"BERTopic", "Top2Vec"}
 
-# Models whose converged is always False (no early-stop logic yet).
-# HDP and GSDMM stochastic Gibbs models return False (no tol criterion).
-_CONVERGED_FALSE_ALWAYS = {"HDP", "GSDMM", "KeyATM", "DTM", "HLDA"}
+# Models that intentionally never early-stop, so converged is always False.
+# HDP and GSDMM discover their topic/cluster counts, so a log-likelihood plateau
+# is not a convergence signal; DTM and HLDA expose no flat per-iteration objective.
+# (keyATM is NOT here: it supports opt-in convergence_tol early-stopping.)
+_CONVERGED_FALSE_ALWAYS = {"HDP", "GSDMM", "DTM", "HLDA"}
 
 # ---------------------------------------------------------------------------
 # Helpers to build a minimal fitted instance for any registry model
@@ -376,6 +378,69 @@ class TestLDAConvergenceInterface:
         path = str(tmp_path / "lda_converged.bin")
         model.save(path)
         loaded = topica.LDA.load(path)
+        assert loaded.converged is True
+
+
+# ---------------------------------------------------------------------------
+# keyATM opt-in convergence (issue #95): base, covariate, and dynamic Gibbs
+# variants early-stop on convergence_tol; CVB0 never does.
+# ---------------------------------------------------------------------------
+
+class TestKeyATMConvergence:
+    """keyATM mirrors the LDA-family convergence contract on its Gibbs backends."""
+
+    def _base(self, iters=400, convergence_tol=0.0, seed=42):
+        m = topica.KeyATM({"a": ["cat"]}, num_topics=2, seed=seed)
+        m.fit(_TOY, iters=iters, convergence_tol=convergence_tol)
+        return m
+
+    def test_default_converged_false_and_trace_nonempty(self):
+        """Default fit (no tol) runs to the cap: converged False, trace recorded."""
+        m = self._base(iters=400)
+        assert m.converged is False
+        assert len(m.fit_history) > 0
+
+    def test_tol_triggers_early_stop(self):
+        """A loose tolerance stops the base sampler well before the cap."""
+        m = self._base(iters=400, convergence_tol=1.0)
+        assert m.converged is True
+        assert m.fit_history[-1][0] < 400
+
+    def test_covariate_variant_early_stops(self):
+        """The covariate (DMR-prior) keyATM honors convergence_tol."""
+        import numpy as np
+        m = topica.KeyATM({"a": ["cat"]}, num_topics=2, seed=42)
+        cov = np.array([[1.0, 0.0]] * 15 + [[0.0, 1.0]] * 15)
+        m.fit(_TOY, covariates=cov, iters=400, convergence_tol=1.0)
+        assert m.converged is True
+
+    def test_dynamic_variant_early_stops(self):
+        """The dynamic (change-point HMM) keyATM honors convergence_tol."""
+        m = topica.KeyATM({"a": ["cat"]}, num_topics=2, seed=42)
+        ts = [0] * 15 + [1] * 15
+        m.fit(_TOY, timestamps=ts, num_states=2, iters=400, convergence_tol=1.0)
+        assert m.converged is True
+
+    def test_cvb0_ignores_tol(self):
+        """The CVB0 backend keeps no trace and never early-stops."""
+        m = topica.KeyATM({"a": ["cat"]}, num_topics=2, seed=42, sampler="cvb0")
+        m.fit(_TOY, iters=50, convergence_tol=1.0)
+        assert m.converged is False
+
+    def test_default_behavior_bit_for_bit(self):
+        """Passing convergence_tol=0.0 must not change the default fit."""
+        import numpy as np
+        a = self._base(iters=200, convergence_tol=0.0, seed=7)
+        b = topica.KeyATM({"a": ["cat"]}, num_topics=2, seed=7)
+        b.fit(_TOY, iters=200)
+        np.testing.assert_array_equal(a.topic_word, b.topic_word)
+
+    def test_converged_persists_across_save_load(self, tmp_path):
+        m = self._base(iters=400, convergence_tol=1.0)
+        assert m.converged is True  # precondition
+        path = str(tmp_path / "keyatm_converged.bin")
+        m.save(path)
+        loaded = topica.KeyATM.load(path)
         assert loaded.converged is True
 
 


### PR DESCRIPTION
Implements #95. Audit-first: most of what #95 asked for was already shipped in code; the issue was written against stale `.pyi` docstrings.

## What was already done (verified, not changed)
The parametric-Gibbs family — LDA, DMR, SeededLDA, LabeledLDA, SAGE, SupervisedLDA, PA, PT — already records a real `fit_history` and supports opt-in `convergence_tol` early stopping. `tests/test_convergence_interface.py` (158 cases) passes; a direct probe confirms early-stop fires for each.

## What this PR adds
**keyATM opt-in early stopping.** The base, covariate, and dynamic Gibbs backends now take `convergence_tol` (default `0.0`, disabled). The sweep halts once the relative change in the recorded `model_fit` log-likelihood falls below the tolerance; `KeyATM.converged` reports it. The check reuses the existing `model_fit` trace cadence, so it adds **no per-token cost** on keyATM's hot path. The CVB0 backend keeps no trace and never early-stops. `converged` persists across save/load.

## Doc cleanup (the stale part of #95)
- Replaced the 7 `_topica.pyi` "Empty until #46 part B" `fit_history` docstrings and the matching "Always False" `converged` docstrings — both were false; traces are populated and early-stop works.
- Updated the `conformance.py` Part-B known-gap note (no convergence gaps remain).
- Synced the `SeededLDA.fit` stub (was missing `doc_topic_prior`, `convergence_tol`, `check_every`) and documented that its `cvb0`/`warp` backends keep no trace.

## Literature-grounded defaults (the explicit ask)
Documented in `docs/guides/diagnostics.md`, each default tied to a source:
- **Variational EM** (STM/CTM/STS): `em_tol=1e-5`, relative variational-bound change — R `stm`'s `emtol` (Roberts, Stewart & Tingley 2019).
- **Collapsed Gibbs**: `convergence_tol=0.0` (fixed sweeps, opt-in early stop) — the MALLET / Griffiths & Steyvers convention; also keeps θ-draw thinning (`thin = iters / num_theta_draws`) well defined.
- **HDP / GSDMM**: intentionally never early-stop — they discover topic/cluster counts, so a log-likelihood plateau is not a convergence signal.

## Tests
- New `TestKeyATMConvergence`: base/cov/dynamic early-stop, cvb0 ignores tol, default fit bit-for-bit identical to `tol=0`, save/load preserves `converged`.
- Full suite: **2005 passed, 18 skipped**. `cargo test --lib`: **90 passed**. `mkdocs build --strict`: clean.

Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)