### PR TITLE
fix: best_k() defaults to coherence/exclusivity frontier, not monotone coherence (#167)

### DIFF
--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -31,7 +31,8 @@ corpus = topica.from_dataframe(df, text_col="text")     # metadata kept aligned
 # corpus.metadata is the surviving rows, already aligned to the documents.
 X, names = topica.design_matrix("~ party + spline(year, df=3)", corpus.metadata)
 
-# Pick K with a safe, direction-aware selector, then fit at that K.
+# Pick K at the coherence/exclusivity frontier (a knee, not a coherence max,
+# which would just return the smallest K), then fit at that K.
 scan = topica.search_k(corpus, [10, 20, 30], model="stm", prevalence=X, iters=200)
 model = topica.STM(num_topics=scan.best_k(), seed=1)
 model.fit(corpus, prevalence=X, prevalence_names=names)

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -721,9 +721,13 @@ class SearchKResult(list):
     optimization direction stamped in and a safe ``best_k`` selector.
 
     It is a ``list`` subclass, so it iterates and indexes exactly like the rows
-    it always returned. The additions remove the trap of sorting the wrong way:
-    ``coherence`` is mean UMass (negative; less-negative is better), so naively
-    taking the minimum picks the worst K.
+    it always returned. The additions remove two traps. The first is sorting the
+    wrong way: ``coherence`` is mean UMass (negative; less-negative is better),
+    so naively taking the minimum picks the worst K. The second is subtler:
+    UMass coherence is roughly *monotone-decreasing* in K, so selecting K by
+    coherence alone returns the smallest K in the grid regardless of the data.
+    ``best_k`` defaults to a coherence/exclusivity *frontier* (a knee, not a
+    maximum) to avoid that, and to the held-out metric when one is supplied.
     """
 
     @property
@@ -732,12 +736,53 @@ class SearchKResult(list):
         present = set().union(*[r.keys() for r in self]) if self else set()
         return {m: d for m, d in SEARCH_K_DIRECTIONS.items() if m in present}
 
-    def best_k(self, metric: str | None = None) -> int:
-        """Return the ``k`` that optimizes ``metric`` in its correct direction.
+    def _frontier_k(self) -> int:
+        """K that maximizes ``z(coherence) + z(exclusivity)`` across the grid.
 
-        ``metric`` defaults to the held-out metric when a held-out set was
-        supplied (``"heldout_loglik"`` for a :class:`Heldout`, ``"perplexity"``
-        for a legacy corpus), otherwise ``"coherence"``. Raises if absent.
+        Each metric is z-scored across the scanned K values (so the two scales
+        are comparable) and added in its own optimization direction. The pick
+        is the K that is jointly high on both — the knee, not either extreme.
+        A metric with zero variance across the grid contributes nothing.
+        """
+        for m in ("coherence", "exclusivity"):
+            if m not in self[0]:
+                raise ValueError(
+                    f"frontier selection needs {m!r} in the results "
+                    f"(present: {sorted(self[0])})"
+                )
+        if len(self) < 2:
+            raise ValueError(
+                "frontier selection needs at least two K values to z-score; "
+                "scan a wider grid or pass a single metric"
+            )
+        score = np.zeros(len(self))
+        for m in ("coherence", "exclusivity"):
+            v = np.array([r[m] for r in self], dtype=np.float64)
+            sd = v.std()
+            if sd > 0:
+                z = (v - v.mean()) / sd
+                score += z if SEARCH_K_DIRECTIONS[m] == "maximize" else -z
+        return int(self[int(np.argmax(score))]["k"])
+
+    def best_k(self, metric: str | None = None) -> int:
+        """Return the ``k`` chosen by ``metric``.
+
+        With ``metric=None`` (the default), selection is:
+
+        - the held-out metric when a held-out set was supplied
+          (``"heldout_loglik"`` for a :class:`Heldout`, ``"perplexity"`` for a
+          legacy corpus) — the principled, non-monotone criterion;
+        - otherwise the ``"frontier"`` (see below), since bare ``"coherence"``
+          is roughly monotone in K and would just return the grid floor.
+
+        ``metric`` may also be given explicitly:
+
+        - ``"frontier"`` — the K maximizing ``z(coherence) + z(exclusivity)``,
+          the knee the ``plot_search_k`` curve shows (needs at least two K).
+        - any column metric (``"coherence"``, ``"exclusivity"``,
+          ``"heldout_loglik"``, ``"perplexity"``), optimized in its correct
+          direction. Asking for bare ``"coherence"`` on a multi-K grid warns,
+          because UMass coherence is roughly monotone in K.
         """
         if not self:
             raise ValueError("search_k returned no rows")
@@ -746,16 +791,30 @@ class SearchKResult(list):
                 metric = "heldout_loglik"
             elif "perplexity" in self[0]:
                 metric = "perplexity"
+            elif len(self) >= 2 and "coherence" in self[0] and "exclusivity" in self[0]:
+                metric = "frontier"
             else:
                 metric = "coherence"
+        if metric == "frontier":
+            return self._frontier_k()
         if metric not in SEARCH_K_DIRECTIONS:
             raise ValueError(
-                f"unknown metric {metric!r}; choose from {sorted(SEARCH_K_DIRECTIONS)}"
+                f"unknown metric {metric!r}; choose 'frontier' or one of "
+                f"{sorted(SEARCH_K_DIRECTIONS)}"
             )
         if metric not in self[0]:
             raise ValueError(
                 f"metric {metric!r} not in results (present: {sorted(self[0])}); "
                 f"pass held_out= to get a held-out metric"
+            )
+        if metric == "coherence" and len(self) >= 2:
+            warnings.warn(
+                "best_k(metric='coherence'): mean UMass coherence is roughly "
+                "monotone-decreasing in K, so this tends to return the smallest "
+                "K in the grid. Prefer metric='frontier' (coherence/exclusivity "
+                "knee) or pass held_out= for held-out log-likelihood.",
+                UserWarning,
+                stacklevel=2,
             )
         pick = max if SEARCH_K_DIRECTIONS[metric] == "maximize" else min
         return int(pick(self, key=lambda r: r[metric])["k"])
@@ -786,8 +845,10 @@ def search_k(
     ``exclusivity`` (mean top-word exclusivity), and — when ``held_out`` is
     supplied — a held-out quality metric. The result also carries
     ``.directions`` (whether higher or lower is better per metric) and a
-    ``.best_k(metric=...)`` selector, so auto-selection cannot sort the wrong way
-    (``coherence`` is negative, so the maximum, not the minimum, is best).
+    ``.best_k(metric=...)`` selector. ``best_k`` defaults to the held-out metric
+    when one is supplied, otherwise to a coherence/exclusivity frontier (a knee),
+    because bare UMass coherence is roughly monotone in K and would just return
+    the smallest K scanned.
 
     Two held-out paths are supported, determined by the type of ``held_out``:
 
@@ -1045,7 +1106,8 @@ def plot_search_k(rows, *, metrics=("coherence", "exclusivity"), ax=None):
     """Plot :func:`search_k` results: each metric against the number of topics.
 
     Researchers read this curve to choose `K`: coherence and exclusivity usually
-    trade off, so the goal is a knee, not a maximum. Each metric gets its own
+    trade off, so the goal is a knee, not a maximum. ``rows.best_k()`` returns
+    that knee directly (the ``"frontier"`` selector). Each metric gets its own
     y-axis (they live on different scales). ``rows`` is the list returned by
     :func:`search_k`; ``metrics`` selects which of its keys to draw (any of
     ``"coherence"``, ``"exclusivity"``, ``"perplexity"``, ``"heldout_loglik"``).

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -136,13 +136,53 @@ def test_search_k_best_k_and_directions():
     assert isinstance(res, list) and len(res) == 2
     assert res.directions["coherence"] == "maximize"
     assert res.directions["exclusivity"] == "maximize"
-    # best_k matches a manual max-by-coherence
+    # explicit coherence still maximizes (least-negative), but warns about
+    # monotonicity (#167)
     expected = max(res, key=lambda r: r["coherence"])["k"]
-    assert res.best_k() == expected
-    assert res.best_k("coherence") == expected
+    with pytest.warns(UserWarning, match="monotone"):
+        assert res.best_k("coherence") == expected
     # asking for an absent held-out metric is a clear error, not a silent wrong pick
     with pytest.raises(ValueError):
         res.best_k("heldout_loglik")
+
+
+def test_search_k_best_k_defaults_to_frontier():
+    # #167: with no held-out set, best_k() picks the coherence/exclusivity
+    # frontier (a knee), not bare coherence (which is monotone in K and would
+    # return the grid floor). The frontier default must not warn.
+    docs = [["cat", "dog", "pet"]] * 12 + [["star", "moon", "sky"]] * 12
+    res = topica.search_k(docs, [2, 3, 4], iters=60, num_samples=1)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # frontier default is silent
+        chosen = res.best_k()
+    assert chosen == res.best_k("frontier")
+    assert chosen in {r["k"] for r in res}
+
+
+def test_frontier_k_is_zscore_argmax():
+    # #167: the frontier is argmax over K of z(coherence)+z(exclusivity), both
+    # maximize. Verify against a hand-built result reproducing the issue's table.
+    from topica.validation import SearchKResult
+    rows = SearchKResult([
+        {"k": 40, "coherence": -108.4, "exclusivity": 0.636},
+        {"k": 60, "coherence": -114.4, "exclusivity": 0.652},
+        {"k": 80, "coherence": -118.4, "exclusivity": 0.657},
+        {"k": 100, "coherence": -125.2, "exclusivity": 0.660},
+    ])
+    # coherence-max would pick the grid floor (40); the frontier picks the knee.
+    assert rows.best_k("frontier") == 60
+    assert rows.best_k() == 60  # frontier is the no-held-out default
+
+
+def test_frontier_needs_two_k():
+    from topica.validation import SearchKResult
+    one = SearchKResult([{"k": 5, "coherence": -10.0, "exclusivity": 0.5}])
+    with pytest.raises(ValueError, match="at least two"):
+        one.best_k("frontier")
+    # a single-K grid falls back to coherence without the monotonicity warning
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert one.best_k() == 5
 
 
 def test_search_k_best_k_defaults_to_heldout_when_present():


### PR DESCRIPTION
## What

`SearchKResult.best_k()` fell back to `coherence` when no held-out set was supplied. But mean UMass coherence is roughly **monotone-decreasing in K**, so the natural path `search_k(...).best_k()` silently returned the smallest K in the grid — the "winner" was set by the grid floor, not the data (#167).

## Fix

- `best_k(metric=None)` with no held-out set now selects the **frontier**: the K maximizing `z(coherence) + z(exclusivity)` across the scanned grid — the knee `plot_search_k` already draws. Held-out metrics (`heldout_loglik` / `perplexity`) remain the default when a held-out set is supplied.
- `metric="frontier"` is accepted explicitly (needs ≥2 K to z-score).
- Explicit `metric="coherence"` on a multi-K grid now emits a `UserWarning` about the monotonicity trap. Single-K grids fall back to coherence silently.

On the issue's reproduction table the frontier picks **K=60** (coherence-max picked the floor, K=40).

## Tests / gates

- New tests: issue reproduction table → K=60, silent frontier default, ≥2-K guard, coherence warning. Updated the prior `best_k`/directions test for the new contract.
- Full suite: 2368 passed, 18 skipped. `mkdocs build --strict` clean.

Closes #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)