### PR TITLE
paper: fix tomotopy crossover corpus size (3,500 -> 2,000 docs) (#109)

### DIFF
--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -627,7 +627,7 @@ two make opposite algorithmic bets. \pkg{tomotopy} computes a dense topic
 distribution for every token and vectorizes it with \pkg{Eigen}, which is fastest
 when $K$ is small; \pkg{topica}, like \pkg{MALLET}, uses a sparse sampler that
 visits only the topics a word actually occupies, which wins when $K$ is large. On
-a 2{,}600-word, 3{,}500-document corpus the two cross between $K=50$ and $K=100$:
+a 2{,}600-word, 2{,}000-document corpus the two cross between $K=50$ and $K=100$:
 \pkg{tomotopy} is about $1.5\times$ faster at $K=20$, the gap closes by $K=50$, and
 \pkg{topica} is faster from $K=100$ on, by about $2.3\times$ at $K=400$, where its
 time has barely grown while \pkg{tomotopy}'s has risen with $K$. The fine-grained models


### PR DESCRIPTION
A factual correction surfaced while re-running the benchmarks for #109.

`benchmarks/k_crossover.py` runs on the 2,000-document poliblog subsample (2,632 vocab, which is the "2,600-word" figure the paper cites), but the tex said a "3,500-document corpus." Corrected to 2,000.

The tomotopy ratios themselves re-ran **unchanged** (tomotopy ~1.5x at K=20, crossover between K=50 and K=100, topica ~2.3x at K=400), so only the corpus size moves.

Part of #109; the STM speed table (Table 3) was re-run and confirmed within timing noise (kept as published); the thread-scaling figure + memory + MALLET prose still need a `bench.py --render` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)