### PR TITLE
fix(core): persist theta_draws on save/load for DMR/LabeledLDA/SAGE/KeyATM (#102)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -69,9 +69,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   format version, model tag). Loading a file saved by an earlier version, or
   loading a file saved as the wrong model, now raises a clear error instead of
   panicking or silently misreading. Models saved before this release must be
-  re-fit and re-saved. `LDA` save/load now also round-trips the retained MCMC
-  `theta_draws` and the sampler-backend flags (part of #102). DMR, LabeledLDA,
-  SAGE, and KeyATM still drop `theta_draws` on load; tracked as remaining work.
+  re-fit and re-saved. Save/load now also round-trips the retained MCMC
+  `theta_draws` (so method-of-composition standard errors survive a round-trip)
+  for every collapsed-Gibbs model: LDA and SeededLDA plus DMR, LabeledLDA, SAGE,
+  and KeyATM, and the LDA sampler-backend flags (#102).
 
 ### Added
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -302,6 +302,8 @@ struct DmrState {
     #[serde(default)] topic_names: Vec<String>,
     #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
     #[serde(default)] converged: bool,
+    // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
+    #[serde(default)] theta_draws: Option<Arr3f32>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct LabeledState {
@@ -311,6 +313,8 @@ struct LabeledState {
     #[serde(default)] topic_names: Vec<String>,
     #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
     #[serde(default)] converged: bool,
+    // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
+    #[serde(default)] theta_draws: Option<Arr3f32>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SageState {
@@ -321,6 +325,8 @@ struct SageState {
     #[serde(default)] topic_names: Vec<String>,
     #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
     #[serde(default)] converged: bool,
+    // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
+    #[serde(default)] theta_draws: Option<Arr3f32>,
 }
 /// serde default for the bound of a model saved before convergence tracking
 /// existed: NaN signals "unknown", distinct from a real bound of 0.
@@ -435,6 +441,8 @@ struct KeyAtmState {
     #[serde(default)] pi_history: Vec<(usize, Vec<f64>)>,
     #[serde(default)] alpha_vec: Option<Vec<f64>>,
     #[serde(default = "default_num_threads")] num_threads: usize,
+    // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
+    #[serde(default)] theta_draws: Option<Arr3f32>,
 }
 fn default_num_threads() -> usize { 1 }
 #[derive(serde::Serialize, serde::Deserialize)]
@@ -3891,6 +3899,7 @@ impl DMR {
             topic_names: self.topic_names.clone(),
             log_likelihood_history: self.log_likelihood_history.clone(),
             converged: self.converged,
+            theta_draws: arr3f32_opt(&self.theta_draws),
         })
     }
 
@@ -3911,7 +3920,7 @@ impl DMR {
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             feature_effects: arr2_back(s.feature_effects),
             feature_names: s.feature_names, corpus: s.corpus,
-            theta_draws: None,
+            theta_draws: arr3f32_back(s.theta_draws),
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
         })
@@ -4434,6 +4443,7 @@ impl LabeledLDA {
             topic_names: self.topic_names.clone(),
             log_likelihood_history: self.log_likelihood_history.clone(),
             converged: self.converged,
+            theta_draws: arr3f32_opt(&self.theta_draws),
         })
     }
 
@@ -4451,7 +4461,7 @@ impl LabeledLDA {
             num_topics: s.num_topics, topic_names,
             phi: arr2_back(s.phi), theta: arr2_back(s.theta),
             label_vocab: s.label_vocab, corpus: s.corpus,
-            theta_draws: None,
+            theta_draws: arr3f32_back(s.theta_draws),
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
         })
@@ -5003,6 +5013,7 @@ impl SAGE {
             topic_names: self.topic_names.clone(),
             log_likelihood_history: self.log_likelihood_history.clone(),
             converged: self.converged,
+            theta_draws: arr3f32_opt(&self.theta_draws),
         })
     }
 
@@ -5021,7 +5032,7 @@ impl SAGE {
             lbfgs_iters: s.lbfgs_iters, fitted: s.fitted, num_groups: s.num_groups,
             topic_names,
             beta: s.beta, theta: arr2_back(s.theta), group_names: s.group_names, corpus: s.corpus,
-            theta_draws: None,
+            theta_draws: arr3f32_back(s.theta_draws),
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
         })
