### PR TITLE
fix: read/write repo text files as UTF-8 (Windows CI red since #182)

### DIFF
--- a/scripts/gen_agents_md.py
+++ b/scripts/gen_agents_md.py
@@ -31,7 +31,7 @@ BANNER = (
 
 def _skill_body() -> str:
     """The SKILL.md text with its YAML frontmatter stripped."""
-    text = SKILL.read_text()
+    text = SKILL.read_text(encoding="utf-8")
     if text.startswith("---"):
         # drop the frontmatter block (between the first two '---' lines)
         end = text.find("\n---", 3)
@@ -46,13 +46,13 @@ def rendered() -> str:
 def main() -> None:
     check = "--check" in sys.argv
     want = rendered()
-    have = AGENTS.read_text() if AGENTS.exists() else ""
+    have = AGENTS.read_text(encoding="utf-8") if AGENTS.exists() else ""
     if check:
         if have != want:
             raise SystemExit("AGENTS.md is stale; run scripts/gen_agents_md.py")
         print("AGENTS.md up to date")
     else:
-        AGENTS.write_text(want)
+        AGENTS.write_text(want, encoding="utf-8")
         print(f"wrote {AGENTS.name} ({len(want.splitlines())} lines)")
 
 

--- a/scripts/gen_model_tables.py
+++ b/scripts/gen_model_tables.py
@@ -40,12 +40,12 @@ def main() -> None:
     check = "--check" in sys.argv
     stale = []
     for path in TARGETS:
-        old = path.read_text()
+        old = path.read_text(encoding="utf-8")
         new = inject(old)
         if old != new:
             stale.append(path.name)
             if not check:
-                path.write_text(new)
+                path.write_text(new, encoding="utf-8")
     if check and stale:
         print(f"stale (run scripts/gen_model_tables.py): {stale}")
         raise SystemExit(1)

--- a/tests/test_agents_md_sync.py
+++ b/tests/test_agents_md_sync.py
@@ -19,14 +19,14 @@ def _load_gen():
 
 def test_agents_md_matches_skill():
     gen = _load_gen()
-    assert (ROOT / "AGENTS.md").read_text() == gen.rendered(), (
+    assert (ROOT / "AGENTS.md").read_text(encoding="utf-8") == gen.rendered(), (
         "AGENTS.md is stale; run scripts/gen_agents_md.py")
 
 
 @pytest.mark.parametrize("skill", ["topica-analysis", "add-topic-model"])
 def test_skill_has_valid_frontmatter(skill):
     path = ROOT / ".claude" / "skills" / skill / "SKILL.md"
-    text = path.read_text()
+    text = path.read_text(encoding="utf-8")
     assert text.startswith("---\n"), f"{skill}: missing YAML frontmatter"
     end = text.find("\n---", 3)
     assert end != -1, f"{skill}: unterminated frontmatter"

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -81,7 +81,7 @@ def test_readme_and_docs_roster_in_sync_with_registry():
     expected = f"{BEGIN}\n\n{markdown_table(by_group=True)}\n{END}"
     root = pathlib.Path(__file__).resolve().parent.parent
     for rel in ("README.md", "docs/guides/models.md"):
-        text = (root / rel).read_text()
+        text = (root / rel).read_text(encoding="utf-8")
         i, j = text.find(BEGIN), text.find(END)
         assert i != -1 and j != -1, f"{rel}: marker comments missing"
         assert text[i:j + len(END)] == expected, (


### PR DESCRIPTION
## Problem

CI's `test / windows-latest` has failed on **every run since #182** (and through #184/#185/#187):

```
FAILED tests/test_registry.py::test_readme_and_docs_roster_in_sync_with_registry
  - UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 ... character maps to <undefined>
```

The roster drift-guard reads `README.md` / `docs/guides/models.md` with `Path.read_text()` and no encoding. On Windows the default is cp1252, which can't decode the UTF-8 bytes in those files. Linux/macOS default to UTF-8, so it only shows on Windows. `cargo test` and the wheel builds were green throughout; this is purely the Python text-read encoding.

## Fix

Pass `encoding="utf-8"` at all `read_text()`/`write_text()` sites in the four files added by #182/#184:
- `tests/test_registry.py`, `tests/test_agents_md_sync.py` (the drift guards)
- `scripts/gen_model_tables.py`, `scripts/gen_agents_md.py` (the generators — so regenerating on Windows writes UTF-8, not cp1252)

No behavior change off Windows. The fix is verifiable only on the Windows runner, which is the point of this PR — **merge once `test / windows-latest` is green here.**

Pre-existing unguarded reads elsewhere (e.g. `test_lda.py`, `test_corpus.py`) read ASCII content and pass on Windows today; left untouched to keep this a focused regression fix.