### PR TITLE
release: 0.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,25 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.18.0] - 2026-06-15
+
+### Changed
+
+- `search_k(...).best_k()` no longer falls back to bare `coherence` when no
+  held-out set is supplied. Mean UMass coherence is roughly monotone-decreasing
+  in K, so that fallback silently returned the smallest K in the grid (#167). It
+  now selects the `"frontier"`: the K maximizing `z(coherence) + z(exclusivity)`
+  across the scanned grid — the knee `plot_search_k` draws. The held-out default
+  (`heldout_loglik` / `perplexity`) is unchanged when a held-out set is supplied.
+  This changes the K returned by `best_k()` for grids scored on coherence alone.
+
+### Added
+
+- `SearchKResult.best_k(metric="frontier")` selects the coherence/exclusivity
+  frontier explicitly (requires at least two K values to z-score). Explicit
+  `best_k(metric="coherence")` on a multi-K grid now warns that UMass coherence
+  is roughly monotone in K and recommends `metric="frontier"` or `held_out=`.
+
 ## [0.17.0] - 2026-06-14
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.17.0"
+version = "0.18.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.17.0"
+version = "0.18.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.18.0**. Bumps `Cargo.toml` / `pyproject.toml` / `Cargo.lock` and adds the CHANGELOG entry.

## Headline

`search_k(...).best_k()` now defaults to the coherence/exclusivity **frontier** (a knee) instead of bare UMass coherence, which is roughly monotone in K and silently returned the grid floor (#167, PR #168). Held-out remains the default when a held-out set is supplied; `metric="frontier"` is accepted explicitly; explicit `metric="coherence"` warns.

Minor bump (not patch) because `best_k()`'s returned K changes for grids scored on coherence alone.

## Gates

- Full suite green (2368 passed / 18 skipped) on the merged main.
- `mkdocs build --strict` clean.
- Rebuilt: `import topica; topica.__version__ == "0.18.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)