### PR TITLE
docs: soften overclaimed validation/uncertainty/framing (design-review #02, #05, #06)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Documentation
 
+- Softened several cross-implementation claims to match what the artifacts show
+  (design-review #02/#05/#06): keyATM/seededlda "verified word-for-word" → topic
+  agreement via the reproducible `parity/` harness; BERTopic/Top2Vec "matching
+  assignments" → "comparable structure; exact cluster assignments differ" (own
+  PCA/UMAP + HDBSCAN); gensim credited for the coherence-pipeline conventions (the
+  measures are Röder et al. and Mimno et al.) and "computed in the Rust core" →
+  "co-occurrence counting in the core." `estimate_effect` now states it propagates
+  per-document θ posterior uncertainty but not global-parameter (β/Σ/γ)
+  uncertainty, so its SEs run slightly smaller than R `stm`'s `estimateEffect`; the
+  Gadarian vignette is hedged as a single fit (confirm with `searchK`,
+  `select_model`, `permutation_test`). `topic_correlation`'s docstring notes it is
+  the raw/simple estimate (matching `stm`'s `topicCorr` default) and points to the
+  closure-corrected `viz.topic_correlation(method="clr")`; the c-TF-IDF
+  row-normalization is labeled a surface-compatibility convenience, not a
+  probability claim.
 - Added `parity/coherence_gensim_compare.py`, a cross-implementation check of c_v
   against gensim's `CoherenceModel`. topica's c_v ranks topics as gensim does
   (Spearman ρ ≈ 0.998 on long-document corpora, ≈ 0.98 on short ones) with a small,

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Every model exposes the same shape: `fit(docs, …)`, then `topic_word` (φ), `d
 
 Model-agnostic: they work on any fitted model's `topic_word`/`doc_topic`:
 
-- **Quality:** `coherence` (`u_mass`, `c_v`, `c_uci`, `c_npmi`; computed in the Rust core), `exclusivity`, `topic_diversity`, `quality_frontier`
+- **Quality:** `coherence` (`u_mass`, `c_v`, `c_uci`, `c_npmi`; co-occurrence counting in the Rust core), `exclusivity`, `topic_diversity`, `quality_frontier`
 - **Labeling:** `label_topics` (prob / FREX / lift / score), `frex`, `relevance`, `find_thoughts`, `topic_table`, `summary`
 - **Validation:** `word_intrusion`, `document_intrusion`, `bootstrap_stability`, `search_k`
 - **Reliability:** `select_model` (fit many seeds) and `ensemble` (combine runs into a consensus more reliable than any single fit — cluster/align/stable methods, the last a gensim `EnsembleLda` port)
@@ -107,7 +107,7 @@ Topica stands on a generation of open topic-modeling research and code. Each ent
 - [**stm**](https://github.com/bstewart/stm) (Roberts, Stewart & Tingley, 2019) — `STM`, `CTM`, `SAGE`: variational EM, `estimateEffect`, `searchK`, FREX, spectral initialization, and the method of composition
 - [**sts**](https://cran.r-project.org/package=sts) (Chen & Mankad, 2024) — `STS`: the Structural Topic and Sentiment-Discourse model — the joint prevalence/sentiment Laplace E-step and the Poisson topic-word M-step, validated against the package
 - [**lda-c / ctm-c / dtm**](https://github.com/blei-lab) and [**hdp**](https://github.com/blei-lab/hdp) (Blei lab, 2006–2007) — `CTM`, `DTM`, `HDP`: the CTM, Dynamic Topic Model, and HDP samplers
-- [**gensim**](https://github.com/piskvorky/gensim) (Řehůřek & Sojka, 2010) — `DTM`, `ensemble`: coherence measures, the `LdaSeqModel` DTM reference, and the `EnsembleLda` (CBDBSCAN stable-topic) method ported for `ensemble(method="stable")`
+- [**gensim**](https://github.com/piskvorky/gensim) (Řehůřek & Sojka, 2010) — `DTM`, `ensemble`: the coherence-pipeline conventions (the `coherence_type=` API and default sliding windows; the measures themselves are Röder et al. 2015 and Mimno et al. 2011), the `LdaSeqModel` DTM reference, and the `EnsembleLda` (CBDBSCAN stable-topic) method ported for `ensemble(method="stable")`
 - [**tomotopy**](https://github.com/bab2min/tomotopy) (bab2min, 2020) — API conventions (`summary`, the short-text models)
 - [**keyATM**](https://github.com/keyATM/keyATM) (Eshima, Imai & Sasaki, 2024) — `KeyATM`: the base, covariate, and dynamic models, the information-theory token weighting, and the Chib (1998) change-point HMM, validated against the package
 - [**seededlda**](https://github.com/koheiw/seededlda) (Watanabe, 2023) — `SeededLDA`: the seeded-prior scheme

--- a/docs/examples/gadarian.md
+++ b/docs/examples/gadarian.md
@@ -80,11 +80,15 @@ T1: coef=-0.044  z=-1.4  ci=(-0.106, +0.018)
 T2: coef=-0.076  z=-2.4  ci=(-0.138, -0.014)
 ```
 
-The anxiety prime **raises** prevalence of the threat frame (T0: benefits,
-services, crime) and **lowers** the procedural frame (T2: process, born, wage).
-This is the substantive finding of the original study. Because treatment was
+In this single 3-topic fit the anxiety prime is associated with higher prevalence
+of the threat frame (T0: benefits, services, crime; z=+3.9) and lower prevalence
+of the procedural frame (T2: process, born, wage; z=−2.4, borderline). That echoes
+the direction of the original study, but read it as one fit, not a settled result:
+before reporting, confirm `K` with `searchK`, the topics across several seeds with
+`select_model`, and the effect with a `permutation_test`. Because treatment was
 randomized and each respondent contributes one independent response, ordinary
-method-of-composition standard errors are appropriate; no clustering is needed.
+method-of-composition standard errors are appropriate here; no clustering is
+needed.
 
 ## Close-read the rising frame
 

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -320,7 +320,9 @@ For statistically-selected phrases instead of every bigram, use
 
 !!! note "Faithful to the references"
     On a shared task with shared document embeddings, topica's `Top2Vec` and
-    `BERTopic` recover the same clusters as the Python `BERTopic` package (same
-    topics, matching assignments). The difference is the dependency footprint:
-    topica runs the pipeline in Rust with none of `torch`, `umap-learn`, or
-    `hdbscan` installed.
+    `BERTopic` recover comparable topic structure to the Python `BERTopic`
+    package. Because topica uses its own PCA/UMAP reducer and a different HDBSCAN
+    implementation, exact cluster assignments will differ from the `umap-learn` +
+    `hdbscan` reference; what matches is the kind of topics recovered. The payoff
+    is the dependency footprint: topica runs the pipeline in Rust with none of
+    `torch`, `umap-learn`, or `hdbscan` installed.

--- a/docs/guides/guided.md
+++ b/docs/guides/guided.md
@@ -148,6 +148,9 @@ Both feed the same [diagnostics](diagnostics.md), [effects](../publishing/effect
 and [validation](../publishing/validation.md) as every other model.
 
 !!! note "Faithful to the references"
-    On a shared corpus with identical seeds, topica recovers the same
-    seeded-topic vocabulary as R's `seededlda` and the same keyword-topic words
-    as R's `keyATM` (verified word-for-word against both packages).
+    On a shared corpus with identical seeds, topica recovers seeded-topic
+    vocabulary close to R's `seededlda` and keyword topics that align with R's
+    `keyATM` as well as R aligns with itself across seeds. The comparison runs the
+    reference packages through the reproducible harness in `parity/` (it needs a
+    local R install with the packages); it measures topic-word agreement, not
+    identical word lists.

--- a/docs/guides/visualization.md
+++ b/docs/guides/visualization.md
@@ -37,7 +37,9 @@ and switch their statistics and labels on it, so they never overclaim:
 
 - A **c-TF-IDF** `topic_word` (BERTopic / Top2Vec) is not a probability, so the
   FREX / lift / relevance modes are disabled and the bars are labeled "c-TF-IDF
-  weight," not "P(w | topic)."
+  weight," not "P(w | topic)." (The matrix is row-normalized to sum to one for
+  surface compatibility with the other models' diagnostics; that normalization is
+  a convenience, not a probability claim.)
 - An **effect-plot confidence interval** is drawn only where a θ posterior exists.
   For an embedding/cluster model the panel shows point estimates and says so; pass
   `method="bootstrap"` for intervals. A topic the bootstrap flags as unreliable is

--- a/docs/publishing/effects.md
+++ b/docs/publishing/effects.md
@@ -24,7 +24,11 @@ A naive regression of point topic proportions on covariates treats θ as if it
 were observed exactly. It isn't. R's `stm` uses the **method of composition**
 (Treier & Jackman 2008): draw θ from the model's posterior, regress each draw,
 and pool by Rubin's rules so the standard errors include topic-estimation
-uncertainty. topica does the same:
+uncertainty. topica does the same, drawing θ from each document's variational
+posterior. (It propagates that per-document θ uncertainty; it does not also
+simulate the global parameters β, Σ, and γ, so its pooled standard errors run a
+touch smaller than `stm`'s. The inflation over naive point-θ OLS is the part that
+matters, and it is there.)
 
 ```python
 from topica import stm

--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -422,7 +422,8 @@ whichever comes first; the collapsed-Gibbs samplers run a fixed number of sweeps
 The \code{converged} flag records which of the two ended the fit.
 Validation is not optional.
 \code{topica.coherence} computes the windowed coherence measures
-\citep{lau2014coherence} in the core, \code{topica.exclusivity} and
+\citep{lau2014coherence}, counting word co-occurrences in the core,
+\code{topica.exclusivity} and
 \code{topica.topic\_diversity} measure distinctness, \code{bootstrap\_stability}
 checks that topics persist across seeds, and \code{word\_intrusion} and
 \code{document\_intrusion} build the human-validation tasks of
@@ -574,7 +575,7 @@ corpus the worked example of Section~\ref{sec:example} runs on) from the
 \citet{chen2024sts} replication package, on the corpus their \proglang{R} code
 regenerates (\code{parity/sts\_r\_compare.py}). \pkg{topica}'s \code{STS} recovers
 the published topics at a topic-word cosine of $0.93$, against $0.08$ for a
-vocabulary-permuted control, with the recovered topics matching word for word
+vocabulary-permuted control, with the leading topics clearly recognizable
 (campaign, Iraq and the war, the Obama--Clinton primary, energy and taxes). The
 representative topic is read at the mean sentiment rather than at zero, because
 \code{STS} parks the topic signal in the sentiment direction $\kappa^{(s)}$ when

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -19,8 +19,12 @@ LabeledLDA). :func:`estimate_effect` does ordinary OLS on a point estimate of θ
 or — given posterior draws from :func:`posterior_theta_samples` (an STM/CTM
 variational posterior) — the **method of composition**, pooling per-draw
 regressions by Rubin's rules so the standard errors propagate topic-estimation
-uncertainty, exactly as R ``stm``'s ``estimateEffect`` does. Nonlinear and
-interaction terms are built with :func:`spline` and :func:`interaction`.
+uncertainty, following the same method-of-composition procedure as R ``stm``'s
+``estimateEffect``. topica propagates the per-document theta posterior
+uncertainty; it does not additionally simulate global-parameter (beta, Sigma,
+gamma) uncertainty, so its pooled standard errors are generally a touch smaller.
+Nonlinear and interaction terms are built with :func:`spline` and
+:func:`interaction`.
 """
 
 from __future__ import annotations

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -644,6 +644,13 @@ def topic_correlation(doc_topic, *, threshold=0.05):
     :class:`TopicCorrelation` with the correlation matrix, a 0/1 adjacency
     matrix (zero diagonal), and the edge list.
 
+    This is the raw across-document theta correlation, matching ``stm``'s
+    ``topicCorr`` default ("simple") method. Raw theta correlation is
+    compositionally biased (the simplex constraint induces spurious negative
+    correlation); for the closure-corrected alternatives use
+    ``viz.topic_correlation(model, method="clr")`` (the viz layer's default) or
+    ``method="partial"``/``"eta"``.
+
     `doc_topic` is a fitted model (uses its ``doc_topic``) or a ``(D, K)`` array.
     """
     theta = _as_doc_topic(doc_topic)

--- a/src/bertopic.rs
+++ b/src/bertopic.rs
@@ -168,6 +168,10 @@ pub fn fit_bertopic(
     // document-topic distribution.
     let ctfidf_raw = represent::ctfidf_weighted(docs, &labels, vocab_size, bm25, reduce_frequent);
     let idf = idf_weights(docs, &labels, vocab_size);
+    // Row-normalize c-TF-IDF to sum to one so topic_word has the same surface as
+    // the probability models' (top_words, topic_table, coherence all read it).
+    // This is for cross-model compatibility, not a probability claim: c-TF-IDF is
+    // not P(w|topic), and the viz layer labels it "c-TF-IDF weight" accordingly.
     let mut topic_word = ctfidf_raw.clone();
     for row in topic_word.iter_mut() {
         let sum: f64 = row.iter().sum();


### PR DESCRIPTION
The last batch from the design review — the "claims overshoot what the artifacts show" items. Prose + comments + docstrings; no model code changed.

## #02 — validation/parity wording
- **keyATM / seededlda** "verified word-for-word against both packages" → topic-word agreement via the reproducible `parity/` harness (needs local R); it measures φ agreement, not identical word lists.
- **BERTopic / Top2Vec** "recover the same clusters … matching assignments" → "comparable topic structure; because topica uses its own PCA/UMAP reducer and a different HDBSCAN, exact cluster assignments differ from the `umap-learn` + `hdbscan` reference."
- **gensim** "coherence measures" → "the coherence-pipeline conventions (the measures themselves are Röder et al. 2015 and Mimno et al. 2011)"; "computed in the Rust core" → "co-occurrence counting in the core."
- Also fixed the **paper**: the STS poliblog paragraph said topics "matching word for word" (Jaccard is 0.62) → "leading topics clearly recognizable"; and the coherence "in the core" → "counting word co-occurrences in the core."

## #05 — `estimate_effect` uncertainty + Gadarian
- `estimate_effect` docstring + `effects.md`: "exactly as R stm's `estimateEffect`" → "the same method-of-composition procedure as," with the caveat that topica propagates **per-document θ** posterior uncertainty but not **global-parameter** (β/Σ/γ) uncertainty, so its pooled SEs run slightly smaller. (The inflation over naive point-θ OLS — the part that matters — is there.)
- Gadarian vignette: dropped "the substantive finding of the original study" from a single K=3 fit; now framed as one fit with T2 borderline (z=−2.4), pointing to `searchK` / `select_model` / `permutation_test` before reporting.

## #06 — honest-framing consistency
- `topic_correlation` docstring notes it is the raw/simple estimate (matching `stm`'s `topicCorr` default) and points to the closure-corrected `viz.topic_correlation(method="clr")` (already the viz default). Kept the raw default to preserve stm drop-in parity rather than silently diverging.
- c-TF-IDF `topic_word` row-normalization labeled a surface-compatibility convenience (so diagnostics work across models), not a probability claim — in `visualization.md` and `src/bertopic.rs`.

Paper rebuilds clean (21 pp); affected suite (1126) + `mkdocs --strict` pass. This closes the design-review items (#01/#03 in #145, #04 in #146, #02/#05/#06 here; #04.3 was a non-issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)