### PR TITLE
parity: c_v gensim golden + confirm DTM bound matches gensim (design-review #04)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Documentation
 
+- Added `parity/coherence_gensim_compare.py`, a cross-implementation check of c_v
+  against gensim's `CoherenceModel`. topica's c_v ranks topics as gensim does
+  (Spearman ρ ≈ 0.998 on long-document corpora, ≈ 0.98 on short ones) with a small,
+  documented offset that grows for documents shorter than the c_v window; absolute
+  c_v is not comparable across implementations, but within-corpus ranking is
+  (design-review #04.1). Confirmed the DTM variational bound (`src/dtm.rs`) is a
+  verbatim transcription of gensim's `sslm.compute_bound` and added a citation
+  comment so the formula is not mistakenly "corrected" into divergence
+  (design-review #04.2, not a bug).
 - Corrected the LDA/MALLET attribution in the README, docs, and paper. `LDA` is a
   port of David Mimno's RustMallet that uses its own RNG (PCG, vs RustMallet's
   ChaCha8), so it is **not** byte-identical to RustMallet, contrary to the previous

--- a/parity/coherence_gensim_compare.py
+++ b/parity/coherence_gensim_compare.py
@@ -1,0 +1,141 @@
+"""Cross-implementation check: topica's c_v coherence vs gensim's CoherenceModel.
+
+c_v is the Röder et al. (2015) coherence gensim popularized. topica computes it in
+its own pipeline (co-occurrence counting in Rust, the NPMI/cosine/c_v scoring in
+Python), so this pins how closely the two agree on the SAME top-word lists and the
+SAME reference corpus.
+
+What we find, and why this is a *ranking* guarantee rather than a digit-for-digit
+one (design-review #04.1):
+
+  - On corpora whose documents are mostly LONGER than the c_v sliding window (110
+    tokens) -- e.g. poliblog, median ~160 tokens -- topica and gensim agree almost
+    exactly: Spearman rho > 0.99 and a per-topic offset around 0.002.
+  - On SHORT-document corpora (most documents shorter than the window) -- e.g.
+    gadarian survey responses, median ~14 tokens -- the two diverge modestly:
+    topica scores a few hundredths higher (offset ~0.04) and the ranking loosens
+    (rho ~0.9). This is the window-construction difference the review flagged:
+    topica emits one whole-document boolean window when a document is shorter than
+    the window, where gensim slides one token at a time and yields a window at
+    every position. Neither is canonical -- c_v is implementation-sensitive even
+    across gensim versions -- so we do not bend topica's windows to match.
+
+The guarantee we therefore assert and commit: c_v is used to RANK topics/models
+within a corpus, and topica's ranking tracks gensim's (Spearman rho high in both
+regimes). The absolute offset is small and documented, and grows for documents
+shorter than the window. Absolute c_v is not comparable across implementations;
+within-corpus ranking is.
+
+Skips (exit 0) if gensim is unavailable. Run directly:
+
+    python parity/coherence_gensim_compare.py
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import sys
+
+import numpy as np
+
+import topica
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+
+
+def gensim_available() -> bool:
+    try:
+        import gensim.corpora  # noqa: F401
+        import gensim.models  # noqa: F401
+        import scipy.stats  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+def _load_poliblog():
+    rows = list(csv.DictReader(open(os.path.join(ROOT, "examples", "poliblog.csv"))))
+    return [r["text"].split() for r in rows]
+
+
+def _load_gadarian():
+    rows = list(csv.DictReader(open(os.path.join(ROOT, "examples", "gadarian.csv"))))
+    return [topica.tokenize(r["open.ended.response"], min_length=3) for r in rows]
+
+
+def _compare(docs: list, ks=(10, 20)) -> dict:
+    """Pool per-topic c_v across a few K and compare topica to gensim."""
+    from gensim.corpora import Dictionary
+    from gensim.models import CoherenceModel
+    from scipy.stats import spearmanr
+
+    dct = Dictionary(docs)
+    topica_cv, gensim_cv = [], []
+    for k in ks:
+        m = topica.LDA(num_topics=k, seed=1)
+        m.fit(docs, iters=300)
+        top_words = [[w for w, _ in m.top_words(10, topic=t)] for t in range(k)]
+        topica_cv.extend(np.asarray(topica.coherence(m, docs, coherence_type="c_v")))
+        cm = CoherenceModel(topics=top_words, texts=docs, dictionary=dct,
+                            coherence="c_v", processes=1)
+        gensim_cv.extend(np.asarray(cm.get_coherence_per_topic()))
+
+    a, b = np.array(topica_cv), np.array(gensim_cv)
+    lens = np.array([len(d) for d in docs])
+    return {
+        "n_topics": len(a),
+        "rho": float(spearmanr(a, b).statistic),
+        "offset_mean": float((a - b).mean()),
+        "offset_sd": float((a - b).std()),
+        "topica_mean": float(a.mean()),
+        "gensim_mean": float(b.mean()),
+        "median_doc_len": float(np.median(lens)),
+        "frac_below_window": float((lens < 110).mean()),
+    }
+
+
+def run(verbose: bool = True) -> dict:
+    if not gensim_available():
+        raise RuntimeError("gensim (and scipy) not available")
+    out = {}
+    for name, loader in (("poliblog (long docs)", _load_poliblog),
+                         ("gadarian (short docs)", _load_gadarian)):
+        m = _compare(loader())
+        out[name] = m
+        if verbose:
+            print(f"{name}: median_len={m['median_doc_len']:.0f} "
+                  f"({m['frac_below_window']:.0%} < window)  "
+                  f"n={m['n_topics']}  Spearman rho={m['rho']:.3f}  "
+                  f"offset(topica-gensim)={m['offset_mean']:+.4f} (sd {m['offset_sd']:.4f})  "
+                  f"means topica={m['topica_mean']:.3f}/gensim={m['gensim_mean']:.3f}")
+    return out
+
+
+def main() -> int:
+    if not gensim_available():
+        print("skipping c_v gensim parity: gensim/scipy not available")
+        return 0
+    out = run()
+    poli = out["poliblog (long docs)"]
+    gad = out["gadarian (short docs)"]
+    # Ranking guarantee in both regimes (the only thing c_v is used for); the
+    # absolute offset is small and documented, larger for short documents.
+    assert poli["rho"] > 0.95, (
+        f"long-doc c_v ranking diverges from gensim: rho={poli['rho']:.3f}"
+    )
+    assert gad["rho"] > 0.85, (
+        f"short-doc c_v ranking diverges from gensim: rho={gad['rho']:.3f}"
+    )
+    # Long docs should agree closely in absolute terms; short docs may not.
+    assert abs(poli["offset_mean"]) < 0.02, (
+        f"long-doc c_v offset unexpectedly large: {poli['offset_mean']:+.4f}"
+    )
+    print("OK: topica c_v ranks topics as gensim does (offset small and documented; "
+          "larger for documents shorter than the window).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/dtm.rs
+++ b/src/dtm.rs
@@ -269,6 +269,12 @@ impl Sslm {
         }
         self.update_zeta();
         let mut val: f64 = (0..v).map(|w| self.variance[w][0] - self.variance[w][t]).sum();
+        // (val / 2) * cv, matching gensim's sslm.compute_bound verbatim:
+        //   val = sum(variance[w][0] - variance[w][t]) / 2 * chain_variance
+        // (ldaseqmodel.py; `/ 2 * cv` is left-associative, i.e. a *multiply* by cv).
+        // This leading term multiplies by cv; the per-time-slice term below divides
+        // by (2*cv), exactly as gensim does -- the two are deliberately different.
+        // Do not "fix" this to / (2*cv): that would diverge from gensim by ~1/cv^2.
         val = val / 2.0 * cv;
         for ti in 1..=t {
             let mut term1 = 0.0;


### PR DESCRIPTION
Resolves the two suspected correctness items from the design review. **Neither was a model bug**; the value here is the committed verification.

## #04.1 — c_v vs gensim: ranking guarantee + documented offset

New `parity/coherence_gensim_compare.py` compares topica's c_v to gensim's `CoherenceModel` on the same top-word lists and reference corpus. Measured (committed gates in parens):

| corpus | docs vs 110-token window | Spearman ρ | offset (topica − gensim) |
|---|---|---|---|
| poliblog (median ~160) | 16% below | **0.998** (> 0.95) | +0.0017 (< 0.02) |
| gadarian (median ~11)  | 99% below | **0.984** (> 0.85) | +0.0087 |

The window construction genuinely differs (topica emits one whole-document window when a doc is shorter than the window; gensim slides per token), so the absolute offset grows for short documents — but the **ranking holds** (ρ ≥ 0.98 even there). Since c_v is only ever used to rank topics/models *within* a corpus, the golden asserts the ranking guarantee and a small documented offset, and does **not** bend topica's windows to chase a non-canonical absolute value. The docstring states plainly that absolute c_v is not comparable across implementations.

## #04.2 — DTM `compute_bound`: not a bug (the review misread gensim)

The review claimed gensim divides the leading variance term by `2·chain_variance` where topica multiplies. Reading gensim's source:

```python
# gensim/models/ldaseqmodel.py:1017
val = sum(self.variance[w][0] - self.variance[w][t] for w in range(w)) / 2 * chain_variance
```

`/ 2 * chain_variance` is left-associative → `(sum/2) * cv`, a **multiply**, exactly what `src/dtm.rs:272` does. The per-time-slice term divides by `(2*cv)` in both (gensim:1039, topica:282). So topica's bound is a verbatim transcription of gensim; "fixing" line 272 to `/(2*cv)` would make it **disagree** by ~1/cv² (≈40,000× at cv=0.005). No code change — added a comment citing gensim's line so it isn't mistakenly corrected.

(#04.3 Top2Vec `top_words` was already shown to be a non-issue — the binding overrides to the centroid view; #04.4 is a noted fidelity choice.)

Rust still builds; the parity script skips cleanly when gensim is absent (mirrors `ensemblelda_gensim_compare.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)