### PR TITLE
paper: fix thread-scaling figure + re-pin timing numbers (#109)

### DIFF
--- a/benchmarks/bench.py
+++ b/benchmarks/bench.py
@@ -837,25 +837,22 @@ def render_thread_figure(records: list[dict] | None = None) -> None:
 
     fig, ax = plt.subplots(figsize=(6, 4))
 
-    ylabel = "Speedup vs single-thread reference"
+    ylabel = "Thread speedup (single-thread / n-thread topica)"
     for model, label, color in [
-        ("lda", "LDA vs MALLET", "steelblue"),
-        ("keyatm", "keyATM vs R keyATM", "firebrick"),
+        ("lda", "LDA", "steelblue"),
+        ("keyatm", "keyATM", "firebrick"),
     ]:
         recs = [r for r in records if r["model"] == model and r["n_docs"] == max_size]
         if not recs:
             continue
         recs_sorted = sorted(recs, key=lambda r: r["threads"])
         threads = [r["threads"] for r in recs_sorted]
-        # Speedup = ref_time / topica_time (using ref from single-thread entry).
-        ref_t = next((r["ref_time"] for r in recs_sorted if r["ref_time"] is not None), None)
-        if ref_t is None:
-            # No reference available; use 1-thread topica as baseline.
-            base = recs_sorted[0]["topica_time"]
-            speedups = [base / r["topica_time"] for r in recs_sorted]
-            ylabel = "Thread speedup (vs 1-thread topica)"
-        else:
-            speedups = [ref_t / r["topica_time"] for r in recs_sorted]
+        # Thread-scaling speedup = topica single-thread time / topica n-thread
+        # time. This is topica's own parallel scaling (what the paper figure
+        # caption describes), not a comparison against the reference.
+        base = next((r["topica_time"] for r in recs_sorted if r["threads"] == 1),
+                    recs_sorted[0]["topica_time"])
+        speedups = [base / r["topica_time"] for r in recs_sorted]
 
         ax.plot(threads, speedups, marker="o", label=label, color=color)
 

--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -607,20 +607,20 @@ The structural topic model is the comparison that matters most for social
 scientists, since \proglang{R} \pkg{stm} is the field standard and its fits can
 take minutes. Table~\ref{tab:stm} shows \pkg{topica} fitting the same model three
 to six times faster on a single core and ten to twenty-two times faster across
-cores. It also fits in roughly a quarter of \proglang{R} \pkg{stm}'s memory
-(about 460MB against 1.7GB at 5{,}000 documents), since it holds the corpus and
+cores. It also fits in under a third of \proglang{R} \pkg{stm}'s memory
+(about 490MB against 1.6GB at 5{,}000 documents), since it holds the corpus and
 the variational state in compact native arrays rather than \proglang{R} objects.
 The keyword-assisted model matches \proglang{R} \pkg{keyATM}'s
-\proglang{C++} sampler single-threaded (25.9s versus 24.5s on a
-2{,}000-document, 10-topic fit of 1{,}000 sweeps) and runs about twice as fast on
-four cores (12.1s), through a document-partitioned parallel sweep that the
+\proglang{C++} sampler single-threaded (22.8s versus 23.5s on a
+2{,}000-document, 10-topic fit of 1{,}000 sweeps) and runs about 1.7 times as fast
+on four cores (13.7s), through a document-partitioned parallel sweep that the
 \proglang{R} package has no equivalent of.
 
 We report the LDA comparison straight, because it does not uniformly favor us.
 Against \pkg{MALLET}, the original \proglang{Java} sampler, the two are at parity
 single-threaded and stay close at matched thread counts, with \pkg{topica}'s
 document-partitioned parallelism pulling ahead on the larger corpora (a
-5{,}000-document fit on ten threads runs in 12.8s against \pkg{MALLET}'s 16.5s),
+5{,}000-document fit on ten threads runs in 11.2s against \pkg{MALLET}'s 13.1s),
 and \pkg{topica} adds no JVM startup. Against \pkg{tomotopy} \citep{tomotopy}, a
 \proglang{C++} library, the comparison turns on the number of topics, because the
 two make opposite algorithmic bets. \pkg{tomotopy} computes a dense topic
@@ -640,9 +640,9 @@ all, at no measurable cost to fit time.
 Both collapsed-Gibbs samplers parallelize by partitioning the documents across
 threads and merging the count tables each sweep, the approximate-distributed
 scheme \pkg{MALLET} also uses. Figure~\ref{fig:threads} shows the scaling on the
-5{,}000-document corpus: LDA reaches about $4.6\times$ on ten threads, while the
+5{,}000-document corpus: LDA reaches about $4.5\times$ on ten threads, while the
 keyword-assisted model, whose per-sweep keyword bookkeeping leaves a larger fixed
-cost in the merge, reaches about $2.3\times$. The merge is fixed overhead, so the
+cost in the merge, reaches about $2.2\times$. The merge is fixed overhead, so the
 multithreaded gain grows with corpus size as more sampling work amortizes it; the
 \proglang{R} packages have no parallel mode at all.
 


### PR DESCRIPTION
Closes #109.

**Figure bug (the caption-vs-plot inconsistency).** `bench.py:render_thread_figure` plotted `ref_time / topica_time` (a vs-reference ratio) while the paper caption says "single-thread fit time divided by n-thread fit time" and the prose cites topica's own thread scaling. Fixed the renderer to plot the self-speedup `topica_t1 / topica_tn`, so plot = caption = prose. Regenerated `fig_thread_scaling.pdf` (LDA 4.49x, keyATM 2.16x at 10 threads on the 5,000-doc corpus).

**Re-pinned bench.py numbers** (5-thread sweep run by the maintainer on the submission machine, `THREADS=1,2,4,8,10`):
- thread prose: LDA `4.6x -> 4.5x`, keyATM `2.3x -> 2.2x`
- LDA vs MALLET, 5,000-doc/10-thread: `12.8s vs 16.5s -> 11.2s vs 13.1s` (LDA genuinely faster after the Gibbs perf work)
- keyATM: single-threaded `25.9s/24.5s -> 22.8s/23.5s`; four cores `twice as fast (12.1s) -> about 1.7x (13.7s)`
- memory: `a quarter ... 460MB against 1.7GB -> under a third ... 490MB against 1.6GB` (the 1.7GB never matched the data; measured R-stm RSS 1.63GB)

**Kept as published:** Table 3 (STM speed) — STM's variational EM was not touched by the perf work and the rerun confirmed it within timing noise; the abstract/intro "three to twenty-two times" headline stays with it. (Maintainer decision.)

Paper rebuilds clean (21 pp, no undefined refs). Figures are gitignored/regenerable, so this PR is the `bench.py` renderer fix + the tex prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)