### PR TITLE
feat(api): cross-model naming aliases — convergence_tol, beta, covariates, progress_interval, num_threads (#107)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,18 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Changed
 
+- API naming consistency (with backward-compatible aliases): the convergence
+  tolerance is now `convergence_tol` in `fit()` for every iterative model
+  (`em_tol` still works and warns; for the neural models `convergence_tol` is
+  also accepted in `fit()` and overrides the constructor value). The topic-word
+  prior is `beta` everywhere (`eta` kept as a deprecated alias on HDP/HLDA). A
+  `covariates=` keyword is now accepted on every covariate model as an alias of
+  the domain name (`prevalence=` for STM/STS, `features=` for DMR, which keep
+  working; passing both raises a clear error). Verbosity is `progress_interval`
+  (`report_interval` deprecated on HDP/GSDMM/KeyATM). `num_threads` is accepted
+  in both the constructor and `fit()` (fit overrides) on LDA and KeyATM. SAGE's
+  `burn_in` default is now 200, matching LDA/DMR. `alpha_sum` is unchanged (it
+  is the sum over topics, intentionally distinct from a per-topic `alpha`). (#107)
 - API consistency: `transform()` now takes `iters` (the canonical name used by
   `fit()`); the old `iterations=` keyword still works but raises a
   `DeprecationWarning` (#104). `SAGE.top_words` now matches every other model's

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -196,7 +196,7 @@ class DMR:
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
-        features: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]],
+        features: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
         *,
         feature_names: list[str] | None = None,
         iters: int = 1000,
@@ -206,13 +206,15 @@ class DMR:
         progress_interval: int = 50,
         keep_theta_draws: bool = True,
         num_theta_draws: int = 25,
+        covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
     ) -> None:
         """Fit by collapsed Gibbs with the per-document Dirichlet prior
-        alpha_{d,t} = exp(lambda_t . x_d). `features` is required: an (num_docs, F)
-        covariate matrix (no intercept column — one is prepended), with
-        feature_names naming the F columns. The L-BFGS optimization of lambda runs
-        every optimize_interval sweeps after burn_in; topic-word phi is averaged
-        over num_samples samples taken every sample_interval sweeps."""
+        alpha_{d,t} = exp(lambda_t . x_d). `features` (or `covariates`, a
+        symmetric alias) is required: an (num_docs, F) covariate matrix (no
+        intercept column — one is prepended), with feature_names naming the F
+        columns. The L-BFGS optimization of lambda runs every optimize_interval
+        sweeps after burn_in; topic-word phi is averaged over num_samples samples
+        taken every sample_interval sweeps."""
         ...
 
     @property
@@ -336,23 +338,27 @@ class CTM:
         data: Corpus | Sequence[Sequence[str]],
         *,
         iters: int = 500,
-        em_tol: float = 1e-5,
+        convergence_tol: float = 1e-5,
         inference: str = "batch",
         batch_size: int = 256,
         tau: float = 64.0,
         kappa: float = 0.7,
+        em_tol: Optional[float] = None,
     ) -> None:
         """EM stops once the relative change in the variational bound falls below
-        em_tol or after iters iterations, whichever comes first. Pass em_tol=0
-        to always run iters steps. Check converged and bound afterward.
+        convergence_tol or after iters iterations, whichever comes first. Pass
+        convergence_tol=0 to always run iters steps. Check converged and bound
+        afterward.
 
         inference selects the backend: "batch" (default, full variational EM) or
         "svi" (stochastic/online VB, Hoffman et al. 2013) for very large corpora.
         Under "svi", iters is the number of epochs (passes over the data), and the
         global parameters update from minibatches of batch_size docs with a Robbins-
         Monro step rho_t = (tau + t)^(-kappa). tau (>= 0) and kappa in (0.5, 1] set
-        the learning-rate schedule; em_tol is ignored. SVI does not retain a
-        per-iteration bound trace."""
+        the learning-rate schedule; convergence_tol is ignored. SVI does not retain a
+        per-iteration bound trace.
+
+        em_tol is a deprecated alias for convergence_tol."""
         ...
 
     @property
@@ -449,25 +455,30 @@ class STM:
         content: Sequence[str] | Sequence[int] | None = None,
         content_names: list[str] | None = None,
         iters: int = 500,
-        em_tol: float = 1e-5,
+        convergence_tol: float = 1e-5,
         gamma_prior: str = "pooled",
         gamma_enet: float = 1.0,
+        em_tol: Optional[float] = None,
+        covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
     ) -> None:
-        """Fit. prevalence is (num_docs, F) covariates driving topic proportions
-        (mu_d = X_d gamma; intercept prepended). content is one group label per
-        document, making topic-word distributions vary by group (SAGE). At least
-        one of prevalence/content must be given.
+        """Fit. prevalence (or covariates, a symmetric alias) is (num_docs, F)
+        covariates driving topic proportions (mu_d = X_d gamma; intercept
+        prepended). content is one group label per document, making topic-word
+        distributions vary by group (SAGE). At least one of
+        prevalence/content must be given.
 
         EM stops once the relative change in the variational bound falls below
-        em_tol (R stm's emtol) or after iters iterations, whichever comes
-        first. Pass em_tol=0 to always run iters steps. Check converged and
-        bound afterward.
+        convergence_tol (R stm's emtol) or after iters iterations, whichever
+        comes first. Pass convergence_tol=0 to always run iters steps. Check
+        converged and bound afterward.
 
         gamma_prior controls the prevalence-coefficient regression in the M-step:
         "pooled" (default) uses ridge regression; "l1" uses an elastic-net path
         with AIC-selected penalty, recommended for high-dimensional prevalence
         designs. gamma_enet is the elastic-net mix (1.0 = pure lasso, values in
-        (0,1) add ridge; R stm's gamma.enet). Ignored when gamma_prior="pooled"."""
+        (0,1) add ridge; R stm's gamma.enet). Ignored when gamma_prior="pooled".
+
+        em_tol is a deprecated alias for convergence_tol."""
         ...
 
     @property
@@ -595,22 +606,27 @@ class STS:
         *,
         prevalence_names: list[str] | None = None,
         iters: int = 30,
-        em_tol: float = 1e-5,
+        convergence_tol: float = 1e-5,
         kappa_estimation: str = "ridge",
         kappa_ridge: float = 1e-3,
+        em_tol: Optional[float] = None,
+        covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
     ) -> None:
         """Fit. sentiment_seed (required, one value per document) defines the
         aggregation groups for the topic-word (kappa) Poisson M-step and seeds the
         initial sentiment — e.g. a star rating the sentiment should track.
-        prevalence is (num_docs, F) covariates driving both topic prevalence and
-        sentiment-discourse (alpha_d ~ N(X_d Gamma, Sigma); intercept prepended).
+        prevalence (or covariates, a symmetric alias) is (num_docs, F) covariates
+        driving both topic prevalence and sentiment-discourse (alpha_d ~ N(X_d
+        Gamma, Sigma); intercept prepended).
 
         EM stops once the relative change in the variational bound falls below
-        em_tol or after iters iterations. kappa_estimation chooses the topic-word
-        estimator: "ridge" (default, fast; kappa_ridge sets the ridge) or "lasso"
-        (an L1 Poisson path with AIC-selected penalty, matching the reference R
-        sts exactly at higher cost). Both give the same topics on well-conditioned
-        corpora."""
+        convergence_tol or after iters iterations. kappa_estimation chooses the
+        topic-word estimator: "ridge" (default, fast; kappa_ridge sets the ridge)
+        or "lasso" (an L1 Poisson path with AIC-selected penalty, matching the
+        reference R sts exactly at higher cost). Both give the same topics on
+        well-conditioned corpora.
+
+        em_tol is a deprecated alias for convergence_tol."""
         ...
 
     @property
@@ -704,17 +720,20 @@ class HDP:
         *,
         alpha: float = 0.1,
         gamma: float = 0.1,
-        eta: float = 0.01,
+        beta: float = 0.01,
         seed: int = 42,
         resample_conc: bool = False,
+        eta: Optional[float] = None,
     ) -> None:
         """alpha/gamma are the document- and corpus-level DP concentrations.
         gamma is the dominant lever on the inferred topic count (0.1 is
         conservative; raise it for more topics). resample_conc defaults to False
         (fixed concentrations -> a stable topic count); set it True to adapt the
         concentrations to the data, which is now capped to avoid the runaway
-        topic count it used to cause (issue #68). eta is the topic-word Dirichlet
-        (base measure). alpha, gamma, eta must be > 0."""
+        topic count it used to cause (issue #68). beta is the topic-word Dirichlet
+        (base measure). alpha, gamma, beta must be > 0.
+
+        eta is a deprecated alias for beta."""
         ...
 
     def fit(
@@ -722,16 +741,19 @@ class HDP:
         data: Corpus | Sequence[Sequence[str]],
         *,
         iters: int = 150,
-        report_interval: int = 0,
+        progress_interval: int = 0,
         keep_theta_draws: bool = True,
         num_theta_draws: int = 25,
+        report_interval: Optional[int] = None,
     ) -> None:
         """Fit by `iters` Gibbs sweeps. The inferred K is then `num_topics`.
 
-        report_interval controls the discovery/convergence trace
+        progress_interval controls the discovery/convergence trace
         (topic_count_history / log_likelihood_history / concentration_history):
         0 (default) records ~50 evenly spaced points; a positive value records
-        every that-many sweeps."""
+        every that-many sweeps.
+
+        report_interval is a deprecated alias for progress_interval."""
         ...
 
     @property
@@ -1022,7 +1044,7 @@ class SAGE:
         alpha: float = 0.1,
         prior_variance: float = 1.0,
         optimize_interval: int = 50,
-        burn_in: int = 100,
+        burn_in: int = 200,
         seed: int = 42,
         lbfgs_iters: int = 20,
     ) -> None: ...
@@ -1348,6 +1370,7 @@ class LDA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
+        num_threads: Optional[int] = None,
     ) -> None:
         """Run Gibbs sampling to fit the model on data.
 
@@ -1362,6 +1385,9 @@ class LDA:
         relative change in log-likelihood across two consecutive check points falls
         below ``convergence_tol``. The default (0.0) disables early stopping and
         reproduces the historical fit bit-for-bit.
+
+        ``num_threads`` overrides the constructor's num_threads for this fit call
+        only (None = use constructor value).
         """
         ...
 
@@ -1665,10 +1691,13 @@ class GSDMM:
         data: Corpus | Sequence[Sequence[str]],
         *,
         iters: int = 30,
-        report_interval: int = 0,
+        progress_interval: int = 0,
+        report_interval: Optional[int] = None,
     ) -> None:
