### PR TITLE
release: 0.19.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.19.0] - 2026-06-15
+
 ### Changed
 
 - Faster LDA, STM/CTM, and keyATM fits, with bit-for-bit identical results

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.18.0"
+version = "0.19.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.18.0"
+version = "0.19.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.18.0"
+version = "0.19.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.19.0**. Bumps `Cargo.toml`/`pyproject.toml`/`Cargo.lock` and moves the CHANGELOG `[Unreleased]` block to `[0.19.0]`.

## Headline

Bit-identical speedups for LDA, STM/CTM, and keyATM (default path unchanged, verified `np.array_equal`), plus two opt-in turbo flags (`LDA.fit(turbo_merge_every=)`, `KeyATM.fit(turbo_alpha_stride=)`). Landed in #170.

- STM/CTM ~2.2× @ K=200, keyATM ~1.6× large, LDA ~1.5–1.9× short-doc/high-K — all bit-identical.

Minor bump for the new opt-in turbo parameters (no breaking change; defaults exact).

## Gates (on merged main / this branch)

- `cargo test --lib`: 99 passed. `pytest tests/`: 2368 passed, 18 skipped. `mkdocs --strict`: clean.
- Rebuilt: `import topica; topica.__version__ == "0.19.0"`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)