### PR TITLE
feat: export spline/interaction at top level; clarify interactive-only views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Added
+
+- The covariate-design helpers `spline` and `interaction` are now exported at the
+  top level as `topica.spline` / `topica.interaction`, matching the `formulas`
+  docstring and reflecting that they build design-matrix blocks usable by any
+  covariate model (DMR, STM, STS, KeyATM), not only STM. The `topica.stm.spline` /
+  `topica.stm.interaction` paths still work (#137 follow-up).
+
 ## [0.16.2] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Model-agnostic: they work on any fitted model's `topic_word`/`doc_topic`:
 - **Validation:** `word_intrusion`, `document_intrusion`, `bootstrap_stability`, `search_k`
 - **Reliability:** `select_model` (fit many seeds) and `ensemble` (combine runs into a consensus more reliable than any single fit — cluster/align/stable methods, the last a gensim `EnsembleLda` port)
 - **Comparison:** `fighting_words` (weighted log-odds) for contrasting corpora
-- **Covariate effects:** `estimate_effect` (method of composition, **cluster-robust SEs**, GLM links), `topic_correlation`, and the design helpers `one_hot` (top level) plus `stm.spline` / `stm.interaction` (an `stm`-style API); `posterior_theta_samples` draws θ for the logistic-normal models (STM/CTM)
+- **Covariate effects:** `estimate_effect` (method of composition, **cluster-robust SEs**, GLM links), `topic_correlation`, and the design helpers `one_hot`, `spline`, and `interaction` (all top level; they build covariate bases for any model's design matrix); `posterior_theta_samples` draws θ for the logistic-normal models (STM/CTM)
 - **Preprocessing:** `tokenize`, `learn_phrases` / `apply_phrases`, `split_documents`, the `Corpus` class
 
 See [diagnostics](https://nealcaren.github.io/topica/guides/diagnostics/) and [covariate effects](https://nealcaren.github.io/topica/guides/covariates/).

--- a/docs/guides/visualization.md
+++ b/docs/guides/visualization.md
@@ -12,7 +12,7 @@ viz.effect_plot(model, corpus, formula="~ year", data=meta).to_png("effects.pdf"
 viz.term_barchart(model, topic=3, mode="frex").to_frame()
 ```
 
-Every view is a **panel** with three renderers:
+Every **static** view is a **panel** with three renderers:
 
 - `.to_frame()` — a pandas DataFrame of the numbers behind the picture. Always
   available; this is your reproducibility and reviewer-armor.
@@ -20,6 +20,11 @@ Every view is a **panel** with three renderers:
   publication renderer.
 - `.to_html(path)` — an interactive (Plotly) build, for the few views interaction
   genuinely helps. Needs the `topica[viz]` extra.
+
+A few views are interactive-only composites (for example `term_topic_browser`,
+the linked topic/term dashboard) and expose just `.to_html(path)`; the static and
+data renderers for that content live in the standalone `topic_similarity` and
+`term_barchart` panels.
 
 Install the toolkit with `pip install topica[viz]` (matplotlib, pandas, scipy,
 and plotly for the interactive `.to_html()` builds), or `pip install topica[all]`

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -109,7 +109,7 @@ def summary(model, topn=8):
 
 
 from . import stm  # noqa: E402  (stm imports names defined above)
-from .stm import align_corpus  # noqa: E402
+from .stm import align_corpus, spline, interaction  # noqa: E402  (general covariate-design helpers)
 from . import keyatm  # noqa: E402  (keyATM-specific workflow helpers)
 from . import effects  # noqa: E402  (model-neutral prevalence analysis)
 from . import validation  # noqa: E402  (post-hoc topic diagnostics surface)
@@ -236,6 +236,8 @@ __all__ = [
     "one_hot",
     "stm",
     "keyatm",
+    "spline",
+    "interaction",
     "phrases",
     "coherence",
     "topic_diversity",

--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -75,6 +75,28 @@ def align_corpus(
     ready to pass to model.transform or topica.stm.transform."""
     ...
 
+def spline(
+    x: Any,
+    df: int = 4,
+    knots: Any | None = None,
+) -> tuple[numpy.typing.NDArray[numpy.float64], list[str]]:
+    """Restricted (natural) cubic-spline basis for a covariate, returned as
+    (basis (n, df), names). A general covariate-design helper: column_stack the
+    basis into any model's design matrix (DMR, STM, STS, KeyATM) and extend
+    feature_names with the returned names. Also exposed inside formula strings as
+    spline(...)."""
+    ...
+
+def interaction(
+    a: Any,
+    b: Any,
+    name: str = "interaction",
+) -> tuple[numpy.typing.NDArray[numpy.float64], list[str]]:
+    """Interaction columns (all pairwise products) between two covariate blocks,
+    returned as (products (n, ncols), names). column_stack into any model's
+    design matrix."""
+    ...
+
 def coherence(
     topics: Any,
     texts: Sequence[Sequence[str]],
@@ -413,6 +435,8 @@ __all__ = [
     "llm_backend",
     "topic_label_prompts",
     "align_corpus",
+    "spline",
+    "interaction",
     "DEFAULT_TOKEN_REGEX",
     "__version__",
     "__citation__",

--- a/tests/test_design_helpers_toplevel.py
+++ b/tests/test_design_helpers_toplevel.py
@@ -1,0 +1,46 @@
+"""The covariate-design helpers `spline` and `interaction` are general (they
+build numpy design-matrix blocks usable by any covariate model), so they are
+exported at the top level as `topica.spline` / `topica.interaction`, not only
+under `topica.stm`. See the #137 follow-up.
+"""
+
+import numpy as np
+
+import topica
+
+
+def test_spline_interaction_exported_at_top_level():
+    assert hasattr(topica, "spline"), "topica.spline should be a top-level export"
+    assert hasattr(topica, "interaction"), "topica.interaction should be top level"
+    # Same object as the stm-namespaced helper (re-export, not a copy).
+    assert topica.spline is topica.stm.spline
+    assert topica.interaction is topica.stm.interaction
+    assert "spline" in topica.__all__
+    assert "interaction" in topica.__all__
+
+
+def test_spline_block_drives_a_non_stm_covariate_model():
+    """spline builds a basis usable in any model's design matrix — here DMR,
+    which is not the STM the helper was first written for."""
+    rng = np.random.default_rng(0)
+    docs = [["cat", "dog", "pet"] if i % 2 else ["tax", "vote", "law"]
+            for i in range(60)]
+    year = np.linspace(2000, 2020, len(docs))
+
+    basis, names = topica.spline(year, df=3)
+    assert basis.shape == (len(docs), 3)
+    assert len(names) == 3
+
+    m = topica.DMR(num_topics=2, seed=1)
+    m.fit(docs, basis, feature_names=names, iters=40)
+    assert m.num_topics == 2
+    tw = np.asarray(m.topic_word)
+    assert tw.shape[0] == 2 and np.isfinite(tw).all()
+
+
+def test_interaction_block_shapes():
+    a = np.array([0.0, 1.0, 0.0, 1.0])
+    b = np.array([1.0, 1.0, 0.0, 0.0])
+    prod, names = topica.interaction(a, b)
+    np.testing.assert_array_equal(prod.ravel(), a * b)
+    assert names == ["interaction"]


### PR DESCRIPTION
Follow-up to the #137 review.

## `topica.spline` / `topica.interaction` at top level

`spline` and `interaction` were only reachable as `topica.stm.spline` / `topica.stm.interaction`, so `topica.spline` raised `AttributeError`. But:

- `formulas.py`'s own docstring already advertises `topica.spline`.
- The helpers are **general** — each returns a `(basis, names)` numpy design-matrix block you `column_stack` into *any* model's design matrix. DMR (`features=`), STS (`prevalence=`), and KeyATM (`covariates=`) all take that shape; STM was just the first documented consumer.

So the missing top-level export read as an oversight, not "by design." This re-exports both from `stm` at the top level (stub + `__all__` updated), keeps the `topica.stm.*` paths working, and updates the README line that #137.3 had pointed at `topica.stm.spline`.

## Guide wording

The visualization guide's "every view is a **panel** with three renderers" is over-broad for interactive-only composites like `term_topic_browser` (whose wrapper exposes only `.to_html()`). Softened to "every **static** view," with a note that the static/data renderers for that content live in the standalone `topic_similarity` / `term_barchart` panels.

## Tests

New `tests/test_design_helpers_toplevel.py`: the top-level export is the same object as the stm one and is in `__all__`; `topica.spline` drives a non-STM (DMR) fit end to end; `interaction` shapes. Stub-drift guard, formula, naming, and stm-transform suites all pass; `mkdocs build --strict` clean. Full suite 2169 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)