-        """Fit by the Movie Group Process. report_interval controls the
-        cluster-discovery trace (0 = auto ~50 points)."""
+        """Fit by the Movie Group Process. progress_interval controls the
+        cluster-discovery trace (0 = auto ~50 points).
+
+        report_interval is a deprecated alias for progress_interval."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...
@@ -1824,10 +1853,17 @@ class HLDA:
         *,
         depth: int = 3,
         gamma: float = 1.0,
-        eta: float = 0.01,
+        beta: float = 0.01,
         alpha: float = 0.1,
         seed: int = 42,
-    ) -> None: ...
+        eta: Optional[float] = None,
+    ) -> None:
+        """depth is the number of levels in the topic tree. gamma controls
+        branching (higher = more nodes). beta is the topic-word Dirichlet base
+        measure. alpha is the document-path concentration.
+
+        eta is a deprecated alias for beta."""
+        ...
     def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 1000) -> None: ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]:
@@ -2173,7 +2209,7 @@ class ETM:
         num_topics: int,
         *,
         inference: str = "em",
-        em_tol: float = 1e-4,
+        convergence_tol: float = 1e-4,
         sigma_shrink: float = 0.0,
         prior_variance: float = 1e6,
         max_inner: int = 25,
@@ -2182,7 +2218,10 @@ class ETM:
         lr: float = 0.005,
         wdecay: float = 1.2e-6,
         seed: int = 42,
-    ) -> None: ...
+        em_tol: Optional[float] = None,
+    ) -> None:
+        """em_tol is a deprecated alias for convergence_tol."""
+        ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2190,10 +2229,14 @@ class ETM:
         vocabulary: Sequence[str],
         *,
         iters: int | None = None,
+        convergence_tol: Optional[float] = None,
     ) -> None:
         """Fit on token documents plus word embeddings (len(vocabulary) x E) and
         the aligned vocabulary, which defines the word ids. `iters` sets the number
-        of training iterations (EM iterations or VAE epochs)."""
+        of training iterations (EM iterations or VAE epochs).
+
+        convergence_tol overrides the constructor's convergence_tol for this fit
+        call only (None = use constructor value)."""
         ...
     @property
     def num_topics(self) -> int: ...
@@ -2241,6 +2284,7 @@ class ETM:
         vocabulary: Sequence[str],
         *,
         iters: int | None = None,
+        convergence_tol: Optional[float] = None,
     ) -> numpy.typing.NDArray[numpy.float64]: ...
     def save(self, path: str) -> None: ...
     @staticmethod
@@ -2266,11 +2310,23 @@ class ProdLDA:
         dropout: float = 0.2,
         batch_size: int = 200,
         lr: float = 0.002,
-        em_tol: float = 0.0,
+        convergence_tol: float = 0.0,
         seed: int = 42,
-    ) -> None: ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int | None = None) -> None:
-        """Fit on a Corpus or a list of token lists. `iters` sets the number of epochs."""
+        em_tol: Optional[float] = None,
+    ) -> None:
+        """em_tol is a deprecated alias for convergence_tol."""
+        ...
+    def fit(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iters: int | None = None,
+        convergence_tol: Optional[float] = None,
+    ) -> None:
+        """Fit on a Corpus or a list of token lists. `iters` sets the number of epochs.
+
+        convergence_tol overrides the constructor's convergence_tol for this fit
+        call only (None = use constructor value)."""
         ...
     @property
     def num_topics(self) -> int: ...
@@ -2332,21 +2388,28 @@ class FASTopic:
         dt_alpha: float = 3.0,
         tw_alpha: float = 2.0,
         theta_temp: float = 1.0,
-        em_tol: float = 1e-6,
+        convergence_tol: float = 1e-6,
         sinkhorn_iters: int = 50,
         sinkhorn_tol: float = 1e-4,
         seed: int = 42,
-    ) -> None: ...
+        em_tol: Optional[float] = None,
+    ) -> None:
+        """em_tol is a deprecated alias for convergence_tol."""
+        ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
         doc_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]],
         *,
         iters: int | None = None,
+        convergence_tol: Optional[float] = None,
     ) -> None:
         """Fit on token documents plus frozen document embeddings (num_docs x E).
         The vocabulary is taken from the corpus; the word embeddings are learned.
-        `iters` sets the number of training epochs."""
+        `iters` sets the number of training epochs.
+
+        convergence_tol overrides the constructor's convergence_tol for this fit
+        call only (None = use constructor value)."""
         ...
     @property
     def num_topics(self) -> int: ...
@@ -2418,6 +2481,7 @@ class KeyATM:
         seed: int = 42,
         estimate_alpha: bool = True,
         sampler: str = "sparse",
+        num_threads: int = 1,
     ) -> None:
         """estimate_alpha (default True, matching R keyATM) slice-samples an
         asymmetric document-topic prior alpha each sweep. Set it False for a
@@ -2431,7 +2495,10 @@ class KeyATM:
         opt-in alternative for the base model only (it errors with covariates,
         timestamps, or a prior_offset) and does NOT preserve R-parity -- it is a
         different, deterministic estimator with no MCMC theta_draws, useful when
-        you want reproducibility/quality over R-faithfulness."""
+        you want reproducibility/quality over R-faithfulness.
+
+        num_threads > 1 enables approximate parallel Gibbs (AD-LDA-style);
+        can be overridden per-call in fit()."""
         ...
     @staticmethod
     def weighted_lda(
@@ -2455,15 +2522,16 @@ class KeyATM:
         timestamps: Sequence[float] | Sequence[str] | None = None,
         num_states: int = 5,
         weights: str = "information-theory",
-        num_threads: int = 1,
+        num_threads: Optional[int] = None,
         optimize_interval: int = 50,
         burn_in: int = 200,
         prior_variance: float = 1.0,
         lbfgs_iters: int = 20,
-        report_interval: int = 0,
+        progress_interval: int = 0,
         keep_theta_draws: bool = True,
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
+        report_interval: Optional[int] = None,
     ) -> None:
         """Fit by collapsed Gibbs. Pass `covariates` (num_docs x F) for the
         covariate keyATM: the document-topic prior becomes a DMR,
@@ -2481,7 +2549,10 @@ class KeyATM:
         'none' (unweighted). Weighting downweights frequent words and applies to
         every variant (base, covariate, dynamic).
 
-        `report_interval` sets how often model_fit is recorded for
+        `num_threads` overrides the constructor's num_threads for this fit call
+        only (None = use constructor value).
+
+        `progress_interval` sets how often model_fit is recorded for
         `log_likelihood_history` (keyATM's model_fit / plot_modelfit): 0
         (default) records ~50 evenly spaced points across the run; a positive
         value records every that-many sweeps.
@@ -2492,7 +2563,9 @@ class KeyATM:
         tolerance, setting `converged` to True (the relative-bound criterion R
         stm uses; 0.0 runs the full `iters`, the field convention for collapsed
         samplers). Applies to the base/covariate/dynamic Gibbs backends; ignored
-        by the CVB0 backend, which keeps no trace."""
+        by the CVB0 backend, which keeps no trace.
+
+        report_interval is a deprecated alias for progress_interval."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...

--- a/src/python.rs
+++ b/src/python.rs
@@ -434,7 +434,9 @@ struct KeyAtmState {
     #[serde(default)] alpha_history: Vec<(usize, Vec<f64>)>,
     #[serde(default)] pi_history: Vec<(usize, Vec<f64>)>,
     #[serde(default)] alpha_vec: Option<Vec<f64>>,
+    #[serde(default = "default_num_threads")] num_threads: usize,
 }
+fn default_num_threads() -> usize { 1 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct PaState {
     num_super: usize, num_sub: usize, alpha: f64, beta: f64, seed: u64, fitted: bool,
@@ -1138,7 +1140,7 @@ impl LDA {
     #[pyo3(signature = (data, *, iters=1000, num_samples=5, sample_interval=25,
                         progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize))]
+                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -1153,6 +1155,7 @@ impl LDA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
+        num_threads: Option<usize>,
     ) -> PyResult<()> {
         // Accept either a Corpus or a list[list[str]].
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -1210,7 +1213,8 @@ impl LDA {
 
         let optimize_interval = self.optimize_interval;
         let burn_in = self.burn_in;
-        let num_threads = self.num_threads;
+        // num_threads from fit() overrides the constructor default for this run.
+        let num_threads = num_threads.unwrap_or(self.num_threads).max(1);
         let seed_base = self.seed;
         let light = self.light;
         let warp = self.warp;
@@ -3241,16 +3245,17 @@ impl DMR {
     /// `features` is a `(num_docs, F)` numpy array or list of float lists (an
     /// intercept column is prepended automatically). `feature_names` (length F)
     /// names the columns; an "intercept" name is prepended.
-    #[pyo3(signature = (data, features, *, feature_names=None, iters=1000,
+    /// `covariates` is accepted as a no-deprecation alias for `features`.
+    #[pyo3(signature = (data, features=None, *, feature_names=None, iters=1000,
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize))]
+                        convergence_tol=0.0_f64, check_every=10_usize, covariates=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
-        features: &Bound<'_, PyAny>,
+        features: Option<&Bound<'_, PyAny>>,
         feature_names: Option<Vec<String>>,
         iters: usize,
         num_samples: usize,
@@ -3261,7 +3266,23 @@ impl DMR {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
+        covariates: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<()> {
+        // covariates= is a no-deprecation alias for features=
+        let features: &Bound<'_, PyAny> = match (features, covariates) {
+            (Some(_), Some(_)) => {
+                return Err(PyValueError::new_err(
+                    "DMR.fit: pass either features= or covariates=, not both",
+                ));
+            }
+            (Some(f), None) => f,
+            (None, Some(c)) => c,
+            (None, None) => {
+                return Err(PyValueError::new_err(
+                    "DMR.fit: features (or covariates) is required",
+                ));
+            }
+        };
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -4522,7 +4543,7 @@ impl SAGE {
     /// `prior_variance` is the Gaussian prior on the κ content deviations.
     #[new]
     #[pyo3(signature = (num_topics, *, alpha=0.1, prior_variance=1.0,
-                        optimize_interval=50, burn_in=100, seed=42, lbfgs_iters=20))]
+                        optimize_interval=50, burn_in=200, seed=42, lbfgs_iters=20))]
     fn new(
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
         alpha: f64,
@@ -5290,8 +5311,8 @@ impl CTM {
 
     /// Fit by variational EM. `data` is a :class:`Corpus` or `list[list[str]]`.
     /// EM runs until the relative change in the variational bound drops below
-    /// `em_tol` (R `stm`'s `emtol`) or `iters` iterations are reached,
-    /// whichever comes first. Pass ``em_tol=0`` to always run `iters` steps.
+    /// `convergence_tol` (R `stm`'s `emtol`) or `iters` iterations are reached,
+    /// whichever comes first. Pass ``convergence_tol=0`` to always run `iters` steps.
     /// Check :attr:`converged` and :attr:`bound` afterward.
     /// `inference="svi"` switches from full-batch variational EM to stochastic
     /// variational inference (online VB): documents are processed in minibatches
@@ -5299,20 +5320,33 @@ impl CTM {
     /// decaying learning rate `(tau + t)^(-kappa)`, for `iters` epochs. SVI is
     /// for very large corpora; on moderate corpora the default `"batch"` EM is
     /// preferable. SVI uses the base logistic-normal model only.
-    #[pyo3(signature = (data, *, iters=500, em_tol=1e-5, inference="batch",
-                        batch_size=256, tau=64.0, kappa=0.7))]
+    #[pyo3(signature = (data, *, iters=500, convergence_tol=1e-5, inference="batch",
+                        batch_size=256, tau=64.0, kappa=0.7, em_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
-        em_tol: f64,
+        convergence_tol: f64,
         inference: &str,
         batch_size: usize,
         tau: f64,
         kappa: f64,
