### PR TITLE
skills: topica-analysis (user) + add-topic-model (dev); AGENTS.md generated from the skill

### DIFF
--- a/.claude/skills/add-topic-model/SKILL.md
+++ b/.claude/skills/add-topic-model/SKILL.md
@@ -16,6 +16,10 @@ is the whole point of a port.
 
 ## Orient first (read these once)
 
+- `CONTRIBUTING-MODELS.md` — the deep implementer's playbook for the Rust/PyO3
+  mechanics (the `Estimator` trait, the binding, the conformance checks, the
+  add-a-model checklist). This skill orchestrates the *process*; that file is the
+  *how-to* for Phase 3. Read it before implementing.
 - `CLAUDE.md` — build/test commands, layout, conventions, branching. Authoritative.
 - `docs/contributing/conventions.md` and `tests/test_naming_conventions.py` — the
   enforced cross-model naming/API contract. New models must pass that test.

--- a/.claude/skills/topica-analysis/SKILL.md
+++ b/.claude/skills/topica-analysis/SKILL.md
@@ -1,6 +1,7 @@
-<!-- Generated from .claude/skills/topica-analysis/SKILL.md by `python scripts/gen_agents_md.py`.
-     This is the cross-tool (agents.md standard) ambient copy of the topica-analysis skill.
-     Edit the skill, not this file. -->
+---
+name: topica-analysis
+description: Working guide for an LLM agent helping a social scientist run a topic-modeling analysis with the topica Python library — building a defensible corpus, choosing and justifying K, fitting a model, validating it, estimating covariate effects with honest uncertainty, and reporting results. Use when the user wants to USE topica to analyze a text corpus (not extend the library). The companion developer skill for adding a model is add-topic-model.
+---
 
 # Using topica well
 

--- a/CONTRIBUTING-MODELS.md
+++ b/CONTRIBUTING-MODELS.md
@@ -6,6 +6,14 @@ step by step, including by an LLM coding agent. For general setup and PR
 mechanics and build commands see [`CONTRIBUTING.md`](CONTRIBUTING.md). Read it
 first; this file assumes it.
 
+> **Adding a whole new model with an LLM agent?** The `add-topic-model` skill
+> (`.claude/skills/add-topic-model/`) orchestrates the end-to-end workflow —
+> grounding in the literature, building a gold standard from the reference
+> implementation, validating with an independent benchmark agent and an
+> author-emulation review agent, and opening the PR. It treats *this* file as the
+> mechanical reference for the Rust/PyO3 work. Use the skill for the process; use
+> this playbook for the how-to it points into.
+
 ## Architecture in sixty seconds
 
 topica is a Rust core exposed to Python through PyO3 (0.22, maturin, abi3-py39),

