### PR TITLE
chore: repo hygiene — badges, project URLs, issue templates (#116)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Report incorrect behavior, a crash, or a result that disagrees with a reference
+title: ""
+labels: bug
+---
+
+**What happened**
+A clear description of the bug.
+
+**Reproducer**
+A minimal script (model, parameters, and the smallest data that triggers it). A
+fixed `seed=` helps.
+
+```python
+import topica
+...
+```
+
+**Expected vs actual**
+What you expected, and what you got (full traceback if it errored).
+
+**Environment**
+- topica version (`python -c "import topica; print(topica.__version__)"`):
+- Python version and OS:
+- Installed from wheel (`pip install topica`) or built from source:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,16 @@
+---
+name: Feature request
+about: Suggest a model, diagnostic, or API improvement
+title: ""
+labels: enhancement
+---
+
+**What you want and why**
+The capability you need and the analysis it would support. If it is a model or
+method, a reference (paper or reference implementation) helps.
+
+**Proposed surface (optional)**
+How you would expect to call it.
+
+**Alternatives**
+Anything you have tried or considered.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,11 @@
 # Topica: fast, all-purpose topic modeling for Python
 
-`topica` is a fast topic-modeling library for Python with more than a dozen models, built for social scientists who want to move from text data to publishable results in a single workflow. It brings together models and tools usually split across JVM software like MALLET and R packages like `stm`, and runs them on a parallel Rust core competitive with the standard implementations, with every fit reproducible from a fixed seed. Each model comes with the validation, covariate-effect, and reporting tools to meet the standards reviewers expect.
+[![PyPI](https://img.shields.io/pypi/v/topica.svg)](https://pypi.org/project/topica/)
+[![CI](https://github.com/nealcaren/topica/actions/workflows/CI.yml/badge.svg)](https://github.com/nealcaren/topica/actions/workflows/CI.yml)
+[![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://nealcaren.github.io/topica/)
+[![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+
+`topica` is a fast topic-modeling library for Python with more than a dozen models, built for social scientists who want to move from text data to publishable results in a single workflow. It brings together models and tools usually split across JVM software like MALLET and R packages like `stm`, and runs them on a parallel Rust core competitive with the standard implementations, with reproducible fits: the variational models are identical to the bit, and the samplers reproduce from a fixed seed and thread count. Each model comes with the validation, covariate-effect, and reporting tools to meet the standards reviewers expect.
 
 ```bash
 pip install topica

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,8 @@ dependencies = ["numpy>=1.21"]
 Homepage = "https://nealcaren.github.io/topica/"
 Repository = "https://github.com/nealcaren/topica"
 Documentation = "https://nealcaren.github.io/topica/"
+Changelog = "https://github.com/nealcaren/topica/blob/main/CHANGELOG.md"
+Issues = "https://github.com/nealcaren/topica/issues"
 
 [project.optional-dependencies]
 # R-style formula interface (topica.design_matrix, estimate_effect(formula=...)).


### PR DESCRIPTION
Closes the cosmetic remainder of #116 (the file-based parts; CITATION/CHANGELOG/CONTRIBUTING-MODELS were done earlier).

- **README**: PyPI / CI / docs / license badges in the header; the determinism sentence now reads accurately (variational models bit-for-bit, samplers from a fixed seed *and thread count*) — also resolves the README item from #113.
- **pyproject**: `Changelog` and `Issues` URLs (surface on the PyPI sidebar). Classifier kept at `4 - Beta` (pre-1.0, recent breaking API changes).
- **Issue templates**: minimal bug-report + feature-request.
- Repo description + topics refreshed via the GitHub API.

These are the PyPI-page-facing bits, landing before the v0.16.1 tag so the published release shows them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)