+        em_tol: Option<f64>,
     ) -> PyResult<()> {
+        let convergence_tol = if let Some(old_val) = em_tol {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "CTM.fit(em_tol=) is deprecated; use convergence_tol= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            // convergence_tol wins if explicitly set (not the default 1e-5); else deprecated.
+            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+        } else {
+            convergence_tol
+        };
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -5348,7 +5382,7 @@ impl CTM {
                 )
             } else {
                 ctm::fit_ctm(
-                    &corpus.docs, k, num_types, iters, em_tol, shrink, None, None, spectral,
+                    &corpus.docs, k, num_types, iters, convergence_tol, shrink, None, None, spectral,
                     ctm::GammaPrior::Pooled, &mut rng,
                 )
             };
@@ -5757,8 +5791,8 @@ impl STM {
     /// component (R `stm`'s ``gamma.enet``). `gamma_enet` is ignored when
     /// `gamma_prior="pooled"`.
     #[pyo3(signature = (data, prevalence=None, *, prevalence_names=None,
-                        content=None, content_names=None, iters=500, em_tol=1e-5,
-                        gamma_prior="pooled", gamma_enet=1.0))]
+                        content=None, content_names=None, iters=500, convergence_tol=1e-5,
+                        gamma_prior="pooled", gamma_enet=1.0, em_tol=None, covariates=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -5769,10 +5803,34 @@ impl STM {
         content: Option<&Bound<'_, PyAny>>,
         content_names: Option<Vec<String>>,
         iters: usize,
-        em_tol: f64,
+        convergence_tol: f64,
         gamma_prior: &str,
         gamma_enet: f64,
+        em_tol: Option<f64>,
+        covariates: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<()> {
+        let convergence_tol = if let Some(old_val) = em_tol {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "STM.fit(em_tol=) is deprecated; use convergence_tol= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+        } else {
+            convergence_tol
+        };
+        // covariates= is a no-deprecation alias for prevalence=
+        let prevalence = match (prevalence, covariates) {
+            (Some(_), Some(_)) => {
+                return Err(PyValueError::new_err(
+                    "STM.fit: pass either prevalence= or covariates=, not both",
+                ));
+            }
+            (Some(p), None) => Some(p),
+            (None, Some(c)) => Some(c),
+            (None, None) => None,
+        };
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -5893,7 +5951,7 @@ impl STM {
             let prev_ref = prevalence_x.as_deref();
             let cont_ref = content_groups.as_ref().map(|(g, n)| (g.as_slice(), *n));
             let m = ctm::fit_ctm(
-                &corpus.docs, k, num_types, iters, em_tol, shrink, prev_ref, cont_ref,
+                &corpus.docs, k, num_types, iters, convergence_tol, shrink, prev_ref, cont_ref,
                 spectral, gprior, &mut rng,
             );
             (m, corpus)
@@ -6582,7 +6640,7 @@ impl STS {
     /// Σ)`); an intercept is prepended.
     ///
     /// EM runs until the relative change in the variational bound drops below
-    /// `em_tol` or `iters` iterations are reached.
+    /// `convergence_tol` or `iters` iterations are reached.
     ///
     /// `kappa_estimation` chooses the topic-word (κ) estimator: ``"ridge"``
     /// (default) is a fast ridge-penalized Poisson fit (`kappa_ridge` sets the
@@ -6590,8 +6648,8 @@ impl STS {
     /// matching the reference R `sts` exactly (sparser κ) at a higher cost. The
     /// two give the same topics on well-conditioned corpora.
     #[pyo3(signature = (data, sentiment_seed, prevalence=None, *,
-                        prevalence_names=None, iters=30, em_tol=1e-5,
-                        kappa_estimation="ridge", kappa_ridge=1e-3))]
+                        prevalence_names=None, iters=30, convergence_tol=1e-5,
+                        kappa_estimation="ridge", kappa_ridge=1e-3, em_tol=None, covariates=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -6601,10 +6659,34 @@ impl STS {
         prevalence: Option<&Bound<'_, PyAny>>,
         prevalence_names: Option<Vec<String>>,
         iters: usize,
-        em_tol: f64,
+        convergence_tol: f64,
         kappa_estimation: &str,
         kappa_ridge: f64,
+        em_tol: Option<f64>,
+        covariates: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<()> {
+        let convergence_tol = if let Some(old_val) = em_tol {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "STS.fit(em_tol=) is deprecated; use convergence_tol= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+        } else {
+            convergence_tol
+        };
+        // covariates= is a no-deprecation alias for prevalence=
+        let prevalence = match (prevalence, covariates) {
+            (Some(_), Some(_)) => {
+                return Err(PyValueError::new_err(
+                    "STS.fit: pass either prevalence= or covariates=, not both",
+                ));
+            }
+            (Some(p), None) => Some(p),
+            (None, Some(c)) => Some(c),
+            (None, None) => None,
+        };
         let kappa_est = match kappa_estimation {
             "lasso" => sts::KappaEst::Lasso { nlambda: 100, lambda_min_ratio: 0.001 },
             "ridge" => sts::KappaEst::Ridge(kappa_ridge),
@@ -6683,7 +6765,7 @@ impl STS {
         let (model, corpus) = py.allow_threads(move || {
             let prev_ref = prevalence_x.as_deref();
             let m = sts::fit_sts(
-                &corpus.docs, k, num_types, iters, em_tol, prev_ref, Some(&sentiment_seed),
+                &corpus.docs, k, num_types, iters, convergence_tol, prev_ref, Some(&sentiment_seed),
                 kappa_est, spectral, &mut rng,
             );
             (m, corpus)
@@ -7068,18 +7150,29 @@ impl HDP {
     /// bounded, but fixed concentrations remain the recommended default; set
     /// `gamma` to choose the granularity directly.
     #[new]
-    #[pyo3(signature = (*, alpha=0.1, gamma=0.1, eta=0.01, seed=42, resample_conc=false))]
-    fn new(alpha: f64, gamma: f64, eta: f64, seed: u64, resample_conc: bool) -> PyResult<Self> {
+    #[pyo3(signature = (*, alpha=0.1, gamma=0.1, beta=0.01, seed=42, resample_conc=false, eta=None))]
+    fn new(py: Python<'_>, alpha: f64, gamma: f64, beta: f64, seed: u64, resample_conc: bool, eta: Option<f64>) -> PyResult<Self> {
+        let beta = if let Some(old_val) = eta {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "HDP(eta=) is deprecated; use beta= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            if (beta - 0.01_f64).abs() > f64::EPSILON { beta } else { old_val }
+        } else {
+            beta
+        };
         if !finite_pos(alpha) || !finite_pos(gamma) {
             return Err(PyValueError::new_err("alpha and gamma must be > 0"));
         }
-        if !finite_pos(eta) {
-            return Err(PyValueError::new_err("eta must be > 0"));
+        if !finite_pos(beta) {
+            return Err(PyValueError::new_err("beta must be > 0"));
         }
         Ok(HDP {
             alpha,
             gamma,
-            eta,
+            eta: beta,
             seed,
             resample_conc,
             fitted: false,
@@ -7097,17 +7190,30 @@ impl HDP {
 
     /// Fit by Gibbs sampling for `iters` sweeps. `data` is a :class:`Corpus` or
     /// `list[list[str]]`. The inferred topic count is available as `num_topics`.
-    #[pyo3(signature = (data, *, iters=150, report_interval=0,
-                        keep_theta_draws=true, num_theta_draws=25))]
+    #[pyo3(signature = (data, *, iters=150, progress_interval=0,
+                        keep_theta_draws=true, num_theta_draws=25, report_interval=None))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
-        report_interval: usize,
+        progress_interval: usize,
         keep_theta_draws: bool,
         num_theta_draws: usize,
+        report_interval: Option<usize>,
     ) -> PyResult<()> {
+        let progress_interval = if let Some(old_val) = report_interval {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "HDP.fit(report_interval=) is deprecated; use progress_interval= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            // progress_interval wins if explicitly set (non-zero); else deprecated value.
+            if progress_interval != 0 { progress_interval } else { old_val }
+        } else {
+            progress_interval
+        };
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -7125,7 +7231,7 @@ impl HDP {
         let (alpha, gamma, eta, conc) = (self.alpha, self.gamma, self.eta, self.resample_conc);
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
         // 0 = auto: ~50 evenly spaced trace points across the run.
-        let ll_interval = if report_interval == 0 { (iters / 50).max(1) } else { report_interval };
+        let ll_interval = if progress_interval == 0 { (iters / 50).max(1) } else { progress_interval };
 
         // HDP's K varies during training, so theta_draws are sampled from the final
         // Dirichlet posterior Dirichlet(njk[d]+alpha*beta[k]) after the chain ends.
@@ -8554,17 +8660,29 @@ impl GSDMM {
     }
 
     /// Fit by the Movie Group Process (collapsed Gibbs) for `iters` sweeps.
-    /// `report_interval` controls the cluster-discovery trace
+    /// `progress_interval` controls the cluster-discovery trace
     /// (`cluster_count_history` / `log_likelihood_history`): 0 = auto (~50
     /// points), a positive value records every that-many sweeps.
-    #[pyo3(signature = (data, *, iters=30, report_interval=0))]
+    #[pyo3(signature = (data, *, iters=30, progress_interval=0, report_interval=None))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
-        report_interval: usize,
+        progress_interval: usize,
+        report_interval: Option<usize>,
     ) -> PyResult<()> {
+        let progress_interval = if let Some(old_val) = report_interval {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "GSDMM.fit(report_interval=) is deprecated; use progress_interval= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            if progress_interval != 0 { progress_interval } else { old_val }
+        } else {
+            progress_interval
+        };
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -8579,7 +8697,7 @@ impl GSDMM {
         let num_types = corpus.num_types();
         let (k, a, b) = (self.k_max, self.alpha, self.beta);
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
-        let ll_interval = if report_interval == 0 { (iters / 50).max(1) } else { report_interval };
+        let ll_interval = if progress_interval == 0 { (iters / 50).max(1) } else { progress_interval };
         let (model, corpus) = py.allow_threads(move || {
             let m = gsdmm::fit_gsdmm(&corpus.docs, num_types, k, a, b, iters, ll_interval, &mut rng);
             (m, corpus)
@@ -10390,20 +10508,21 @@ impl ETM {
     /// Create an unfitted model. `inference` selects the engine: `"em"` (default)
     /// is per-document variational EM, accurate but not minibatched; `"vae"` is the
     /// reference's amortized autoencoder, which scales to large corpora and maps new
-    /// documents with a single encoder pass. `em_tol`/`prior_variance`/
+    /// documents with a single encoder pass. `convergence_tol`/`prior_variance`/
     /// `max_inner`/`sigma_shrink` govern the EM path; `hidden_size`/
-    /// `batch_size`/`lr`/`wdecay`/`em_tol` govern the VAE path.
+    /// `batch_size`/`lr`/`wdecay`/`convergence_tol` govern the VAE path.
     /// Pass `iters` to :meth:`fit` to set the iteration count.
     #[new]
-    #[pyo3(signature = (num_topics, *, inference="em", em_tol=1e-4,
+    #[pyo3(signature = (num_topics, *, inference="em", convergence_tol=1e-4,
                         sigma_shrink=0.0, prior_variance=1e6, max_inner=25,
                         hidden_size=800, batch_size=1000, lr=0.005,
-                        wdecay=1.2e-6, seed=42))]
+                        wdecay=1.2e-6, seed=42, em_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
+        py: Python<'_>,
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
         inference: &str,
-        em_tol: f64,
+        convergence_tol: f64,
         sigma_shrink: f64,
         prior_variance: f64,
         max_inner: usize,
@@ -10412,7 +10531,19 @@ impl ETM {
         lr: f64,
         wdecay: f64,
         seed: u64,
+        em_tol: Option<f64>,
     ) -> PyResult<Self> {
+        let convergence_tol = if let Some(old_val) = em_tol {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "ETM(em_tol=) is deprecated; use convergence_tol= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            if (convergence_tol - 1e-4_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+        } else {
+            convergence_tol
+        };
         if num_topics < 2 {
             return Err(PyValueError::new_err("need at least 2 topics"));
         }
@@ -10425,7 +10556,7 @@ impl ETM {
         Ok(ETM {
             num_topics,
             inference: inference.to_string(),
-            em_tol,
+            em_tol: convergence_tol,
             sigma_shrink,
             prior_variance,
             max_inner,
@@ -10447,7 +10578,8 @@ impl ETM {
     /// (`(len(vocabulary), E)`) and the aligned `vocabulary`. The vocabulary
     /// defines the word ids; tokens outside it are dropped.
     /// `iters` sets the number of training iterations (EM iterations or VAE epochs).
-    #[pyo3(signature = (data, word_embeddings, vocabulary, *, iters=None))]
+    /// `convergence_tol` overrides the constructor value for this run (when given).
+    #[pyo3(signature = (data, word_embeddings, vocabulary, *, iters=None, convergence_tol=None))]
     fn fit(
         &mut self,
         py: Python<'_>,
@@ -10455,7 +10587,10 @@ impl ETM {
         word_embeddings: &Bound<'_, PyAny>,
         vocabulary: Vec<String>,
         iters: Option<usize>,
+        convergence_tol: Option<f64>,
     ) -> PyResult<()> {
+        // Use fit()-level convergence_tol if given, else fall back to constructor value.
+        let tol = convergence_tol.unwrap_or(self.em_tol);
         let (docs_str, corpus_opt): (Vec<Vec<String>>, Option<corpus::Corpus>) =
             if let Ok(c) = data.extract::<Corpus>() {
                 let strings = c.inner.docs.iter()
@@ -10497,7 +10632,7 @@ impl ETM {
             let ep = iters.unwrap_or(150);
             let (k, h, bs, lr, wd, et) = (
                 self.num_topics, self.hidden_size, self.batch_size,
-                self.lr, self.wdecay, self.em_tol,
+                self.lr, self.wdecay, tol,
             );
             let m = py.allow_threads(move || {
                 etm_vae::fit_etm_vae(&docs_ids, k, num_types, &rho, h, ep, bs, lr, wd, et, &mut rng)
@@ -10507,7 +10642,7 @@ impl ETM {
         } else {
             let ei = iters.unwrap_or(100);
             let (k, et, ss, pv, mi) = (
-                self.num_topics, self.em_tol, self.sigma_shrink,
+                self.num_topics, tol, self.sigma_shrink,
                 self.prior_variance, self.max_inner,
             );
             let model = py.allow_threads(move || {
@@ -10788,7 +10923,7 @@ impl ETM {
         vocabulary: Vec<String>,
         iters: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        self.fit(py, data, word_embeddings, vocabulary, iters)?;
+        self.fit(py, data, word_embeddings, vocabulary, iters, None)?;
         Ok(vecs_to_arr2(&self.surf_doc_topic()?).to_pyarray_bound(py))
     }
 
@@ -10878,22 +11013,36 @@ impl ProdLDA {
     /// concentration (reference 1.0); `hidden_size` is the encoder width (reference
     /// 100); `dropout` is the dropout rate on the hidden layer and on `theta`;
     /// `batch_size`/`lr` drive Adam (reference 200/0.002, with `beta1 = 0.99`);
-    /// `em_tol > 0` stops early on the relative change in the epoch ELBO (0 runs
+    /// `convergence_tol > 0` stops early on the relative change in the epoch ELBO (0 runs
     /// all epochs). Pass `iters` to :meth:`fit` to set the number of epochs.
     #[new]
     #[pyo3(signature = (num_topics, *, alpha=1.0, hidden_size=100, dropout=0.2,
-                        batch_size=200, lr=0.002, em_tol=0.0, seed=42))]
+                        batch_size=200, lr=0.002, convergence_tol=0.0, seed=42, em_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
+        py: Python<'_>,
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
         alpha: f64,
         hidden_size: usize,
         dropout: f64,
         batch_size: usize,
         lr: f64,
-        em_tol: f64,
+        convergence_tol: f64,
         seed: u64,
+        em_tol: Option<f64>,
     ) -> PyResult<Self> {
+        let convergence_tol = if let Some(old_val) = em_tol {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "ProdLDA(em_tol=) is deprecated; use convergence_tol= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            // ProdLDA default is 0.0; if unchanged, use the deprecated value.
+            if convergence_tol != 0.0 { convergence_tol } else { old_val }
+        } else {
+            convergence_tol
+        };
         if num_topics < 2 {
             return Err(PyValueError::new_err("need at least 2 topics"));
         }
@@ -10910,7 +11059,7 @@ impl ProdLDA {
             dropout,
             batch_size,
             lr,
-            em_tol,
+            em_tol: convergence_tol,
             seed,
             fitted: false,
             topic_names: Vec::new(),
@@ -10921,8 +11070,10 @@ impl ProdLDA {
 
     /// Fit on `data` (a Corpus or list of token lists).
     /// `iters` sets the number of training epochs (default 200).
-    #[pyo3(signature = (data, *, iters=None))]
-    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>, iters: Option<usize>) -> PyResult<()> {
+    /// `convergence_tol` overrides the constructor value for this run (when given).
+    #[pyo3(signature = (data, *, iters=None, convergence_tol=None))]
+    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>, iters: Option<usize>, convergence_tol: Option<f64>) -> PyResult<()> {
+        let tol = convergence_tol.unwrap_or(self.em_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -10941,7 +11092,7 @@ impl ProdLDA {
         let ep = iters.unwrap_or(200);
         let (k, h, a, dp, bs, lr, et) = (
             self.num_topics, self.hidden_size, self.alpha, self.dropout,
-            self.batch_size, self.lr, self.em_tol,
+            self.batch_size, self.lr, tol,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let (model, corpus) = py.allow_threads(move || {
@@ -11064,7 +11215,7 @@ impl ProdLDA {
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        self.fit(py, data, None)?;
+        self.fit(py, data, None, None)?;
         Ok(vecs_to_arr2(&self.fitted_model()?.doc_topic).to_pyarray_bound(py))
     }
 
@@ -11230,24 +11381,37 @@ impl FASTopic {
     /// Create an unfitted model. `lr` drives the full-batch Adam optimizer;
     /// `dt_alpha`/`tw_alpha` are the inverse entropic regularizations for the
     /// doc-topic and topic-word transport (reference defaults 3.0 and 2.0);
-    /// `theta_temp` is the inference temperature; `em_tol` stops on the relative
+    /// `theta_temp` is the inference temperature; `convergence_tol` stops on the relative
     /// loss change. `sinkhorn_iters`/`sinkhorn_tol` cap each Sinkhorn solve.
     /// Pass `iters` to :meth:`fit` to set the number of training epochs.
     #[new]
     #[pyo3(signature = (num_topics, *, lr=0.002, dt_alpha=3.0, tw_alpha=2.0,
-                        theta_temp=1.0, em_tol=1e-6, sinkhorn_iters=50, sinkhorn_tol=1e-4, seed=42))]
+                        theta_temp=1.0, convergence_tol=1e-6, sinkhorn_iters=50, sinkhorn_tol=1e-4, seed=42, em_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
+        py: Python<'_>,
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
         lr: f64,
         dt_alpha: f64,
         tw_alpha: f64,
         theta_temp: f64,
-        em_tol: f64,
+        convergence_tol: f64,
         sinkhorn_iters: usize,
         sinkhorn_tol: f64,
         seed: u64,
+        em_tol: Option<f64>,
     ) -> PyResult<Self> {
+        let convergence_tol = if let Some(old_val) = em_tol {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "FASTopic(em_tol=) is deprecated; use convergence_tol= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            if (convergence_tol - 1e-6_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+        } else {
+            convergence_tol
+        };
         if num_topics < 2 {
             return Err(PyValueError::new_err("need at least 2 topics"));
         }
@@ -11260,7 +11424,7 @@ impl FASTopic {
             dt_alpha,
             tw_alpha,
             theta_temp,
-            em_tol,
+            em_tol: convergence_tol,
             sinkhorn_iters,
             sinkhorn_tol,
             seed,
@@ -11276,14 +11440,17 @@ impl FASTopic {
     /// (`(num_docs, E)`), one frozen row per document. The vocabulary is taken from
     /// the corpus; FASTopic learns the word embeddings itself, so none are passed.
     /// `iters` sets the number of training epochs (default 200).
-    #[pyo3(signature = (data, doc_embeddings, *, iters=None))]
+    /// `convergence_tol` overrides the constructor value for this run (when given).
+    #[pyo3(signature = (data, doc_embeddings, *, iters=None, convergence_tol=None))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         doc_embeddings: &Bound<'_, PyAny>,
         iters: Option<usize>,
+        convergence_tol: Option<f64>,
     ) -> PyResult<()> {
+        let tol = convergence_tol.unwrap_or(self.em_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -11314,7 +11481,7 @@ impl FASTopic {
 
         let (k, lr, dta, twa, tt, et, si, st) = (
             self.num_topics, self.lr, self.dt_alpha, self.tw_alpha,
-            self.theta_temp, self.em_tol, self.sinkhorn_iters, self.sinkhorn_tol,
+            self.theta_temp, tol, self.sinkhorn_iters, self.sinkhorn_tol,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let model = py.allow_threads(move || {
@@ -11450,7 +11617,7 @@ impl FASTopic {
         data: &Bound<'py, PyAny>,
         doc_embeddings: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        self.fit(py, data, doc_embeddings, None)?;
+        self.fit(py, data, doc_embeddings, None, None)?;
         Ok(vecs_to_arr2(&self.fitted_model()?.doc_topic).to_pyarray_bound(py))
     }
 
@@ -11545,6 +11712,8 @@ pub struct KeyATM {
     gamma2: f64,
     seed: u64,
     estimate_alpha: bool,
+    // Default thread count for fit(); can be overridden per-call via fit(num_threads=).
+    num_threads: usize,
     // CVB0 deterministic collapsed-variational inference for the base model
     // (optional, non-R-parity; covariate/dynamic variants stay Gibbs-only).
     cvb0: bool,
@@ -11601,7 +11770,7 @@ impl KeyATM {
     /// `beta`/`beta_keyword` are the regular and keyword topic-word smoothing, and
     /// `gamma1`/`gamma2` the Beta prior on the keyword-vs-regular switch.
     #[new]
-    #[pyo3(signature = (keywords, *, num_topics=None, alpha=None, beta=0.01, beta_keyword=0.1, gamma1=1.0, gamma2=1.0, seed=42, estimate_alpha=true, sampler="sparse"))]
+    #[pyo3(signature = (keywords, *, num_topics=None, alpha=None, beta=0.01, beta_keyword=0.1, gamma1=1.0, gamma2=1.0, seed=42, estimate_alpha=true, sampler="sparse", num_threads=1))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         keywords: &Bound<'_, PyDict>,
@@ -11614,6 +11783,7 @@ impl KeyATM {
         seed: u64,
         estimate_alpha: bool,
         sampler: &str,
+        num_threads: usize,
     ) -> PyResult<Self> {
         let (names, words) = parse_seed_dict(keywords)?;
         let k = num_topics.unwrap_or(names.len());
@@ -11641,7 +11811,8 @@ impl KeyATM {
         };
         Ok(KeyATM {
             key_names: names, keywords: words, num_topics: k, alpha, beta, beta_keyword,
-            gamma1, gamma2, seed, estimate_alpha, cvb0, fitted: false, topic_names: Vec::new(),
+            gamma1, gamma2, seed, estimate_alpha, num_threads: num_threads.max(1),
+            cvb0, fitted: false, topic_names: Vec::new(),
             keyword_rate: Vec::new(), phi: None, theta: None, corpus: None,
             feature_effects: None, feature_names: Vec::new(),
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
@@ -11669,6 +11840,7 @@ impl KeyATM {
         Ok(KeyATM {
             key_names: Vec::new(), keywords: Vec::new(), num_topics, alpha, beta,
             beta_keyword: 0.1, gamma1: 1.0, gamma2: 1.0, seed, estimate_alpha: true,
+            num_threads: 1,
             cvb0: false,
             fitted: false,
             topic_names: Vec::new(), keyword_rate: Vec::new(), phi: None, theta: None,
@@ -11698,9 +11870,10 @@ impl KeyATM {
     /// and `covariates` are mutually exclusive.
     #[pyo3(signature = (data, *, iters=1500, covariates=None, feature_names=None,
                         timestamps=None, num_states=5, weights="information-theory",
-                        num_threads=1, optimize_interval=50, burn_in=200, prior_variance=1.0,
-                        lbfgs_iters=20, report_interval=0, prior_offset=None,
-                        keep_theta_draws=true, num_theta_draws=25, convergence_tol=0.0_f64))]
+                        num_threads=None, optimize_interval=50, burn_in=200, prior_variance=1.0,
+                        lbfgs_iters=20, progress_interval=0, prior_offset=None,
+                        keep_theta_draws=true, num_theta_draws=25, convergence_tol=0.0_f64,
+                        report_interval=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -11712,17 +11885,31 @@ impl KeyATM {
         timestamps: Option<&Bound<'_, PyAny>>,
         num_states: usize,
         weights: &str,
-        num_threads: usize,
+        num_threads: Option<usize>,
         optimize_interval: usize,
         burn_in: usize,
         prior_variance: f64,
         lbfgs_iters: usize,
-        report_interval: usize,
+        progress_interval: usize,
         prior_offset: Option<&Bound<'_, PyAny>>,
         keep_theta_draws: bool,
         num_theta_draws: usize,
         convergence_tol: f64,
+        report_interval: Option<usize>,
     ) -> PyResult<()> {
+        let progress_interval = if let Some(old_val) = report_interval {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "KeyATM.fit(report_interval=) is deprecated; use progress_interval= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            if progress_interval != 0 { progress_interval } else { old_val }
+        } else {
+            progress_interval
+        };
+        // num_threads: fit()-level value overrides the constructor default.
+        let nthreads_fit = num_threads.unwrap_or(self.num_threads).max(1);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -11769,7 +11956,7 @@ impl KeyATM {
             (self.alpha, self.beta, self.beta_keyword, self.gamma1, self.gamma2);
         let estimate_alpha = self.estimate_alpha;
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
-        let nthreads = num_threads.max(1);
+        let nthreads = nthreads_fit;
         let weight_scheme = match weights {
             "information-theory" | "info" => keyatm::WeightScheme::InfoTheory,
             "inv-freq" | "inverse-frequency" => keyatm::WeightScheme::InvFreq,
@@ -11782,10 +11969,10 @@ impl KeyATM {
         };
         // Convergence trace cadence (keyATM's model_fit). 0 = auto: ~50 evenly
         // spaced points across the run.
-        let ll_interval = if report_interval == 0 {
+        let ll_interval = if progress_interval == 0 {
             (iters / 50).max(1)
         } else {
-            report_interval
+            progress_interval
         };
 
         // The CVB0 backend covers only the base model.
@@ -12204,6 +12391,7 @@ impl KeyATM {
             alpha_history: self.alpha_history.clone(),
             pi_history: self.pi_history.clone(),
             alpha_vec: self.alpha_vec.clone(),
+            num_threads: self.num_threads,
         })
     }
     /// Load a model previously written by :meth:`save`.
@@ -12214,7 +12402,7 @@ impl KeyATM {
             key_names: Vec::new(), keywords: Vec::new(), num_topics: s.num_topics,
             alpha: s.alpha, beta: s.beta, beta_keyword: s.beta_keyword, gamma1: s.gamma1,
             gamma2: s.gamma2, seed: s.seed, estimate_alpha: true, cvb0: false, fitted: s.fitted,
-            topic_names: s.topic_names,
+            topic_names: s.topic_names, num_threads: s.num_threads,
             keyword_rate: s.keyword_rate, phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             corpus: s.corpus, feature_effects: None, feature_names: Vec::new(),
             time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
@@ -12592,19 +12780,30 @@ impl HLDA {
 #[pymethods]
 impl HLDA {
     /// Create an unfitted model. `depth` is the (fixed) tree depth; `gamma` is
-    /// the nested-CRP concentration (larger ⇒ more child topics); `eta` the
+    /// the nested-CRP concentration (larger => more child topics); `beta` the
     /// topic-word Dirichlet; `alpha` the per-document level distribution.
     #[new]
-    #[pyo3(signature = (*, depth=3, gamma=1.0, eta=0.01, alpha=0.1, seed=42))]
-    fn new(#[pyo3(from_py_with = "py_depth")] depth: usize, gamma: f64, eta: f64, alpha: f64, seed: u64) -> PyResult<Self> {
+    #[pyo3(signature = (*, depth=3, gamma=1.0, beta=0.01, alpha=0.1, seed=42, eta=None))]
+    fn new(py: Python<'_>, #[pyo3(from_py_with = "py_depth")] depth: usize, gamma: f64, beta: f64, alpha: f64, seed: u64, eta: Option<f64>) -> PyResult<Self> {
+        let beta = if let Some(old_val) = eta {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (
+                "HLDA(eta=) is deprecated; use beta= instead",
+                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                2_i32,
+            ))?;
+            if (beta - 0.01_f64).abs() > f64::EPSILON { beta } else { old_val }
+        } else {
+            beta
+        };
         if depth < 2 {
             return Err(PyValueError::new_err("depth must be >= 2"));
         }
-        if !finite_pos(gamma) || !finite_pos(eta) || !finite_pos(alpha) {
-            return Err(PyValueError::new_err("gamma, eta, alpha must be > 0"));
+        if !finite_pos(gamma) || !finite_pos(beta) || !finite_pos(alpha) {
+            return Err(PyValueError::new_err("gamma, beta, alpha must be > 0"));
         }
         Ok(HLDA {
-            depth, gamma, eta, alpha, seed,
+            depth, gamma, eta: beta, alpha, seed,
             fitted: false, num_nodes: 0, topic_names: Vec::new(),
             node_topic_word: None,
             node_levels: Vec::new(), node_parents: Vec::new(), doc_paths: Vec::new(), corpus: None,

--- a/tests/test_gsdmm.py
+++ b/tests/test_gsdmm.py
@@ -88,7 +88,7 @@ class TestClusterDiscovery:
     def test_count_collapses_from_k_max(self):
         docs = _short_corpus(n=300)
         m = topica.GSDMM(num_topics=12, seed=1)
-        m.fit(docs, iters=40, report_interval=5)
+        m.fit(docs, iters=40, progress_interval=5)
         cch = m.cluster_count_history
         assert [it for it, _ in cch] == list(range(5, 41, 5))
         # The Movie Group Process starts near the cap and collapses.
@@ -98,7 +98,7 @@ class TestClusterDiscovery:
     def test_log_likelihood_stabilizes(self):
         docs = _short_corpus(n=300)
         m = topica.GSDMM(num_topics=12, seed=1)
-        m.fit(docs, iters=60, report_interval=5)
+        m.fit(docs, iters=60, progress_interval=5)
         lls = [ll for _, ll in m.log_likelihood_history]
         assert all(np.isfinite(ll) and ll < 0 for ll in lls)
         # The cluster-fit score settles once the clustering stops moving (it can
@@ -115,7 +115,7 @@ class TestClusterDiscovery:
     def test_trace_survives_save_load(self, tmp_path):
         docs = _short_corpus(n=150)
         m = topica.GSDMM(num_topics=10, seed=1)
-        m.fit(docs, iters=30, report_interval=5)
+        m.fit(docs, iters=30, progress_interval=5)
         path = str(tmp_path / "g.bin")
         m.save(path)
         ld = topica.GSDMM.load(path)

--- a/tests/test_hdp.py
+++ b/tests/test_hdp.py
@@ -120,7 +120,7 @@ class TestDeterminismAndApi:
         with pytest.raises(ValueError):
             HDP(alpha=0.0)
         with pytest.raises(ValueError):
-            HDP(eta=-1.0)
+            HDP(beta=-1.0)
 
 
 class TestDiscoveryTrace:
@@ -129,7 +129,7 @@ class TestDiscoveryTrace:
     def test_traces_recorded_and_aligned(self):
         docs, _, _ = _planted_corpus()
         m = HDP(seed=1)
-        m.fit(docs, iters=120, report_interval=10)
+        m.fit(docs, iters=120, progress_interval=10)
         tch = m.topic_count_history
         llh = m.log_likelihood_history
         ch = m.concentration_history
@@ -143,26 +143,26 @@ class TestDiscoveryTrace:
     def test_auto_spacing(self):
         docs, _, _ = _planted_corpus()
         m = HDP(seed=1)
-        m.fit(docs, iters=150)  # report_interval=0 -> auto
+        m.fit(docs, iters=150)  # progress_interval=0 -> auto
         assert len(m.topic_count_history) == 50
 
     def test_final_count_matches_num_topics(self):
         docs, _, _ = _planted_corpus()
         m = HDP(seed=1)
-        m.fit(docs, iters=120, report_interval=20)
+        m.fit(docs, iters=120, progress_interval=20)
         assert m.topic_count_history[-1][1] == m.num_topics
 
     def test_log_likelihood_improves(self):
         docs, _, _ = _planted_corpus()
         m = HDP(seed=1, alpha=1.0, gamma=1.0)
-        m.fit(docs, iters=120, report_interval=5)
+        m.fit(docs, iters=120, progress_interval=5)
         lls = [ll for _, ll in m.log_likelihood_history]
         assert lls[-1] > lls[0]
 
     def test_trace_survives_save_load(self, tmp_path):
         docs, _, _ = _planted_corpus()
         m = HDP(seed=1)
-        m.fit(docs, iters=80, report_interval=10)
+        m.fit(docs, iters=80, progress_interval=10)
         path = str(tmp_path / "hdp.bin")
         m.save(path)
         reloaded = HDP.load(path)
@@ -176,7 +176,7 @@ class TestDiscoveryTrace:
         plt = pytest.importorskip("matplotlib.pyplot")
         docs, _, _ = _planted_corpus()
         m = HDP(seed=1)
-        m.fit(docs, iters=80, report_interval=10)
+        m.fit(docs, iters=80, progress_interval=10)
         ax = topica.plot_topic_discovery(m)
         assert ax.get_xlabel() == "Gibbs iteration"
         plt.close("all")

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -41,7 +41,7 @@ def test_other_constructors_reject_nan():
         (topica.DMR, dict(num_topics=2, beta=NAN)),
         (topica.DMR, dict(num_topics=2, prior_variance=NAN)),
         (topica.LabeledLDA, dict(alpha=NAN)),
-        (topica.HDP, dict(eta=NAN)),
+        (topica.HDP, dict(beta=NAN)),
         (topica.HDP, dict(alpha=NAN)),
         (topica.DTM, dict(num_topics=2, chain_variance=NAN)),
         (topica.SupervisedLDA, dict(num_topics=2, alpha=NAN)),

--- a/tests/test_keyatm_modelfit.py
+++ b/tests/test_keyatm_modelfit.py
@@ -43,14 +43,14 @@ def test_trace_recorded_auto_spacing():
 def test_trace_explicit_interval():
     docs, _ = _corpus()
     m = topica.KeyATM(SEEDS, num_topics=2, seed=1)
-    m.fit(docs, iters=100, report_interval=25)
+    m.fit(docs, iters=100, progress_interval=25)
     assert [it for it, _, _ in m.log_likelihood_history] == [25, 50, 75, 100]
 
 
 def test_trace_rises_from_random_start():
     docs, _ = _corpus()
     m = topica.KeyATM(SEEDS, num_topics=2, seed=1)
-    m.fit(docs, iters=200, report_interval=5)
+    m.fit(docs, iters=200, progress_interval=5)
     lls = [ll for _, ll, _ in m.log_likelihood_history]
     # The fit should improve overall as Gibbs moves away from the random start.
     assert lls[-1] > lls[0]
@@ -72,7 +72,7 @@ def test_trace_for_covariate_and_dynamic():
 def test_alpha_and_pi_traces():
     docs, _ = _corpus()
     m = topica.KeyATM(SEEDS, num_topics=4, seed=1)
-    m.fit(docs, iters=200, report_interval=20)
+    m.fit(docs, iters=200, progress_interval=20)
     # plot_alpha: base model estimates an asymmetric alpha that moves over sweeps.
     assert len(m.alpha_history) == 10
     it, alpha = m.alpha_history[-1]

--- a/tests/test_naming_aliases.py
+++ b/tests/test_naming_aliases.py
@@ -1,0 +1,333 @@
+"""Alias and rename regression tests (issue #107).
+
+Checks:
+  - Canonical names work on all affected models.
+  - Deprecated aliases work and emit a DeprecationWarning.
+  - ETM/ProdLDA/FASTopic convergence_tol actually affects the fit.
+  - covariates= works on DMR and STM; conflicts raise ValueError.
+  - num_threads in both constructor and fit() for LDA and KeyATM.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+
+# ---------------------------------------------------------------------------
+# Shared tiny corpora
+# ---------------------------------------------------------------------------
+
+def _tiny_docs(n=80, seed=0):
+    rng = np.random.default_rng(seed)
+    vocab = [["cat", "dog", "pet"], ["tax", "vote", "law"]]
+    docs = []
+    for i in range(n):
+        block = vocab[i % 2]
+        docs.append([block[int(rng.integers(3))] for _ in range(5)])
+    return docs
+
+
+def _short_docs(n=150, seed=0):
+    rng = np.random.default_rng(seed)
+    blocks = [["cat", "dog", "pet", "vet"],
+              ["star", "moon", "sky", "sun"],
+              ["tax", "vote", "law", "bill"]]
+    docs = []
+    for _ in range(n):
+        blk = blocks[int(rng.integers(3))]
+        docs.append([blk[int(rng.integers(4))] for _ in range(3)])
+    return docs
+
+
+# ---------------------------------------------------------------------------
+# Item 1: em_tol -> convergence_tol (CTM / STM / STS)
+# ---------------------------------------------------------------------------
+
+class TestConvergenceTolCanonical:
+    def test_ctm_canonical(self):
+        docs = _tiny_docs()
+        m = topica.CTM(num_topics=2, seed=1)
+        m.fit(docs, iters=20, convergence_tol=0.0)
+        assert m.doc_topic.shape[0] == len(docs)
+
+    def test_stm_canonical(self):
+        docs = _tiny_docs()
+        x = np.random.default_rng(0).standard_normal((len(docs), 1))
+        m = topica.STM(num_topics=2, seed=1)
+        m.fit(docs, x, prevalence_names=["x"], iters=15, convergence_tol=0.0)
+        assert m.doc_topic.shape[0] == len(docs)
+
+
+class TestEmTolDeprecatedAliasWarns:
+    def test_ctm_em_tol_warns(self):
+        docs = _tiny_docs()
+        m = topica.CTM(num_topics=2, seed=1)
+        with pytest.warns(DeprecationWarning, match="em_tol"):
+            m.fit(docs, iters=10, em_tol=1e-5)
+
+    def test_stm_em_tol_warns(self):
+        docs = _tiny_docs()
+        x = np.random.default_rng(0).standard_normal((len(docs), 1))
+        m = topica.STM(num_topics=2, seed=1)
+        with pytest.warns(DeprecationWarning, match="em_tol"):
+            m.fit(docs, x, prevalence_names=["x"], iters=10, em_tol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Item 1b: ETM / ProdLDA / FASTopic  convergence_tol constructor + fit()
+# ---------------------------------------------------------------------------
+
+class TestNeuralConvergenceTol:
+    """convergence_tol in constructor and fit() override actually changes
+    the number of epochs the model runs (tight tol stops earlier than loose)."""
+
+    def _word_embeddings(self, vocab, d=10, seed=42):
+        rng = np.random.default_rng(seed)
+        return rng.standard_normal((len(vocab), d))
+
+    def _doc_embeddings(self, docs, d=10, seed=42):
+        rng = np.random.default_rng(seed)
+        return rng.standard_normal((len(docs), d))
+
+    def test_etm_convergence_tol_constructor(self):
+        docs = _tiny_docs(n=60)
+        m_tight = topica.ETM(num_topics=2, convergence_tol=1.0, seed=1)
+        m_loose = topica.ETM(num_topics=2, convergence_tol=0.0, seed=1)
+        vocab = sorted({w for d in docs for w in d})
+        emb = self._word_embeddings(vocab)
+        m_tight.fit(docs, emb, vocab, iters=50)
+        m_loose.fit(docs, emb, vocab, iters=50)
+        # tight tol should converge early (fewer bound_history entries) or both converge
+        # at minimum the model runs without error
+        assert m_tight.topic_word.shape[0] == 2
+        assert m_loose.topic_word.shape[0] == 2
+
+    def test_etm_convergence_tol_fit_override(self):
+        docs = _tiny_docs(n=60)
+        vocab = sorted({w for d in docs for w in d})
+        emb = self._word_embeddings(vocab)
+        m = topica.ETM(num_topics=2, convergence_tol=0.0, seed=1)
+        # Override via fit(); tight tol should stop early (or at minimum not error)
+        m.fit(docs, emb, vocab, iters=50, convergence_tol=1.0)
+        assert m.topic_word.shape[0] == 2
+
+    def test_prodlda_convergence_tol_fit_override(self):
+        docs = _tiny_docs(n=60)
+        m = topica.ProdLDA(num_topics=2, convergence_tol=0.0, seed=1)
+        m.fit(docs, iters=30, convergence_tol=1.0)
+        assert m.topic_word.shape[0] == 2
+
+    def test_fastopic_convergence_tol_fit_override(self):
+        docs = _tiny_docs(n=60)
+        emb = self._doc_embeddings(docs)
+        m = topica.FASTopic(num_topics=2, convergence_tol=0.0, seed=1)
+        m.fit(docs, emb, iters=30, convergence_tol=1.0)
+        assert m.topic_word.shape[0] == 2
+
+    def test_etm_em_tol_constructor_warns(self):
+        docs = _tiny_docs(n=60)
+        vocab = sorted({w for d in docs for w in d})
+        emb = self._word_embeddings(vocab)
+        with pytest.warns(DeprecationWarning, match="em_tol"):
+            m = topica.ETM(num_topics=2, em_tol=1e-4, seed=1)
+        m.fit(docs, emb, vocab, iters=5)
+        assert m.topic_word.shape[0] == 2
+
+    def test_prodlda_em_tol_constructor_warns(self):
+        docs = _tiny_docs(n=60)
+        with pytest.warns(DeprecationWarning, match="em_tol"):
+            m = topica.ProdLDA(num_topics=2, em_tol=0.0, seed=1)
+        m.fit(docs, iters=5)
+        assert m.topic_word.shape[0] == 2
+
+    def test_fastopic_em_tol_constructor_warns(self):
+        docs = _tiny_docs(n=60)
+        emb = self._doc_embeddings(docs)
+        with pytest.warns(DeprecationWarning, match="em_tol"):
+            m = topica.FASTopic(num_topics=2, em_tol=1e-6, seed=1)
+        m.fit(docs, emb, iters=5)
+        assert m.topic_word.shape[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# Item 2: eta -> beta in HDP and HLDA
+# ---------------------------------------------------------------------------
+
+class TestHDPBetaCanonical:
+    def test_hdp_beta_canonical(self):
+        docs = _tiny_docs()
+        m = topica.HDP(beta=0.01, seed=1)
+        m.fit(docs, iters=30)
+        assert m.topic_word.shape[1] > 0
+
+    def test_hdp_eta_deprecated_warns(self):
+        docs = _tiny_docs()
+        with pytest.warns(DeprecationWarning, match="eta"):
+            m = topica.HDP(eta=0.01, seed=1)
+        m.fit(docs, iters=30)
+        assert m.topic_word.shape[1] > 0
+
+
+class TestHLDABetaCanonical:
+    def test_hlda_beta_canonical(self):
+        docs = _tiny_docs()
+        m = topica.HLDA(beta=0.01, seed=1)
+        m.fit(docs, iters=30)
+        assert m.topic_word.shape[1] > 0
+
+    def test_hlda_eta_deprecated_warns(self):
+        docs = _tiny_docs()
+        with pytest.warns(DeprecationWarning, match="eta"):
+            m = topica.HLDA(eta=0.01, seed=1)
+        m.fit(docs, iters=30)
+        assert m.topic_word.shape[1] > 0
+
+
+# ---------------------------------------------------------------------------
+# Item 3: covariates= alias (DMR and STM)
+# ---------------------------------------------------------------------------
+
+class TestCovariatesAlias:
+    def test_dmr_covariates_alias(self):
+        docs = _tiny_docs()
+        x = np.ones((len(docs), 1))
+        m = topica.DMR(num_topics=2, seed=1)
+        # covariates= is a symmetric alias for features=
+        m.fit(docs, covariates=x, feature_names=["x"], iters=50)
+        assert m.doc_topic.shape[0] == len(docs)
+
+    def test_dmr_features_canonical(self):
+        docs = _tiny_docs()
+        x = np.ones((len(docs), 1))
+        m = topica.DMR(num_topics=2, seed=1)
+        m.fit(docs, x, feature_names=["x"], iters=50)
+        assert m.doc_topic.shape[0] == len(docs)
+
+    def test_dmr_both_raises(self):
+        docs = _tiny_docs()
+        x = np.ones((len(docs), 1))
+        m = topica.DMR(num_topics=2, seed=1)
+        with pytest.raises(ValueError, match="features.*covariates|covariates.*features"):
+            m.fit(docs, x, covariates=x, iters=5)
+
+    def test_dmr_neither_raises(self):
+        docs = _tiny_docs()
+        m = topica.DMR(num_topics=2, seed=1)
+        with pytest.raises(ValueError):
+            m.fit(docs, iters=5)
+
+    def test_stm_covariates_alias(self):
+        docs = _tiny_docs()
+        x = np.ones((len(docs), 1))
+        m = topica.STM(num_topics=2, seed=1)
+        m.fit(docs, covariates=x, prevalence_names=["x"], iters=10, convergence_tol=0.0)
+        assert m.doc_topic.shape[0] == len(docs)
+
+    def test_stm_both_raises(self):
+        docs = _tiny_docs()
+        x = np.ones((len(docs), 1))
+        m = topica.STM(num_topics=2, seed=1)
+        with pytest.raises(ValueError, match="prevalence.*covariates|covariates.*prevalence"):
+            m.fit(docs, x, covariates=x, iters=5, convergence_tol=0.0)
+
+
+# ---------------------------------------------------------------------------
+# Item 4: report_interval -> progress_interval (HDP / GSDMM / KeyATM)
+# ---------------------------------------------------------------------------
+
+class TestProgressIntervalCanonical:
+    def test_hdp_progress_interval(self):
+        docs = _tiny_docs()
+        m = topica.HDP(seed=1)
+        m.fit(docs, iters=30, progress_interval=10)
+        iters = [it for it, _ in m.topic_count_history]
+        assert iters == list(range(10, 31, 10))
+
+    def test_gsdmm_progress_interval(self):
+        docs = _short_docs()
+        m = topica.GSDMM(num_topics=10, seed=1)
+        m.fit(docs, iters=20, progress_interval=5)
+        iters = [it for it, _ in m.cluster_count_history]
+        assert iters == list(range(5, 21, 5))
+
+    def test_keyatm_progress_interval(self):
+        docs = _tiny_docs()
+        seeds = {"pets": ["cat", "dog"], "politics": ["tax", "vote"]}
+        m = topica.KeyATM(seeds, num_topics=2, seed=1)
+        m.fit(docs, iters=20, progress_interval=5)
+        iters = [it for it, _, _ in m.log_likelihood_history]
+        assert iters == list(range(5, 21, 5))
+
+
+class TestReportIntervalDeprecatedWarns:
+    def test_hdp_report_interval_warns(self):
+        docs = _tiny_docs()
+        m = topica.HDP(seed=1)
+        with pytest.warns(DeprecationWarning, match="report_interval"):
+            m.fit(docs, iters=30, report_interval=10)
+        iters = [it for it, _ in m.topic_count_history]
+        assert iters == list(range(10, 31, 10))
+
+    def test_gsdmm_report_interval_warns(self):
+        docs = _short_docs()
+        m = topica.GSDMM(num_topics=10, seed=1)
+        with pytest.warns(DeprecationWarning, match="report_interval"):
+            m.fit(docs, iters=20, report_interval=5)
+        iters = [it for it, _ in m.cluster_count_history]
+        assert iters == list(range(5, 21, 5))
+
+    def test_keyatm_report_interval_warns(self):
+        docs = _tiny_docs()
+        seeds = {"pets": ["cat", "dog"], "politics": ["tax", "vote"]}
+        m = topica.KeyATM(seeds, num_topics=2, seed=1)
+        with pytest.warns(DeprecationWarning, match="report_interval"):
+            m.fit(docs, iters=20, report_interval=5)
+        iters = [it for it, _, _ in m.log_likelihood_history]
+        assert iters == list(range(5, 21, 5))
+
+
+# ---------------------------------------------------------------------------
+# Item 5: num_threads in LDA and KeyATM
+# ---------------------------------------------------------------------------
+
+class TestNumThreads:
+    def test_lda_num_threads_in_fit(self):
+        docs = _tiny_docs(n=100)
+        m = topica.LDA(num_topics=2, seed=1)
+        m.fit(docs, iters=20, num_threads=1)
+        assert m.topic_word.shape[0] == 2
+
+    def test_lda_num_threads_fit_overrides_constructor(self):
+        docs = _tiny_docs(n=100)
+        m2 = topica.LDA(num_topics=2, seed=1, num_threads=2)
+        m1 = topica.LDA(num_topics=2, seed=1, num_threads=1)
+        # fit(num_threads=1) override makes them equivalent to single-threaded
+        m2.fit(docs, iters=20, num_threads=1)
+        m1.fit(docs, iters=20, num_threads=1)
+        assert np.array_equal(m1.topic_word, m2.topic_word)
+
+    def test_keyatm_num_threads_in_constructor(self):
+        docs = _tiny_docs()
+        seeds = {"pets": ["cat", "dog"], "politics": ["tax", "vote"]}
+        m = topica.KeyATM(seeds, num_topics=2, seed=1, num_threads=1)
+        m.fit(docs, iters=30)
+        assert m.topic_word.shape[0] == 2
+
+    def test_keyatm_num_threads_in_fit(self):
+        docs = _tiny_docs()
+        seeds = {"pets": ["cat", "dog"], "politics": ["tax", "vote"]}
+        m = topica.KeyATM(seeds, num_topics=2, seed=1)
+        m.fit(docs, iters=30, num_threads=1)
+        assert m.topic_word.shape[0] == 2
+
+    def test_keyatm_num_threads_fit_overrides_constructor(self):
+        docs = _tiny_docs()
+        seeds = {"pets": ["cat", "dog"], "politics": ["tax", "vote"]}
+        # Constructor sets 2 threads, fit() overrides with 1
+        m_c2_f1 = topica.KeyATM(seeds, num_topics=2, seed=3, num_threads=2)
+        m_c1_f1 = topica.KeyATM(seeds, num_topics=2, seed=3, num_threads=1)
+        m_c2_f1.fit(docs, iters=50, num_threads=1)
+        m_c1_f1.fit(docs, iters=50, num_threads=1)
+        # Both use 1 thread -> identical results
+        assert np.array_equal(m_c1_f1.topic_word, m_c2_f1.topic_word)

--- a/tests/test_naming_aliases.py
+++ b/tests/test_naming_aliases.py
@@ -107,16 +107,21 @@ class TestNeuralConvergenceTol:
         docs = _tiny_docs(n=60)
         vocab = sorted({w for d in docs for w in d})
         emb = self._word_embeddings(vocab)
+        # Constructor sets a loose (never-stop) tol; the fit() override sets a
+        # tight one, so the fit() value must take effect: the run stops early.
         m = topica.ETM(num_topics=2, convergence_tol=0.0, seed=1)
-        # Override via fit(); tight tol should stop early (or at minimum not error)
         m.fit(docs, emb, vocab, iters=50, convergence_tol=1.0)
         assert m.topic_word.shape[0] == 2
+        assert m.converged is True
+        assert len(m.fit_history) < 50
 
     def test_prodlda_convergence_tol_fit_override(self):
         docs = _tiny_docs(n=60)
         m = topica.ProdLDA(num_topics=2, convergence_tol=0.0, seed=1)
         m.fit(docs, iters=30, convergence_tol=1.0)
         assert m.topic_word.shape[0] == 2
+        assert m.converged is True
+        assert len(m.fit_history) < 30
 
     def test_fastopic_convergence_tol_fit_override(self):
         docs = _tiny_docs(n=60)
@@ -124,6 +129,8 @@ class TestNeuralConvergenceTol:
         m = topica.FASTopic(num_topics=2, convergence_tol=0.0, seed=1)
         m.fit(docs, emb, iters=30, convergence_tol=1.0)
         assert m.topic_word.shape[0] == 2
+        assert m.converged is True
+        assert len(m.fit_history) < 30
 
     def test_etm_em_tol_constructor_warns(self):
         docs = _tiny_docs(n=60)

--- a/tests/test_reference_default_contracts.py
+++ b/tests/test_reference_default_contracts.py
@@ -111,7 +111,7 @@ def test_stm_fit_defaults_match_r_stm() -> None:
 
     assert init_defaults["init"] == r["init"].lower()
     assert fit_defaults["iters"] == int(r["max_em_its"])
-    assert math.isclose(fit_defaults["em_tol"], float(r["emtol"]), rel_tol=0, abs_tol=0)
+    assert math.isclose(fit_defaults["convergence_tol"], float(r["emtol"]), rel_tol=0, abs_tol=0)
 
 
 def test_keyatm_base_defaults_match_r_keyatm_for_shared_controls() -> None:
@@ -147,7 +147,11 @@ def test_keyatm_base_defaults_match_r_keyatm_for_shared_controls() -> None:
     assert init_defaults["gamma2"] == float(r["gamma2"])
     assert init_defaults["estimate_alpha"] is (r["estimate_alpha"] == "1")
     assert fit_defaults["weights"] == r["weights"]
-    assert fit_defaults["num_threads"] == (1 if r["parallel_init"] == "FALSE" else None)
+    # num_threads defaults to 1 in the constructor (matching R keyATM's single-threaded
+    # default when parallel_init=FALSE). In fit(), num_threads=None means "use the
+    # constructor value", so the effective default is still 1.
+    assert init_defaults["num_threads"] == (1 if r["parallel_init"] == "FALSE" else 4)
+    assert fit_defaults["num_threads"] is None  # fit() overrides constructor; None = use constructor
 
 
 def test_keyatm_alpha_default_matches_r_keyatm() -> None:

--- a/tests/test_seeded_gsdmm_contracts.py
+++ b/tests/test_seeded_gsdmm_contracts.py
@@ -150,7 +150,7 @@ def test_gsdmm_public_outputs_follow_movie_group_process_formulas() -> None:
 def test_gsdmm_trace_records_effective_cluster_count_and_formula_likelihood() -> None:
     docs = [["cat", "cat"], ["dog", "dog"], ["cat", "dog"]]
     model = topica.GSDMM(num_topics=3, alpha=0.1, beta=0.1, seed=2)
-    model.fit(docs, iters=1, report_interval=1)
+    model.fit(docs, iters=1, progress_interval=1)
 
     clusters = np.asarray(model.doc_cluster)
     encoded_docs, _, n, nw = _manual_gsdmm_counts(docs, clusters, model.vocabulary)

--- a/tests/test_stm_gamma_prior.py
+++ b/tests/test_stm_gamma_prior.py
@@ -83,7 +83,7 @@ def pooled_model():
     """Default-prior STM on the binary corpus."""
     docs, x = _make_binary_corpus()
     m = topica.STM(num_topics=2, seed=1)
-    m.fit(docs, x, prevalence_names=["x"], iters=30, em_tol=0.0)
+    m.fit(docs, x, prevalence_names=["x"], iters=30, convergence_tol=0.0)
     return m
 
 
@@ -92,7 +92,7 @@ def pooled_model_explicit():
     """Explicit gamma_prior='pooled' — must give bit-for-bit identical result."""
     docs, x = _make_binary_corpus()
     m = topica.STM(num_topics=2, seed=1)
-    m.fit(docs, x, prevalence_names=["x"], iters=30, em_tol=0.0, gamma_prior="pooled")
+    m.fit(docs, x, prevalence_names=["x"], iters=30, convergence_tol=0.0, gamma_prior="pooled")
     return m
 
 
@@ -101,7 +101,7 @@ def l1_model_high_dim():
     """L1 prior STM on the high-dimensional one-hot design."""
     docs, x = _make_high_dim_corpus()
     m = topica.STM(num_topics=2, seed=1)
-    m.fit(docs, x, iters=30, em_tol=0.0, gamma_prior="l1")
+    m.fit(docs, x, iters=30, convergence_tol=0.0, gamma_prior="l1")
     return m
 
 
@@ -110,7 +110,7 @@ def pooled_model_high_dim():
     """Pooled (ridge) STM on the same high-dimensional design (for sparsity comparison)."""
     docs, x = _make_high_dim_corpus()
     m = topica.STM(num_topics=2, seed=1)
-    m.fit(docs, x, iters=30, em_tol=0.0, gamma_prior="pooled")
+    m.fit(docs, x, iters=30, convergence_tol=0.0, gamma_prior="pooled")
     return m
 
 
@@ -205,37 +205,37 @@ class TestGammaPriorValidation:
         docs, x = self._base_docs_and_x()
         m = topica.STM(num_topics=2, seed=1)
         with pytest.raises(ValueError, match="gamma_prior"):
-            m.fit(docs, x, iters=2, em_tol=0.0, gamma_prior="bayes")
+            m.fit(docs, x, iters=2, convergence_tol=0.0, gamma_prior="bayes")
 
     def test_gamma_enet_zero_raises(self):
         docs, x = self._base_docs_and_x()
         m = topica.STM(num_topics=2, seed=1)
         with pytest.raises(ValueError, match="gamma_enet"):
-            m.fit(docs, x, iters=2, em_tol=0.0, gamma_prior="l1", gamma_enet=0.0)
+            m.fit(docs, x, iters=2, convergence_tol=0.0, gamma_prior="l1", gamma_enet=0.0)
 
     def test_gamma_enet_negative_raises(self):
         docs, x = self._base_docs_and_x()
         m = topica.STM(num_topics=2, seed=1)
         with pytest.raises(ValueError, match="gamma_enet"):
-            m.fit(docs, x, iters=2, em_tol=0.0, gamma_prior="l1", gamma_enet=-0.5)
+            m.fit(docs, x, iters=2, convergence_tol=0.0, gamma_prior="l1", gamma_enet=-0.5)
 
     def test_gamma_enet_above_one_raises(self):
         docs, x = self._base_docs_and_x()
         m = topica.STM(num_topics=2, seed=1)
         with pytest.raises(ValueError, match="gamma_enet"):
-            m.fit(docs, x, iters=2, em_tol=0.0, gamma_prior="l1", gamma_enet=1.5)
+            m.fit(docs, x, iters=2, convergence_tol=0.0, gamma_prior="l1", gamma_enet=1.5)
 
     def test_gamma_enet_one_accepted(self):
         docs, x = self._base_docs_and_x()
         m = topica.STM(num_topics=2, seed=1)
-        m.fit(docs, x, iters=2, em_tol=0.0, gamma_prior="l1", gamma_enet=1.0)
+        m.fit(docs, x, iters=2, convergence_tol=0.0, gamma_prior="l1", gamma_enet=1.0)
         # No exception raised; doc_topic is accessible.
         assert m.doc_topic.shape[0] > 0
 
     def test_gamma_enet_midrange_accepted(self):
         docs, x = self._base_docs_and_x()
         m = topica.STM(num_topics=2, seed=1)
-        m.fit(docs, x, iters=2, em_tol=0.0, gamma_prior="l1", gamma_enet=0.5)
+        m.fit(docs, x, iters=2, convergence_tol=0.0, gamma_prior="l1", gamma_enet=0.5)
         assert m.doc_topic.shape[0] > 0
 
     def test_pooled_accepts_any_gamma_enet(self):
@@ -243,5 +243,5 @@ class TestGammaPriorValidation:
         docs, x = self._base_docs_and_x()
         m = topica.STM(num_topics=2, seed=1)
         # gamma_enet=0 is only rejected for l1; pooled ignores it entirely.
-        m.fit(docs, x, iters=2, em_tol=0.0, gamma_prior="pooled", gamma_enet=0.0)
+        m.fit(docs, x, iters=2, convergence_tol=0.0, gamma_prior="pooled", gamma_enet=0.0)
         assert m.doc_topic.shape[0] > 0

--- a/tests/test_stm_model.py
+++ b/tests/test_stm_model.py
@@ -516,14 +516,14 @@ class TestSTMCoherence:
 
 
 # ---------------------------------------------------------------------------
-# EM convergence (em_tol / bound / converged) — matches R stm's emtol stop
+# EM convergence (convergence_tol / bound / converged) — matches R stm's emtol stop
 # ---------------------------------------------------------------------------
 
 class TestSTMConvergence:
     def test_bound_history_monotone_increasing(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], iters=200, em_tol=1e-6)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=200, convergence_tol=1e-6)
         h = m.bound_history
         assert len(h) >= 2
         assert all(h[i + 1] >= h[i] - 1e-6 for i in range(len(h) - 1))
@@ -533,21 +533,21 @@ class TestSTMConvergence:
     def test_converges_before_cap(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], iters=500, em_tol=1e-5)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=500, convergence_tol=1e-5)
         assert m.converged is True
         assert len(m.bound_history) < 500
 
-    def test_em_tol_zero_runs_full_cap(self, stm_corpus_and_x):
+    def test_convergence_tol_zero_runs_full_cap(self, stm_corpus_and_x):
         docs, x_2d = stm_corpus_and_x
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], iters=15, em_tol=0.0)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=15, convergence_tol=0.0)
         assert m.converged is False
         assert len(m.bound_history) == 15
 
     def test_convergence_state_survives_save_load(self, stm_corpus_and_x, tmp_path):
         docs, x_2d = stm_corpus_and_x
         m = STM(num_topics=2, seed=1)
-        m.fit(docs, x_2d, prevalence_names=["x"], iters=500, em_tol=1e-5)
+        m.fit(docs, x_2d, prevalence_names=["x"], iters=500, convergence_tol=1e-5)
         path = str(tmp_path / "stm.bin")
         m.save(path)
         reloaded = STM.load(path)


### PR DESCRIPTION
Closes #107 (the naming adjudication). Per the maintainer's decisions, with backward-compatible aliases throughout (the package migrates its own call sites so it does not warn at itself).

- **convergence_tol** is the canonical convergence tolerance in `fit()` for every iterative model. CTM/STM/STS renamed from `em_tol` (kept as a deprecated alias). The neural models (ETM/ProdLDA/FASTopic) move it to `fit()` as well: `convergence_tol` in `fit()` overrides the constructor value, verified to genuinely stop the loop early (tight tol converges in ~2 epochs vs the full count). `em_tol` stays as a deprecated constructor/fit alias.
- **beta** is the canonical topic-word prior everywhere; `eta` kept as a deprecated alias on HDP/HLDA.
- **covariates=** is accepted on every covariate model as an alias; the domain names (`prevalence` for STM/STS, `features` for DMR) keep working and are *not* deprecated. Passing both the domain name and `covariates` raises a clear `ValueError`.
- **progress_interval** is canonical; `report_interval` deprecated on HDP/GSDMM/KeyATM.
- **num_threads** is accepted in both the constructor and `fit()` (fit overrides) on LDA and KeyATM. KeyATM now stores `num_threads` in its save state.
- SAGE `burn_in` default 100 -> 200 (matches LDA/DMR). `alpha_sum` left as-is (documented as the sum over topics).

The stub (`_topica.pyi`) is updated for every changed signature. Verified: `cargo test --lib` 97 pass; full pytest 2095 pass / 18 skip (+32 new alias/deprecation/override tests). #108 (the broader pre-existing stub drift) follows as a separate stub-only PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)