### PR TITLE
release: 0.16.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.16.2] - 2026-06-13
+
 ### Fixed
 
 - `BERTopic`/`Top2Vec` no longer panic when `min_cluster_size` (or `min_samples`)
   exceeds the number of documents: the degenerate regime now resolves to a clean
   `num_topics=0` with the usual "lower min_cluster_size / add data" warning,
   instead of letting a `petal-clustering` MST panic escape into Python (#122).
+- `term_topic_browser(...).to_html(path)` now writes the interactive figure to the
+  given path (via an `_InteractiveFigure` wrapper that also delegates the Plotly
+  figure's own methods), instead of silently doing nothing (#135).
 
 ### Documentation
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.16.1
-date-released: 2026-06-12
+version: 0.16.2
+date-released: 2026-06-13
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than a dozen

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.16.1"
+version = "0.16.2"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.16.1"
+version = "0.16.2"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.16.1"
+version = "0.16.2"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Patch release of the two user-facing bug fixes that landed since v0.16.1.

### Fixed
- **#122** — `BERTopic`/`Top2Vec` no longer panic when `min_cluster_size` (or `min_samples`) exceeds the number of documents; the degenerate regime resolves to a clean `num_topics=0` with the usual warning instead of a `petal-clustering` MST `PanicException`.
- **#135** — `term_topic_browser(...).to_html(path)` now writes the interactive figure to the given path, instead of silently doing nothing.

Bumps `Cargo.toml` / `pyproject.toml` / `CITATION.cff` to 0.16.2 and finalizes the CHANGELOG `[0.16.2]` section. (#142's test additions are also on main but aren't part of the shipped wheel.)

Once merged I'll tag `v0.16.2` to fire the build-wheels/sdist/release jobs (trusted publish to PyPI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)