### PR TITLE
fix(core): non-finite covariate validation + numeric robustness (#100, #103)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   covariate-aware models (STM, DMR, KeyATM), matching `stm::permutationTest`;
   p-values use the `(1 + count) / (1 + n)` convention and drop NaN null entries
   (#101).
+- Covariate, feature, embedding, and timestamp matrices are now checked for
+  non-finite values (NaN/inf) at the boundary and raise a clear `ValueError`
+  naming the parameter, instead of panicking (KeyATM) or silently producing
+  garbage estimates (STM, DMR) (#100).
+- `top_words`/`top_documents` and related rankings sort with `f64::total_cmp`,
+  so a stray NaN can no longer panic them into a `PanicException`. `BERTopic`
+  and `Top2Vec` raise a clear `RuntimeError` from `transform`/`top_words` when
+  clustering found no topics, rather than returning empty `(n, 0)` output.
+  `u_mass` coherence against an external reference corpus no longer rewards a
+  top word absent from the reference with a large positive score (#103).
 
 ### Changed
 

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -170,8 +170,12 @@ def _score_umass(topic, vocab, occ, co, eps):
     for i in range(1, len(idx)):
         for j in range(i):
             a, b = idx[i], idx[j]  # a follows b in the ranked list
-            denom = occ[b] if occ[b] > 0 else eps
-            total += math.log((co[a, b] + 1.0) / denom)
+            # If the conditioning word b never appears in the reference corpus,
+            # skip this pair rather than using eps as denominator, which would
+            # produce a spuriously large positive score.
+            if occ[b] == 0:
+                continue
+            total += math.log((co[a, b] + 1.0) / occ[b])
             n += 1
     return total / n if n else float("nan")
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -113,18 +113,6 @@ fn check_all_finite_1d(name: &str, vals: &[f64]) -> PyResult<()> {
     Ok(())
 }
 
-/// Validate that `iters` is at least 1.  Called at the top of every `fit()`
-/// that accepts an explicit iteration count as `usize` (PyO3 already rejects
-/// negatives with an OverflowError; this catches the silent zero no-op).
-fn require_iters(iters: usize, name: &str) -> PyResult<()> {
-    if iters < 1 {
-        return Err(PyValueError::new_err(format!(
-            "{name} must be >= 1, got {iters}"
-        )));
-    }
-    Ok(())
-}
-
 // `from_py_with` hooks for count constructor arguments. They take the int as a
 // signed `i64` so a negative value yields a clean `ValueError` here rather than
 // PyO3's raw `OverflowError`. Per-model minimums above 1 (e.g. CTM/STM need >= 2)
@@ -1166,7 +1154,6 @@ impl LDA {
         convergence_tol: f64,
         check_every: usize,
     ) -> PyResult<()> {
-        require_iters(iters, "iters")?;
         // Accept either a Corpus or a list[list[str]].
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -3253,7 +3240,6 @@ impl DMR {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
 
         let raw = parse_features(features)?;
         if raw.len() != corpus.num_docs() {
@@ -4002,7 +3988,6 @@ impl LabeledLDA {
         if num_docs == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         if labels.len() != num_docs {
             return Err(PyValueError::new_err(format!(
                 "labels has {} entries but corpus has {} documents",
@@ -4573,7 +4558,6 @@ impl SAGE {
         if num_docs == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
 
         let groups_str = parse_groups(groups)?;
         if groups_str.len() != num_docs {
@@ -5284,7 +5268,6 @@ impl CTM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         let svi = match inference {
             "batch" => false,
             "svi" => true,
@@ -5746,7 +5729,6 @@ impl STM {
         if num_docs == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         if prevalence.is_none() && content.is_none() {
             return Err(PyValueError::new_err(
                 "STM needs prevalence and/or content covariates; use CTM for neither",
@@ -6567,7 +6549,6 @@ impl STS {
         kappa_estimation: &str,
         kappa_ridge: f64,
     ) -> PyResult<()> {
-        require_iters(iters, "iters")?;
         let kappa_est = match kappa_estimation {
             "lasso" => sts::KappaEst::Lasso { nlambda: 100, lambda_min_ratio: 0.001 },
             "ridge" => sts::KappaEst::Ridge(kappa_ridge),
@@ -7082,7 +7063,6 @@ impl HDP {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
 
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
@@ -7488,7 +7468,6 @@ impl DTM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         if times.len() != corpus.num_docs() {
             return Err(PyValueError::new_err(format!(
                 "times has length {} but there are {} documents",
@@ -7853,7 +7832,6 @@ impl SupervisedLDA {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         if y.len() != corpus.num_docs() {
             return Err(PyValueError::new_err(format!(
                 "y has length {} but there are {} documents",
@@ -8270,7 +8248,6 @@ impl PT {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (k, p, a, b) = (self.num_topics, self.num_pseudo, self.alpha, self.beta);
@@ -8537,7 +8514,6 @@ impl GSDMM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         let num_types = corpus.num_types();
         let (k, a, b) = (self.k_max, self.alpha, self.beta);
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
@@ -8879,7 +8855,6 @@ impl SeededLDA {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         let num_topics = self.num_topics_val();
         let num_types = corpus.num_types();
         let seeds = seed_word_ids(&self.seed_words, &corpus.id_to_word, num_topics);
@@ -11675,7 +11650,6 @@ impl KeyATM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         let num_topics = self.num_topics;
         let num_types = corpus.num_types();
         // Thinned θ-draw retention schedule (issue #31), shared by all three fits.
@@ -12291,7 +12265,6 @@ impl PA {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        require_iters(iters, "iters")?;
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (s, k, a, b) = (self.num_super, self.num_sub, self.alpha, self.beta);
@@ -12803,20 +12776,6 @@ mod tests {
         let arr = Array2::from_shape_vec((2, 2), vec![1.0, f64::NAN, 3.0, 4.0]).unwrap();
         let err = check_all_finite_arr2("features", &arr.view()).unwrap_err();
         assert!(err.to_string().contains("features"));
-    }
-
-    #[test]
-    fn require_iters_accepts_positive() {
-        assert!(require_iters(1, "iters").is_ok());
-        assert!(require_iters(1000, "iters").is_ok());
-    }
-
-    #[test]
-    fn require_iters_rejects_zero() {
-        let err = require_iters(0, "iters").unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("iters"), "message should name the parameter");
-        assert!(msg.contains("0"), "message should include the bad value");
     }
 
     #[test]

--- a/src/python.rs
+++ b/src/python.rs
@@ -71,6 +71,60 @@ fn require_count(value: i64, min: i64, name: &str) -> PyResult<usize> {
     Ok(value as usize)
 }
 
+/// Guard that every element of a 2-D feature/covariate/embedding matrix is
+/// finite. Called right after `parse_features` returns and the row-count check
+/// passes, so the error names the parameter exactly as the user passed it.
+fn check_all_finite_2d(name: &str, rows: &[Vec<f64>]) -> PyResult<()> {
+    for (i, row) in rows.iter().enumerate() {
+        for (j, &v) in row.iter().enumerate() {
+            if !v.is_finite() {
+                return Err(PyValueError::new_err(format!(
+                    "{name} contains non-finite values (NaN or inf) at row {i}, col {j}"
+                )));
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Guard that every element of a 2-D ndarray view is finite. Used when data
+/// enters via `PyReadonlyArray2` rather than through `parse_features`.
+fn check_all_finite_arr2(name: &str, arr: &numpy::ndarray::ArrayView2<f64>) -> PyResult<()> {
+    for ((i, j), &v) in arr.indexed_iter() {
+        if !v.is_finite() {
+            return Err(PyValueError::new_err(format!(
+                "{name} contains non-finite values (NaN or inf) at row {i}, col {j}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Guard that every element of a 1-D numeric sequence (e.g. timestamps) is
+/// finite.
+fn check_all_finite_1d(name: &str, vals: &[f64]) -> PyResult<()> {
+    for (i, &v) in vals.iter().enumerate() {
+        if !v.is_finite() {
+            return Err(PyValueError::new_err(format!(
+                "{name} contains non-finite values (NaN or inf) at index {i}"
+            )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate that `iters` is at least 1.  Called at the top of every `fit()`
+/// that accepts an explicit iteration count as `usize` (PyO3 already rejects
+/// negatives with an OverflowError; this catches the silent zero no-op).
+fn require_iters(iters: usize, name: &str) -> PyResult<()> {
+    if iters < 1 {
+        return Err(PyValueError::new_err(format!(
+            "{name} must be >= 1, got {iters}"
+        )));
+    }
+    Ok(())
+}
+
 // `from_py_with` hooks for count constructor arguments. They take the int as a
 // signed `i64` so a negative value yields a clean `ValueError` here rather than
 // PyO3's raw `OverflowError`. Per-model minimums above 1 (e.g. CTM/STM need >= 2)
@@ -935,7 +989,7 @@ impl LDA {
         (0..self.num_topics)
             .map(|t| {
                 let mut idx: Vec<usize> = (0..num_words).collect();
-                idx.sort_by(|&a, &b| phi[[t, b]].partial_cmp(&phi[[t, a]]).unwrap());
+                idx.sort_by(|&a, &b| f64::total_cmp(&phi[[t, b]], &phi[[t, a]]));
                 idx.truncate(n);
                 idx
             })
@@ -1112,6 +1166,7 @@ impl LDA {
         convergence_tol: f64,
         check_every: usize,
     ) -> PyResult<()> {
+        require_iters(iters, "iters")?;
         // Accept either a Corpus or a list[list[str]].
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -1482,7 +1537,7 @@ impl LDA {
                 )));
             }
             let mut idx: Vec<usize> = (0..num_words).collect();
-            idx.sort_by(|&a, &b| phi[[t, b]].partial_cmp(&phi[[t, a]]).unwrap());
+            idx.sort_by(|&a, &b| f64::total_cmp(&phi[[t, b]], &phi[[t, a]]));
             let items: Vec<Bound<'py, PyTuple>> = idx
                 .iter()
                 .take(n)
@@ -2030,7 +2085,7 @@ impl LDA {
         let num_docs = theta.shape()[0];
 
         let mut idx: Vec<usize> = (0..num_docs).collect();
-        idx.sort_by(|&a, &b| theta[[b, topic]].partial_cmp(&theta[[a, topic]]).unwrap());
+        idx.sort_by(|&a, &b| f64::total_cmp(&theta[[b, topic]], &theta[[a, topic]]));
         let items: Vec<Bound<'py, PyTuple>> = idx
             .iter()
             .take(n)
@@ -2103,7 +2158,7 @@ impl LDA {
                 (d, js_divergence(&target, &q))
             })
             .collect();
-        scored.sort_by(|a, b| a.1.partial_cmp(&b.1).unwrap());
+        scored.sort_by(|a, b| f64::total_cmp(&a.1, &b.1));
 
         let items: Vec<Bound<'py, PyTuple>> = scored
             .iter()
@@ -2974,7 +3029,7 @@ fn top_word_ids_phi(phi: &Array2<f64>, num_topics: usize, n: usize) -> Vec<Vec<u
     (0..num_topics)
         .map(|t| {
             let mut idx: Vec<usize> = (0..w).collect();
-            idx.sort_by(|&a, &b| phi[[t, b]].partial_cmp(&phi[[t, a]]).unwrap());
+            idx.sort_by(|&a, &b| f64::total_cmp(&phi[[t, b]], &phi[[t, a]]));
             idx.truncate(n);
             idx
         })
@@ -3013,6 +3068,7 @@ fn build_time_index(
                 num_docs
             )));
         }
+        check_all_finite_1d("timestamps", &vals)?;
         let mut uniq = vals.clone();
         uniq.sort_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
         uniq.dedup();
@@ -3197,6 +3253,7 @@ impl DMR {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
 
         let raw = parse_features(features)?;
         if raw.len() != corpus.num_docs() {
@@ -3206,6 +3263,7 @@ impl DMR {
                 corpus.num_docs()
             )));
         }
+        check_all_finite_2d("features", &raw)?;
         let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
         if raw.iter().any(|r| r.len() != f_in) {
             return Err(PyValueError::new_err("all feature rows must have the same length"));
@@ -3733,6 +3791,7 @@ impl DMR {
                         nf - 1
                     )));
                 }
+                check_all_finite_arr2("features", &x)?;
                 (0..docs_usize.len())
                     .map(|d| {
                         (0..k)
@@ -3943,6 +4002,7 @@ impl LabeledLDA {
         if num_docs == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         if labels.len() != num_docs {
             return Err(PyValueError::new_err(format!(
                 "labels has {} entries but corpus has {} documents",
@@ -4513,6 +4573,7 @@ impl SAGE {
         if num_docs == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
 
         let groups_str = parse_groups(groups)?;
         if groups_str.len() != num_docs {
@@ -4819,7 +4880,7 @@ impl SAGE {
             }
         };
         let mut idx: Vec<usize> = (0..vocab.len()).collect();
-        idx.sort_by(|&a, &b| dist[b].partial_cmp(&dist[a]).unwrap());
+        idx.sort_by(|&a, &b| f64::total_cmp(&dist[b], &dist[a]));
         let items: Vec<Bound<'py, PyTuple>> = idx
             .iter()
             .take(n)
@@ -4853,7 +4914,7 @@ impl SAGE {
             .map(|v| (a[v].max(1e-300) / b[v].max(1e-300)).ln())
             .collect();
         let mut idx: Vec<usize> = (0..vocab.len()).collect();
-        idx.sort_by(|&x, &y| ratio[y].partial_cmp(&ratio[x]).unwrap());
+        idx.sort_by(|&x, &y| f64::total_cmp(&ratio[y], &ratio[x]));
         let items: Vec<Bound<'py, PyTuple>> = idx
             .iter()
             .take(n)
@@ -5223,6 +5284,7 @@ impl CTM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         let svi = match inference {
             "batch" => false,
             "svi" => true,
@@ -5684,6 +5746,7 @@ impl STM {
         if num_docs == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         if prevalence.is_none() && content.is_none() {
             return Err(PyValueError::new_err(
                 "STM needs prevalence and/or content covariates; use CTM for neither",
@@ -5702,6 +5765,7 @@ impl STM {
                     num_docs
                 )));
             }
+            check_all_finite_2d("prevalence", &raw)?;
             let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
             if raw.iter().any(|r| r.len() != f_in) {
                 return Err(PyValueError::new_err("all prevalence rows must have the same length"));
@@ -6018,7 +6082,7 @@ impl STM {
             .map(|v| (a[v].max(1e-300) / b[v].max(1e-300)).ln())
             .collect();
         let mut idx: Vec<usize> = (0..vocab.len()).collect();
-        idx.sort_by(|&x, &y| ratio[y].partial_cmp(&ratio[x]).unwrap());
+        idx.sort_by(|&x, &y| f64::total_cmp(&ratio[y], &ratio[x]));
         let items: Vec<Bound<'py, PyTuple>> = idx
             .iter()
             .take(n)
@@ -6503,6 +6567,7 @@ impl STS {
         kappa_estimation: &str,
         kappa_ridge: f64,
     ) -> PyResult<()> {
+        require_iters(iters, "iters")?;
         let kappa_est = match kappa_estimation {
             "lasso" => sts::KappaEst::Lasso { nlambda: 100, lambda_min_ratio: 0.001 },
             "ridge" => sts::KappaEst::Ridge(kappa_ridge),
@@ -6544,6 +6609,7 @@ impl STS {
                     num_docs
                 )));
             }
+            check_all_finite_2d("prevalence", &raw)?;
             let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
             if raw.iter().any(|r| r.len() != f_in) {
                 return Err(PyValueError::new_err("all prevalence rows must have the same length"));
@@ -7016,6 +7082,7 @@ impl HDP {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
 
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
@@ -7421,6 +7488,7 @@ impl DTM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         if times.len() != corpus.num_docs() {
             return Err(PyValueError::new_err(format!(
                 "times has length {} but there are {} documents",
@@ -7533,7 +7601,7 @@ impl DTM {
         let vocab = &self.corpus.as_ref().unwrap().id_to_word;
         let row = &self.topic_words.as_ref().unwrap()[time][topic];
         let mut idx: Vec<usize> = (0..row.len()).collect();
-        idx.sort_by(|&a, &b| row[b].partial_cmp(&row[a]).unwrap());
+        idx.sort_by(|&a, &b| f64::total_cmp(&row[b], &row[a]));
         Ok(idx.into_iter().take(n).map(|w| (vocab[w].clone(), row[w])).collect())
     }
 
@@ -7567,7 +7635,7 @@ impl DTM {
         let a = &tw[from_time][topic];
         let b = &tw[to][topic];
         let mut deltas: Vec<(usize, f64)> = (0..a.len()).map(|w| (w, b[w] - a[w])).collect();
-        deltas.sort_by(|x, y| y.1.partial_cmp(&x.1).unwrap()); // descending by delta
+        deltas.sort_by(|x, y| f64::total_cmp(&y.1, &x.1)); // descending by delta
 
         let to_pairs = |items: Vec<(usize, f64)>| -> Vec<(String, f64)> {
             items.into_iter().map(|(w, d)| (vocab[w].clone(), d)).collect()
@@ -7785,6 +7853,7 @@ impl SupervisedLDA {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         if y.len() != corpus.num_docs() {
             return Err(PyValueError::new_err(format!(
                 "y has length {} but there are {} documents",
@@ -8201,6 +8270,7 @@ impl PT {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (k, p, a, b) = (self.num_topics, self.num_pseudo, self.alpha, self.beta);
@@ -8467,6 +8537,7 @@ impl GSDMM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         let num_types = corpus.num_types();
         let (k, a, b) = (self.k_max, self.alpha, self.beta);
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
@@ -8808,6 +8879,7 @@ impl SeededLDA {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         let num_topics = self.num_topics_val();
         let num_types = corpus.num_types();
         let seeds = seed_word_ids(&self.seed_words, &corpus.id_to_word, num_topics);
@@ -9314,6 +9386,7 @@ impl Top2Vec {
                 corpus.num_docs()
             )));
         }
+        check_all_finite_2d("doc_embeddings", &doc_emb)?;
         let num_types = corpus.num_types();
 
         // Realign user word embeddings to topica's vocabulary order; words topica
@@ -9331,6 +9404,7 @@ impl Top2Vec {
                         vocab.len()
                     )));
                 }
+                check_all_finite_2d("word_embeddings", &rows)?;
                 let e = rows.first().map(|r| r.len()).unwrap_or(0);
                 let map: std::collections::HashMap<&str, usize> =
                     vocab.iter().enumerate().map(|(i, w)| (w.as_str(), i)).collect();
@@ -9445,6 +9519,12 @@ impl Top2Vec {
         representation: Option<&str>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let m = self.fitted_model()?;
+        if m.num_topics == 0 {
+            return Err(PyRuntimeError::new_err(
+                "model found no topics (num_topics=0); refit with a smaller \
+                 min_cluster_size or more data",
+            ));
+        }
         let rep = match representation {
             Some(r) => r,
             None if self.has_word_vectors => "centroid",
@@ -9553,6 +9633,12 @@ impl Top2Vec {
         doc_embeddings: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
         let m = self.fitted_model()?;
+        if m.num_topics == 0 {
+            return Err(PyRuntimeError::new_err(
+                "model found no topics (num_topics=0); refit with a smaller \
+                 min_cluster_size or more data",
+            ));
+        }
         let _ = data;
         let de = parse_features(doc_embeddings)?;
         Ok(vecs_to_arr2(&m.assign(&de)).to_pyarray_bound(py))
@@ -9819,6 +9905,7 @@ impl BERTopic {
                 corpus.num_docs()
             )));
         }
+        check_all_finite_2d("doc_embeddings", &doc_emb)?;
         let num_types = corpus.num_types();
         self.id_to_word = corpus.id_to_word.clone();
         self.docs = corpus.docs.clone();
@@ -9900,6 +9987,12 @@ impl BERTopic {
         topic: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let m = self.fitted_model()?;
+        if m.num_topics == 0 {
+            return Err(PyRuntimeError::new_err(
+                "model found no topics (num_topics=0); refit with a smaller \
+                 min_cluster_size or more data",
+            ));
+        }
         let phi = vecs_to_arr2(&m.topic_word);
         topic_words_helper(py, &phi, &self.id_to_word, m.num_topics, n, topic)
     }
@@ -9947,6 +10040,12 @@ impl BERTopic {
         stride: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
         let m = self.fitted_model()?;
+        if m.num_topics == 0 {
+            return Err(PyRuntimeError::new_err(
+                "model found no topics (num_topics=0); refit with a smaller \
+                 min_cluster_size or more data",
+            ));
+        }
         let docs_str: Vec<Vec<String>> = if let Ok(c) = data.extract::<Corpus>() {
             c.inner.docs.iter().map(|d| d.iter().map(|&w| c.inner.id_to_word[w as usize].clone()).collect()).collect()
         } else {
@@ -10331,6 +10430,7 @@ impl ETM {
                 vocabulary.len()
             )));
         }
+        check_all_finite_2d("word_embeddings", &rho)?;
         if vocabulary.len() < self.num_topics {
             return Err(PyValueError::new_err("vocabulary must have at least num_topics words"));
         }
@@ -11152,6 +11252,7 @@ impl FASTopic {
                 corpus.num_docs()
             )));
         }
+        check_all_finite_2d("doc_embeddings", &doc_emb)?;
         let num_types = corpus.num_types();
         if num_types < self.num_topics {
             return Err(PyValueError::new_err("vocabulary must have at least num_topics words"));
@@ -11574,6 +11675,7 @@ impl KeyATM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         let num_topics = self.num_topics;
         let num_types = corpus.num_types();
         // Thinned θ-draw retention schedule (issue #31), shared by all three fits.
@@ -11718,6 +11820,7 @@ impl KeyATM {
                         corpus.num_docs()
                     )));
                 }
+                check_all_finite_2d("covariates", &raw)?;
                 let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
                 if raw.iter().any(|r| r.len() != f_in) {
                     return Err(PyValueError::new_err("all covariate rows must have the same length"));
@@ -11767,6 +11870,7 @@ impl KeyATM {
                         "prior_offset must have {num_topics} columns (one per topic)"
                     )));
                 }
+                check_all_finite_2d("prior_offset", &off)?;
                 Some(off)
             }
             None => None,
@@ -12187,6 +12291,7 @@ impl PA {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        require_iters(iters, "iters")?;
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (s, k, a, b) = (self.num_super, self.num_sub, self.alpha, self.beta);
@@ -12570,7 +12675,7 @@ impl HLDA {
         let vocab = &self.corpus.as_ref().unwrap().id_to_word;
         let v = tw.shape()[1];
         let mut idx: Vec<usize> = (0..v).collect();
-        idx.sort_by(|&a, &b| tw[[node, b]].partial_cmp(&tw[[node, a]]).unwrap());
+        idx.sort_by(|&a, &b| f64::total_cmp(&tw[[node, b]], &tw[[node, a]]));
         Ok(idx.into_iter().take(n).map(|w| (vocab[w].clone(), tw[[node, w]])).collect())
     }
 
@@ -12642,4 +12747,86 @@ fn _topica(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add("DEFAULT_TOKEN_REGEX", corpus::DEFAULT_TOKEN_REGEX)?;
     m.add("__version__", env!("CARGO_PKG_VERSION"))?;
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use numpy::ndarray::Array2;
+
+    #[test]
+    fn check_all_finite_2d_accepts_clean_data() {
+        let rows = vec![vec![1.0, 2.0], vec![3.0, 4.0]];
+        assert!(check_all_finite_2d("x", &rows).is_ok());
+    }
+
+    #[test]
+    fn check_all_finite_2d_rejects_nan() {
+        let rows = vec![vec![1.0, f64::NAN], vec![3.0, 4.0]];
+        let err = check_all_finite_2d("prevalence", &rows).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("prevalence"), "message should name the parameter");
+        assert!(msg.contains("non-finite"), "message should mention non-finite");
+        assert!(msg.contains("row 0"), "message should include row number");
+    }
+
+    #[test]
+    fn check_all_finite_2d_rejects_inf() {
+        let rows = vec![vec![0.0, f64::INFINITY]];
+        assert!(check_all_finite_2d("features", &rows).is_err());
+    }
+
+    #[test]
+    fn check_all_finite_1d_accepts_clean_data() {
+        assert!(check_all_finite_1d("timestamps", &[1.0, 2.0, 3.0]).is_ok());
+    }
+
+    #[test]
+    fn check_all_finite_1d_rejects_nan() {
+        let vals = vec![1.0, f64::NAN, 3.0];
+        let err = check_all_finite_1d("timestamps", &vals).unwrap_err();
+        assert!(err.to_string().contains("timestamps"));
+    }
+
+    #[test]
+    fn check_all_finite_arr2_accepts_clean() {
+        let arr = Array2::from_shape_vec((2, 2), vec![1.0, 2.0, 3.0, 4.0]).unwrap();
+        assert!(check_all_finite_arr2("features", &arr.view()).is_ok());
+    }
+
+    #[test]
+    fn check_all_finite_arr2_rejects_nan() {
+        let arr = Array2::from_shape_vec((2, 2), vec![1.0, f64::NAN, 3.0, 4.0]).unwrap();
+        let err = check_all_finite_arr2("features", &arr.view()).unwrap_err();
+        assert!(err.to_string().contains("features"));
+    }
+
+    #[test]
+    fn require_iters_accepts_positive() {
+        assert!(require_iters(1, "iters").is_ok());
+        assert!(require_iters(1000, "iters").is_ok());
+    }
+
+    #[test]
+    fn require_iters_rejects_zero() {
+        let err = require_iters(0, "iters").unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("iters"), "message should name the parameter");
+        assert!(msg.contains("0"), "message should include the bad value");
+    }
+
+    #[test]
+    fn total_cmp_sort_with_nan_does_not_panic() {
+        // A NaN in a float slice should sort without panicking when using total_cmp.
+        let data = vec![3.0f64, f64::NAN, 1.0, 2.0];
+        let mut idx: Vec<usize> = (0..data.len()).collect();
+        // Descending sort: using total_cmp equivalent pattern.
+        idx.sort_by(|&a, &b| f64::total_cmp(&data[b], &data[a]));
+        // NaN is larger than any finite value under total_cmp, so it sorts to position 0.
+        assert_eq!(idx[0], 1); // NaN is "greatest" under total_cmp
+    }
 }

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -129,3 +129,35 @@ class TestAnalysisContract:
         )
         assert topica.topic_diversity(c) == topica.topic_diversity(m)
         np.testing.assert_allclose(topica.exclusivity(c), topica.exclusivity(m))
+
+
+class TestUMassExternalCorpus:
+    """u_mass with an external reference corpus that does not contain some top
+    words must not produce a spuriously large positive score (issue #103)."""
+
+    def test_absent_word_does_not_inflate_umass(self):
+        # Reference corpus contains only "a" and "b"; "z" is absent.
+        reference = [["a", "b"]] * 20
+        topic_present = ["a", "b"]   # both words in reference: normal score
+        topic_absent = ["a", "z"]    # "z" absent from reference
+
+        s_present = topica.coherence([topic_present], reference,
+                                     coherence_type="u_mass", topn=2)[0]
+        s_absent = topica.coherence([topic_absent], reference,
+                                    coherence_type="u_mass", topn=2)[0]
+
+        # Before the fix, s_absent was a large positive (log(1/eps)).
+        # After the fix: the pair (a, z) is skipped, so s_absent equals
+        # nan (no pairs counted) or a non-positive finite value.
+        assert np.isnan(s_absent) or s_absent <= 0.0, (
+            f"u_mass with absent word should be nan or <= 0, got {s_absent}"
+        )
+
+    def test_umass_all_words_present_is_nonpositive(self):
+        # Classic case: topic words all appear in the reference.
+        reference = [["a", "b", "c"]] * 50
+        score = topica.coherence([["a", "b", "c"]], reference,
+                                 coherence_type="u_mass", topn=3)[0]
+        # UMass is always <= 0 when words are present (log <= 0 since
+        # co + 1 <= occ + 1 <= denom + 1, but occ >= co so denom >= co).
+        assert score <= 0.0 or np.isnan(score)

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -153,11 +153,13 @@ class TestUMassExternalCorpus:
             f"u_mass with absent word should be nan or <= 0, got {s_absent}"
         )
 
-    def test_umass_all_words_present_is_nonpositive(self):
-        # Classic case: topic words all appear in the reference.
+    def test_umass_all_words_present_is_small_and_finite(self):
+        # Classic case: topic words all appear in the reference. With numerator
+        # +1 smoothing and perfect co-occurrence the score can be a hair above
+        # zero (log((occ+1)/occ)), but it is finite and near zero, never the
+        # large spurious positive the absent-word path used to produce.
         reference = [["a", "b", "c"]] * 50
         score = topica.coherence([["a", "b", "c"]], reference,
                                  coherence_type="u_mass", topn=3)[0]
-        # UMass is always <= 0 when words are present (log <= 0 since
-        # co + 1 <= occ + 1 <= denom + 1, but occ >= co so denom >= co).
-        assert score <= 0.0 or np.isnan(score)
+        assert np.isfinite(score)
+        assert score < 0.1

--- a/tests/test_embedding_transform.py
+++ b/tests/test_embedding_transform.py
@@ -58,12 +58,14 @@ def _fit_bertopic_no_clusters():
     """Return a fitted BERTopic that found zero clusters (min_cluster_size too
     large for the data), which is the condition that triggered issue #103."""
     import warnings
-    rng = np.random.default_rng(99)
-    # Very few documents with min_cluster_size larger than the dataset forces
-    # HDBSCAN to find no clusters.
-    docs = [["a", "b"], ["c", "d"]]
+    rng = np.random.default_rng(0)
+    # Structureless (random) embeddings over enough documents that HDBSCAN
+    # runs cleanly but finds no cluster at this min_cluster_size, so num_topics
+    # is 0. (A handful of documents with min_cluster_size above the dataset
+    # size instead panics inside the MST crate; see the follow-up issue.)
+    docs = [["a", "b", "c"], ["b", "c", "d"], ["a", "d", "e"]] * 30
     emb = rng.standard_normal((len(docs), 4))
-    m = topica.BERTopic(min_cluster_size=100, seed=1)
+    m = topica.BERTopic(min_cluster_size=40, seed=1)
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         m.fit(docs, emb)

--- a/tests/test_embedding_transform.py
+++ b/tests/test_embedding_transform.py
@@ -52,3 +52,35 @@ def test_bertopic_transform_and_ctfidf_options():
     for t in range(mb.num_topics):
         blocks = {w.split("w")[0] for w, _ in mb.top_words(4, topic=t)}
         assert len(blocks) == 1
+
+
+def _fit_bertopic_no_clusters():
+    """Return a fitted BERTopic that found zero clusters (min_cluster_size too
+    large for the data), which is the condition that triggered issue #103."""
+    import warnings
+    rng = np.random.default_rng(99)
+    # Very few documents with min_cluster_size larger than the dataset forces
+    # HDBSCAN to find no clusters.
+    docs = [["a", "b"], ["c", "d"]]
+    emb = rng.standard_normal((len(docs), 4))
+    m = topica.BERTopic(min_cluster_size=100, seed=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        m.fit(docs, emb)
+    return m, docs
+
+
+def test_bertopic_zero_clusters_transform_raises():
+    m, docs = _fit_bertopic_no_clusters()
+    if m.num_topics > 0:
+        pytest.skip("clustering found topics with this seed; skip zero-cluster guard test")
+    with pytest.raises(RuntimeError, match="num_topics=0"):
+        m.transform(docs)
+
+
+def test_bertopic_zero_clusters_top_words_raises():
+    m, _ = _fit_bertopic_no_clusters()
+    if m.num_topics > 0:
+        pytest.skip("clustering found topics with this seed; skip zero-cluster guard test")
+    with pytest.raises(RuntimeError, match="num_topics=0"):
+        m.top_words(5)

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -6,6 +6,8 @@ Adversarial inputs must fail loudly, not silently corrupt the fit:
   3. Misusing the diagnostics (raw matrix, non-integer topn) gives a clear error.
   4. coherence on an empty reference corpus errors rather than returning NaN.
   5. frex rejects out-of-range frequency weights.
+  6. NaN/Inf in covariate/embedding matrices raises ValueError (issue #100).
+  7. iters=0 and iters=-1 raise ValueError (issue #103).
 """
 
 import numpy as np
@@ -113,3 +115,107 @@ def test_frex_rejects_bad_weight(model, w):
 def test_frex_valid_weight_works(model):
     out = topica.frex(model, w=0.5)
     assert len(out) == 2 and isinstance(out[0][0][0], str)
+
+
+# --- 6. NaN/Inf in covariate and embedding matrices (issue #100) -----------
+
+BIGGER_DOCS = [["a", "b", "c"], ["b", "c", "d"], ["a", "d", "e"]] * 10
+N = len(BIGGER_DOCS)
+
+
+def _nan_matrix(n, cols=2, nan_row=0, nan_col=0):
+    x = np.ones((n, cols))
+    x[nan_row, nan_col] = float("nan")
+    return x
+
+
+def _inf_matrix(n, cols=2):
+    x = np.ones((n, cols))
+    x[0, 0] = float("inf")
+    return x
+
+
+def test_stm_prevalence_nan_raises():
+    m = topica.STM(num_topics=2, seed=42)
+    prev = _nan_matrix(N)
+    with pytest.raises(ValueError, match="non-finite"):
+        m.fit(BIGGER_DOCS, prevalence=prev, iters=5)
+
+
+def test_stm_prevalence_inf_raises():
+    m = topica.STM(num_topics=2, seed=42)
+    prev = _inf_matrix(N)
+    with pytest.raises(ValueError, match="non-finite"):
+        m.fit(BIGGER_DOCS, prevalence=prev, iters=5)
+
+
+def test_dmr_features_nan_raises():
+    m = topica.DMR(num_topics=2, seed=42)
+    feats = _nan_matrix(N)
+    with pytest.raises(ValueError, match="non-finite"):
+        m.fit(BIGGER_DOCS, feats, iters=5)
+
+
+def test_keyatm_covariates_nan_raises():
+    keywords = {"topic_a": ["a", "b"], "topic_b": ["c", "d"]}
+    m = topica.KeyATM(keywords, seed=42)
+    covs = _nan_matrix(N)
+    with pytest.raises(ValueError, match="non-finite"):
+        m.fit(BIGGER_DOCS, iters=5, covariates=covs)
+
+
+def test_embedding_doc_embeddings_nan_raises():
+    rng = np.random.default_rng(0)
+    docs = BIGGER_DOCS
+    emb = rng.standard_normal((N, 8))
+    emb[2, 3] = float("nan")
+    m = topica.BERTopic(min_cluster_size=5, seed=1)
+    with pytest.raises(ValueError, match="non-finite"):
+        m.fit(docs, emb)
+
+
+def test_embedding_doc_embeddings_valid_passes():
+    rng = np.random.default_rng(0)
+    docs = [["a", "b", "c"], ["b", "c", "d"], ["a", "d", "e"]] * 20
+    emb = rng.standard_normal((len(docs), 4))
+    m = topica.BERTopic(min_cluster_size=5, seed=1)
+    # Should not raise; cluster count may be 0 (just warns).
+    m.fit(docs, emb)
+
+
+# --- 7. iters=0 and iters=-1 raise ValueError (issue #103) ----------------
+
+@pytest.mark.parametrize("bad_iters", [0])
+def test_lda_iters_zero_raises(bad_iters):
+    m = topica.LDA(num_topics=2, seed=42)
+    with pytest.raises(ValueError, match="iters"):
+        m.fit(DOCS, iters=bad_iters)
+
+
+@pytest.mark.parametrize("bad_iters", [0])
+def test_stm_iters_zero_raises(bad_iters):
+    m = topica.STM(num_topics=2, seed=42)
+    prev = np.ones((len(DOCS), 1))
+    with pytest.raises(ValueError, match="iters"):
+        m.fit(DOCS, prevalence=prev, iters=bad_iters)
+
+
+@pytest.mark.parametrize("bad_iters", [0])
+def test_keyatm_iters_zero_raises(bad_iters):
+    keywords = {"topic_a": ["a", "b"], "topic_b": ["c", "d"]}
+    m = topica.KeyATM(keywords, seed=42)
+    with pytest.raises(ValueError, match="iters"):
+        m.fit(DOCS, iters=bad_iters)
+
+
+def test_lda_iters_negative_raises():
+    m = topica.LDA(num_topics=2, seed=42)
+    # Negative iters hits PyO3's OverflowError (usize) or our ValueError for 0.
+    with pytest.raises((ValueError, OverflowError)):
+        m.fit(DOCS, iters=-1)
+
+
+def test_lda_iters_positive_works():
+    m = topica.LDA(num_topics=2, seed=42)
+    m.fit(DOCS, iters=5)
+    assert m.topic_word.shape[0] == 2

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -183,36 +183,21 @@ def test_embedding_doc_embeddings_valid_passes():
     m.fit(docs, emb)
 
 
-# --- 7. iters=0 and iters=-1 raise ValueError (issue #103) ----------------
-
-@pytest.mark.parametrize("bad_iters", [0])
-def test_lda_iters_zero_raises(bad_iters):
-    m = topica.LDA(num_topics=2, seed=42)
-    with pytest.raises(ValueError, match="iters"):
-        m.fit(DOCS, iters=bad_iters)
-
-
-@pytest.mark.parametrize("bad_iters", [0])
-def test_stm_iters_zero_raises(bad_iters):
-    m = topica.STM(num_topics=2, seed=42)
-    prev = np.ones((len(DOCS), 1))
-    with pytest.raises(ValueError, match="iters"):
-        m.fit(DOCS, prevalence=prev, iters=bad_iters)
-
-
-@pytest.mark.parametrize("bad_iters", [0])
-def test_keyatm_iters_zero_raises(bad_iters):
-    keywords = {"topic_a": ["a", "b"], "topic_b": ["c", "d"]}
-    m = topica.KeyATM(keywords, seed=42)
-    with pytest.raises(ValueError, match="iters"):
-        m.fit(DOCS, iters=bad_iters)
-
+# --- 7. iters bounds (issue #103) -----------------------------------------
+# iters=0 is a supported "initialize only" operation (e.g. inspecting the seed
+# prior before any sweep; see test_seeded_gsdmm_contracts), so it is NOT an
+# error. Negative iters is rejected by PyO3's usize conversion (OverflowError).
 
 def test_lda_iters_negative_raises():
     m = topica.LDA(num_topics=2, seed=42)
-    # Negative iters hits PyO3's OverflowError (usize) or our ValueError for 0.
     with pytest.raises((ValueError, OverflowError)):
         m.fit(DOCS, iters=-1)
+
+
+def test_lda_iters_zero_is_accepted():
+    m = topica.LDA(num_topics=2, seed=42)
+    m.fit(DOCS, iters=0)  # initialize without sweeping; must not raise
+    assert m.topic_word.shape[0] == 2
 
 
 def test_lda_iters_positive_works():


### PR DESCRIPTION
Closes #100 and #103.

**#100 — non-finite covariates.** A shared finite-check at the PyO3 boundary now rejects NaN/inf in covariate/feature/embedding/timestamp matrices with a clear `ValueError` naming the parameter, applied at every ingest site (STM/STS `prevalence`, DMR `features` in fit and transform, KeyATM `covariates` and `prior_offset`, the embedding models' `doc_embeddings`/`word_embeddings`, and numeric `timestamps`). Previously a single NaN panicked KeyATM in a rayon worker (and could wedge the process) and was silently accepted by STM/DMR.

**#103 — numeric/input robustness.**
- All phi/theta ranking sorts use `f64::total_cmp`, so a stray NaN yields a clean ordering instead of a `PanicException`.
- `BERTopic`/`Top2Vec` raise a clear `RuntimeError` from `transform`/`top_words` when clustering found zero topics, instead of returning empty `(n, 0)` output.
- `u_mass` coherence against an external reference no longer rewards a top word absent from the reference with a large positive score (the absent conditioning word's pair is skipped).

**Note — `iters` bound, deliberately not added.** The audit suggested rejecting `iters=0`, but `iters=0` is a supported "initialize only" operation (the zero-sweep seed-prior contract in `test_seeded_gsdmm_contracts` depends on it), and a `usize` guard could only ever reject that valid case (negatives are already caught by PyO3's `OverflowError`). So no `iters` guard was added; a test now documents that `iters=0` is accepted.

A latent panic in the petal-clustering MST crate on degenerate tiny inputs (fewer documents than `min_cluster_size`) surfaced while testing the zero-cluster guard; filed separately as a follow-up.

Tests: Rust unit tests for the finite-check helpers and a NaN-safe sort; Python tests for NaN/inf rejection across model families, the BERTopic zero-cluster guard, and the u_mass external-corpus case. Verified: `cargo test --lib` 97 pass; full pytest 2044 pass / 18 skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)