### PR TITLE
fix(api): transform iters, SAGE top_words, embedding transform consistency (#104, #105, #106)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Changed
 
+- API consistency: `transform()` now takes `iters` (the canonical name used by
+  `fit()`); the old `iterations=` keyword still works but raises a
+  `DeprecationWarning` (#104). `SAGE.top_words` now matches every other model's
+  shape, `top_words(n=10, *, topic=None, group=None)`, so `n` is the first
+  positional argument and `topic=None` returns all topics; **breaking** for code
+  that passed the topic index positionally (#105). The embedding models share one
+  `transform(data, doc_embeddings=None)` signature and raise a clear `ValueError`
+  when a required input is missing; **breaking** for `FASTopic.transform(emb)`
+  called positionally, which now needs `transform(doc_embeddings=emb)` (#106).
 - **Breaking (save format):** model files now carry an 8-byte header (magic,
   format version, model tag). Loading a file saved by an earlier version, or
   loading a file saved as the wrong model, now raises a clear error instead of

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -284,16 +284,18 @@ class DMR:
         data: Corpus | Sequence[Sequence[str]],
         features: numpy.typing.NDArray[numpy.float64] | None = None,
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer document-topic theta for new documents by collapsed Gibbs
         against the fitted topic-word matrix. `features` (optional, no intercept)
         sets each document's Dirichlet prior alpha_d = exp(Xgamma); if omitted
-        the intercept-only baseline is used. Shape (num_new_docs, num_topics)."""
+        the intercept-only baseline is used. Shape (num_new_docs, num_topics).
+        `iterations` is deprecated; use `iters` instead."""
         ...
 
     @property
@@ -806,15 +808,16 @@ class HDP:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer theta over the discovered topics for new documents by collapsed
         Gibbs against the fixed topic-word matrix. Shape (num_new_docs,
-        num_topics)."""
+        num_topics). `iterations` is deprecated; use `iters` instead."""
         ...
     def __repr__(self) -> str: ...
 
@@ -981,15 +984,17 @@ class SupervisedLDA:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer document-topic theta for new documents by collapsed Gibbs
         against the fitted topic-word matrix (the response is not used). Shape
-        (num_new_docs, num_topics). Predict the response with transform @ eta."""
+        (num_new_docs, num_topics). Predict the response with transform @ eta.
+        `iterations` is deprecated; use `iters` instead."""
         ...
     @property
     def fit_history(self) -> list[tuple[int, float]]:
@@ -1091,11 +1096,17 @@ class SAGE:
     @topic_names.setter
     def topic_names(self, value: list[str]) -> None: ...
 
+    @overload
+    def top_words(self, n: int = ..., *, topic: int, group: str | int | None = ...) -> list[tuple[str, float]]: ...
+    @overload
+    def top_words(self, n: int = ..., *, topic: None = ..., group: str | int | None = ...) -> list[list[tuple[str, float]]]: ...
     def top_words(
-        self, topic: int, *, group: str | int | None = None, n: int = 10
-    ) -> list[tuple[str, float]]:
-        """Top n (word, prob) for a topic; for a given group (name/index) or the
-        group-averaged distribution when group is None."""
+        self, n: int = 10, *, topic: int | None = None, group: str | int | None = None
+    ) -> list[tuple[str, float]] | list[list[tuple[str, float]]]:
+        """Top n (word, prob) pairs. `topic=None` (default) returns a list of
+        lists, one per topic. `topic=k` returns that topic's list. `group`
+        (name or index) selects a group-specific distribution; None uses the
+        group-averaged distribution."""
         ...
 
     def word_contrast(
@@ -1111,16 +1122,18 @@ class SAGE:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer document-topic theta for new documents by collapsed Gibbs against
         the fitted group-averaged topic-word matrix. The group-specific word
         distributions are held fixed and averaged; no group covariate is needed for
-        held-out documents. Shape (num_new_docs, num_topics); rows sum to 1."""
+        held-out documents. Shape (num_new_docs, num_topics); rows sum to 1.
+        `iterations` is deprecated; use `iters` instead."""
         ...
 
     def save(self, path: str) -> None: ...
@@ -1241,15 +1254,17 @@ class LabeledLDA:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer label (topic) proportions theta for new documents by collapsed
         Gibbs against the fitted topic-word matrix, treating every label as
-        available. Shape (num_new_docs, num_topics); columns align with labels."""
+        available. Shape (num_new_docs, num_topics); columns align with labels.
+        `iterations` is deprecated; use `iters` instead."""
         ...
 
     @property
@@ -1475,14 +1490,16 @@ class LDA:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer document-topic distributions for new, unseen documents under
-        the fitted model. Returns shape (num_new_docs, num_topics); rows sum to 1."""
+        the fitted model. Returns shape (num_new_docs, num_topics); rows sum to 1.
+        `iterations` is deprecated; use `iters` instead."""
         ...
 
     def top_documents(self, topic: int, n: int = 10) -> list[tuple[str, float]]:
@@ -1599,16 +1616,18 @@ class PT:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer document-topic theta for new documents by collapsed Gibbs against the
         fitted topic-word matrix. The pseudo-document layer is a training-time device;
         held-out documents infer theta over the K topics directly under the fitted phi.
-        Shape (num_new_docs, num_topics); rows sum to 1."""
+        Shape (num_new_docs, num_topics); rows sum to 1.
+        `iterations` is deprecated; use `iters` instead."""
         ...
     def save(self, path: str) -> None: ...
     @staticmethod
@@ -1766,15 +1785,17 @@ class PA:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer sub-topic proportions for new documents by collapsed Gibbs against the
         fitted sub-topic-word matrix. Projects onto the num_sub sub-topics, marginalizing
-        the super-topic layer. Shape (num_new_docs, num_sub); rows sum to 1."""
+        the super-topic layer. Shape (num_new_docs, num_sub); rows sum to 1.
+        `iterations` is deprecated; use `iters` instead."""
         ...
     def save(self, path: str) -> None: ...
     @staticmethod
@@ -1934,16 +1955,18 @@ class SeededLDA:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer document-topic theta for new documents by collapsed Gibbs against the
         fitted topic-word matrix. The seed-word boost is baked into the fitted phi;
         new documents infer theta under those distributions without re-estimating the
-        seed prior. Shape (num_new_docs, num_topics); rows sum to 1."""
+        seed prior. Shape (num_new_docs, num_topics); rows sum to 1.
+        `iterations` is deprecated; use `iters` instead."""
         ...
     def save(self, path: str) -> None: ...
     @staticmethod
@@ -2018,8 +2041,12 @@ class Top2Vec:
     def transform(
         self,
         data: Corpus | Sequence[Sequence[str]],
-        doc_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]],
-    ) -> numpy.typing.NDArray[numpy.float64]: ...
+        doc_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Assign new documents to topics from their embeddings. `doc_embeddings`
+        is required (raises ValueError if omitted); `data` is accepted for API
+        consistency but not used in assignment. Shape (num_docs, num_topics)."""
+        ...
     def fit_transform(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2102,8 +2129,14 @@ class BERTopic:
         stride: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]: ...
     def transform(
-        self, data: Corpus | Sequence[Sequence[str]]
-    ) -> numpy.typing.NDArray[numpy.float64]: ...
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        doc_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Soft topic distribution for new documents. BERTopic reads topics from
+        text; `doc_embeddings` is accepted for API consistency but not used.
+        Shape (num_docs, num_topics)."""
+        ...
     def fit_transform(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2193,8 +2226,14 @@ class ETM:
     ) -> list[tuple[str, float]] | list[list[tuple[str, float]]]: ...
     def coherence(self, n: int = 10) -> numpy.typing.NDArray[numpy.float64]: ...
     def transform(
-        self, data: Corpus | Sequence[Sequence[str]]
-    ) -> numpy.typing.NDArray[numpy.float64]: ...
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        doc_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Held-out topic proportions for new documents. ETM reads topics from
+        text; `doc_embeddings` is accepted for API consistency but not used.
+        Shape (num_docs, num_topics)."""
+        ...
     def fit_transform(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2340,8 +2379,14 @@ class FASTopic:
     ) -> list[tuple[str, float]] | list[list[tuple[str, float]]]: ...
     def coherence(self, n: int = 10) -> numpy.typing.NDArray[numpy.float64]: ...
     def transform(
-        self, doc_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]]
-    ) -> numpy.typing.NDArray[numpy.float64]: ...
+        self,
+        data: Corpus | Sequence[Sequence[str]] | None = None,
+        doc_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Held-out topic proportions from document embeddings. `doc_embeddings`
+        is required (raises ValueError if omitted); `data` is accepted for API
+        consistency but not used. Shape (num_docs, num_topics)."""
+        ...
     def fit_transform(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2542,17 +2587,19 @@ class KeyATM:
         self,
         data: Corpus | Sequence[Sequence[str]],
         *,
-        iterations: int = 100,
+        iters: int = 100,
         burn_in: int = 10,
         num_samples: int = 10,
         sample_interval: int = 5,
         seed: int | None = None,
+        iterations: int | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Infer document-topic theta for new documents by collapsed Gibbs against the
         fitted effective topic-word matrix. The effective P(w|topic) already marginalizes
         over the keyword switch; held-out inference does not re-estimate the switch for
         new tokens. Uses the estimated asymmetric alpha when available. Shape
-        (num_new_docs, num_topics); rows sum to 1."""
+        (num_new_docs, num_topics); rows sum to 1.
+        `iterations` is deprecated; use `iters` instead."""
         ...
     def save(self, path: str) -> None: ...
     @staticmethod

--- a/src/python.rs
+++ b/src/python.rs
@@ -2016,18 +2016,20 @@ impl LDA {
     /// string (OOV dropped). A document with no in-vocabulary tokens gets the
     /// prior θ. Returns an array of shape ``(num_new_docs, num_topics)`` whose
     /// rows sum to 1.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iterations = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let (docs, _n, _oov) = self.map_heldout(data)?;
         let model = self.model.as_ref().unwrap();
@@ -2889,6 +2891,37 @@ fn infer_theta_gibbs<R: Rng>(
     theta
 }
 
+/// Resolve the `iters`/`iterations` deprecation for `transform()`: if the
+/// caller passed the old `iterations` keyword, emit a `DeprecationWarning` and
+/// use that value; otherwise use `iters`. When both are supplied `iters` wins
+/// (the caller is already using the new name) but the warning still fires.
+fn resolve_iters_deprecated(
+    py: Python<'_>,
+    iters: usize,
+    iterations: Option<usize>,
+) -> PyResult<usize> {
+    if let Some(old_val) = iterations {
+        let warnings = py.import_bound("warnings")?;
+        warnings.call_method1(
+            "warn",
+            (
+                "transform(iterations=) is deprecated; use iters= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ),
+        )?;
+        // iters wins when both are supplied (caller already migrated), but we
+        // still fire the warning because `iterations` was passed explicitly.
+        if iters != 100 {
+            Ok(iters)
+        } else {
+            Ok(old_val)
+        }
+    } else {
+        Ok(iters)
+    }
+}
+
 /// Batch wrapper for [`infer_theta_gibbs`]: maps new docs to ids, runs the
 /// sampler per document (parallel, seeded deterministically per doc), and
 /// returns a ``(num_docs, K)`` array. `alpha` is the length-K prior.
@@ -3736,20 +3769,22 @@ impl DMR {
     /// ``(num_docs, F)`` covariate array matching training, no intercept) sets
     /// each document's Dirichlet prior `α_d = exp(Xγ)`; if omitted the
     /// intercept-only baseline prior is used. Returns ``(num_docs, num_topics)``.
-    #[pyo3(signature = (data, features=None, *, iterations=100, burn_in=10,
-                        num_samples=10, sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, features=None, *, iters=100, burn_in=10,
+                        num_samples=10, sample_interval=5, seed=None, iterations=None))]
     #[allow(clippy::too_many_arguments)]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
         features: Option<PyReadonlyArray2<f64>>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iterations = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let k = self.num_topics;
         let eff = self.feature_effects.as_ref().unwrap(); // (K, F) incl. intercept at col 0
@@ -4345,23 +4380,25 @@ impl LabeledLDA {
     /// (unsupervised inference). `data` is a :class:`Corpus` or
     /// `list[list[str]]`; OOV tokens are dropped. Returns ``(num_docs,
     /// num_topics)``; columns align with :attr:`labels`.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iters = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let alpha = vec![self.alpha; self.num_topics];
         transform_gibbs(
             py, data, &self.corpus.as_ref().unwrap().id_to_word, self.phi.as_ref().unwrap(),
-            &alpha, iterations, burn_in, num_samples, sample_interval,
+            &alpha, iters, burn_in, num_samples, sample_interval,
             seed.unwrap_or(self.seed),
         )
     }
@@ -4835,42 +4872,59 @@ impl SAGE {
         Ok(self.num_groups)
     }
 
-    /// Top `n` words for a topic. With `group` (name or index) given, uses that
-    /// group's word distribution; otherwise the group-averaged distribution.
-    #[pyo3(signature = (topic, *, group=None, n=10))]
+    /// Top `n` words per topic. `topic=None` (default) returns a list of lists
+    /// (one per topic); `topic=k` returns the list for topic k. With `group`
+    /// (name or index) given, uses that group's word distribution; otherwise the
+    /// group-averaged distribution is used.
+    #[pyo3(signature = (n=10, *, topic=None, group=None))]
     fn top_words<'py>(
         &self,
         py: Python<'py>,
-        topic: usize,
-        group: Option<&Bound<'py, PyAny>>,
         n: usize,
-    ) -> PyResult<Bound<'py, PyList>> {
+        topic: Option<usize>,
+        group: Option<&Bound<'py, PyAny>>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
-        if topic >= self.num_topics {
-            return Err(PyValueError::new_err(format!(
-                "topic {} out of range (num_topics={})",
-                topic, self.num_topics
-            )));
-        }
         let vocab = &self.corpus.as_ref().unwrap().id_to_word;
-        let dist: Vec<f64> = match group {
-            Some(gobj) => {
-                let gi = self.resolve_group(gobj)?;
-                self.beta[topic * self.num_groups + gi].clone()
+
+        // Helper: top-n words for a single topic index.
+        let top_for = |t: usize| -> PyResult<Bound<'py, PyList>> {
+            if t >= self.num_topics {
+                return Err(PyValueError::new_err(format!(
+                    "topic {} out of range (num_topics={})",
+                    t, self.num_topics
+                )));
             }
-            None => {
-                let m = self.topic_marginal();
-                (0..vocab.len()).map(|v| m[[topic, v]]).collect()
-            }
+            let dist: Vec<f64> = match group {
+                Some(gobj) => {
+                    let gi = self.resolve_group(gobj)?;
+                    self.beta[t * self.num_groups + gi].clone()
+                }
+                None => {
+                    let m = self.topic_marginal();
+                    (0..vocab.len()).map(|v| m[[t, v]]).collect()
+                }
+            };
+            let mut idx: Vec<usize> = (0..vocab.len()).collect();
+            idx.sort_by(|&a, &b| f64::total_cmp(&dist[b], &dist[a]));
+            let items: Vec<Bound<'py, PyTuple>> = idx
+                .iter()
+                .take(n)
+                .map(|&v| {
+                    PyTuple::new_bound(py, &[vocab[v].clone().into_py(py), dist[v].into_py(py)])
+                })
+                .collect();
+            Ok(PyList::new_bound(py, items))
         };
-        let mut idx: Vec<usize> = (0..vocab.len()).collect();
-        idx.sort_by(|&a, &b| f64::total_cmp(&dist[b], &dist[a]));
-        let items: Vec<Bound<'py, PyTuple>> = idx
-            .iter()
-            .take(n)
-            .map(|&v| PyTuple::new_bound(py, &[vocab[v].clone().into_py(py), dist[v].into_py(py)]))
-            .collect();
-        Ok(PyList::new_bound(py, items))
+
+        match topic {
+            Some(t) => Ok(top_for(t)?.into_any()),
+            None => {
+                let all: Vec<Bound<'py, PyList>> =
+                    (0..self.num_topics).map(top_for).collect::<PyResult<_>>()?;
+                Ok(PyList::new_bound(py, all).into_any())
+            }
+        }
     }
 
     /// Words that most distinguish how `topic` is worded in `group_a` vs
@@ -4963,23 +5017,25 @@ impl SAGE {
     /// a group covariate for new documents. This is a baseline projection;
     /// the group-specific word distributions are a training-time device and
     /// cannot be recovered for documents whose group label is unknown.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iters = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let phi = self.topic_marginal();
         let alpha = vec![self.alpha; self.num_topics];
-        transform_gibbs(py, data, id_to_word, &phi, &alpha, iterations, burn_in,
+        transform_gibbs(py, data, id_to_word, &phi, &alpha, iters, burn_in,
                         num_samples, sample_interval, seed.unwrap_or(self.seed))
     }
 
@@ -7286,24 +7342,26 @@ impl HDP {
     /// :class:`Corpus` or `list[list[str]]`; OOV tokens are dropped. The
     /// document-level prior is symmetric with total mass equal to the learned
     /// concentration α. Returns a ``(num_docs, num_topics)`` array.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iters = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let k = self.num_topics;
         let alpha = vec![self.learned_alpha / k as f64; k];
         transform_gibbs(
             py, data, &self.corpus.as_ref().unwrap().id_to_word, self.beta.as_ref().unwrap(),
-            &alpha, iterations, burn_in, num_samples, sample_interval,
+            &alpha, iters, burn_in, num_samples, sample_interval,
             seed.unwrap_or(self.seed),
         )
     }
@@ -8081,23 +8139,25 @@ impl SupervisedLDA {
     /// unsupervised E-step). `data` is a :class:`Corpus` or `list[list[str]]`;
     /// OOV tokens are dropped. Returns ``(num_docs, num_topics)``. To predict the
     /// response for new documents, take ``transform(data) @ eta``.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iters = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let alpha = vec![self.alpha; self.num_topics];
         transform_gibbs(
             py, data, &self.corpus.as_ref().unwrap().id_to_word, self.beta.as_ref().unwrap(),
-            &alpha, iterations, burn_in, num_samples, sample_interval,
+            &alpha, iters, burn_in, num_samples, sample_interval,
             seed.unwrap_or(self.seed),
         )
     }
@@ -8406,23 +8466,25 @@ impl PT {
     /// aggregation device. Held-out documents infer θ over the K topics
     /// directly under the fitted topic-word matrix, without pseudo-document
     /// assignment.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iters = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let phi = self.phi.as_ref().unwrap();
         let alpha = vec![self.alpha; self.num_topics];
-        transform_gibbs(py, data, id_to_word, phi, &alpha, iterations, burn_in,
+        transform_gibbs(py, data, id_to_word, phi, &alpha, iters, burn_in,
                         num_samples, sample_interval, seed.unwrap_or(self.seed))
     }
 
@@ -9130,24 +9192,26 @@ impl SeededLDA {
     /// **Approximation:** the seed-word boost is baked into the fitted
     /// topic-word matrix. New documents infer θ under those distributions
     /// without re-estimating the seed prior.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iters = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let phi = self.phi.as_ref().unwrap();
         let k = self.num_topics_val();
         let alpha = vec![self.alpha; k];
-        transform_gibbs(py, data, id_to_word, phi, &alpha, iterations, burn_in,
+        transform_gibbs(py, data, id_to_word, phi, &alpha, iters, burn_in,
                         num_samples, sample_interval, seed.unwrap_or(self.seed))
     }
 
@@ -9600,12 +9664,12 @@ impl Top2Vec {
         Ok(Array1::from(umass_coherence(&corpus, &tops)).to_pyarray_bound(py))
     }
 
-    #[pyo3(signature = (data, doc_embeddings))]
+    #[pyo3(signature = (data, doc_embeddings=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        doc_embeddings: &Bound<'py, PyAny>,
+        doc_embeddings: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
         let m = self.fitted_model()?;
         if m.num_topics == 0 {
@@ -9614,8 +9678,11 @@ impl Top2Vec {
                  min_cluster_size or more data",
             ));
         }
+        let de_obj = doc_embeddings.ok_or_else(|| {
+            PyValueError::new_err("Top2Vec.transform requires doc_embeddings")
+        })?;
         let _ = data;
-        let de = parse_features(doc_embeddings)?;
+        let de = parse_features(de_obj)?;
         Ok(vecs_to_arr2(&m.assign(&de)).to_pyarray_bound(py))
     }
 
@@ -10038,13 +10105,17 @@ impl BERTopic {
     }
 
     /// Soft topic distribution for new documents (the approximate distribution
-    /// over their words). BERTopic reads topics from text, so no new embeddings
-    /// are needed. Returns `(num_docs, num_topics)`.
+    /// over their words). BERTopic reads topics from text; `doc_embeddings` is
+    /// accepted but not used (for API consistency with the other embedding
+    /// models). Returns `(num_docs, num_topics)`.
+    #[pyo3(signature = (data, doc_embeddings=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
-        data: &Bound<'_, PyAny>,
+        data: &Bound<'py, PyAny>,
+        doc_embeddings: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let _ = doc_embeddings;
         self.approximate_distribution(py, data, None, None)
     }
 
@@ -10686,12 +10757,17 @@ impl ETM {
     /// Held-out topic proportions for new documents. For the EM path this is the
     /// logistic-normal E-step with the fitted `beta` and prior held fixed; for the
     /// VAE path it is a single encoder forward pass (`theta = softmax(mu)`). Tokens
-    /// outside the vocabulary are dropped. Returns `(num_docs, num_topics)`.
+    /// outside the vocabulary are dropped. `doc_embeddings` is accepted but not
+    /// used (for API consistency with the other embedding models). Returns
+    /// `(num_docs, num_topics)`.
+    #[pyo3(signature = (data, doc_embeddings=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
+        doc_embeddings: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let _ = doc_embeddings;
         self.ensure_fitted()?;
         let docs = docs_to_ids(data, &self.id_to_word)?;
         if let Some(m) = &self.vae {
@@ -11347,14 +11423,22 @@ impl FASTopic {
 
     /// Held-out topic proportions for new documents from their embeddings
     /// (`(n, E)`): the reference's distance-softmax over the fitted topic
-    /// embeddings, normalized by the training documents. Returns `(n, num_topics)`.
+    /// embeddings, normalized by the training documents. `data` is accepted but
+    /// not used (for API consistency with the other embedding models);
+    /// `doc_embeddings` is required. Returns `(n, num_topics)`.
+    #[pyo3(signature = (data=None, doc_embeddings=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
-        doc_embeddings: &Bound<'py, PyAny>,
+        data: Option<&Bound<'py, PyAny>>,
+        doc_embeddings: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let _ = data;
+        let de_obj = doc_embeddings.ok_or_else(|| {
+            PyValueError::new_err("FASTopic.transform requires doc_embeddings")
+        })?;
         let m = self.fitted_model()?;
-        let doc_emb = parse_features(doc_embeddings)?;
+        let doc_emb = parse_features(de_obj)?;
         Ok(vecs_to_arr2(&m.transform(&doc_emb)).to_pyarray_bound(py))
     }
 
@@ -12152,18 +12236,20 @@ impl KeyATM {
     /// estimated asymmetric document-topic prior α (falling back to the
     /// symmetric base value when α was not estimated). The keyword switch
     /// variable is not re-estimated for new tokens.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iters = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let phi = self.phi.as_ref().unwrap();
@@ -12171,7 +12257,7 @@ impl KeyATM {
             Some(v) => v.clone(),
             None => vec![self.alpha; self.num_topics],
         };
-        transform_gibbs(py, data, id_to_word, phi, &alpha, iterations, burn_in,
+        transform_gibbs(py, data, id_to_word, phi, &alpha, iters, burn_in,
                         num_samples, sample_interval, seed.unwrap_or(self.seed))
     }
 
@@ -12440,23 +12526,25 @@ impl PA {
     /// fitted sub-topics, marginalizing the super-topic layer. The
     /// super-topic assignments are a training-time device and are not
     /// re-estimated for new documents.
-    #[pyo3(signature = (data, *, iterations=100, burn_in=10, num_samples=10,
-                        sample_interval=5, seed=None))]
+    #[pyo3(signature = (data, *, iters=100, burn_in=10, num_samples=10,
+                        sample_interval=5, seed=None, iterations=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
-        iterations: usize,
+        iters: usize,
         burn_in: usize,
         num_samples: usize,
         sample_interval: usize,
         seed: Option<u64>,
+        iterations: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let iters = resolve_iters_deprecated(py, iters, iterations)?;
         self.require_fitted()?;
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let phi = self.phi.as_ref().unwrap();
         let alpha = vec![self.alpha; self.num_sub];
-        transform_gibbs(py, data, id_to_word, phi, &alpha, iterations, burn_in,
+        transform_gibbs(py, data, id_to_word, phi, &alpha, iters, burn_in,
                         num_samples, sample_interval, seed.unwrap_or(self.seed))
     }
 

--- a/tests/test_embedding_transform.py
+++ b/tests/test_embedding_transform.py
@@ -86,3 +86,94 @@ def test_bertopic_zero_clusters_top_words_raises():
         pytest.skip("clustering found topics with this seed; skip zero-cluster guard test")
     with pytest.raises(RuntimeError, match="num_topics=0"):
         m.top_words(5)
+
+
+# ---------------------------------------------------------------------------
+# #106: all four embedding models share transform(data, doc_embeddings=None)
+# ---------------------------------------------------------------------------
+
+class TestEmbeddingTransformSignature:
+    """Verify the canonical transform(data, doc_embeddings=None) signature
+    for the four embedding models: correct inputs work, missing required
+    inputs raise ValueError."""
+
+    @pytest.fixture(scope="class")
+    def setup(self):
+        docs, vocab, word_emb, doc_emb = _setup()
+        return docs, vocab, word_emb, doc_emb
+
+    def test_etm_transform_with_data_only(self, setup):
+        docs, vocab, word_emb, _ = setup
+        m = topica.ETM(num_topics=3, seed=1)
+        m.fit(docs, word_emb, vocab, iters=30)
+        result = m.transform(docs[:5])
+        assert result.shape == (5, 3)
+
+    def test_etm_transform_ignores_doc_embeddings(self, setup):
+        """ETM.transform does not use doc_embeddings; passing it is a no-op."""
+        docs, vocab, word_emb, doc_emb = setup
+        m = topica.ETM(num_topics=3, seed=1)
+        m.fit(docs, word_emb, vocab, iters=30)
+        result_a = m.transform(docs[:5])
+        result_b = m.transform(docs[:5], doc_emb[:5])
+        np.testing.assert_array_equal(result_a, result_b)
+
+    def test_bertopic_transform_with_data_only(self, setup):
+        docs, _, _, doc_emb = setup
+        m = topica.BERTopic(min_cluster_size=8, seed=1)
+        m.fit(docs, doc_emb)
+        if m.num_topics == 0:
+            pytest.skip("no clusters found; skip transform test")
+        result = m.transform(docs[:5])
+        assert result.shape == (5, m.num_topics)
+
+    def test_bertopic_transform_ignores_doc_embeddings(self, setup):
+        """BERTopic.transform does not use doc_embeddings; passing it is a no-op."""
+        docs, _, _, doc_emb = setup
+        m = topica.BERTopic(min_cluster_size=8, seed=1)
+        m.fit(docs, doc_emb)
+        if m.num_topics == 0:
+            pytest.skip("no clusters found; skip transform test")
+        result_a = m.transform(docs[:5])
+        result_b = m.transform(docs[:5], doc_emb[:5])
+        np.testing.assert_array_equal(result_a, result_b)
+
+    def test_top2vec_transform_with_both_args(self, setup):
+        docs, vocab, word_emb, doc_emb = setup
+        m = topica.Top2Vec(min_cluster_size=8, seed=1)
+        m.fit(docs, doc_emb, word_embeddings=word_emb, vocabulary=vocab)
+        if m.num_topics == 0:
+            pytest.skip("no clusters found; skip transform test")
+        result = m.transform(docs[:5], doc_emb[:5])
+        assert result.shape == (5, m.num_topics)
+
+    def test_top2vec_transform_missing_doc_embeddings_raises(self, setup):
+        docs, vocab, word_emb, doc_emb = setup
+        m = topica.Top2Vec(min_cluster_size=8, seed=1)
+        m.fit(docs, doc_emb, word_embeddings=word_emb, vocabulary=vocab)
+        if m.num_topics == 0:
+            pytest.skip("no clusters found; skip ValueError guard test")
+        with pytest.raises(ValueError, match="doc_embeddings"):
+            m.transform(docs[:5])
+
+    def test_fastopic_transform_with_doc_embeddings(self, setup):
+        docs, _, _, doc_emb = setup
+        m = topica.FASTopic(num_topics=3, seed=1)
+        m.fit(docs, doc_emb, iters=20)
+        result = m.transform(doc_embeddings=doc_emb[:5])
+        assert result.shape == (5, 3)
+
+    def test_fastopic_transform_data_positional_doc_embeddings_kwarg(self, setup):
+        docs, _, _, doc_emb = setup
+        m = topica.FASTopic(num_topics=3, seed=1)
+        m.fit(docs, doc_emb, iters=20)
+        # data is first positional but ignored; doc_embeddings is second or kwarg
+        result = m.transform(None, doc_emb[:5])
+        assert result.shape == (5, 3)
+
+    def test_fastopic_transform_missing_doc_embeddings_raises(self, setup):
+        docs, _, _, doc_emb = setup
+        m = topica.FASTopic(num_topics=3, seed=1)
+        m.fit(docs, doc_emb, iters=20)
+        with pytest.raises(ValueError, match="doc_embeddings"):
+            m.transform(docs[:5])

--- a/tests/test_fastopic.py
+++ b/tests/test_fastopic.py
@@ -64,7 +64,7 @@ def test_transform_held_out():
     m.fit(docs, doc_emb, iters=200)
     # One clean embedding per block; each should land on a distinct topic.
     new = np.array([np.eye(8)[b] * 3.0 for b in range(3)])
-    theta = m.transform(new)
+    theta = m.transform(doc_embeddings=new)
     assert theta.shape == (3, 3)
     assert np.allclose(theta.sum(axis=1), 1.0)
     assert len(set(theta.argmax(axis=1))) == 3

--- a/tests/test_phase6_transform.py
+++ b/tests/test_phase6_transform.py
@@ -55,24 +55,24 @@ class TestKeyATMTransform:
         return m
 
     def test_shape(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert out.shape == (len(HELD_OUT), model.num_topics)
 
     def test_rows_sum_to_one(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert _rows_sum_to_one(out)
 
     def test_oov_only_doc_is_valid(self, model):
         """A document with no in-vocabulary tokens gets the prior row (sums to 1)."""
-        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+        out = model.transform([["unknown_xyz"]], iters=20, burn_in=5,
                               num_samples=5, sample_interval=2, seed=0)
         assert out.shape == (1, model.num_topics)
         assert _rows_sum_to_one(out)
 
     def test_deterministic(self, model):
-        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        kw = dict(iters=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
         a = model.transform(HELD_OUT, **kw)
         b = model.transform(HELD_OUT, **kw)
         np.testing.assert_array_equal(a, b)
@@ -103,23 +103,23 @@ class TestSeededLDATransform:
         return m
 
     def test_shape(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert out.shape == (len(HELD_OUT), model.num_topics)
 
     def test_rows_sum_to_one(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert _rows_sum_to_one(out)
 
     def test_oov_only_doc_is_valid(self, model):
-        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+        out = model.transform([["unknown_xyz"]], iters=20, burn_in=5,
                               num_samples=5, sample_interval=2, seed=0)
         assert out.shape == (1, model.num_topics)
         assert _rows_sum_to_one(out)
 
     def test_deterministic(self, model):
-        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        kw = dict(iters=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
         a = model.transform(HELD_OUT, **kw)
         b = model.transform(HELD_OUT, **kw)
         np.testing.assert_array_equal(a, b)
@@ -150,23 +150,23 @@ class TestSAGETransform:
         return m
 
     def test_shape(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert out.shape == (len(HELD_OUT), model.num_topics)
 
     def test_rows_sum_to_one(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert _rows_sum_to_one(out)
 
     def test_oov_only_doc_is_valid(self, model):
-        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+        out = model.transform([["unknown_xyz"]], iters=20, burn_in=5,
                               num_samples=5, sample_interval=2, seed=0)
         assert out.shape == (1, model.num_topics)
         assert _rows_sum_to_one(out)
 
     def test_deterministic(self, model):
-        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        kw = dict(iters=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
         a = model.transform(HELD_OUT, **kw)
         b = model.transform(HELD_OUT, **kw)
         np.testing.assert_array_equal(a, b)
@@ -185,23 +185,23 @@ class TestPATransform:
 
     def test_shape_is_num_sub(self, model):
         """PA transform returns (n, num_sub), not (n, num_super)."""
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert out.shape == (len(HELD_OUT), model.num_sub)
 
     def test_rows_sum_to_one(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert _rows_sum_to_one(out)
 
     def test_oov_only_doc_is_valid(self, model):
-        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+        out = model.transform([["unknown_xyz"]], iters=20, burn_in=5,
                               num_samples=5, sample_interval=2, seed=0)
         assert out.shape == (1, model.num_sub)
         assert _rows_sum_to_one(out)
 
     def test_deterministic(self, model):
-        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        kw = dict(iters=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
         a = model.transform(HELD_OUT, **kw)
         b = model.transform(HELD_OUT, **kw)
         np.testing.assert_array_equal(a, b)
@@ -219,23 +219,23 @@ class TestPTTransform:
         return m
 
     def test_shape(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert out.shape == (len(HELD_OUT), model.num_topics)
 
     def test_rows_sum_to_one(self, model):
-        out = model.transform(HELD_OUT, iterations=20, burn_in=5, num_samples=5,
+        out = model.transform(HELD_OUT, iters=20, burn_in=5, num_samples=5,
                               sample_interval=2, seed=0)
         assert _rows_sum_to_one(out)
 
     def test_oov_only_doc_is_valid(self, model):
-        out = model.transform([["unknown_xyz"]], iterations=20, burn_in=5,
+        out = model.transform([["unknown_xyz"]], iters=20, burn_in=5,
                               num_samples=5, sample_interval=2, seed=0)
         assert out.shape == (1, model.num_topics)
         assert _rows_sum_to_one(out)
 
     def test_deterministic(self, model):
-        kw = dict(iterations=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
+        kw = dict(iters=20, burn_in=5, num_samples=5, sample_interval=2, seed=42)
         a = model.transform(HELD_OUT, **kw)
         b = model.transform(HELD_OUT, **kw)
         np.testing.assert_array_equal(a, b)

--- a/tests/test_sage.py
+++ b/tests/test_sage.py
@@ -152,7 +152,7 @@ class TestSAGEUnfittedGuards:
     def test_top_words_raises_before_fit(self):
         model = SAGE(2)
         with pytest.raises(RuntimeError, match="not fitted"):
-            model.top_words(0)
+            model.top_words(5)
 
     def test_word_contrast_raises_before_fit(self):
         model = SAGE(2)
@@ -189,19 +189,19 @@ class TestSAGEFitValidation:
         model = SAGE(2, seed=1)
         model.fit(self.docs, self.groups, iters=50, num_samples=1, sample_interval=5)
         with pytest.raises(ValueError):
-            model.top_words(99)
+            model.top_words(5, topic=99)
 
     def test_top_words_unknown_group_name_raises(self):
         model = SAGE(2, seed=1)
         model.fit(self.docs, self.groups, iters=50, num_samples=1, sample_interval=5)
         with pytest.raises(ValueError):
-            model.top_words(0, group="z")
+            model.top_words(5, topic=0, group="z")
 
     def test_top_words_group_index_out_of_range_raises(self):
         model = SAGE(2, seed=1)
         model.fit(self.docs, self.groups, iters=50, num_samples=1, sample_interval=5)
         with pytest.raises(ValueError):
-            model.top_words(0, group=99)
+            model.top_words(5, topic=0, group=99)
 
     def test_word_contrast_topic_out_of_range_raises(self):
         model = SAGE(2, seed=1)
@@ -277,7 +277,7 @@ class TestSAGEGroupSpecificWording:
         """Top words for each topic in the 'en' group are English words."""
         m = bilingual_model
         for t in range(2):
-            top = {w for w, _ in m.top_words(t, group="en", n=7)}
+            top = {w for w, _ in m.top_words(7, topic=t, group="en")}
             assert top <= _EN_VOCAB, (
                 f"Topic {t} en top-words contain non-English words: "
                 f"{top - _EN_VOCAB}"
@@ -287,7 +287,7 @@ class TestSAGEGroupSpecificWording:
         """Top words for each topic in the 'de' group are German words."""
         m = bilingual_model
         for t in range(2):
-            top = {w for w, _ in m.top_words(t, group="de", n=7)}
+            top = {w for w, _ in m.top_words(7, topic=t, group="de")}
             # German vocab + shared word "wind"
             assert top <= _DE_VOCAB, (
                 f"Topic {t} de top-words contain non-German words: "
@@ -298,8 +298,8 @@ class TestSAGEGroupSpecificWording:
         """The top-word sets for 'en' and 'de' should share at most 1 word."""
         m = bilingual_model
         for t in range(2):
-            en_words = {w for w, _ in m.top_words(t, group="en", n=7)}
-            de_words = {w for w, _ in m.top_words(t, group="de", n=7)}
+            en_words = {w for w, _ in m.top_words(7, topic=t, group="en")}
+            de_words = {w for w, _ in m.top_words(7, topic=t, group="de")}
             shared = en_words & de_words
             assert len(shared) <= 1, (
                 f"Topic {t}: en and de top-word sets share too many words: "
@@ -362,21 +362,21 @@ class TestSAGETopWordsByNameVsIndex:
         en_idx = m.groups.index("en")
 
         for t in range(2):
-            tw_de_name = m.top_words(t, group="de", n=5)
-            tw_de_idx  = m.top_words(t, group=de_idx, n=5)
+            tw_de_name = m.top_words(5, topic=t, group="de")
+            tw_de_idx  = m.top_words(5, topic=t, group=de_idx)
             assert tw_de_name == tw_de_idx, (
                 f"top_words(topic={t}, group='de') != top_words(topic={t}, group={de_idx})"
             )
 
-            tw_en_name = m.top_words(t, group="en", n=5)
-            tw_en_idx  = m.top_words(t, group=en_idx, n=5)
+            tw_en_name = m.top_words(5, topic=t, group="en")
+            tw_en_idx  = m.top_words(5, topic=t, group=en_idx)
             assert tw_en_name == tw_en_idx
 
     def test_group_none_returns_marginal(self, bilingual_model):
         """top_words with group=None should return the group-averaged distribution."""
         m = bilingual_model
         for t in range(2):
-            tw_none = m.top_words(t, group=None, n=5)
+            tw_none = m.top_words(5, topic=t, group=None)
             assert isinstance(tw_none, list)
             assert len(tw_none) == 5
             for w, p in tw_none:
@@ -443,8 +443,8 @@ class TestSAGEGroupNames:
         m_de0.fit(docs, groups, group_names=["de", "en"],
                   iters=50, num_samples=1, sample_interval=5)
         # group_names ordering should change which slice is index 0
-        tw_en0_g0 = m_en0.top_words(0, group=0, n=3)
-        tw_en0_gname = m_en0.top_words(0, group="en", n=3)
+        tw_en0_g0 = m_en0.top_words(3, topic=0, group=0)
+        tw_en0_gname = m_en0.top_words(3, topic=0, group="en")
         assert tw_en0_g0 == tw_en0_gname
 
 
@@ -488,7 +488,7 @@ class TestSAGECoherence:
 
 class TestSAGETopWordsStructure:
     def test_top_words_returns_word_prob_tuples(self, bilingual_model):
-        result = bilingual_model.top_words(0, group="en", n=5)
+        result = bilingual_model.top_words(5, topic=0, group="en")
         assert isinstance(result, list)
         assert len(result) == 5
         for w, p in result:
@@ -499,12 +499,12 @@ class TestSAGETopWordsStructure:
     def test_top_words_probabilities_descending(self, bilingual_model):
         for t in range(2):
             for g in ["en", "de"]:
-                probs = [p for _, p in bilingual_model.top_words(t, group=g, n=7)]
+                probs = [p for _, p in bilingual_model.top_words(7, topic=t, group=g)]
                 assert probs == sorted(probs, reverse=True)
 
     def test_top_words_marginal_probabilities_descending(self, bilingual_model):
         for t in range(2):
-            probs = [p for _, p in bilingual_model.top_words(t, n=5)]
+            probs = [p for _, p in bilingual_model.top_words(5, topic=t)]
             assert probs == sorted(probs, reverse=True)
 
     def test_word_contrast_returns_word_log_ratio_tuples(self, bilingual_model):
@@ -523,3 +523,66 @@ class TestSAGETopWordsStructure:
             assert all(lr > 0 for lr in top_lr), (
                 f"Topic {t}: expected positive log-ratios, got {top_lr}"
             )
+
+
+# ---------------------------------------------------------------------------
+# #105: canonical top_words(n=10, *, topic=None, group=None) shape contract
+# ---------------------------------------------------------------------------
+
+class TestSAGETopWordsCanonicalSignature:
+    """Verify that SAGE.top_words now matches the canonical model shape:
+    - top_words(5) returns 5 words per topic (all topics, list of lists)
+    - top_words(5, topic=0) returns just topic 0's 5 words (flat list)
+    - group= still filters by group as before
+    """
+
+    def test_top_words_n_only_returns_all_topics(self, bilingual_model):
+        """top_words(5) returns a list[list] with one entry per topic."""
+        result = bilingual_model.top_words(5)
+        assert isinstance(result, list)
+        assert len(result) == bilingual_model.num_topics
+        for topic_words in result:
+            assert isinstance(topic_words, list)
+            assert len(topic_words) == 5
+            for w, p in topic_words:
+                assert isinstance(w, str)
+                assert isinstance(p, float)
+
+    def test_top_words_5_returns_5_words_per_topic(self, bilingual_model):
+        """Explicit check: top_words(5) gives exactly 5 words for each topic."""
+        result = bilingual_model.top_words(5)
+        for topic_words in result:
+            assert len(topic_words) == 5
+
+    def test_top_words_topic_kwarg_returns_single_list(self, bilingual_model):
+        """top_words(5, topic=0) returns a flat list (not a list of lists)."""
+        result = bilingual_model.top_words(5, topic=0)
+        assert isinstance(result, list)
+        assert len(result) == 5
+        # Each element is a (word, prob) tuple, not a nested list.
+        for item in result:
+            assert isinstance(item, tuple)
+            w, p = item
+            assert isinstance(w, str)
+            assert isinstance(p, float)
+
+    def test_top_words_topic_1_returns_single_list(self, bilingual_model):
+        result = bilingual_model.top_words(5, topic=1)
+        assert isinstance(result, list)
+        assert len(result) == 5
+
+    def test_top_words_with_group_all_topics(self, bilingual_model):
+        """top_words(5, group='en') returns 5 words per topic using en distribution."""
+        result = bilingual_model.top_words(5, group="en")
+        assert len(result) == bilingual_model.num_topics
+        for topic_words in result:
+            assert len(topic_words) == 5
+
+    def test_top_words_with_group_single_topic(self, bilingual_model):
+        """top_words(5, topic=0, group='de') returns the de words for topic 0."""
+        result = bilingual_model.top_words(5, topic=0, group="de")
+        assert isinstance(result, list)
+        assert len(result) == 5
+        words = {w for w, _ in result}
+        # Must be German words (fully disjoint vocabulary)
+        assert words <= _DE_VOCAB

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -155,3 +155,44 @@ def test_transform_deterministic():
     m = topica.LDA(num_topics=2, seed=1)
     m.fit(docs, iters=200)
     np.testing.assert_array_equal(m.transform(NEW, seed=7), m.transform(NEW, seed=7))
+
+
+# ---------------------------------------------------------------------------
+# #104: iters= is canonical; iterations= is a deprecated alias
+# ---------------------------------------------------------------------------
+
+class TestTransformIterationsAlias:
+    """transform(iters=N) and transform(iterations=N) give identical results;
+    the deprecated form emits a DeprecationWarning."""
+
+    def setup_method(self):
+        docs, _ = _two_topic_corpus()
+        self.m = topica.LDA(num_topics=2, seed=1)
+        self.m.fit(docs, iters=200)
+
+    def test_lda_iters_works(self):
+        theta = self.m.transform(NEW, iters=20, seed=0)
+        assert theta.shape == (len(NEW), 2)
+        np.testing.assert_allclose(theta.sum(axis=1), 1.0, atol=1e-6)
+
+    def test_lda_iterations_deprecated_warns(self):
+        with pytest.warns(DeprecationWarning, match="iterations="):
+            theta = self.m.transform(NEW, iterations=20, seed=0)
+        assert theta.shape == (len(NEW), 2)
+
+    def test_lda_iters_and_iterations_same_result(self):
+        """Both aliases must produce numerically identical output for the same seed."""
+        theta_new = self.m.transform(NEW, iters=20, seed=0)
+        with pytest.warns(DeprecationWarning):
+            theta_old = self.m.transform(NEW, iterations=20, seed=0)
+        np.testing.assert_array_equal(theta_new, theta_old)
+
+    def test_dmr_iterations_deprecated_warns(self):
+        """Check a second Gibbs model (DMR) also emits the warning."""
+        docs, is_a = _two_topic_corpus()
+        x = is_a.astype(float).reshape(-1, 1)
+        m = topica.DMR(num_topics=2, seed=1)
+        m.fit(docs, x)
+        with pytest.warns(DeprecationWarning, match="iterations="):
+            theta = m.transform(NEW, iterations=20, seed=0)
+        assert theta.shape == (len(NEW), 2)


### PR DESCRIPTION
Closes #104, #105, #106. Part of the API-consistency pass before the R bindings.

- **#104** `transform()` now uses the canonical `iters` (matching `fit()`); `iterations=` stays as a deprecated alias that emits a `DeprecationWarning`, across all collapsed-Gibbs models.
- **#105** `SAGE.top_words` now matches the canonical `top_words(n=10, *, topic=None, group=None)`: `n` is the first positional arg and `topic=None` returns all topics (like every other model), with the SAGE `group=` dimension preserved. **Breaking** for callers that passed the topic index positionally.
- **#106** The four embedding models share one `transform(data, doc_embeddings=None)` signature and raise a clear `ValueError` when their required input is missing (BERTopic/ETM use `data`; Top2Vec/FASTopic use `doc_embeddings`). **Breaking** for `FASTopic.transform(emb)` positionally, now `transform(doc_embeddings=emb)`.

Stub (`_topica.pyi`) updated for every changed signature. Verified: `cargo test --lib` 97 pass; full pytest 2063 pass / 18 skip (+19 new tests for the aliases, SAGE shape, and embedding guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)