### PR TITLE
paper: re-pin deterministic + parity numbers to 0.16.0 (#109)

### DIFF
--- a/paper/topica.bib
+++ b/paper/topica.bib
@@ -505,7 +505,7 @@
   author       = {Caren, Neal},
   title        = {\pkg{topica}: Fast, All-Purpose Topic Modeling for {Python}},
   year         = {2026},
-  note         = {Python package, version 0.10.0},
+  note         = {Python package, version 0.16.0},
   howpublished = {\url{https://github.com/nealcaren/topica}}
 }
 

--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -539,8 +539,8 @@ top-word Jaccard and cosine of $1.000$ on a planted-topic corpus
 \code{model\_fit} log-likelihood \citep{eshima2024keyatm}. \pkg{keyATM}
 initializes at random, so even two \proglang{R} runs differ; on the poliblog
 corpus the keyword topics, the ones the method pins, agree between \pkg{topica}
-and \proglang{R} at a cosine of $0.91$, as close as \proglang{R}'s two seeds agree
-with each other ($0.90$) (\code{parity/keyatm\_r\_compare.py}).
+and \proglang{R} at a cosine of $0.889$, about as close as \proglang{R}'s two seeds
+agree with each other ($0.902$) (\code{parity/keyatm\_r\_compare.py}).
 
 \paragraph{Structural topic model.} The structural topic model is non-convex, so
 the right question is not whether two engines produce identical matrices, which
@@ -750,7 +750,7 @@ model presents the same surface. Numbers reproduce from \code{paper/replication.
 \toprule
 Model & Family & Topics & Coherence ($c_v$) & Exclusivity & Diversity \\
 \midrule
-\code{LDA}      & count-based     & 15 & 0.358 & 0.514 & 0.683 \\
+\code{LDA}      & count-based     & 15 & 0.365 & 0.580 & 0.717 \\
 \code{CTM}      & count-based     & 15 & 0.351 & 0.446 & 0.579 \\
 \code{STM}      & count-based     & 15 & 0.350 & 0.435 & 0.565 \\
 \code{BERTopic} & embedding-based &  3 & 0.459 & 0.526 & 0.693 \\
@@ -941,7 +941,8 @@ estimands for the effect-estimation tools.
 
 \pkg{topica} is released under the Apache-2.0 license and installs from the
 Python Package Index with \code{pip install topica}; the core requires only
-\pkg{NumPy}. Source code, documentation, and worked examples are available at
+\pkg{NumPy}. The results reported in this article were produced with
+\pkg{topica} 0.16.0. Source code, documentation, and worked examples are available at
 \url{https://github.com/nealcaren/topica} and
 \url{https://nealcaren.github.io/topica/}. A single script,
 \code{paper/replication.py}, regenerates every quantitative artifact in this


### PR DESCRIPTION
Partial fix for #109 — the deterministic and parity numbers, regenerated against 0.16.0 (`paper/replication.py` + the `parity/` scripts on this machine).

**Re-pinned (regenerated, deterministic):**
- Table 4 spanning, LDA row: `0.358/0.514/0.683` → `0.365/0.580/0.717`. CTM/STM/BERTopic rows and all five §7.2 effect coefficients/CIs re-ran **unchanged**.
- keyATM parity: `0.91` (vs R-R `0.90`) → `0.889` (vs R-R `0.902`), and "as close as" softened to "about as close as" (topica is now a hair below R's self-agreement, not above).
- STM parity (`0.973`, median `0.993`, R spread `~0.61`) and MALLET (`1.000`) re-ran **unchanged** — verified, no edit needed.
- bib `caren2026topica` `0.10.0` → `0.16.0`; added "produced with topica 0.16.0" to the Availability section.

**Deliberately NOT changed here — needs a dedicated quiet-machine run:**
The timing tables (Table 3 STM speed; the keyATM/MALLET/tomotopy speed prose), `fig_thread_scaling`, and the memory figures are load-sensitive, and this machine was busy (topica keyATM measured 33.8s here vs the paper's 25.9s — noise, not regression). I did not fudge them. Before submission, run on a quiet machine:
```
VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/python benchmarks/bench.py --render   # thread fig + memory + MALLET
VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/python benchmarks/bench_stm.py        # Table 3 STM speed
VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/python benchmarks/k_crossover.py      # tomotopy crossover
```
The `fig_thread_scaling` caption-vs-plot inconsistency (#109) should be resolved as part of that regeneration. #109 stays open for the timing pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)