### PR TITLE
viz+docs: term_topic_browser .to_html writes (#135); doc-accuracy fixes (#137)

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Model-agnostic: they work on any fitted model's `topic_word`/`doc_topic`:
 - **Validation:** `word_intrusion`, `document_intrusion`, `bootstrap_stability`, `search_k`
 - **Reliability:** `select_model` (fit many seeds) and `ensemble` (combine runs into a consensus more reliable than any single fit — cluster/align/stable methods, the last a gensim `EnsembleLda` port)
 - **Comparison:** `fighting_words` (weighted log-odds) for contrasting corpora
-- **Covariate effects:** `estimate_effect` (method of composition, **cluster-robust SEs**, GLM links), `topic_correlation`, and the design helpers `spline` / `interaction` / `one_hot` (an `stm`-style API); `posterior_theta_samples` draws θ for the logistic-normal models (STM/CTM)
+- **Covariate effects:** `estimate_effect` (method of composition, **cluster-robust SEs**, GLM links), `topic_correlation`, and the design helpers `one_hot` (top level) plus `stm.spline` / `stm.interaction` (an `stm`-style API); `posterior_theta_samples` draws θ for the logistic-normal models (STM/CTM)
 - **Preprocessing:** `tokenize`, `learn_phrases` / `apply_phrases`, `split_documents`, the `Corpus` class
 
 See [diagnostics](https://nealcaren.github.io/topica/guides/diagnostics/) and [covariate effects](https://nealcaren.github.io/topica/guides/covariates/).

--- a/docs/examples/dubois.md
+++ b/docs/examples/dubois.md
@@ -48,7 +48,7 @@ print(len(rows), "articles;", {d: by_decade[d] for d in sorted(by_decade)})
 phrases = topica.learn_phrases(docs, min_count=8, threshold=12.0)
 docs = topica.apply_phrases(docs, phrases)            # "jim crow" -> "jim_crow"
 corpus = Corpus.from_documents(docs, min_doc_freq=10, rm_top=20)
-print("vocab", corpus.num_words)                  # 3418
+print("vocab", corpus.num_words)                  # 3423
 ```
 
 ## 3. LDA

--- a/docs/examples/gadarian.md
+++ b/docs/examples/gadarian.md
@@ -31,6 +31,7 @@ import csv, numpy as np, topica
 from topica import tokenize, stm
 
 rows = list(csv.DictReader(open("examples/gadarian.csv")))
+stop = set(open("examples/english-stoplist.txt").read().split())
 docs = [tokenize(r["open.ended.response"], stopwords=stop, min_length=3) for r in rows]
 treatment = np.array([float(r["treatment"]) for r in rows]).reshape(-1, 1)
 print("treated:", int(treatment.sum()), "control:", int((1 - treatment).sum()))

--- a/python/topica/viz/terms.py
+++ b/python/topica/viz/terms.py
@@ -212,11 +212,35 @@ class TopicSimilarity(Panel):
         fig.colorbar(im, ax=ax, fraction=0.046, pad=0.04, label=f"1 − {self.metric}")
 
 
+class _InteractiveFigure:
+    """Thin wrapper around a Plotly ``Figure`` that gives it the panel-style
+    ``.to_html(path)`` writer. A raw Plotly ``Figure.to_html`` takes ``config`` as
+    its first positional argument and returns a string, so the documented
+    ``.to_html("page.html")`` call would silently write nothing; here it writes the
+    file. Every other attribute (``.show()``, ``.write_html()``, ``.write_image()``,
+    ``.data``, ``.layout``, ...) delegates to the underlying figure, available as
+    ``.figure``."""
+
+    def __init__(self, figure):
+        self.figure = figure
+
+    def to_html(self, path=None, **kwargs):
+        """Write a self-contained interactive HTML page to ``path`` (matching the
+        panel renderers); with ``path=None`` return the HTML as a string."""
+        if path is None:
+            return self.figure.to_html(**kwargs)
+        self.figure.write_html(path, **kwargs)
+        return path
+
+    def __getattr__(self, name):
+        return getattr(self.figure, name)
+
+
 def term_topic_browser(model, *, n=10, mode="prob"):
     """An interactive (Plotly) term browser + topic-similarity heatmap: the seriated
     K x K heatmap for the overview, and a dropdown to pick a topic and read its top
-    words. Returns a Plotly ``Figure``; ``.write_html("page.html")`` (or this
-    function's ``.to_html``) writes a self-contained page. Needs
+    words. Returns an interactive view whose ``.to_html("page.html")`` writes a
+    self-contained page (the wrapped Plotly figure is at ``.figure``). Needs
     ``topica[viz]``."""
     go = _require("plotly.graph_objects", "viz")
     from plotly.subplots import make_subplots
@@ -261,4 +285,4 @@ def term_topic_browser(model, *, n=10, mode="prob"):
     fig.update_xaxes(title_text="topic", row=1, col=1)
     fig.update_yaxes(title_text="topic", autorange="reversed", row=1, col=1)
     fig.update_xaxes(title_text=weight_label, row=1, col=2)
-    return fig
+    return _InteractiveFigure(fig)

--- a/tests/test_viz.py
+++ b/tests/test_viz.py
@@ -389,7 +389,7 @@ def test_dashboard_content_and_inspector(sage_content):
 
 # --- interactive build (skips if plotly absent) ----------------------------
 
-def test_interactive_browser():
+def test_interactive_browser(tmp_path):
     pytest.importorskip("plotly")
     rng = np.random.default_rng(0)
     docs = [["a", "b", "c"]] * 15 + [["x", "y", "z"]] * 15
@@ -398,3 +398,9 @@ def test_interactive_browser():
     fig = viz.term_topic_browser(m, n=5)
     html = fig.to_html(full_html=False)
     assert "plotly" in html.lower()
+    # to_html(path) must write a self-contained page (regression for #135: a raw
+    # Plotly Figure treats the first positional arg as config and writes nothing).
+    out = tmp_path / "browser.html"
+    ret = fig.to_html(str(out))
+    assert out.exists() and out.stat().st_size > 0
+    assert ret == str(out)


### PR DESCRIPTION
**#135** — `viz.term_topic_browser` returned a raw Plotly `Figure`, whose `.to_html(path)` treats the first positional arg as `config` and returns a string, so the documented `.to_html("explore.html")` silently wrote nothing. It now returns a small `_InteractiveFigure` wrapper whose `.to_html(path)` writes the file (and `.to_html()` still returns the HTML string); all other attributes delegate to the underlying figure (`.figure`, `.show()`, `.data`, ...). Docstring updated; `test_viz` extended to assert the path write. (`document_map` was already a proper panel — only this one returned a bare figure.)

**#137** — doc-accuracy fixes from the new-user walkthrough:
- `docs/examples/gadarian.md` now defines `stop` (was an undefined-name crash on copy-paste; the stoplist-file version reproduces the page's stated z-scores).
- `docs/examples/dubois.md` vocab comment `3418` → `3423` (verified by re-running the documented pipeline).
- README clarifies that `one_hot` is top-level while `spline` / `interaction` live in `topica.stm`.

**#136** is resolved separately by the v0.16.1 publish (in progress) — once PyPI has 0.16.1, `pip install topica` gets `STS`/`ensemble`.

`mkdocs build --strict` clean; `test_viz` 31 pass.