### PR TITLE
perf(keyatm): sparse, parallel topic-word reconcile in parallel_sweep_keyatm (#84)

### DIFF
--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -848,6 +848,10 @@ fn parallel_sweep_keyatm(
         start: usize,
         ndk: Vec<Vec<f64>>,
         asgn: Vec<Vec<(usize, u8)>>,
+        // Distinct word ids in this worker's document partition — the only `nkw`
+        // columns it can have modified (`resample_token_inner` writes nkw[*][w]
+        // for the token's own word w only). The merge folds just these columns.
+        touched: Vec<u32>,
     }
 
     let outs: Vec<WorkerOut> = ranges
@@ -878,7 +882,11 @@ fn parallel_sweep_keyatm(
                     asgn[li][pos] = (new_z, new_s);
                 }
             }
-            WorkerOut { nkw, nk0, nkx, nk1, start, ndk, asgn }
+            // Distinct words in this partition: the columns this worker touched.
+            let mut touched: Vec<u32> = docs[start..end].iter().flatten().copied().collect();
+            touched.sort_unstable();
+            touched.dedup();
+            WorkerOut { nkw, nk0, nkx, nk1, start, ndk, asgn, touched }
         })
         .collect();
 
@@ -890,15 +898,46 @@ fn parallel_sweep_keyatm(
         }
     }
 
-    // Reconcile the global tables: final = Σ_w worker_w − (W−1)·original,
-    // clamping tiny negative floating-point residues to zero.
     let wm1 = (outs.len() as f64) - 1.0;
     let k = p.num_topics;
+
+    // Reconcile the topic-word table `nkw` (the K×V cost center) as a sparse
+    // delta merge, parallel over topic rows (which are contiguous in the
+    // topic-major layout). Each row starts from the original and adds, in fixed
+    // worker order, each worker's net change on the columns that worker touched:
+    //     nkw[k][w] = orig[k][w] + Σ_w (worker_w[k][w] − orig[k][w]).
+    // Untouched columns stay exactly `orig` (the old dense `Σ_w − (W−1)·orig`
+    // left ULP residue on every cell; this is algebraically equal and cleaner —
+    // closer to the exact sequential path). Fixed worker order keeps the result
+    // deterministic for a given (seed, thread count). Touched cells are clamped
+    // to ≥0 after summing, matching the AD-LDA non-negativity guarantee.
+    model.nkw = (0..k)
+        .into_par_iter()
+        .map(|kk| {
+            let mut row = orig_nkw[kk].clone();
+            for out in &outs {
+                let wk = &out.nkw[kk];
+                let ok = &orig_nkw[kk];
+                for &w in &out.touched {
+                    let w = w as usize;
+                    row[w] += wk[w] - ok[w];
+                }
+            }
+            for out in &outs {
+                for &w in &out.touched {
+                    let w = w as usize;
+                    if row[w] < 0.0 {
+                        row[w] = 0.0;
+                    }
+                }
+            }
+            row
+        })
+        .collect();
+
+    // nk0, nk1, nkx are per-topic / per-keyword (length K and K×keywords), not
+    // K×V, so the dense reconcile over them is cheap; keep it unchanged.
     for kk in 0..k {
-        for w in 0..p.num_types {
-            let sum: f64 = outs.iter().map(|o| o.nkw[kk][w]).sum();
-            model.nkw[kk][w] = (sum - wm1 * orig_nkw[kk][w]).max(0.0);
-        }
         let sum0: f64 = outs.iter().map(|o| o.nk0[kk]).sum();
         model.nk0[kk] = (sum0 - wm1 * orig_nk0[kk]).max(0.0);
         let sum1: f64 = outs.iter().map(|o| o.nk1[kk]).sum();

--- a/tests/test_keyatm_parallel.py
+++ b/tests/test_keyatm_parallel.py
@@ -59,6 +59,24 @@ def test_parallel_counts_stay_nonnegative():
     assert np.allclose(phi.sum(axis=1), 1.0)
 
 
+def test_parallel_merge_higher_k_deterministic_and_valid():
+    # The sparse topic-word reconcile is parallel over topic rows, so exercise it
+    # with K well above the worker count to cover the multi-row merge path. It
+    # must stay deterministic for a fixed (num_threads, seed) and produce a valid
+    # (non-negative, row-normalized) topic-word matrix.
+    docs = _corpus(seed=3, n=800)
+    for nt in (4, 8):
+        a = topica.KeyATM(SEEDS, num_topics=24, seed=11)
+        a.fit(docs, iters=120, num_threads=nt)
+        b = topica.KeyATM(SEEDS, num_topics=24, seed=11)
+        b.fit(docs, iters=120, num_threads=nt)
+        assert np.array_equal(a.topic_word, b.topic_word), (
+            f"non-deterministic topic_word at num_threads={nt}"
+        )
+        assert (a.topic_word >= 0).all()
+        assert np.allclose(a.topic_word.sum(axis=1), 1.0)
+
+
 def test_parallel_dynamic_recovers_change_point():
     # Threading composes with the dynamic model.
     rng = np.random.default_rng(0)


### PR DESCRIPTION
Implements #84. Replaces the dense, serial `Σ_workers − (W−1)·orig` reconcile of keyATM's K×V topic-word table with a **sparse delta merge parallelized over topic rows**.

## Change
Each topic row starts from the original and adds, in fixed worker order, each worker's net change on the columns that worker actually touched — the distinct words in its document partition, which (verified) are the only `nkw` columns `resample_token_inner` can modify. `nk0/nk1/nkx` are per-topic/per-keyword (not K×V), so their dense reconcile is cheap and left unchanged.

## Determinism & numerics
- **Deterministic:** fixed worker-order fold → identical output for a given `(seed, num_threads)`. New test exercises the parallel-over-topics path at K=24.
- **Numerics:** changes the old path by ULPs. Untouched columns now stay exactly `orig` instead of carrying the dense reconcile's residue — the old `Σ−(W−1)·orig` left a residue on **58–80% of untouched cells for W≥3** (W=2 is exact). The new result is algebraically equal, numerically *closer* to the exact sequential path, and stays within `np.allclose` of both. Parity unaffected.

## Honest performance note
The #84 premise — that the dense merge is the bottleneck — **does not hold on realistic corpora.** On real poliblog (avg 203 tokens/doc), sampling dominates and threading already reaches ~1.7–2× at nt=4. This change is a refinement, not the large win first imagined.

Best-of-2, real poliblog (2000 docs), nt=4 speedup vs nt=1 (intra-build ratio, controls for cross-build noise):

| K | main | this PR |
|---|---|---|
| 10 | 1.85× | 2.02× |
| 30 | 1.69× | 1.88× |
| 60 | 1.73× | 1.83× |

A modest, consistent scaling gain (larger at higher K), and it removes the last serial section of the AD-LDA sweep. Measurements were on a thermally-noisy laptop; only the intra-build speedup ratios are trustworthy.

## Tests
- New K=24 multi-thread determinism + validity check in `test_keyatm_parallel.py`.
- Full suite: **2006 passed, 18 skipped**. `cargo test --lib keyatm`: **10 passed**.

Closes #84

🤖 Generated with [Claude Code](https://claude.com/claude-code)