### PR TITLE
release: 0.17.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-06-14
+
 ### Added
 
 - `KeyATM.fit` accepts `times=` as the canonical per-document time index (the

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.16.2"
+version = "0.17.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.16.2"
+version = "0.17.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.16.2"
+version = "0.17.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.17.0** (from 0.16.2): version bumps in `Cargo.toml`/`Cargo.lock`/`pyproject.toml` and the `CHANGELOG.md` [0.17.0] section. No code changes beyond the version bump — all features below already landed on `main`.

## Highlights

**New model**
- `GDMR` (generalized DMR): DMR over continuous metadata via a Legendre basis with a decay prior, plus `tdf`/`tdf_linspace` topic distribution functions; validated against tomotopy `GDMRModel`.

**STM/CTM/STS memory** — the `O(N·K²)` per-document variational covariance, eliminated
- float32 `eta_cov` (~2× by default)
- optional `keep_eta_cov=False` → `O(N·K)` fit, exact on-demand recompute
- chunked E-step reduce → fit-time transient peak `O(N·K²)`→~128 MB
- `variational="diagonal"` mean-field mode (skips the per-doc K³ inverse)

**STM/CTM speed**
- parallelized Σ cross-term M-step (~28% on a representative fit; the serial-tail / low-CPU cause)
- `num_threads=` control

**DX & API**
- `TopicEffect.to_frame()`, `search_k` `best_k`/`directions`, `GDMR` `feature_names`/`metadata_names`
- end-to-end STM-with-covariates recipe, canonical import-path docs, `topica[formula]` visibility
- cross-model API conventions guide (`docs/contributing/conventions.md`) enforced by `tests/test_naming_conventions.py`

All changes were verified bit-identical to their baselines where applicable (f32 fit outputs, `keep_eta_cov` fit, chunked reduce, parallel Σ-cross, diagonal mode's laplace path) or carry documented, intentional tradeoffs. Full suite green on `main` (2365 passed, 18 skipped); strict docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)