### PR TITLE
perf: LDA/STM/keyATM speed — bit-identical core + opt-in turbo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Changed
+
+- Faster LDA, STM/CTM, and keyATM fits, with bit-for-bit identical results
+  (same seed and thread count) — the default path is unchanged:
+  - **STM/CTM**: the L-BFGS E-step now evaluates value and gradient in one fused
+    pass and exploits the symmetry of the Hessian and its inverse, cutting the
+    dominant per-document O(K^3) work. Up to ~2.2x faster at K=200, ~1.5x at K=60.
+  - **keyATM**: a word-major shadow of the topic-word counts makes the per-token
+    s=0 candidate loop a contiguous cache-friendly read instead of a strided
+    column walk. Up to ~1.6x faster on large, high-K/V corpora.
+  - **LDA**: the SparseLDA per-document setup is built directly from the
+    document's own token assignments instead of an O(K) zero-and-scan, helping
+    short-document and high-K fits (~1.5-1.9x) at no cost to long documents.
+
+### Added
+
+- Opt-in "turbo" approximations that trade exactness for speed, off by default
+  (the default path stays bit-identical):
+  - `LDA.fit(turbo_merge_every=m)` runs `m` parallel sweeps against private count
+    tables before reconciling, amortizing the per-sweep merge. Helps when the
+    merge dominates (large, wide-vocabulary, many-thread fits); it can hurt
+    smaller corpora, so it is documented as situational. `m=1` (default) is exact.
+  - `KeyATM.fit(turbo_alpha_stride=s)` subsamples documents in the base alpha
+    slice-sampler (an unbiased estimate of the data term at ~1/s the cost),
+    ~2.3-2.5x faster at `s>=4` with topic coherence preserved and a moderate
+    shift in per-document topic mixtures. `s=1` (default) is exact. Base model
+    only, with `estimate_alpha`.
+
 ## [0.18.0] - 2026-06-15
 
 ### Changed

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1504,6 +1504,7 @@ class LDA:
         convergence_tol: float = 0.0,
         check_every: int = 10,
         num_threads: Optional[int] = None,
+        turbo_merge_every: int = 1,
     ) -> None:
         """Run Gibbs sampling to fit the model on data.
 
@@ -1521,6 +1522,19 @@ class LDA:
 
         ``num_threads`` overrides the constructor's num_threads for this fit call
         only (None = use constructor value).
+
+        ``turbo_merge_every`` (default 1, exact) is an opt-in approximate-speed
+        knob for multi-threaded runs. With ``m > 1`` each worker runs ``m`` sweeps
+        against its own counts before the shared topic-word table is reconciled,
+        so the per-sweep merge -- the thread-scaling ceiling -- happens once per
+        ``m`` sweeps instead of every sweep. Results differ from the exact path
+        and are not bit-reproducible against it; ``m = 1`` (or single-threaded, or
+        the lightlda/warp/cvb0 samplers) runs the exact per-sweep path unchanged.
+        On a large wide-vocabulary corpus (30k docs, 30k vocabulary, K=400, 8
+        threads), ``m = 3`` ran 1.55x faster for a 0.010 drop in c_npmi
+        coherence. The win appears only when the merge dominates (large corpus,
+        wide vocabulary, high K, many threads); on smaller corpora it does not
+        help and can run slower. Recommended range when it helps: 3 to 4.
         """
         ...
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2693,6 +2693,7 @@ class KeyATM:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         report_interval: Optional[int] = None,
+        turbo_alpha_stride: int = 1,
     ) -> None:
         """Fit by collapsed Gibbs. Pass `covariates` (num_docs x F) for the
         covariate keyATM: the document-topic prior becomes a DMR,
@@ -2726,7 +2727,16 @@ class KeyATM:
         samplers). Applies to the base/covariate/dynamic Gibbs backends; ignored
         by the CVB0 backend, which keeps no trace.
 
-        report_interval is a deprecated alias for progress_interval."""
+        report_interval is a deprecated alias for progress_interval.
+
+        turbo_alpha_stride (default 1, exact) is an opt-in approximate speedup
+        for the base model's asymmetric-alpha slice sampler, the dominant
+        non-sweep cost on large corpora. With a stride s > 1 the slice sampler
+        evaluates its Dirichlet-multinomial data term over every s-th document and
+        scales that sum up by s, an unbiased estimate of the full term that touches
+        ~1/s of the documents. It changes the estimated alpha (and therefore the
+        fit), so it is off by default; it applies to the base model only (it errors
+        with covariates or timestamps) and only when estimate_alpha is True."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...

--- a/src/ctm.rs
+++ b/src/ctm.rs
@@ -81,6 +81,73 @@ pub fn ctm_lhood(
     0.5 * part2 - part1
 }
 
