### PR TITLE
feat: model registry + purpose taxonomy (#182)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,36 +30,71 @@ See the [getting-started guide](https://nealcaren.github.io/topica/getting-start
 
 ## Models
 
-**Count-based models** learn topics from word counts (collapsed Gibbs, variational EM, or an amortized VAE):
+Models are organized by **what you bring and what you want**, not by inference
+family. The `from topica import X` namespace is flat; `topica.list_models(group=…,
+brings=…, inference=…, determinism=…)` filters this roster in code. **Brings** is
+what you supply beyond raw text; **Reproducibility** is `bit-exact` (identical
+regardless of thread count), `seed-reproducible` (identical from a fixed seed and
+thread count), or `llm-bounded`.
 
-| Model | What it's for |
-|-------|---------------|
-| **`LDA`** | Classic topics via fast collapsed-Gibbs (SparseLDA); optional multi-threaded and LightLDA alias samplers |
-| **`STM`** | The Structural Topic Model: correlated topics with prevalence **and** content covariates |
-| **`STS`** | Structural Topic **and Sentiment-Discourse**: covariate-driven topic sentiment/tone on top of STM |
-| **`CTM`** | Correlated topics (logistic-normal) |
-| **`DMR`** | Topics conditioned on document metadata (Dirichlet-multinomial regression) |
-| **`GDMR`** | Generalized DMR over continuous metadata via a Legendre basis, with topic distribution functions across the metadata range |
-| **`DTM`** | Dynamic topics that evolve across time slices |
-| **`HDP`** | Nonparametric LDA that learns the number of topics from the data; by default fits with fixed concentrations (topic count steered by `gamma`), with optional concentration resampling |
-| **`keyATM` / `seededlda`** | Guided topics steered by seed words |
-| **`ProdLDA`** | Sharper, more coherent topics via a product-of-experts word model, fit as an amortized VAE (no PyTorch) |
-| **`PT` / `GSDMM`** | Short-text models for tweets, survey answers, headlines |
-| **`SupervisedLDA`** | Topics shaped to predict a per-document response |
-| **`LabeledLDA`** | Supervised topics tied to document labels |
-| **`SAGE`** | Content-covariate topics: the same topic worded differently across groups |
-| **`PA` / `HLDA`** | Topic hierarchies (Pachinko, nested-CRP) |
+<!-- BEGIN MODEL TABLE (generated from topica.registry; edit registry.py, not this block) -->
 
-**Embedding-based models** start from document embeddings you supply (no PyTorch, no UMAP/numba in the wheel):
+### General-purpose
 
-| Model | What it's for |
-|-------|---------------|
-| **`BERTopic`** | Cluster document embeddings, label topics by class-TF-IDF; topic reduction and a soft per-document distribution |
-| **`Top2Vec`** | Topics as points in the embedding space; topic words are the nearest word vectors |
-| **`ETM`** | Embedded Topic Model: a logistic-normal topic model with the topic-word distribution factored through embeddings (`β = softmax(ρ·α)`); per-document EM or an amortized VAE (`inference="vae"`) |
-| **`FASTopic`** | Topics read off two optimal-transport plans between document, topic, and word embeddings |
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `LDA` | text | gibbs | seed-reproducible | Classic latent Dirichlet allocation via a fast SparseLDA collapsed-Gibbs sampler. |
+| `CTM` | text | variational | bit-exact | Correlated topic model: a logistic-normal prior that lets topics co-occur. |
+| `ProdLDA` | text | vae | seed-reproducible | Product-of-experts LDA (AVITM) for sharper, more coherent topics; hand-coded VAE. |
+| `HDP` | text | gibbs | seed-reproducible | Hierarchical Dirichlet process: infers the number of topics from the data. |
 
-Every model exposes the same shape: `fit(docs, …)`, then `topic_word` (φ), `doc_topic` (θ), `top_words(n)`, and `save`/`load`. The count-based variational models (`CTM`/`STM`/`STS`/`SupervisedLDA`/`DTM`) parallelize across cores while staying bit-for-bit deterministic. The embedding models split into two kinds: `BERTopic` and `Top2Vec` run the `reduce → cluster → represent` pipeline, while `ETM` and `FASTopic` are generative and mixed-membership; all of them take vectors from any embedder (sentence-transformers, an API, a local model such as ollama). Full guides: [the models](https://nealcaren.github.io/topica/guides/models/) and [embedding topics](https://nealcaren.github.io/topica/guides/embedding/).
+### Covariates & structure
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `STM` | text, metadata | variational | bit-exact | Structural topic model: relate topic prevalence and content to covariates. |
+| `STS` | text, metadata | variational | bit-exact | Structural topic-and-sentiment model over document metadata. |
+| `SAGE` | text, metadata | gibbs | seed-reproducible | Sparse additive generative model: the same topic worded differently across groups. |
+| `DMR` | text, metadata | gibbs | seed-reproducible | Dirichlet-multinomial regression: a document-metadata prior on topic proportions. |
+| `GDMR` | text, metadata | gibbs | seed-reproducible | Generalized DMR with a smooth (Legendre-basis) prior over continuous covariates. |
+
+### Guided & supervised
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `KeyATM` | text, seeds | gibbs | seed-reproducible | Keyword-assisted topics: anchor named topics with a few seed words each. |
+| `SeededLDA` | text, seeds | gibbs | seed-reproducible | Seeded LDA: steer named topics toward supplied seed words. |
+| `LabeledLDA` | text, labels | gibbs | seed-reproducible | Labeled LDA: each document label is a topic; tokens are restricted to its labels. |
+| `SupervisedLDA` | text, labels | gibbs | seed-reproducible | Supervised LDA: topics shaped to predict a per-document real-valued response. |
+
+### Short text
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `GSDMM` | text | gibbs | seed-reproducible | Gibbs-sampling Dirichlet mixture: one topic per short document. |
+| `PT` | text | gibbs | seed-reproducible | Pseudo-document topic model: pool short texts into pseudo-documents. |
+
+### Dynamic & hierarchical
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `DTM` | text, times | variational | bit-exact | Dynamic topic model: a fixed topic set whose word distributions drift across time slices. |
+| `HLDA` | text | gibbs | seed-reproducible | Hierarchical LDA (nested CRP): a learned tree of super- and sub-topics. |
+| `PA` | text | gibbs | seed-reproducible | Pachinko allocation: a DAG of super- and sub-topics. |
+
+### Embedding-based
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `BERTopic` | text, embeddings | clustering | seed-reproducible | Cluster document embeddings; label topics by class-based TF-IDF. |
+| `Top2Vec` | text, embeddings | clustering | seed-reproducible | Topics as dense regions in a joint document-word embedding space. |
+| `ETM` | text, embeddings | variational | bit-exact | Embedded topic model: topic-word distributions factored through word embeddings. |
+| `FASTopic` | text, embeddings | optimal-transport | bit-exact | Topics from optimal-transport plans between document, topic, and word embeddings. |
+| `EmbeddingLDA` | text, embeddings, seeds | gibbs | seed-reproducible | Seeded LDA whose seed sets are expanded with nearest neighbors in an embedding space. |
+
+<!-- END MODEL TABLE -->
+
+Every model exposes the same shape: `fit(docs, …)`, then `topic_word` (φ), `doc_topic` (θ), `top_words(n)`, and `save`/`load`, so one diagnostic, labeling, and effect-estimation stack applies to all of them and a new model inherits it for free. The embedding-based models take document vectors from any embedder (sentence-transformers, an API, or a local model such as ollama; no PyTorch or UMAP/numba in the wheel). Full guides: [the models](https://nealcaren.github.io/topica/guides/models/) and [embedding topics](https://nealcaren.github.io/topica/guides/embedding/).
 
 ## Diagnostics & analysis
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -23,6 +23,72 @@ Every model shares the same shape: construct with hyperparameters and a `seed`,
 | Model short texts (tweets, answers) | [`PT`, `GSDMM`](short-text.md) |
 | Build a topic hierarchy | `PA`, `HLDA` |
 
+## The roster
+
+Every model, grouped by purpose. **Brings** is what you supply beyond raw text;
+**Reproducibility** is `bit-exact` (identical regardless of thread count),
+`seed-reproducible` (identical from a fixed seed and thread count), or
+`llm-bounded`. Filter this roster in code with
+`topica.list_models(group=…, brings=…, inference=…, determinism=…)`. The table is
+generated from `python/topica/registry.py`.
+
+<!-- BEGIN MODEL TABLE (generated from topica.registry; edit registry.py, not this block) -->
+
+### General-purpose
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `LDA` | text | gibbs | seed-reproducible | Classic latent Dirichlet allocation via a fast SparseLDA collapsed-Gibbs sampler. |
+| `CTM` | text | variational | bit-exact | Correlated topic model: a logistic-normal prior that lets topics co-occur. |
+| `ProdLDA` | text | vae | seed-reproducible | Product-of-experts LDA (AVITM) for sharper, more coherent topics; hand-coded VAE. |
+| `HDP` | text | gibbs | seed-reproducible | Hierarchical Dirichlet process: infers the number of topics from the data. |
+
+### Covariates & structure
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `STM` | text, metadata | variational | bit-exact | Structural topic model: relate topic prevalence and content to covariates. |
+| `STS` | text, metadata | variational | bit-exact | Structural topic-and-sentiment model over document metadata. |
+| `SAGE` | text, metadata | gibbs | seed-reproducible | Sparse additive generative model: the same topic worded differently across groups. |
+| `DMR` | text, metadata | gibbs | seed-reproducible | Dirichlet-multinomial regression: a document-metadata prior on topic proportions. |
+| `GDMR` | text, metadata | gibbs | seed-reproducible | Generalized DMR with a smooth (Legendre-basis) prior over continuous covariates. |
+
+### Guided & supervised
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `KeyATM` | text, seeds | gibbs | seed-reproducible | Keyword-assisted topics: anchor named topics with a few seed words each. |
+| `SeededLDA` | text, seeds | gibbs | seed-reproducible | Seeded LDA: steer named topics toward supplied seed words. |
+| `LabeledLDA` | text, labels | gibbs | seed-reproducible | Labeled LDA: each document label is a topic; tokens are restricted to its labels. |
+| `SupervisedLDA` | text, labels | gibbs | seed-reproducible | Supervised LDA: topics shaped to predict a per-document real-valued response. |
+
+### Short text
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `GSDMM` | text | gibbs | seed-reproducible | Gibbs-sampling Dirichlet mixture: one topic per short document. |
+| `PT` | text | gibbs | seed-reproducible | Pseudo-document topic model: pool short texts into pseudo-documents. |
+
+### Dynamic & hierarchical
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `DTM` | text, times | variational | bit-exact | Dynamic topic model: a fixed topic set whose word distributions drift across time slices. |
+| `HLDA` | text | gibbs | seed-reproducible | Hierarchical LDA (nested CRP): a learned tree of super- and sub-topics. |
+| `PA` | text | gibbs | seed-reproducible | Pachinko allocation: a DAG of super- and sub-topics. |
+
+### Embedding-based
+
+| Model | Brings | Inference | Reproducibility | Summary |
+|---|---|---|---|---|
+| `BERTopic` | text, embeddings | clustering | seed-reproducible | Cluster document embeddings; label topics by class-based TF-IDF. |
+| `Top2Vec` | text, embeddings | clustering | seed-reproducible | Topics as dense regions in a joint document-word embedding space. |
+| `ETM` | text, embeddings | variational | bit-exact | Embedded topic model: topic-word distributions factored through word embeddings. |
+| `FASTopic` | text, embeddings | optimal-transport | bit-exact | Topics from optimal-transport plans between document, topic, and word embeddings. |
+| `EmbeddingLDA` | text, embeddings, seeds | gibbs | seed-reproducible | Seeded LDA whose seed sets are expanded with nearest neighbors in an embedding space. |
+
+<!-- END MODEL TABLE -->
+
 ## LDA
 
 Classic Latent Dirichlet Allocation via MALLET's fast SparseLDA collapsed-Gibbs

--- a/docs/publishing/choosing-model.md
+++ b/docs/publishing/choosing-model.md
@@ -5,6 +5,20 @@ you think generates the text and what you want to learn, and reviewers will ask
 you to justify it. Pick the simplest model that matches your question and your
 data structure.
 
+The decision tree below is keyed on your *question*. Two practical axes narrow it
+further, both filterable with `topica.list_models(...)` (see the
+[roster](../guides/models.md#the-roster)):
+
+- **What you bring.** Beyond raw text, do you have document **metadata**
+  (covariates), a few **seed** words per topic, document **labels**, document
+  **embeddings**, or **time** stamps? Each points to a group:
+  `list_models(brings="metadata")`, `brings="embeddings"`, and so on.
+- **Reproducibility.** The variational models are `bit-exact` (identical
+  regardless of thread count); the samplers are `seed-reproducible` (fix the seed
+  *and* the thread count); an LLM-backed model is `llm-bounded`. If exact
+  replication is a requirement, prefer a `bit-exact` model:
+  `topica.list_models(determinism="bit-exact")`.
+
 ## First: is a topic model even the right tool?
 
 !!! note "Good fit"

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -139,6 +139,8 @@ from .coherence import (  # noqa: E402
     word_intrusion,
     document_intrusion,
 )
+from .registry import list_models, ModelInfo, REGISTRY  # noqa: E402  model taxonomy / discovery
+
 from .validation import (  # noqa: E402  general, model-agnostic post-hoc analyses
     diagnostics,
     perplexity,
@@ -211,6 +213,9 @@ from .frames import from_dataframe, align, prep_documents, plot_removed  # noqa:
 from .formulas import design_matrix  # noqa: E402
 
 __all__ = [
+    "list_models",
+    "ModelInfo",
+    "REGISTRY",
     "LDA",
     "DMR",
     "GDMR",

--- a/python/topica/registry.py
+++ b/python/topica/registry.py
@@ -1,0 +1,223 @@
+"""The model registry: one entry per exported model, the single source of truth
+for every model list (the README table, the docs roster, and the programmatic
+``topica.list_models`` discovery helper).
+
+The flat ``from topica import X`` namespace is frozen and stays flat; this module
+is a *presentation and discovery* layer over it, not a second import path. A
+conformance test (``tests/test_registry.py``) asserts the registry and the
+exported model classes stay in one-to-one correspondence, so neither drifts as
+models are added.
+
+Adding a model: export its class from ``__init__`` and add one ``ModelInfo`` here.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class ModelInfo:
+    """One model's place in the taxonomy and its cross-cutting properties.
+
+    Attributes
+    ----------
+    name : the exported class name (``"LDA"`` resolves as ``topica.LDA``).
+    group : the purpose group (one of :data:`GROUPS`).
+    brings : what the user supplies beyond raw text — any of ``"text"``,
+        ``"embeddings"``, ``"metadata"``, ``"seeds"``, ``"labels"``, ``"times"``.
+    inference : the inference engine — ``"gibbs"``, ``"variational"``, ``"vae"``,
+        ``"optimal-transport"``, ``"clustering"`` (more as models are added).
+    determinism : ``"bit-exact"`` (identical regardless of thread count),
+        ``"seed-reproducible"`` (identical from a fixed seed and thread count), or
+        ``"llm-bounded"`` (subject to an external model's nondeterminism).
+    tags : cross-cutting labels for filtered views (e.g. ``"short-text"``,
+        ``"nonparametric"``, ``"temporal"``, ``"hierarchical"``, ``"cross-lingual"``).
+    summary : a one-line description for tables.
+    doc : the docs anchor, relative to the docs root.
+    """
+
+    name: str
+    group: str
+    brings: tuple[str, ...]
+    inference: str
+    determinism: str
+    tags: tuple[str, ...]
+    summary: str
+    doc: str
+
+
+# Purpose groups, in display order. Organized by what the user brings and wants,
+# not by inference family.
+GROUPS: dict[str, str] = {
+    "general-purpose": "General-purpose",
+    "covariates": "Covariates & structure",
+    "guided": "Guided & supervised",
+    "short-text": "Short text",
+    "dynamic-hierarchical": "Dynamic & hierarchical",
+    "embedding": "Embedding-based",
+    "llm": "LLM-based",
+}
+
+
+def _m(*args, **kwargs) -> ModelInfo:
+    return ModelInfo(*args, **kwargs)
+
+
+REGISTRY: dict[str, ModelInfo] = {
+    m.name: m for m in [
+        # ---- General-purpose ------------------------------------------------
+        _m("LDA", "general-purpose", ("text",), "gibbs", "seed-reproducible", (),
+           "Classic latent Dirichlet allocation via a fast SparseLDA collapsed-Gibbs sampler.",
+           "guides/models.md#lda"),
+        _m("CTM", "general-purpose", ("text",), "variational", "bit-exact", (),
+           "Correlated topic model: a logistic-normal prior that lets topics co-occur.",
+           "guides/models.md#ctm"),
+        _m("ProdLDA", "general-purpose", ("text",), "vae", "seed-reproducible", (),
+           "Product-of-experts LDA (AVITM) for sharper, more coherent topics; hand-coded VAE.",
+           "guides/models.md#prodlda"),
+        _m("HDP", "general-purpose", ("text",), "gibbs", "seed-reproducible", ("nonparametric",),
+           "Hierarchical Dirichlet process: infers the number of topics from the data.",
+           "guides/models.md#hdp"),
+        # ---- Covariates & structure ----------------------------------------
+        _m("STM", "covariates", ("text", "metadata"), "variational", "bit-exact", (),
+           "Structural topic model: relate topic prevalence and content to covariates.",
+           "guides/models.md#stm"),
+        _m("STS", "covariates", ("text", "metadata"), "variational", "bit-exact", (),
+           "Structural topic-and-sentiment model over document metadata.",
+           "guides/models.md#sts"),
+        _m("SAGE", "covariates", ("text", "metadata"), "gibbs", "seed-reproducible", (),
+           "Sparse additive generative model: the same topic worded differently across groups.",
+           "guides/models.md#sage"),
+        _m("DMR", "covariates", ("text", "metadata"), "gibbs", "seed-reproducible", (),
+           "Dirichlet-multinomial regression: a document-metadata prior on topic proportions.",
+           "guides/models.md#dmr"),
+        _m("GDMR", "covariates", ("text", "metadata"), "gibbs", "seed-reproducible", (),
+           "Generalized DMR with a smooth (Legendre-basis) prior over continuous covariates.",
+           "guides/models.md#gdmr"),
+        # ---- Guided & supervised -------------------------------------------
+        _m("KeyATM", "guided", ("text", "seeds"), "gibbs", "seed-reproducible", (),
+           "Keyword-assisted topics: anchor named topics with a few seed words each.",
+           "guides/guided.md"),
+        _m("SeededLDA", "guided", ("text", "seeds"), "gibbs", "seed-reproducible", (),
+           "Seeded LDA: steer named topics toward supplied seed words.",
+           "guides/guided.md"),
+        _m("LabeledLDA", "guided", ("text", "labels"), "gibbs", "seed-reproducible", (),
+           "Labeled LDA: each document label is a topic; tokens are restricted to its labels.",
+           "guides/models.md#labeledlda"),
+        _m("SupervisedLDA", "guided", ("text", "labels"), "gibbs", "seed-reproducible", (),
+           "Supervised LDA: topics shaped to predict a per-document real-valued response.",
+           "guides/models.md#supervisedlda"),
+        # ---- Short text -----------------------------------------------------
+        _m("GSDMM", "short-text", ("text",), "gibbs", "seed-reproducible", ("short-text",),
+           "Gibbs-sampling Dirichlet mixture: one topic per short document.",
+           "guides/short-text.md"),
+        _m("PT", "short-text", ("text",), "gibbs", "seed-reproducible", ("short-text",),
+           "Pseudo-document topic model: pool short texts into pseudo-documents.",
+           "guides/short-text.md"),
+        # ---- Dynamic & hierarchical ----------------------------------------
+        _m("DTM", "dynamic-hierarchical", ("text", "times"), "variational", "bit-exact", ("temporal",),
+           "Dynamic topic model: a fixed topic set whose word distributions drift across time slices.",
+           "guides/models.md#dtm"),
+        _m("HLDA", "dynamic-hierarchical", ("text",), "gibbs", "seed-reproducible", ("hierarchical",),
+           "Hierarchical LDA (nested CRP): a learned tree of super- and sub-topics.",
+           "guides/models.md#hierarchy-models"),
+        _m("PA", "dynamic-hierarchical", ("text",), "gibbs", "seed-reproducible", ("hierarchical",),
+           "Pachinko allocation: a DAG of super- and sub-topics.",
+           "guides/models.md#hierarchy-models"),
+        # ---- Embedding-based ------------------------------------------------
+        _m("BERTopic", "embedding", ("text", "embeddings"), "clustering", "seed-reproducible", (),
+           "Cluster document embeddings; label topics by class-based TF-IDF.",
+           "guides/embedding.md"),
+        _m("Top2Vec", "embedding", ("text", "embeddings"), "clustering", "seed-reproducible", (),
+           "Topics as dense regions in a joint document-word embedding space.",
+           "guides/embedding.md"),
+        _m("ETM", "embedding", ("text", "embeddings"), "variational", "bit-exact", (),
+           "Embedded topic model: topic-word distributions factored through word embeddings.",
+           "guides/embedding.md"),
+        _m("FASTopic", "embedding", ("text", "embeddings"), "optimal-transport", "bit-exact", (),
+           "Topics from optimal-transport plans between document, topic, and word embeddings.",
+           "guides/embedding.md"),
+        _m("EmbeddingLDA", "embedding", ("text", "embeddings", "seeds"), "gibbs", "seed-reproducible", (),
+           "Seeded LDA whose seed sets are expanded with nearest neighbors in an embedding space.",
+           "guides/embedding.md"),
+    ]
+}
+
+
+def list_models(
+    *,
+    group: str | None = None,
+    brings: str | None = None,
+    inference: str | None = None,
+    determinism: str | None = None,
+    tag: str | None = None,
+) -> list[ModelInfo]:
+    """Return the registered models matching every supplied filter.
+
+    With no filters, returns all models in registry (insertion) order. Each
+    filter narrows the result:
+
+    - ``group`` — one of :data:`GROUPS` (e.g. ``"short-text"``).
+    - ``brings`` — a single requirement the model accepts (e.g. ``"embeddings"``,
+      ``"metadata"``, ``"seeds"``); matches models whose ``brings`` contains it.
+    - ``inference`` — the engine (e.g. ``"gibbs"``, ``"variational"``, ``"vae"``).
+    - ``determinism`` — ``"bit-exact"``, ``"seed-reproducible"``, ``"llm-bounded"``.
+    - ``tag`` — a cross-cutting tag (e.g. ``"short-text"``, ``"nonparametric"``).
+
+    Examples
+    --------
+    >>> import topica
+    >>> [m.name for m in topica.list_models(brings="embeddings")]
+    ['BERTopic', 'Top2Vec', 'ETM', 'FASTopic', 'EmbeddingLDA']
+    >>> [m.name for m in topica.list_models(group="short-text")]
+    ['GSDMM', 'PT']
+    """
+    if group is not None and group not in GROUPS:
+        raise ValueError(f"unknown group {group!r}; choose from {sorted(GROUPS)}")
+    out = []
+    for m in REGISTRY.values():
+        if group is not None and m.group != group:
+            continue
+        if brings is not None and brings not in m.brings:
+            continue
+        if inference is not None and m.inference != inference:
+            continue
+        if determinism is not None and m.determinism != determinism:
+            continue
+        if tag is not None and tag not in m.tags:
+            continue
+        out.append(m)
+    return out
+
+
+def markdown_table(by_group: bool = True) -> str:
+    """Render the registry as a Markdown table, grouped by purpose by default.
+
+    Used to (re)generate the README model section and the docs roster so the
+    hand-maintained lists cannot drift from the registry.
+    """
+    lines: list[str] = []
+    if by_group:
+        for key, label in GROUPS.items():
+            models = [m for m in REGISTRY.values() if m.group == key]
+            if not models:
+                continue
+            lines.append(f"### {label}\n")
+            lines.append("| Model | Brings | Inference | Reproducibility | Summary |")
+            lines.append("|---|---|---|---|---|")
+            for m in models:
+                brings = ", ".join(m.brings)
+                lines.append(
+                    f"| `{m.name}` | {brings} | {m.inference} | {m.determinism} | {m.summary} |"
+                )
+            lines.append("")
+    else:
+        lines.append("| Model | Group | Brings | Inference | Reproducibility | Summary |")
+        lines.append("|---|---|---|---|---|---|")
+        for m in REGISTRY.values():
+            brings = ", ".join(m.brings)
+            lines.append(
+                f"| `{m.name}` | {GROUPS[m.group]} | {brings} | {m.inference} | "
+                f"{m.determinism} | {m.summary} |"
+            )
+    return "\n".join(lines)

--- a/scripts/gen_model_tables.py
+++ b/scripts/gen_model_tables.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+"""Render the model roster from ``topica.registry`` into the README and the docs.
+
+The registry (``python/topica/registry.py``) is the single source of truth. This
+script injects its grouped Markdown table between the marker comments in
+``README.md`` and ``docs/api/models.md`` so the two lists cannot drift. Run it
+after editing the registry; ``tests/test_registry.py`` fails if a target file is
+out of sync.
+
+    python scripts/gen_model_tables.py          # rewrite the targets in place
+    python scripts/gen_model_tables.py --check   # exit 1 if any target is stale
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "python"))
+
+from topica.registry import markdown_table  # noqa: E402
+
+BEGIN = "<!-- BEGIN MODEL TABLE (generated from topica.registry; edit registry.py, not this block) -->"
+END = "<!-- END MODEL TABLE -->"
+TARGETS = [ROOT / "README.md", ROOT / "docs" / "guides" / "models.md"]
+
+
+def _rendered_block() -> str:
+    return f"{BEGIN}\n\n{markdown_table(by_group=True)}\n{END}"
+
+
+def inject(text: str) -> str:
+    i, j = text.find(BEGIN), text.find(END)
+    if i == -1 or j == -1:
+        raise SystemExit("marker comments not found in target")
+    return text[:i] + _rendered_block() + text[j + len(END):]
+
+
+def main() -> None:
+    check = "--check" in sys.argv
+    stale = []
+    for path in TARGETS:
+        old = path.read_text()
+        new = inject(old)
+        if old != new:
+            stale.append(path.name)
+            if not check:
+                path.write_text(new)
+    if check and stale:
+        print(f"stale (run scripts/gen_model_tables.py): {stale}")
+        raise SystemExit(1)
+    print("up to date" if check else f"wrote {[t.name for t in TARGETS]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,88 @@
+"""The model registry stays in one-to-one correspondence with the exported
+model classes, and its fields use the allowed vocabularies (#182)."""
+import inspect
+
+import pytest
+
+import topica
+from topica.registry import GROUPS, REGISTRY, ModelInfo, list_models, markdown_table
+
+# Exported classes that are NOT topic models (so not in the registry).
+_NON_MODEL_CLASSES = {"Heldout", "HeldoutResult", "Corpus", "ModelInfo"}
+
+_BRINGS = {"text", "embeddings", "metadata", "seeds", "labels", "times", "llm"}
+_INFERENCE = {"gibbs", "variational", "vae", "optimal-transport", "clustering",
+              "matrix-factorization", "svd", "prompting"}
+_DETERMINISM = {"bit-exact", "seed-reproducible", "llm-bounded"}
+
+
+def _exported_model_classes() -> set[str]:
+    names = set()
+    for name in topica.__all__:
+        obj = getattr(topica, name)
+        if (inspect.isclass(obj) and hasattr(obj, "fit")
+                and name not in _NON_MODEL_CLASSES):
+            names.add(name)
+    return names
+
+
+def test_every_exported_model_has_a_registry_entry():
+    exported = _exported_model_classes()
+    missing = exported - set(REGISTRY)
+    assert not missing, f"exported models missing from the registry: {sorted(missing)}"
+
+
+def test_no_registry_entry_without_an_exported_model():
+    exported = _exported_model_classes()
+    extra = set(REGISTRY) - exported
+    assert not extra, f"registry entries with no exported model: {sorted(extra)}"
+
+
+def test_registry_name_matches_key_and_resolves():
+    for key, info in REGISTRY.items():
+        assert info.name == key
+        assert hasattr(topica, info.name), f"{info.name} not importable from topica"
+
+
+def test_registry_fields_use_allowed_vocabularies():
+    for info in REGISTRY.values():
+        assert info.group in GROUPS, f"{info.name}: bad group {info.group!r}"
+        assert info.inference in _INFERENCE, f"{info.name}: bad inference {info.inference!r}"
+        assert info.determinism in _DETERMINISM, f"{info.name}: bad determinism"
+        assert set(info.brings) <= _BRINGS, f"{info.name}: bad brings {info.brings}"
+        assert "text" in info.brings, f"{info.name}: every model brings text"
+        assert info.summary and info.doc
+
+
+def test_list_models_filters():
+    assert {m.name for m in list_models(group="short-text")} == {"GSDMM", "PT"}
+    emb = {m.name for m in list_models(brings="embeddings")}
+    assert {"BERTopic", "Top2Vec", "ETM", "FASTopic"} <= emb
+    assert all(m.inference == "variational" for m in list_models(inference="variational"))
+    assert len(list_models()) == len(REGISTRY)
+    with pytest.raises(ValueError):
+        list_models(group="not-a-group")
+
+
+def test_markdown_table_renders_all_models():
+    table = markdown_table(by_group=True)
+    for name in REGISTRY:
+        assert f"`{name}`" in table
+
+
+def test_readme_and_docs_roster_in_sync_with_registry():
+    # The generated blocks in README.md and docs/guides/models.md must match the
+    # registry render; regenerate with scripts/gen_model_tables.py if this fails.
+    import pathlib
+
+    BEGIN = ("<!-- BEGIN MODEL TABLE (generated from topica.registry; "
+             "edit registry.py, not this block) -->")
+    END = "<!-- END MODEL TABLE -->"
+    expected = f"{BEGIN}\n\n{markdown_table(by_group=True)}\n{END}"
+    root = pathlib.Path(__file__).resolve().parent.parent
+    for rel in ("README.md", "docs/guides/models.md"):
+        text = (root / rel).read_text()
+        i, j = text.find(BEGIN), text.find(END)
+        assert i != -1 and j != -1, f"{rel}: marker comments missing"
+        assert text[i:j + len(END)] == expected, (
+            f"{rel} roster is stale; run scripts/gen_model_tables.py")


### PR DESCRIPTION
Closes #182.

A single source of truth for the model roster, so the README table, the docs roster, and programmatic discovery stay in sync as models are added. The flat `from topica import X` namespace is unchanged — this is a presentation/discovery layer, not a second import path.

## What

- **`python/topica/registry.py`** — `ModelInfo` + `REGISTRY` (all 23 current models) + `list_models(group=, brings=, inference=, determinism=, tag=)` + a `markdown_table()` renderer. The `inference`/`determinism` classifications are taken from the conformance layer (the collapsed-Gibbs family list, the logistic-normal variational set), not guessed.
- **`topica.list_models` / `ModelInfo` / `REGISTRY`** exported.
- **Seven purpose groups** (general-purpose, covariates & structure, guided & supervised, short text, dynamic & hierarchical, embedding-based, llm-based), organized by what the user brings and wants.
- **Cross-cutting axes** surfaced as columns: `brings` (text/metadata/seeds/labels/embeddings/times) and `determinism` (`bit-exact` / `seed-reproducible` / `llm-bounded`) — the determinism axis matters now that bit-exact (NMF/LSA incoming) and llm-bounded (TopicGPT incoming) models will share the roster.
- **`scripts/gen_model_tables.py`** regenerates the grouped table in `README.md` and `docs/guides/models.md` from the registry (`--check` fails if stale).
- **`choosing-model.md`** gains the "what you bring" + reproducibility framing with `list_models()` filters.

## Tests / gates

- `tests/test_registry.py` (7): exported models ↔ registry entries are one-to-one; field vocabularies valid; README + docs roster blocks match the registry render (drift guard).
- Full suite green on a clean build (2375+ passed); `mkdocs build --strict` clean.

## Notes

- `docs/api/models.md` is the mkdocstrings autodoc page; left untouched (the roster table lives in the `docs/guides/models.md` roster guide instead).
- Lands the registry **before** the next batch of model issues (#172–#181) so they slot into a structure. DETM (in flight) will add its own registry entry — the round-trip test enforces it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)