@@ -12392,6 +12403,7 @@ impl KeyATM {
             pi_history: self.pi_history.clone(),
             alpha_vec: self.alpha_vec.clone(),
             num_threads: self.num_threads,
+            theta_draws: arr3f32_opt(&self.theta_draws),
         })
     }
     /// Load a model previously written by :meth:`save`.
@@ -12409,7 +12421,7 @@ impl KeyATM {
             transition_matrix: None, log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
             alpha_history: s.alpha_history, pi_history: s.pi_history,
-            alpha_vec: s.alpha_vec, theta_draws: None,
+            alpha_vec: s.alpha_vec, theta_draws: arr3f32_back(s.theta_draws),
         })
     }
 

--- a/tests/test_save_load_fixes.py
+++ b/tests/test_save_load_fixes.py
@@ -189,3 +189,53 @@ def test_seededlda_file_cannot_load_as_lda(tmp_path):
     msg = str(exc_info.value)
     assert "SeededLDA" in msg, f"error should mention SeededLDA: {msg}"
     assert "LDA" in msg, f"error should mention LDA: {msg}"
+
+
+# ---------------------------------------------------------------------------
+# Issue #102b (extended): DMR/LabeledLDA/SAGE/KeyATM also persist theta_draws.
+# Before the fix these four set theta_draws=None on load, so a saved-then-loaded
+# model silently fell back to the Dirichlet approximation in composition_theta,
+# changing estimate_effect / standard_errors uncertainty.
+# ---------------------------------------------------------------------------
+
+_TD_DOCS = [["a", "b", "c"], ["b", "c", "d"], ["a", "d", "e"],
+            ["c", "e", "f"], ["a", "b", "f"]] * 8
+
+
+def _fit_dmr():
+    X = np.ones((len(_TD_DOCS), 1))
+    m = topica.DMR(num_topics=3, seed=1)
+    m.fit(_TD_DOCS, X, feature_names=["x"], iters=30)
+    return m
+
+
+def _fit_labeled():
+    m = topica.LabeledLDA(seed=1)
+    m.fit(_TD_DOCS, [["t0", "t1"]] * len(_TD_DOCS), iters=30)
+    return m
+
+
+def _fit_sage():
+    groups = ["g0", "g1"] * (len(_TD_DOCS) // 2)
+    m = topica.SAGE(num_topics=3, seed=1)
+    m.fit(_TD_DOCS, groups, iters=30)
+    return m
+
+
+def _fit_keyatm():
+    m = topica.KeyATM({"k0": ["a", "b"], "k1": ["c", "d"]}, seed=1)
+    m.fit(_TD_DOCS, iters=30)
+    return m
+
+
+@pytest.mark.parametrize("fit_fn", [_fit_dmr, _fit_labeled, _fit_sage, _fit_keyatm])
+def test_theta_draws_survive_save_load(fit_fn, tmp_path):
+    m = fit_fn()
+    before = m.theta_draws
+    assert before is not None, "model should retain theta_draws by default"
+    path = str(tmp_path / "m.bin")
+    m.save(path)
+    m2 = type(m).load(path)
+    after = m2.theta_draws
+    assert after is not None, "theta_draws must survive load (issue #102)"
+    assert np.array_equal(before, after)


### PR DESCRIPTION
Closes #102.

Completes the save-format work from #120. `DmrState`/`LabeledState`/`SageState`/`KeyAtmState` now serialize the thinned MCMC `theta_draws` stack (same `arr3f32_opt`/`arr3f32_back` pattern as `LdaState`/`SeededState`), and `load()` restores it instead of setting `theta_draws=None`.

Before this, a saved-then-loaded DMR/LabeledLDA/SAGE/KeyATM silently fell back to the within-document Dirichlet approximation in `composition_theta`, so `estimate_effect` / `standard_errors` / `prevalence_ci` reported *different* uncertainty for the same model after a round-trip. Now the draws survive bit-identically, verified across all four models.

Adds a parametrized `test_theta_draws_survive_save_load` (DMR/LabeledLDA/SAGE/KeyATM) to `tests/test_save_load_fixes.py`. Verified: `cargo test --lib` 97 pass; full pytest 2143 pass / 18 skip.

Folded into 0.16.0 (not yet tagged), and the CHANGELOG save-format note updated accordingly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)