### PR TITLE
release: 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-06-12
+
 ### Fixed
 
 - `SeededLDA` save/load is no longer lossy: the seed topic names, seed words, and

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.15.0
-date-released: 2026-06-10
+version: 0.16.0
+date-released: 2026-06-12
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than a dozen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.15.0"
+version = "0.16.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.15.0"
+version = "0.16.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.15.0"
+version = "0.16.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts the 0.16.0 release.

- Version bump: Cargo.toml, pyproject.toml, CITATION.cff (date 2026-06-12).
- CHANGELOG: `[Unreleased]` finalized as `[0.16.0]`.

This release bundles the pre-publicity hardening from #118-126: correctness fixes (predicted_prevalence, permutation_test, versioned save format + SeededLDA round-trip, non-finite covariate validation, numeric robustness), API-naming and signature consistency (transform `iters`, SAGE `top_words`, embedding `transform`, `convergence_tol`/`beta`/`covariates`/`progress_interval`/`num_threads` with backward-compatible aliases), the type-stub sync + drift guard, and CI/docs hardening (cargo test + `mkdocs --strict` gates).

It includes breaking changes (the save-format header, SAGE `top_words` positional shape, `FASTopic.transform` positional input); in 0.x these go in a minor bump.

No `v*` tag is pushed by this PR; tagging/PyPI publish is a separate manual step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)