### PR TITLE
docs/paper: correct LDA/RustMallet attribution + ETM/HDP labels (design-review #01, #03)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,20 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   covariate model (DMR, STM, STS, KeyATM), not only STM. The `topica.stm.spline` /
   `topica.stm.interaction` paths still work (#137 follow-up).
 
+### Documentation
+
+- Corrected the LDA/MALLET attribution in the README, docs, and paper. `LDA` is a
+  port of David Mimno's RustMallet that uses its own RNG (PCG, vs RustMallet's
+  ChaCha8), so it is **not** byte-identical to RustMallet, contrary to the previous
+  "binds RustMallet … byte-for-byte" claim. The byte-for-byte guarantee that
+  `tests/test_cli_parity.py` verifies is internal — the Python binding versus
+  topica's own bundled `train` CLI. The Java MALLET cosine-1.000 result is a
+  planted-corpus sanity check, now labeled as such (design-review #01).
+- Corrected two model descriptions: `ETM` is a logistic-normal topic model (not
+  "Generative LDA," which implies a Dirichlet prior), and `HDP` learns the topic
+  count with concentrations held fixed by default (steered by `gamma`), rather than
+  freely "inferring" it (design-review #03).
+
 ## [0.16.2] - 2026-06-13
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ See the [getting-started guide](https://nealcaren.github.io/topica/getting-start
 | **`CTM`** | Correlated topics (logistic-normal) |
 | **`DMR`** | Topics conditioned on document metadata (Dirichlet-multinomial regression) |
 | **`DTM`** | Dynamic topics that evolve across time slices |
-| **`HDP`** | Nonparametric LDA that *infers* the number of topics |
+| **`HDP`** | Nonparametric LDA that learns the number of topics from the data; by default fits with fixed concentrations (topic count steered by `gamma`), with optional concentration resampling |
 | **`keyATM` / `seededlda`** | Guided topics steered by seed words |
 | **`ProdLDA`** | Sharper, more coherent topics via a product-of-experts word model, fit as an amortized VAE (no PyTorch) |
 | **`PT` / `GSDMM`** | Short-text models for tweets, survey answers, headlines |
@@ -55,7 +55,7 @@ See the [getting-started guide](https://nealcaren.github.io/topica/getting-start
 |-------|---------------|
 | **`BERTopic`** | Cluster document embeddings, label topics by class-TF-IDF; topic reduction and a soft per-document distribution |
 | **`Top2Vec`** | Topics as points in the embedding space; topic words are the nearest word vectors |
-| **`ETM`** | Generative LDA with the topic-word distribution factored through embeddings (`β = softmax(ρ·α)`); per-document EM or an amortized VAE (`inference="vae"`) |
+| **`ETM`** | Embedded Topic Model: a logistic-normal topic model with the topic-word distribution factored through embeddings (`β = softmax(ρ·α)`); per-document EM or an amortized VAE (`inference="vae"`) |
 | **`FASTopic`** | Topics read off two optimal-transport plans between document, topic, and word embeddings |
 
 Every model exposes the same shape: `fit(docs, …)`, then `topic_word` (φ), `doc_topic` (θ), `top_words(n)`, and `save`/`load`. The count-based variational models (`CTM`/`STM`/`STS`/`SupervisedLDA`/`DTM`) parallelize across cores while staying bit-for-bit deterministic. The embedding models split into two kinds: `BERTopic` and `Top2Vec` run the `reduce → cluster → represent` pipeline, while `ETM` and `FASTopic` are generative and mixed-membership; all of them take vectors from any embedder (sentence-transformers, an API, a local model such as ollama). Full guides: [the models](https://nealcaren.github.io/topica/guides/models/) and [embedding topics](https://nealcaren.github.io/topica/guides/embedding/).
@@ -103,7 +103,7 @@ Requires `numpy >= 1.21`. Use `--release` (the debug build is much slower).
 
 Topica stands on a generation of open topic-modeling research and code. Each entry below lists the reference, its authors and year, and the topica class(es) it underlies; the other models are Rust ports or reimplementations, validated against these reference implementations.
 
-- [**MALLET**](https://github.com/mimno/Mallet) (McCallum, 2002) — `LDA`, `DMR`, `LabeledLDA`: the SparseLDA sampler, Dirichlet-multinomial regression, and hyperparameter optimization. `LDA` binds David Mimno's [**RustMallet**](https://github.com/mimno/RustMallet) (Apache-2.0), reproducing its `train` CLI byte-for-byte; against Java MALLET (a different RNG) it recovers the same topics (cosine 1.000)
+- [**MALLET**](https://github.com/mimno/Mallet) (McCallum, 2002) — `LDA`, `DMR`, `LabeledLDA`: the SparseLDA sampler, Dirichlet-multinomial regression, and hyperparameter optimization. `LDA` began as a port of David Mimno's [**RustMallet**](https://github.com/mimno/RustMallet) (Apache-2.0) and follows its SparseLDA sampler and fixed-point optimizer closely, but uses its own RNG (PCG), so it is not byte-identical to RustMallet. Against Java MALLET (also a different RNG) it recovers the same topics on a planted corpus (cosine 1.000)
 - [**stm**](https://github.com/bstewart/stm) (Roberts, Stewart & Tingley, 2019) — `STM`, `CTM`, `SAGE`: variational EM, `estimateEffect`, `searchK`, FREX, spectral initialization, and the method of composition
 - [**sts**](https://cran.r-project.org/package=sts) (Chen & Mankad, 2024) — `STS`: the Structural Topic and Sentiment-Discourse model — the joint prevalence/sentiment Laplace E-step and the Poisson topic-word M-step, validated against the package
 - [**lda-c / ctm-c / dtm**](https://github.com/blei-lab) and [**hdp**](https://github.com/blei-lab/hdp) (Blei lab, 2006–2007) — `CTM`, `DTM`, `HDP`: the CTM, Dynamic Topic Model, and HDP samplers

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -47,9 +47,11 @@ RAYON_NUM_THREADS=1 python benchmarks/bench_stm.py  # single core
 
 ## LDA: MALLET's algorithm without the JVM
 
-topica's LDA binds RustMallet, David Mimno's Rust port of MALLET's SparseLDA
-collapsed-Gibbs sampler, and reproduces its `train` CLI byte-for-byte; against
-Java MALLET (a different RNG) it recovers the same topics (cosine 1.000). On fit
+topica's LDA began as a port of RustMallet, David Mimno's Rust port of MALLET's
+SparseLDA collapsed-Gibbs sampler, and follows its sampler and fixed-point
+optimizer closely. It uses its own RNG (PCG) rather than RustMallet's, so it is
+not byte-identical to RustMallet; against Java MALLET (also a different RNG) it
+recovers the same topics on a planted corpus (cosine 1.000). On fit
 time it is roughly at parity with Java MALLET — and adds no JVM startup, unlike
 the JVM samplers or pure-Python gensim.
 

--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -335,7 +335,7 @@ Model & What it is for & Reference \\
 \code{STM}          & Prevalence \emph{and} content covariates             & \citet{roberts2016model} \\
 \code{STS}          & Covariate-driven topic sentiment-discourse on STM    & \citet{chen2024sts} \\
 \code{SAGE}         & A topic worded differently across groups             & \citet{eisenstein2011sage} \\
-\code{HDP}          & Infers the number of topics                          & \citet{teh2006hdp} \\
+\code{HDP}          & Learns the number of topics (\code{gamma}-steered)   & \citet{teh2006hdp} \\
 \code{DTM}          & Topics that evolve across time slices                & \citet{blei2006dtm} \\
 \code{SupervisedLDA}& Topics shaped to predict a response                  & \citet{blei2008slda} \\
 \code{PT}, \code{GSDMM} & Short-text models                                & \citet{zuo2016pt, yin2014gsdmm} \\
@@ -345,7 +345,7 @@ Model & What it is for & Reference \\
 \multicolumn{3}{l}{\emph{Embedding-based}}\\
 \code{BERTopic}     & Cluster embeddings, label by class-TF-IDF            & \citet{grootendorst2022bertopic} \\
 \code{Top2Vec}      & Topics as points in the embedding space              & \citet{angelov2020top2vec} \\
-\code{ETM}          & Generative LDA factored through embeddings           & \citet{dieng2020etm} \\
+\code{ETM}          & Logistic-normal topic model factored through embeddings & \citet{dieng2020etm} \\
 \code{FASTopic}     & Topics from optimal-transport plans                  & \citet{wu2024fastopic} \\
 \bottomrule
 \end{tabularx}
@@ -528,16 +528,22 @@ generator, ``agreement'' means \emph{statistical} agreement on the fitted topics
 benchmarked against each reference's own run-to-run reproducibility, arguably the
 fairest yardstick for stochastic inference. We report it without inflating it.
 
-\paragraph{Collapsed-Gibbs LDA.} \pkg{topica}'s LDA binds \pkg{RustMallet}, David
-Mimno's \proglang{Rust} port of \pkg{MALLET}'s SparseLDA sampler
-\citep{yao2009sparselda}, and reproduces its \code{train} command-line output
-byte-for-byte: the topic-word and document-topic matrices are bit-identical to the
-reference binary's (\code{tests/test\_cli\_parity.py}). Against the original
-\proglang{Java} \pkg{MALLET}, whose independent random number generator rules out
-byte equality, \pkg{topica} instead recovers the \emph{same} topics, aligning at a
-top-word Jaccard and cosine of $1.000$ on a planted-topic corpus
-(\code{parity/mallet\_parity.py}); \code{LabeledLDA} and \code{DMR} likewise match
-\pkg{MALLET} at a topic cosine of $1.000$.
+\paragraph{Collapsed-Gibbs LDA.} \pkg{topica}'s LDA began as a port of
+\pkg{RustMallet}, David Mimno's \proglang{Rust} port of \pkg{MALLET}'s SparseLDA
+sampler \citep{yao2009sparselda}, and follows its sampler and fixed-point
+hyperparameter optimizer closely. It uses its own random number generator (PCG)
+rather than \pkg{RustMallet}'s, so it is not byte-identical to \pkg{RustMallet}.
+What is byte-identical is \pkg{topica}'s own pairing of library and command-line
+tool: the Python binding and the bundled \code{train} CLI share one sampler and
+produce bit-identical topic-word and document-topic matrices for matched
+parameters (\code{tests/test\_cli\_parity.py}), so the library and the CLI cannot
+silently diverge. Against the original \proglang{Java} \pkg{MALLET}, whose
+independent random number generator likewise rules out byte equality, \pkg{topica}
+recovers the \emph{same} topics, aligning at a top-word Jaccard and cosine of
+$1.000$ on a planted, disjoint-vocabulary corpus (\code{parity/mallet\_parity.py}),
+with \code{LabeledLDA} and \code{DMR} likewise matching \pkg{MALLET} at a topic
+cosine of $1.000$ on planted corpora. These are checks of correct topic recovery,
+not claims of byte-equivalence on real text.
 
 \paragraph{Keyword-assisted topics.} \pkg{topica}'s \code{KeyATM} shares the
 \proglang{R} \pkg{keyATM} package's per-sweep asymmetric-$\alpha$ estimation and

--- a/src/mh.rs
+++ b/src/mh.rs
@@ -7,8 +7,9 @@
 //!
 //! The default SparseLDA sampler is deliberately *not* behind this trait: it
 //! mutates a [`TopicModel`] in place, supports the convergence-tol trace and the
-//! document-partitioned parallel sweep, and carries the MALLET byte-parity
-//! guarantee, so it keeps its dedicated path.
+//! document-partitioned parallel sweep, and carries the CLI byte-parity
+//! guarantee (the Python binding matches the bundled `train` CLI byte-for-byte),
+//! so it keeps its dedicated path.
 
 use rand_pcg::Pcg64Mcg;
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -914,8 +914,9 @@ pub struct LDA {
     // keeping every alpha[t] equal, instead of learning the per-topic shape.
     use_symmetric_alpha: bool,
     // Seed the initial token→topic assignment from a spectral anchor-word β
-    // instead of a uniform random draw. Opt-in (default random) so the MALLET
-    // byte-parity guarantee and existing determinism baselines are unchanged.
+    // instead of a uniform random draw. Opt-in (default random) so the CLI
+    // byte-parity (binding == bundled train CLI) and existing determinism
+    // baselines are unchanged.
     init_spectral: bool,
 
     // Populated after fit().
@@ -1279,7 +1280,7 @@ impl LDA {
         // difference. Unlike the SparseLDA path below, these compute no inline
         // log_likelihood, so convergence_tol is unsupported (full iters, empty
         // trace, converged=false). The SparseLDA path stays separate to keep its
-        // convergence trace, parallel sweep, and MALLET byte-parity untouched.
+        // convergence trace, parallel sweep, and CLI byte-parity untouched.
         if warp || light {
             let (acc_phi, acc_theta, theta_draw_buf, model, corpus) =
                 py.allow_threads(move || {

--- a/tests/test_cli_parity.py
+++ b/tests/test_cli_parity.py
@@ -1,10 +1,12 @@
 """CLI-parity regression test.
 
-The Python binding ports `src/bin/train.rs` verbatim — same ChaCha8Rng seed,
-same initialize/sample/optimize/average order, same TSV writers. So for an
-identical corpus and identical parameters it must reproduce the upstream
-`train` CLI **byte-for-byte**. This test pins that guarantee so it can't
-silently drift.
+The Python binding and the bundled `train` CLI (`src/bin/train.rs`) share one
+sampler — same PCG (`Pcg64Mcg`) seed, same initialize/sample/optimize/average
+order, same TSV writers. So for an identical corpus and identical parameters the
+binding must reproduce topica's own `train` CLI **byte-for-byte**. This test pins
+that internal guarantee so the library and the CLI can't silently drift. (It is
+not a parity check against MALLET or RustMallet, which use different RNGs and so
+are not byte-identical to topica.)
 
 It builds the release binaries once, runs `preprocess` + `train`, runs the
 binding on the same corpus with matched parameters, and asserts the output


### PR DESCRIPTION
From an external designer-panel review of 0.16.2. The implementations are faithful; two **claims** were verifiably wrong. This PR fixes the verified-false items; the softer overclaims (#02/#05/#06) and the correctness-verification items (#04) are tracked separately.

## #01 — LDA does **not** "bind RustMallet … byte-for-byte" (verified false)

README, `docs/benchmarks.md`, and **the paper** (`topica.tex:531`) claimed topica's LDA *binds* David Mimno's RustMallet and reproduces its `train` CLI byte-for-byte.

Investigated per @nealcaren ("inspired by RustMallet; not sure if it still holds — investigate"):
- **No RustMallet dependency** exists (`Cargo.toml`/`Cargo.lock`).
- topica's LDA core was clearly **ported** from RustMallet (identical file layout + CLI, down to line numbers) but **swapped the RNG**: RustMallet uses `ChaCha8Rng`, topica uses `Pcg64Mcg` (`train.rs:187` in both).
- **Empirical proof**: built both CLIs, ran them on the same corpus with identical params/seed. Preprocessing is identical (55 docs, 536 types, 804 tokens) but the trained topic-word/doc-topic matrices **differ** (topic-word line 2: topica `0.00090336` vs RustMallet `0.00303505`). topica is **not** byte-identical to RustMallet.
- The byte-for-byte guarantee `tests/test_cli_parity.py` actually pins is **internal**: topica's Python binding vs topica's *own* bundled `train` CLI (both PCG). Its docstring even mislabeled the RNG ("ChaCha8") and called the CLI "upstream."

**Fix:** all surfaces now say "a port of RustMallet … uses its own RNG (PCG) … not byte-identical to RustMallet"; the internal binding↔CLI parity is described as such; the Java MALLET cosine-1.000 is labeled a planted-corpus sanity check; stale "MALLET byte-parity" code comments and the test docstring are corrected.

## #03 — ETM / HDP labels (verified)

- **ETM** "Generative LDA" → "logistic-normal topic model factored through embeddings." ("Generative LDA" implies a Dirichlet prior; ETM — and topica's implementation, which reuses CTM's logistic-normal Laplace E-step — is logistic-normal. The README contradicted the guide.)
- **HDP** "infers the number of topics" → "learns the number of topics; fixed concentrations by default (steered by `gamma`), with optional resampling," matching `docs/guides/models.md`.

## Verification
Paper rebuilds clean (21 pp, no undefined refs); `tests/test_cli_parity.py` passes (internal parity intact); `mkdocs build --strict` clean.

## Not in this PR (tracked for follow-up)
- **#02** soften "validated"/"word-for-word"/"matching assignments"/"computed in Rust core."
- **#05** "exactly as estimateEffect" (omits global-param uncertainty); Gadarian vignette underhedged.
- **#06** raw `topic_correlation` default; c-TF-IDF normalization framing.
- **#04** suspected correctness divergences needing gensim goldens (c_v window; DTM `compute_bound` `/2*cv` vs `/(2*cv)`). #04.3 (Top2Vec `top_words`) is a non-issue — the binding overrides to centroid.

🤖 Generated with [Claude Code](https://claude.com/claude-code)