--- a/scripts/gen_agents_md.py
+++ b/scripts/gen_agents_md.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python
+"""Render the root ``AGENTS.md`` from the ``topica-analysis`` skill.
+
+The skill (``.claude/skills/topica-analysis/SKILL.md``) is the single source of
+truth for the "using topica well" guide. ``AGENTS.md`` is its cross-tool ambient
+copy (the agents.md open standard, read automatically by Claude Code, Cursor, and
+similar) — generated, not hand-edited, so the two cannot drift.
+
+    python scripts/gen_agents_md.py          # rewrite AGENTS.md
+    python scripts/gen_agents_md.py --check   # exit 1 if AGENTS.md is stale
+
+Edit the skill, then regenerate. ``tests/test_agents_md_sync.py`` fails if stale.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SKILL = ROOT / ".claude" / "skills" / "topica-analysis" / "SKILL.md"
+AGENTS = ROOT / "AGENTS.md"
+
+BANNER = (
+    "<!-- Generated from .claude/skills/topica-analysis/SKILL.md by "
+    "`python scripts/gen_agents_md.py`.\n"
+    "     This is the cross-tool (agents.md standard) ambient copy of the "
+    "topica-analysis skill.\n"
+    "     Edit the skill, not this file. -->"
+)
+
+
+def _skill_body() -> str:
+    """The SKILL.md text with its YAML frontmatter stripped."""
+    text = SKILL.read_text()
+    if text.startswith("---"):
+        # drop the frontmatter block (between the first two '---' lines)
+        end = text.find("\n---", 3)
+        text = text[end + 4:].lstrip("\n")
+    return text
+
+
+def rendered() -> str:
+    return f"{BANNER}\n\n{_skill_body()}"
+
+
+def main() -> None:
+    check = "--check" in sys.argv
+    want = rendered()
+    have = AGENTS.read_text() if AGENTS.exists() else ""
+    if check:
+        if have != want:
+            raise SystemExit("AGENTS.md is stale; run scripts/gen_agents_md.py")
+        print("AGENTS.md up to date")
+    else:
+        AGENTS.write_text(want)
+        print(f"wrote {AGENTS.name} ({len(want.splitlines())} lines)")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_agents_md_sync.py
+++ b/tests/test_agents_md_sync.py
@@ -1,0 +1,34 @@
+"""AGENTS.md is generated from the topica-analysis skill and must stay in sync
+(regenerate with scripts/gen_agents_md.py). Also checks both shipped skills have
+valid frontmatter."""
+import importlib.util
+import pathlib
+
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _load_gen():
+    spec = importlib.util.spec_from_file_location(
+        "gen_agents_md", ROOT / "scripts" / "gen_agents_md.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_agents_md_matches_skill():
+    gen = _load_gen()
+    assert (ROOT / "AGENTS.md").read_text() == gen.rendered(), (
+        "AGENTS.md is stale; run scripts/gen_agents_md.py")
+
+
+@pytest.mark.parametrize("skill", ["topica-analysis", "add-topic-model"])
+def test_skill_has_valid_frontmatter(skill):
+    path = ROOT / ".claude" / "skills" / skill / "SKILL.md"
+    text = path.read_text()
+    assert text.startswith("---\n"), f"{skill}: missing YAML frontmatter"
+    end = text.find("\n---", 3)
+    assert end != -1, f"{skill}: unterminated frontmatter"
+    fm = text[4:end]
+    assert "name:" in fm and "description:" in fm, f"{skill}: name/description required"


### PR DESCRIPTION
Packages topica's two agent workflows as coherent skills, with one source of truth each and no hand-maintained duplication.

## The two skills

| Skill | Audience | Trigger |
|---|---|---|
| **`topica-analysis`** (new) | social scientists *using* topica | "help me run a topic model on this corpus" |
| **`add-topic-model`** | contributors *extending* topica | "add/port model X" |

## What changed

- **`topica-analysis` skill** — the "using topica well" analysis workflow (corpus → K → fit → validate → effects → report), moved verbatim from `AGENTS.md` into the skill. It is the canonical source now.
- **`AGENTS.md` stays at the repo root** for cross-tool ambient discovery (the agents.md open standard, read automatically by Claude Code, Cursor, and similar) — but is **generated** from the skill by `scripts/gen_agents_md.py` (`--check` for CI). Moving it into `.claude/skills/` would have broken that standard discovery, so instead the skill is canonical and `AGENTS.md` is a generated, drift-guarded copy. Net diff to `AGENTS.md`: a generated banner + a reworded intro; the substance is byte-identical.
- **`add-topic-model` ↔ `CONTRIBUTING-MODELS.md` cross-link** — the skill orchestrates the *process* (literature → gold standard → validation agents → PR); the existing playbook is the *mechanical* Rust/PyO3 how-to. They now point at each other instead of overlapping silently.
- **`tests/test_agents_md_sync.py`** — fails if `AGENTS.md` drifts from the skill, and checks both skills' frontmatter.

## Gates

- `pytest tests/test_agents_md_sync.py tests/test_registry.py` — 10 passed; `mkdocs build --strict` clean.
- Both skills validate; distributable `.skill` files build to `dist/` (gitignored).

Independent of the `feat/detm` LSTM work still in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)