### PR TITLE
viz(plot_report): mask correlation diagonal; dumbbell prevalence-by-class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   `save`/`load`, `log_likelihood_history`, `doc_names`, several `fit()` keywords,
   and `Corpus.from_documents` parameters added; a bogus `HLDA.coherence` removed),
   and a parametrized test now guards against future drift (#108).
+- `plot_report`'s topic-correlation panel now masks the always-1.0 diagonal and
+  scales to the off-diagonal range, instead of drawing the raw matrix on a
+  saturated +/-1 scale where the diagonal swamped the real structure. (The
+  original fix had only reached the standalone `viz.TopicCorrelation`.)
+
+### Changed
+
+- `plot_report`'s "Prevalence by class" panel is now a connected-dot (dumbbell)
+  plot for up to five classes: one dot per class per topic joined by a line, with
+  topics ordered by the between-class gap, so the class differences read directly.
+  It falls back to the heatmap for more than five classes.
 - Covariate, feature, embedding, and timestamp matrices are now checked for
   non-finite values (NaN/inf) at the boundary and raise a clear `ValueError`
   naming the parameter, instead of panicking (KeyATM) or silently producing

--- a/python/topica/analysis.py
+++ b/python/topica/analysis.py
@@ -349,7 +349,18 @@ def plot_report(model, *, texts=None, timestamps=None, groups=None, n=8,
             # (e.g. "1e-10+9.99e-1") from rendering on the axis.
             ax.ticklabel_format(useOffset=False, style="plain")
         elif panel == "correlation":
-            im = ax.imshow(corr, cmap="RdBu_r", vmin=-1, vmax=1)
+            # Mask the always-1.0 diagonal (self-correlation carries no
+            # information and, left in, saturates the diverging scale and
+            # dominates the panel) and set the color range from the off-diagonal
+            # magnitudes so the real structure reads. Matches
+            # topica.viz.TopicCorrelation.
+            import matplotlib as mpl
+            cmax = max(float(np.abs(corr - np.eye(K)).max()), 1e-3)
+            disp = corr.astype(float).copy()
+            np.fill_diagonal(disp, np.nan)
+            cmap = mpl.colormaps["RdBu_r"].copy()
+            cmap.set_bad("#f0f0f0")
+            im = ax.imshow(disp, cmap=cmap, vmin=-cmax, vmax=cmax)
             ax.set_title("Topic correlation")
             ax.set_xlabel("topic")
             ax.set_ylabel("topic")
@@ -366,13 +377,38 @@ def plot_report(model, *, texts=None, timestamps=None, groups=None, n=8,
             ax.set_title("Topics over time (top 6)")
             ax.legend(fontsize=6, ncol=2)
         elif panel == "class":
-            levels, means = per_class
-            im = ax.imshow(means, aspect="auto", cmap="viridis")
-            ax.set_yticks(range(len(levels)))
-            ax.set_yticklabels([str(lv) for lv in levels], fontsize=7)
-            ax.set_xlabel("topic")
-            ax.set_title("Prevalence by class")
-            fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
+            import matplotlib as mpl
+            levels, means = per_class  # means: (num_levels, K)
+            n_lv = len(levels)
+            if n_lv <= 5:
+                # Connected-dot ("dumbbell") plot: each topic is a row with one
+                # dot per class joined by a line, so the between-class gap -- the
+                # quantity of interest -- reads directly, which a few-row heatmap
+                # hides. Topics are ordered by that gap, putting the most
+                # class-differentiated topics on top.
+                spread = means.max(axis=0) - means.min(axis=0)
+                order = np.argsort(spread)
+                ypos = np.arange(K)
+                cmap = mpl.colormaps["tab10"]
+                for yi, t in enumerate(order):
+                    col = means[:, t]
+                    ax.plot([col.min(), col.max()], [yi, yi],
+                            color="#cccccc", lw=1.5, zorder=1)
+                for j, lv in enumerate(levels):
+                    ax.scatter(means[j, order], ypos, s=28, color=cmap(j),
+                               label=str(lv), zorder=2)
+                ax.set_yticks(ypos)
+                ax.set_yticklabels([captions[i] for i in order], fontsize=7)
+                ax.set_xlabel("Mean prevalence (θ)")
+                ax.set_title("Prevalence by class")
+                ax.legend(fontsize=6)
+            else:
+                im = ax.imshow(means, aspect="auto", cmap="viridis")
+                ax.set_yticks(range(n_lv))
+                ax.set_yticklabels([str(lv) for lv in levels], fontsize=7)
+                ax.set_xlabel("topic")
+                ax.set_title("Prevalence by class")
+                fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04)
 
     fig.suptitle(title or f"{type(model).__name__} — {K} topics", fontsize=12)
     fig.tight_layout(rect=(0, 0, 1, 0.98))

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -237,3 +237,29 @@ def test_plot_report_saves(tmp_path, lda_corpus):
     fig.savefig(out, dpi=60)
     assert out.exists() and out.stat().st_size > 0
     plt.close(fig)
+
+
+def test_plot_report_correlation_masks_diagonal(lda_corpus):
+    """The correlation panel masks the always-1.0 self-correlation diagonal and
+    scales its colors to the off-diagonal range, instead of drawing the raw
+    matrix on a saturated +/-1 scale (regression for the plot_report sub-panel,
+    which the original viz.TopicCorrelation fix had missed)."""
+    import matplotlib.pyplot as plt
+
+    m, docs, texts, *_ = lda_corpus
+    fig = topica.plot_report(m, texts=texts)
+    corr_axes = [ax for ax in fig.get_axes() if ax.get_title() == "Topic correlation"]
+    if not corr_axes:
+        plt.close(fig)
+        pytest.skip("correlation panel not drawn for this model")
+    im = corr_axes[0].images[0]
+    data = im.get_array()
+    # Diagonal is masked (drawn as neutral background), not a saturated 1.0.
+    if np.ma.isMaskedArray(data):
+        assert np.ma.getmaskarray(data).diagonal().all()
+    else:
+        assert np.all(np.isnan(np.asarray(data, dtype=float).diagonal()))
+    # Color range comes from the off-diagonal magnitudes, not a hard +/-1.
+    vmin, vmax = im.get_clim()
+    assert vmin == pytest.approx(-vmax)
+    plt.close(fig)


### PR DESCRIPTION
Two `plot_report` panel fixes.

**Topic correlation — the saturated diagonal.** The panel drew the raw correlation matrix with `vmin=-1, vmax=1`, so the always-1.0 self-correlation diagonal rendered dark-red and washed out the real off-diagonal structure. The 0.12.1 fix had only reached the standalone `viz.TopicCorrelation`, not `plot_report`'s own sub-panel. Now it masks the diagonal (neutral background) and scales the color range to the off-diagonal magnitudes, matching `TopicCorrelation`. Adds a regression test.

**Prevalence by class — the 2-row heatmap.** For a binary covariate this was a meh two-row heatmap that hid the quantity of interest (the gap between classes). Replaced with a connected-dot (dumbbell) plot for <=5 classes: one dot per class per topic joined by a line, topics ordered by the between-class gap. On poliblog the partisan split reads instantly (McCain/Wright/Bush-torture up top with wide gaps; economy/abortion at the bottom with overlapping dots). Heatmap fallback for >5 classes.

This also re-renders the paper's Figure 1 (`fig_poliblog_report`) correctly. Full suite 2144 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)