+/// Fused objective + gradient: returns exactly `(ctm_lhood(..), ctm_grad(..))`
+/// but evaluates `exp(η)`, `Σ exp(η)`, and the per-word column sum
+/// `Σ_t e_t β_{t,w}` once instead of once each in the two separate functions.
+/// The L-BFGS E-step calls value and gradient together at every point, so the
+/// separate path recomputes this O(W·K) inner loop twice per evaluation.
+///
+/// Every partial sum is accumulated in the same order as the standalone
+/// `ctm_lhood`/`ctm_grad`, so the returned value and gradient are bit-for-bit
+/// identical to calling those two functions.
+pub fn ctm_lhood_grad(
+    eta: &[f64],
+    beta: &[Vec<f64>],
+    words: &[usize],
+    counts: &[f64],
+    mu: &[f64],
+    siginv: &[f64],
+) -> (f64, Vec<f64>) {
+    let km1 = eta.len();
+    let k = km1 + 1;
+    let e = expeta(eta);
+    let sum_e: f64 = e.iter().sum();
+    let ndoc: f64 = counts.iter().sum();
+
+    // Single pass over the document's words: accumulate the objective's
+    // `Σ_w counts[w]·ln(colsum)` (= `part1` in ctm_lhood) and the gradient's
+    // `Σ_w counts[w]·φ_{·,w}` (= `part1` in ctm_grad) from the same `colsum`.
+    let mut obj_part1 = 0.0;
+    let mut grad_part1 = vec![0.0f64; k];
+    for (wi, &w) in words.iter().enumerate() {
+        let mut colsum = 0.0;
+        for t in 0..k {
+            colsum += e[t] * beta[t][w];
+        }
+        obj_part1 += counts[wi] * colsum.ln();
+        let c = counts[wi] / colsum;
+        for t in 0..k {
+            grad_part1[t] += c * e[t] * beta[t][w];
+        }
+    }
+    obj_part1 -= ndoc * sum_e.ln();
+    let f = ndoc / sum_e;
+    for t in 0..k {
+        grad_part1[t] -= f * e[t];
+    }
+
+    // Quadratic prior term: objective `0.5·(η-μ)ᵀΣ⁻¹(η-μ)`, gradient `Σ⁻¹(η-μ)`.
+    // To stay bit-for-bit identical to the separate functions, the value's
+    // double sum is accumulated EXACTLY as ctm_lhood does — `part2 += di ·
+    // siginv[ij] · (η_j−μ_j)` with the same left-to-right multiply/add order —
+    // and the gradient's `s = Σ_j siginv[ij]·(η_j−μ_j)` EXACTLY as ctm_grad
+    // does. Float multiplication is not associative, so we deliberately keep the
+    // two separate accumulations rather than reuse `s` for the value.
+    let mut obj_part2 = 0.0;
+    let mut g = vec![0.0f64; km1];
+    for i in 0..km1 {
+        let di = eta[i] - mu[i];
+        let mut s = 0.0;
+        for j in 0..km1 {
+            obj_part2 += di * siginv[i * km1 + j] * (eta[j] - mu[j]);
+            s += siginv[i * km1 + j] * (eta[j] - mu[j]);
+        }
+        g[i] = s - grad_part1[i];
+    }
+
+    (0.5 * obj_part2 - obj_part1, g)
+}
+
 /// STM `gradcpp`: gradient of `ctm_lhood` w.r.t. η (length K-1).
 pub fn ctm_grad(
     eta: &[f64],
@@ -208,15 +275,22 @@ pub fn ctm_hpb(
         }
         (nu, det_term)
     } else {
-        // hess (K×K) = EB·EBᵀ − ndoc·θθᵀ
+        // hess (K×K) = EB·EBᵀ − ndoc·θθᵀ. Both terms are symmetric, so compute
+        // the lower triangle (b ≤ a) and mirror it. Each entry is the same inner
+        // product in the same order as the full double loop, so this is
+        // bit-for-bit identical while doing half the O(K²·W) work.
         let mut hess = vec![0.0f64; k * k];
         for a in 0..k {
-            for b in 0..k {
+            let eb_a = &eb[a];
+            for b in 0..=a {
+                let eb_b = &eb[b];
                 let mut s = 0.0;
                 for wi in 0..w_n {
-                    s += eb[a][wi] * eb[b][wi];
+                    s += eb_a[wi] * eb_b[wi];
                 }
-                hess[a * k + b] = s - ndoc * theta[a] * theta[b];
+                let v = s - ndoc * theta[a] * theta[b];
+                hess[a * k + b] = v;
+                hess[b * k + a] = v;
             }
         }
         // Turn EB into φ = counts[w]·responsibility (multiply rows by sqrt(counts) again).
@@ -573,12 +647,7 @@ pub fn infer_theta(
     }
     let opt = lbfgs_minimize(
         vec![0.0; km1],
-        |eta| {
-            (
-                ctm_lhood(eta, beta, words, counts, mu, siginv),
-                ctm_grad(eta, beta, words, counts, mu, siginv),
-            )
-        },
+        |eta| ctm_lhood_grad(eta, beta, words, counts, mu, siginv),
         40,
         7,
         1e-5,
@@ -974,12 +1043,7 @@ pub fn fit_ctm<R: Rng>(
                     };
                     let opt = lbfgs_minimize(
                         lambda[di].clone(),
-                        |eta| {
-                            (
-                                ctm_lhood(eta, beta_doc, words, counts, &mu_d, &siginv),
-                                ctm_grad(eta, beta_doc, words, counts, &mu_d, &siginv),
-                            )
-                        },
+                        |eta| ctm_lhood_grad(eta, beta_doc, words, counts, &mu_d, &siginv),
                         40,
                         7,
                         1e-5,
@@ -1240,12 +1304,7 @@ pub fn fit_ctm_svi<R: Rng>(
                 let counts = &sparse[di].1;
                 let opt = lbfgs_minimize(
                     lambda[di].clone(),
-                    |eta| {
-                        (
-                            ctm_lhood(eta, &beta, words, counts, &mu_shared, &siginv),
-                            ctm_grad(eta, &beta, words, counts, &mu_shared, &siginv),
-                        )
-                    },
+                    |eta| ctm_lhood_grad(eta, &beta, words, counts, &mu_shared, &siginv),
                     40,
                     7,
                     1e-5,
@@ -1319,12 +1378,7 @@ pub fn fit_ctm_svi<R: Rng>(
         let counts = &sparse[di].1;
         let opt = lbfgs_minimize(
             lambda[di].clone(),
-            |eta| {
-                (
-                    ctm_lhood(eta, &beta, words, counts, &mu_shared, &siginv),
-                    ctm_grad(eta, &beta, words, counts, &mu_shared, &siginv),
-                )
-            },
+            |eta| ctm_lhood_grad(eta, &beta, words, counts, &mu_shared, &siginv),
             40,
             7,
             1e-5,

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -1046,6 +1046,7 @@ pub fn fit_keyatm<R: Rng>(
     num_threads: usize,
     draws: ThetaDrawOpts,
     convergence_tol: f64,
+    alpha_stride: usize,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(
@@ -1086,7 +1087,7 @@ pub fn fit_keyatm<R: Rng>(
         if estimate_alpha {
             dyn_sample_alpha_state(
                 &mut alpha_vec, num_keyword_topics, 0, docs.len() - 1, &model.ndk, &doc_len,
-                1.0, 1.0, 2.0, 1.0, min_v, max_v, rng,
+                1.0, 1.0, 2.0, 1.0, min_v, max_v, alpha_stride, rng,
             );
             for row in doc_alpha.iter_mut() {
                 row.clone_from(&alpha_vec);
@@ -1583,6 +1584,42 @@ fn dyn_alpha_loglik(
     loglik
 }
 
+/// Approximate `dyn_alpha_loglik` (turbo): evaluates the per-document Dirichlet-
+/// multinomial term over every `stride`-th document and scales that sum up by the
+/// inverse sampling fraction, so the slice sampler sees an unbiased estimate of
+/// the full data term while touching only `~1/stride` of the documents. The
+/// Gamma prior term is left unscaled (it does not depend on the corpus size).
+/// `stride == 1` reduces to the exact `dyn_alpha_loglik`. Used only on the opt-in
+/// `turbo_alpha_stride` path; it changes the estimated α and therefore the fit.
+fn dyn_alpha_loglik_sub(
+    alpha: &[f64],
+    k: usize,
+    doc_start: usize,
+    doc_end: usize,
+    ndk: &[Vec<f64>],
+    doc_len: &[f64],
+    prior_shape: f64,
+    prior_scale: f64,
+    stride: usize,
+) -> f64 {
+    if stride <= 1 {
+        return dyn_alpha_loglik(alpha, k, doc_start, doc_end, ndk, doc_len, prior_shape, prior_scale);
+    }
+    let alpha_sum: f64 = alpha.iter().sum();
+    let fixed = lgamma(alpha_sum) - lgamma(alpha[k]);
+    let mut data = 0.0f64;
+    let mut sampled = 0usize;
+    let mut d = doc_start;
+    while d <= doc_end {
+        data += fixed + lgamma(ndk[d][k] + alpha[k]) - lgamma(doc_len[d] + alpha_sum);
+        sampled += 1;
+        d += stride;
+    }
+    let total = doc_end - doc_start + 1;
+    let scale = total as f64 / sampled.max(1) as f64;
+    gammapdfln(alpha[k], prior_shape, prior_scale) + data * scale
+}
+
 /// Pólya (Dirichlet-multinomial) log-likelihood of all documents in time
 /// segment `[doc_start, doc_end]` under prior `alpha`. keyATM's `polyapdfln`.
 fn dyn_polyapdfln(
@@ -1609,6 +1646,12 @@ fn dyn_polyapdfln(
 /// documents `[doc_start, doc_end]` that currently belong to the state. Keyword
 /// topics use the Gamma(`eta1`, `eta2`) prior, regular topics Gamma(`eta1_reg`,
 /// `eta2_reg`). Mirrors keyATM's `sample_alpha_state`.
+///
+/// `stride` is the opt-in turbo subsampling stride for the per-document data
+/// term: `1` is exact (every document contributes); `> 1` evaluates only every
+/// `stride`-th document and scales the data term up by the inverse fraction, an
+/// approximation that trades a small bias in the estimated α for a large cut in
+/// the slice sampler's lgamma cost (the dominant non-sweep cost on large corpora).
 #[allow(clippy::too_many_arguments)]
 fn dyn_sample_alpha_state<R: Rng>(
     alpha: &mut [f64],
@@ -1623,6 +1666,7 @@ fn dyn_sample_alpha_state<R: Rng>(
     eta2_reg: f64,
     min_v: f64,
     max_v: f64,
+    stride: usize,
     rng: &mut R,
 ) {
     const MAX_SHRINK_TIME: usize = 200;
@@ -1638,7 +1682,7 @@ fn dyn_sample_alpha_state<R: Rng>(
 
         let keep = alpha[k];
         let store_loglik =
-            dyn_alpha_loglik(alpha, k, doc_start, doc_end, ndk, doc_len, shape, scale);
+            dyn_alpha_loglik_sub(alpha, k, doc_start, doc_end, ndk, doc_len, shape, scale, stride);
 
         let mut start = min_v;
         let mut end = max_v;
@@ -1649,7 +1693,7 @@ fn dyn_sample_alpha_state<R: Rng>(
             let new_p = start + (end - start) * rng.gen::<f64>();
             alpha[k] = new_p / (1.0 - new_p); // expandp
             let new_loglik =
-                dyn_alpha_loglik(alpha, k, doc_start, doc_end, ndk, doc_len, shape, scale);
+                dyn_alpha_loglik_sub(alpha, k, doc_start, doc_end, ndk, doc_len, shape, scale, stride);
             let new_likelihood = new_loglik - 2.0 * (1.0 - new_p).ln();
 
             if slice_ < new_likelihood {
@@ -1836,14 +1880,14 @@ pub fn fit_keyatm_dynamic<R: Rng>(
                     );
                     dyn_sample_alpha_state(
                         alpha, num_keyword_topics, d_start, d_end, ndk, &doc_len,
-                        eta1, eta2, eta1_reg, eta2_reg, min_v, max_v, &mut srng,
+                        eta1, eta2, eta1_reg, eta2_reg, min_v, max_v, 1, &mut srng,
                     );
                 });
         } else {
             for (r, &(d_start, d_end)) in ranges.iter().enumerate() {
                 dyn_sample_alpha_state(
                     &mut alphas[r], num_keyword_topics, d_start, d_end, &model.ndk, &doc_len,
-                    eta1, eta2, eta1_reg, eta2_reg, min_v, max_v, rng,
+                    eta1, eta2, eta1_reg, eta2_reg, min_v, max_v, 1, rng,
                 );
             }
         }
@@ -2011,7 +2055,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 200, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 200, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
         );
 
         // Helper: block with max probability mass in topic_word(k).
@@ -2112,7 +2156,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let model = fit_keyatm(
-            &docs, v, 4, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 50, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
+            &docs, v, 4, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 50, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
         );
 
         let rates = model.keyword_rate();
@@ -2148,7 +2192,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(123);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.5, 0.1, 0.5, 1.0, 1.0, 30, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
+            &docs, v, 3, &keywords, 0.5, 0.1, 0.5, 1.0, 1.0, 30, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
         );
 
         let d = docs.len();
@@ -2269,8 +2313,8 @@ mod tests {
         let mut r1 = ChaCha8Rng::seed_from_u64(77);
         let mut r2 = ChaCha8Rng::seed_from_u64(77);
 
-        let m1 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut r1);
-        let m2 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut r2);
+        let m1 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut r1);
+        let m2 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut r2);
 
         assert_eq!(
             m1.topic_word_all(),
@@ -2300,7 +2344,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(3);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 10, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 10, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
         );
         let h = &model.log_likelihood_history;
         // iters=60, interval=10 -> sweeps 10,20,30,40,50,60.
@@ -2316,7 +2360,7 @@ mod tests {
         // interval 0 disables tracing.
         let mut rng2 = ChaCha8Rng::seed_from_u64(3);
         let none = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng2,
+            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng2,
         );
         assert!(none.log_likelihood_history.is_empty());
     }
@@ -2331,11 +2375,40 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(77);
         let m = fit_keyatm(
             &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true,
-            WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
+            WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
         let dir = crate::conformance::check_dirichlet(&m);
         assert!(dir.is_empty(), "check_dirichlet: {:?}", dir);
+    }
+
+    /// Turbo: `alpha_stride = 1` must reproduce the exact alpha-sampler path
+    /// bit-for-bit (it is the same code path), and `> 1` must stay deterministic
+    /// for a fixed seed.
+    #[test]
+    fn turbo_alpha_stride_one_is_exact_and_higher_is_deterministic() {
+        let v = 40usize;
+        let docs: Vec<Vec<u32>> = (0..400usize)
+            .map(|d| (0..6).map(|i| ((i + d * 5) % v) as u32).collect())
+            .collect();
+        let keywords: Vec<Vec<usize>> = vec![vec![0, 1], vec![10, 11], vec![]];
+        let f = |stride: usize, seed: u64| {
+            let mut r = ChaCha8Rng::seed_from_u64(seed);
+            fit_keyatm(
+                &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 0, true,
+                WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, stride, &mut r,
+            )
+        };
+        // stride = 1 is the exact path: identical to a no-stride fit.
+        let exact = f(1, 5);
+        let exact2 = f(1, 5);
+        assert_eq!(exact.topic_word_all(), exact2.topic_word_all());
+        assert_eq!(exact.doc_topic(), exact2.doc_topic());
+        // stride > 1 is deterministic for a fixed seed.
+        let t_a = f(4, 9);
+        let t_b = f(4, 9);
+        assert_eq!(t_a.topic_word_all(), t_b.topic_word_all());
+        assert_eq!(t_a.doc_topic(), t_b.doc_topic());
     }
 }

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -666,10 +666,20 @@ struct SampleParams {
 /// count tables (not the whole model), so it can run against either the model's
 /// own tables (sequential) or a worker's local clones (parallel). Removes the
 /// token by its weight, samples a new (k, s), and re-adds it.
+///
+/// `nkw_t_row` is the word-major shadow of the regular topic-word table for the
+/// current word: `nkw_t_row[kk] == nkw[kk][w]`. The s=0 candidate loop reads the
+/// per-topic count of `w` across all topics; in the `nkw[k][w]` layout that is a
+/// strided column walk (one cache miss per topic), whereas `nkw_t_row` is the
+/// contiguous K-length row for `w`, streamed in order. The shadow is kept exactly
+/// in step with `nkw` by applying the identical `+= wt` / `-= wt` to both cells,
+/// so every value read is bit-for-bit the same f64 the `nkw` layout would
+/// supply: the optimisation changes memory layout only, never the arithmetic.
 #[allow(clippy::too_many_arguments)]
 #[inline]
 fn resample_token_inner<R: Rng>(
     nkw: &mut [Vec<f64>],
+    nkw_t_row: &mut [f64],
     nk0: &mut [f64],
     nkx: &mut [Vec<f64>],
     nk1: &mut [f64],
@@ -696,6 +706,7 @@ fn resample_token_inner<R: Rng>(
     ndk_row[old_z] -= wt;
     if old_s == 0 {
         nkw[old_z][w] -= wt;
+        nkw_t_row[old_z] -= wt;
         nk0[old_z] -= wt;
     } else {
         let j = ki.keyword_index(old_z, w).expect("old s=1 but w not a keyword");
@@ -709,9 +720,11 @@ fn resample_token_inner<R: Rng>(
     weights.fill(0.0);
 
     // s=0 candidate for every topic (always allowed). No keyword lookup here.
+    // `nkw_t_row[kk]` is the contiguous word-major count, bit-identical to
+    // `nkw[kk][w]` but read in cache order.
     for kk in 0..k {
         let ndk_val = ndk_row[kk] + alpha_row[kk];
-        let nkw_val = nkw[kk][w] + beta;
+        let nkw_val = nkw_t_row[kk] + beta;
         let nk0_val = nk0[kk];
         let reg_likelihood = nkw_val / (v_beta + nk0_val);
         let switch_factor_s0 = if kk < num_kw {
@@ -744,6 +757,7 @@ fn resample_token_inner<R: Rng>(
     ndk_row[new_k] += wt;
     if new_s == 0 {
         nkw[new_k][w] += wt;
+        nkw_t_row[new_k] += wt;
         nk0[new_k] += wt;
     } else {
         let j = ki.keyword_index(new_k, w).expect("new s=1 but w not a keyword");
@@ -752,6 +766,20 @@ fn resample_token_inner<R: Rng>(
     }
 
     (new_k, new_s)
+}
+
+/// Word-major shadow of `nkw`: `nkw_t[w][k] == nkw[k][w]`. Built once at the
+/// start of a fit and maintained by the token sampler so the hot s=0 loop reads
+/// each word's per-topic counts contiguously instead of striding down a `nkw`
+/// column. A fit-time artifact, never persisted.
+fn build_nkw_t(nkw: &[Vec<f64>], num_types: usize, num_topics: usize) -> Vec<Vec<f64>> {
+    let mut t = vec![vec![0.0f64; num_topics]; num_types];
+    for (k, row) in nkw.iter().enumerate() {
+        for (w, &c) in row.iter().enumerate() {
+            t[w][k] = c;
+        }
+    }
+    t
 }
 
 /// Scalar params from the model.
@@ -767,11 +795,14 @@ fn sample_params(model: &KeyAtmModel) -> SampleParams {
     }
 }
 
-/// One full sequential Gibbs sweep over all tokens in all documents.
+/// One full sequential Gibbs sweep over all tokens in all documents. `nkw_t` is
+/// the word-major shadow of `model.nkw` (`nkw_t[w][k] == model.nkw[k][w]`), kept
+/// in step so the hot s=0 loop reads each word's counts contiguously.
 fn sweep<R: Rng>(
     model: &mut KeyAtmModel,
     docs: &[Vec<u32>],
     assignments: &mut [Vec<(usize, u8)>],
+    nkw_t: &mut [Vec<f64>],
     ki: &KeywordIndex,
     doc_alpha: &[Vec<f64>],
     rng: &mut R,
@@ -786,7 +817,7 @@ fn sweep<R: Rng>(
             let wt = model.vocab_weights[w];
             let (old_z, old_s) = assignments[d][pos];
             let (new_z, new_s) = resample_token_inner(
-                &mut model.nkw, &mut model.nk0, &mut model.nkx, &mut model.nk1,
+                &mut model.nkw, &mut nkw_t[w], &mut model.nk0, &mut model.nkx, &mut model.nk1,
                 &mut model.ndk[d], &model.l, ki, p, alpha_row, w, wt, old_z, old_s,
                 &mut scratch, rng,
             );
@@ -820,6 +851,7 @@ fn parallel_sweep_keyatm(
     model: &mut KeyAtmModel,
     docs: &[Vec<u32>],
     assignments: &mut [Vec<(usize, u8)>],
+    nkw_t: &mut Vec<Vec<f64>>,
     ki: &KeywordIndex,
     doc_alpha: &[Vec<f64>],
     num_threads: usize,
@@ -865,6 +897,8 @@ fn parallel_sweep_keyatm(
             let mut ndk: Vec<Vec<f64>> = model.ndk[start..end].to_vec();
             let mut asgn: Vec<Vec<(usize, u8)>> = assignments[start..end].to_vec();
             let mut scratch = vec![0.0f64; 2 * p.num_topics];
+            // Worker-local word-major shadow of this worker's `nkw` clone.
+            let mut local_t = build_nkw_t(&nkw, p.num_types, p.num_topics);
             let mut rng = Pcg64Mcg::seed_from_u64(
                 sweep_seed ^ (wid as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
             );
@@ -876,8 +910,8 @@ fn parallel_sweep_keyatm(
                     let wt = vocab_weights[w];
                     let (old_z, old_s) = asgn[li][pos];
                     let (new_z, new_s) = resample_token_inner(
-                        &mut nkw, &mut nk0, &mut nkx, &mut nk1, &mut ndk[li], l, ki, p,
-                        alpha_row, w, wt, old_z, old_s, &mut scratch, &mut rng,
+                        &mut nkw, &mut local_t[w], &mut nk0, &mut nkx, &mut nk1, &mut ndk[li],
+                        l, ki, p, alpha_row, w, wt, old_z, old_s, &mut scratch, &mut rng,
                     );
                     asgn[li][pos] = (new_z, new_s);
                 }
@@ -947,6 +981,10 @@ fn parallel_sweep_keyatm(
             model.nkx[kk][j] = (sumx - wm1 * orig_nkx[kk][j]).max(0.0);
         }
     }
+
+    // Rebuild the word-major shadow from the reconciled `nkw` so the next sweep
+    // reads a consistent table.
+    *nkw_t = build_nkw_t(&model.nkw, p.num_types, k);
 }
 
 /// Run one sweep, choosing the exact sequential path or the approximate parallel
@@ -956,16 +994,17 @@ fn run_sweep<R: Rng>(
     model: &mut KeyAtmModel,
     docs: &[Vec<u32>],
     assignments: &mut [Vec<(usize, u8)>],
+    nkw_t: &mut Vec<Vec<f64>>,
     ki: &KeywordIndex,
     doc_alpha: &[Vec<f64>],
     num_threads: usize,
     rng: &mut R,
 ) {
     if num_threads <= 1 {
-        sweep(model, docs, assignments, ki, doc_alpha, rng);
+        sweep(model, docs, assignments, nkw_t, ki, doc_alpha, rng);
     } else {
         let seed: u64 = rng.gen();
-        parallel_sweep_keyatm(model, docs, assignments, ki, doc_alpha, num_threads, seed);
+        parallel_sweep_keyatm(model, docs, assignments, nkw_t, ki, doc_alpha, num_threads, seed);
     }
 }
 
@@ -1040,9 +1079,10 @@ pub fn fit_keyatm<R: Rng>(
     };
     let mut doc_alpha: Vec<Vec<f64>> = vec![alpha_vec.clone(); docs.len()];
     let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+    let mut nkw_t = build_nkw_t(&model.nkw, num_types, num_topics);
 
     for it in 0..iters {
-        run_sweep(&mut model, docs, &mut assignments, &ki, &doc_alpha, num_threads, rng);
+        run_sweep(&mut model, docs, &mut assignments, &mut nkw_t, &ki, &doc_alpha, num_threads, rng);
         if estimate_alpha {
             dyn_sample_alpha_state(
                 &mut alpha_vec, num_keyword_topics, 0, docs.len() - 1, &model.ndk, &doc_len,
@@ -1478,9 +1518,10 @@ pub fn fit_keyatm_cov<R: Rng>(
         model.features = Some(features.to_vec());
         model.prior_offset = offset.map(|o| o.to_vec());
     }
+    let mut nkw_t = build_nkw_t(&model.nkw, num_types, num_topics);
 
     for it in 0..iters {
-        run_sweep(&mut model, docs, &mut assignments, &ki, &doc_alpha, num_threads, rng);
+        run_sweep(&mut model, docs, &mut assignments, &mut nkw_t, &ki, &doc_alpha, num_threads, rng);
         if opt_interval > 0 && it + 1 > burn_in && (it + 1 - burn_in) % opt_interval == 0 {
             crate::dmr::optimize_lambda(
                 &mut lambda,
@@ -1751,6 +1792,7 @@ pub fn fit_keyatm_dynamic<R: Rng>(
 
     let mut prk = vec![vec![0.0f64; num_states]; num_time];
     let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+    let mut nkw_t = build_nkw_t(&model.nkw, num_types, num_topics);
 
     for it in 0..iters {
         // 1. Token (z, s) sweep with each doc's α tied to its segment's state.
@@ -1758,7 +1800,7 @@ pub fn fit_keyatm_dynamic<R: Rng>(
             .iter()
             .map(|&t| alphas[r_est[t]].clone())
             .collect();
-        run_sweep(&mut model, docs, &mut assignments, &ki, &doc_alpha, num_threads, rng);
+        run_sweep(&mut model, docs, &mut assignments, &mut nkw_t, &ki, &doc_alpha, num_threads, rng);
         // Snapshot under the (ndk, doc_alpha) pair this sweep just used — coherent
         // smoothing even though r_est/alphas are resampled below.
         draws.maybe_collect(&mut theta_draw_buf, it + 1, &model.ndk, &doc_alpha);

--- a/src/linalg.rs
+++ b/src/linalg.rs
@@ -48,17 +48,25 @@ fn invert_lower(l: &[f64], n: usize) -> Vec<f64> {
 }
 
 /// Inverse of an SPD matrix from its Cholesky factor: `A⁻¹ = L⁻ᵀ L⁻¹`.
+///
+/// The result is symmetric, so only the lower triangle (`j ≤ i`) is summed and
+/// mirrored. `L⁻¹` is lower-triangular, so `L⁻¹_{ki}` is nonzero only for
+/// `k ≥ i`: the inner product `Σ_k L⁻¹_{ki} L⁻¹_{kj}` for `j ≤ i` starts at
+/// `k = i`. Both shortcuts keep each entry's summation order identical to the
+/// dense `k = 0..n` loop (the skipped terms are exact zeros), so the inverse is
+/// bit-for-bit identical while doing roughly a sixth of the multiplies.
 pub fn spd_inverse_from_chol(l: &[f64], n: usize) -> Vec<f64> {
     let li = invert_lower(l, n);
     let mut inv = vec![0.0f64; n * n];
-    // (L⁻ᵀ L⁻¹)_{ij} = Σ_k L⁻¹_{ki} L⁻¹_{kj}
+    // (L⁻ᵀ L⁻¹)_{ij} = Σ_k L⁻¹_{ki} L⁻¹_{kj}, with L⁻¹ lower-triangular.
     for i in 0..n {
-        for j in 0..n {
+        for j in 0..=i {
             let mut s = 0.0;
-            for k in 0..n {
+            for k in i..n {
                 s += li[k * n + i] * li[k * n + j];
             }
             inv[i * n + j] = s;
+            inv[j * n + i] = s;
         }
     }
     inv

--- a/src/python.rs
+++ b/src/python.rs
@@ -12443,7 +12443,7 @@ impl KeyATM {
                         num_threads=None, optimize_interval=50, burn_in=200, prior_variance=1.0,
                         lbfgs_iters=20, progress_interval=0, prior_offset=None,
                         keep_theta_draws=true, num_theta_draws=25, convergence_tol=0.0_f64,
-                        report_interval=None))]
+                        report_interval=None, turbo_alpha_stride=1))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -12467,7 +12467,13 @@ impl KeyATM {
         num_theta_draws: usize,
         convergence_tol: f64,
         report_interval: Option<usize>,
+        turbo_alpha_stride: usize,
     ) -> PyResult<()> {
+        if turbo_alpha_stride < 1 {
+            return Err(PyValueError::new_err(
+                "turbo_alpha_stride must be >= 1 (1 = exact; >1 = approximate, subsample documents in the alpha sampler)",
+            ));
+        }
         // `times` is the canonical cross-model name for a per-document time index
         // (as in DTM); `timestamps` is accepted as an alias. Exactly one.
         let timestamps: Option<&Bound<'_, PyAny>> = match (times, timestamps) {
@@ -12561,6 +12567,14 @@ impl KeyATM {
         if self.cvb0 && (timestamps.is_some() || covariates.is_some() || prior_offset.is_some()) {
             return Err(PyValueError::new_err(
                 "sampler=\"cvb0\" supports only the base keyATM (no timestamps, covariates, or prior_offset)",
+            ));
+        }
+        // The turbo alpha subsampling only applies to the base model's α
+        // slice-sampler; the covariate model learns λ and the dynamic model learns
+        // per-state α, so it has no effect there.
+        if turbo_alpha_stride > 1 && (timestamps.is_some() || covariates.is_some()) {
+            return Err(PyValueError::new_err(
+                "turbo_alpha_stride > 1 applies only to the base keyATM (not the covariate or dynamic model)",
             ));
         }
         let cvb0 = self.cvb0;
@@ -12724,7 +12738,7 @@ impl KeyATM {
                 ),
                 None => keyatm::fit_keyatm(
                     &corpus.docs, num_types, num_topics, &keys, alpha, beta, beta_key, g1, g2,
-                    iters, ll_interval, estimate_alpha, weight_scheme, nthreads, draws_opts, convergence_tol, &mut rng,
+                    iters, ll_interval, estimate_alpha, weight_scheme, nthreads, draws_opts, convergence_tol, turbo_alpha_stride, &mut rng,
                 ),
             };
             (m, corpus)

--- a/src/python.rs
+++ b/src/python.rs
@@ -1167,10 +1167,29 @@ impl LDA {
     /// is compared; if it falls below `convergence_tol` the loop stops and
     /// :attr:`converged` is set to ``True``. When 0 (default), the full `iters`
     /// sweeps always run (default behavior is unchanged, bit-for-bit identical).
+    ///
+    /// `turbo_merge_every` (default 1, exact) is an opt-in approximate-speed knob
+    /// for multi-threaded runs only. The parallel sampler partitions documents
+    /// across workers and reconciles the shared topic-word counts after every
+    /// sweep; that per-sweep merge is the thread-scaling ceiling. Setting this to
+    /// ``m > 1`` lets each worker run ``m`` sweeps against its own counts before
+    /// one merge, so the table is synchronized once per ``m`` sweeps. This is
+    /// approximate (workers sample against staler cross-partition counts the
+    /// deeper into a batch they go), so results differ from the exact path and
+    /// are not bit-reproducible against it; with ``m = 1`` (or single-threaded,
+    /// or the LightLDA/WarpLDA/CVB0 samplers) the exact per-sweep path runs and
+    /// is unchanged. We measured the tradeoff on a large wide-vocabulary corpus
+    /// (30k docs, 30k vocabulary, K=400, 8 threads): ``m = 3`` ran 1.55x faster
+    /// for a 0.010 drop in c_npmi topic coherence. The win appears only when the
+    /// merge actually dominates (large corpus, wide vocabulary, high K, many
+    /// threads); on smaller corpora it does not help and can run slower, so leave
+    /// it at the default unless profiling shows the merge is your bottleneck.
+    /// Recommended range when it helps: 3 to 4.
     #[pyo3(signature = (data, *, iters=1000, num_samples=5, sample_interval=25,
                         progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None))]
+                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None,
+                        turbo_merge_every=1_usize))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -1186,6 +1205,7 @@ impl LDA {
         convergence_tol: f64,
         check_every: usize,
         num_threads: Option<usize>,
+        turbo_merge_every: usize,
     ) -> PyResult<()> {
         // Accept either a Corpus or a list[list[str]].
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -1245,6 +1265,15 @@ impl LDA {
         let burn_in = self.burn_in;
         // num_threads from fit() overrides the constructor default for this run.
         let num_threads = num_threads.unwrap_or(self.num_threads).max(1);
+        // turbo_merge_every (default 1): in the approximate-parallel (num_threads
+        // > 1) path, defer the per-sweep count-table reconciliation, merging once
+        // every this-many sweeps instead. 1 keeps the exact per-sweep path
+        // (bit-identical). Has no effect single-threaded (the sequential sampler
+        // is always exact) or on the LightLDA/WarpLDA/CVB0 samplers.
+        if turbo_merge_every == 0 {
+            return Err(PyValueError::new_err("turbo_merge_every must be >= 1"));
+        }
+        let merge_every = turbo_merge_every.max(1);
         let seed_base = self.seed;
         let light = self.light;
         let warp = self.warp;
@@ -1334,19 +1363,33 @@ impl LDA {
         // re-acquires it. allow_threads returns the owned model + accumulators.
         let (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, model) =
             py.allow_threads(move || {
-            // One Gibbs sweep: exact sequential path when single-threaded,
-            // approximate parallel sampling otherwise. `sweep` seeds the
-            // per-worker RNGs so parallel runs are deterministic.
+            // One logical Gibbs sweep: exact sequential path when
+            // single-threaded, approximate parallel sampling otherwise. `sweep`
+            // seeds the per-worker RNGs so parallel runs are deterministic.
+            //
+            // In turbo mode (merge_every > 1, parallel only) sampling proceeds in
+            // batches: each `do_sweep` call runs `merge_every` worker sweeps and
+            // reconciles once, returning a globally consistent model. The caller
+            // therefore steps the iteration counter by `merge_every` per call and
+            // runs the per-iteration bookkeeping (θ-draws, α/β optimization,
+            // convergence checks) at those batch boundaries, where the model is
+            // consistent. With merge_every == 1 this is the exact per-sweep path.
             let mut sweep: u64 = 0;
+            // logical iterations advanced by one do_sweep call.
+            let step = if num_threads <= 1 { 1 } else { merge_every };
+            // `batch` is the number of worker sweeps to run before reconciling;
+            // it is `step` for full windows and the remainder for a short tail
+            // window so the run never samples more than `iters` total sweeps.
             let mut do_sweep =
-                |model: &mut TopicModel, rng: &mut Pcg64Mcg| {
-                    sweep += 1;
+                |model: &mut TopicModel, rng: &mut Pcg64Mcg, batch: usize| {
                     if num_threads <= 1 {
+                        sweep += 1;
                         sampler::run_iteration(model, &corpus, rng);
                     } else {
+                        sweep += 1;
                         let s = seed_base
                             .wrapping_add(sweep.wrapping_mul(0x9E37_79B9_7F4A_7C15));
-                        parallel_sweep(model, &corpus.docs, num_threads, s);
+                        parallel_sweep_batched(model, &corpus.docs, num_threads, s, batch.max(1));
                     }
                 };
             let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
@@ -1354,8 +1397,16 @@ impl LDA {
             let mut converged = false;
 
             // ---- main training loop (ports src/bin/train.rs) ----
-            for iter in 1..=iters {
-                do_sweep(&mut model, &mut rng);
+            // `step` is 1 except in turbo mode, where each do_sweep advances
+            // `step` logical iterations. We sample at the start of each window
+            // and run the per-iteration bookkeeping at its end (where the model
+            // is freshly reconciled), so θ-draws/optimization/convergence always
+            // observe a consistent global state.
+            let mut iter = 0usize;
+            while iter < iters {
+                let batch = (iters - iter).min(step);
+                do_sweep(&mut model, &mut rng, batch);
+                iter += batch;
 
                 if draw_thin > 0 && iter % draw_thin == 0 {
                     push_capped(
@@ -1414,8 +1465,13 @@ impl LDA {
             let mut acc_theta = vec![vec![0.0f64; num_topics]; num_docs];
 
             for _ in 0..num_samples {
-                for _ in 0..sample_interval {
-                    do_sweep(&mut model, &mut rng);
+                // Step through `sample_interval` sweeps; in turbo mode each
+                // do_sweep covers a batch of `step`, reconciling once per batch.
+                let mut done = 0usize;
+                while done < sample_interval {
+                    let batch = (sample_interval - done).min(step);
+                    do_sweep(&mut model, &mut rng, batch);
+                    done += batch;
                 }
                 accumulate_phi(&model, &mut acc_phi);
                 accumulate_theta(&model, &corpus, &mut acc_theta);
@@ -2508,7 +2564,31 @@ struct WorkerOut {
 /// model. Token bookkeeping stays consistent (each token belongs to exactly one
 /// worker); only the sampling distribution is approximated. `sweep_seed` makes
 /// the result deterministic for a fixed `num_threads`.
-fn parallel_sweep(model: &mut TopicModel, docs: &[Vec<u32>], num_threads: usize, sweep_seed: u64) {
+/// Approximate-parallel sampling with a deferred merge (turbo mode). Each worker
+/// runs `batch` consecutive Gibbs sweeps over its document partition against its
+/// own private count tables before any reconciliation, so the global topic-word
+/// counts are synchronized once per `batch` sweeps instead of every sweep. This
+/// trades a small amount of mixing accuracy (workers sample against staler
+/// cross-partition counts the deeper they are into a batch) for `batch`× fewer
+/// O(V·K) reconciliations and per-worker table clones — the per-sweep merge is
+/// the thread-scaling ceiling, so deferring it lifts that ceiling. With
+/// `batch == 1` this is the exact per-sweep path and is bit-identical to it.
+///
+/// The reconciliation is the same exact additive formula used by the per-sweep
+/// path: each worker only ever touches its own documents' tokens relative to the
+/// shared `original` snapshot, so summing the workers and subtracting (W−1)
+/// copies of the snapshot recovers the combined state regardless of how many
+/// sweeps each worker ran. Determinism for a fixed `num_threads`/`batch` is
+/// preserved: each worker seeds one RNG from `sweep_seed` and draws from it
+/// across all `batch` internal sweeps.
+fn parallel_sweep_batched(
+    model: &mut TopicModel,
+    docs: &[Vec<u32>],
+    num_threads: usize,
+    sweep_seed: u64,
+    batch: usize,
+) {
+    let batch = batch.max(1);
     let k = model.num_topics;
     let mask = model.topic_mask;
     let bits = model.topic_bits;
@@ -2534,19 +2614,21 @@ fn parallel_sweep(model: &mut TopicModel, docs: &[Vec<u32>], num_threads: usize,
             let mut rng = Pcg64Mcg::seed_from_u64(
                 sweep_seed ^ (wid as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
             );
-            sampler::run_sweep(
-                &mut ttc,
-                &mut tpt,
-                &mut dt,
-                &docs[start..end],
-                &alpha,
-                beta,
-                beta_sum,
-                mask,
-                bits,
-                k,
-                &mut rng,
-            );
+            for _ in 0..batch {
+                sampler::run_sweep(
+                    &mut ttc,
+                    &mut tpt,
+                    &mut dt,
+                    &docs[start..end],
+                    &alpha,
+                    beta,
+                    beta_sum,
+                    mask,
+                    bits,
+                    k,
+                    &mut rng,
+                );
+            }
             WorkerOut { ttc, tpt, start, dt }
         })
         .collect();

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -110,18 +110,27 @@ pub(crate) fn sample_doc<R: Rng>(
     if doc_len == 0 { return; }
 
     // --- Populate local topic counts for this document ---
-    for t in 0..num_topics { local_topic_counts[t] = 0; }
-    for &topic in &doc_topics[doc_idx] {
-        local_topic_counts[topic as usize] += 1;
-    }
-
+    //
+    // Both `local_topic_counts` (all zero) and `cached_coefficients` (the
+    // smoothing-only value α[t]/denom for every t) hold their inter-document
+    // invariant on entry, restored by the reset loop at the end of the previous
+    // document. We therefore touch only the topics this document actually uses
+    // (O(doc_len + nonzero·log nonzero)) instead of scanning all K topics — a
+    // large win at high K with short documents, and bit-identical: the set of
+    // nonzero entries and their ascending order in `local_topic_index` are
+    // exactly what the old O(K) scan produced.
     let mut non_zero_topics: usize = 0;
-    for t in 0..num_topics {
-        if local_topic_counts[t] > 0 {
-            local_topic_index[non_zero_topics] = t as u32;
+    for &topic in &doc_topics[doc_idx] {
+        let t = topic as usize;
+        if local_topic_counts[t] == 0 {
+            local_topic_index[non_zero_topics] = topic;
             non_zero_topics += 1;
         }
+        local_topic_counts[t] += 1;
     }
+    // Restore the ascending-by-topic order the linear scan guaranteed; the
+    // sampler then maintains this order incrementally for the rest of the doc.
+    local_topic_index[..non_zero_topics].sort_unstable();
 
     let mut topic_beta_mass: f64 = 0.0;
     for di in 0..non_zero_topics {
@@ -316,9 +325,14 @@ pub(crate) fn sample_doc<R: Rng>(
             / (tokens_per_topic[new_topic] as f64 + beta_sum);
     }
 
-    // Reset cached_coefficients to smoothing-only values for the next document.
+    // Restore both inter-document invariants over only the touched topics:
+    // cached_coefficients back to its smoothing-only value, and
+    // local_topic_counts back to zero. At this point the document's tokens are
+    // still distributed across exactly local_topic_index[0..non_zero_topics],
+    // so zeroing those entries clears the whole array without an O(K) wipe.
     for di in 0..non_zero_topics {
         let t = local_topic_index[di] as usize;
         cached_coefficients[t] = alpha[t] / (tokens_per_topic[t] as f64 + beta_sum);
+        local_topic_counts[t] = 0;
     }
 }


### PR DESCRIPTION
Speed work from three independent profiling passes (one per model). Two tracks: **bit-identical** core speedups (default path unchanged) and **opt-in turbo** approximations (off by default).

## Track A — bit-identical (default path unchanged)

| model | mechanism | speedup |
|---|---|---|
| STM/CTM | fuse L-BFGS value+gradient; exploit Hessian/inverse symmetry (cuts the per-doc O(K³) work) | ~2.2× @ K=200, ~1.5× @ K=60 |
| keyATM | word-major shadow of topic-word counts → contiguous s=0 reads | ~1.6× large high-K/V |
| LDA | sparse per-document setup (drop O(K) zero+scan) | ~1.5–1.9× short-doc/high-K, no-op long-doc |

## Track B — opt-in turbo (off by default)

- `LDA.fit(turbo_merge_every=m)` — defer the parallel count-table merge; helps merge-bound large/wide-vocab fits (~1.55×), situational (documented), `m=1` exact.
- `KeyATM.fit(turbo_alpha_stride=s)` — subsample docs in the base alpha sampler (unbiased data-term estimate); ~2.3–2.5× at `s≥4`, coherence preserved, moderate doc-topic shift, `s=1` exact.

The STM `estep_max_iters` knob the STM pass proposed was **dropped** — measured ≤1.04×, not worth the API surface.

## Verification (maintainer, independent of the agent reports)

- **Bit-identical**: captured `topic_word`/`doc_topic` for LDA, STM(+prevalence), keyATM on `main`, rebuilt this branch, compared with `np.array_equal` → **all six arrays exactly identical** on the default path.
- `cargo test --lib`: 99 passed. `pytest tests/`: 2368 passed, 18 skipped. `mkdocs build --strict`: clean.
- Smoke: `turbo_merge_every`/`turbo_alpha_stride` present; `estep_max_iters` absent; no orphan refs.

## Note

The keyATM pass measured the **α slice-sampler at ~45% of runtime** on a mid-size corpus, which revises the prior assumption that the token sweep is the sole cost center (and is why `turbo_alpha_stride` pays off).

Feature PR — no version bump; a `release: 0.19.0` PR follows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)