### PR TITLE
Add contrastive (CLNTM) and Dirichlet-prior flags to the VAE models

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ Topica stands on a generation of open topic-modeling research and code. Each ent
 - [**ETM**](https://github.com/adjidieng/ETM) (Dieng, Ruiz & Blei, 2020) — `ETM`: the Embedded Topic Model (per-document variational EM and an amortized VAE)
 - [**FASTopic**](https://github.com/BobXWu/FASTopic) (Wu et al., 2024) — `FASTopic`: the optimal-transport topic model
 - [**contextualized-topic-models**](https://github.com/MilaNLProc/contextualized-topic-models) (Bianchi et al., MIT) — `CombinedTM` (Bianchi, Terragni & Hovy, 2021) and `ZeroShotTM` (Bianchi, Nozza & Hovy, 2021): ProdLDA encoders that read a contextual document embedding, alongside or in place of the bag of words
+- [**CLNTM**](https://arxiv.org/abs/2110.12764) (Nguyen & Luu, 2021) — the InfoNCE contrastive regularization on topic vectors offered by the `contrastive=` flag on the VAE models
+- [**WHAI / Weibull-Dirichlet VAE**](https://arxiv.org/abs/1803.01328) (Zhang et al., 2018; Burkhardt & Kramer, 2019) — the Weibull-reparameterized Dirichlet prior offered by `prior="dirichlet"` on the VAE models
 
 The embedding-native models build on two pure-Rust crates: [**petal-clustering**](https://github.com/petabi/petal-clustering) for HDBSCAN and [**umap-rs**](https://github.com/wilsonzlin/umap-rs) for the optional UMAP reducer, both BLAS-free.
 

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -173,6 +173,11 @@ the same surface (`topic_word`, `doc_topic`, `topic_embeddings`); `bound` is the
 variational bound for EM and the ELBO for VAE. The trade is the usual one: EM is
 more accurate per document, the VAE scales.
 
+The VAE path also accepts the shared `prior=` and `contrastive=` flags described
+under [ProdLDA](models.md#objective-and-prior-options): a Weibull-reparameterized
+Dirichlet prior and a CLNTM-style InfoNCE term on the topic vectors. They are
+ignored on the EM path and default off.
+
 ## FASTopic
 
 FASTopic also drops the encoder, but it is not a clustering pipeline and not a
@@ -250,7 +255,9 @@ The reference fits the encoder with PyTorch autograd. We hand-code the encoder's
 forward and backward, including the dense embedding block of the first layer
 (every gradient checked against finite differences), and step with Adam, so this
 is the same model with no PyTorch. Because the encoder is deterministic given a
-seed, fits are bit-identical across reruns. The reference implementation is
+seed, fits are bit-identical across reruns. CombinedTM also accepts the shared
+`prior=` and `contrastive=` flags described under
+[ProdLDA](models.md#objective-and-prior-options). The reference implementation is
 [contextualized-topic-models](https://github.com/MilaNLProc/contextualized-topic-models)
 (Bianchi et al., MIT).
 
@@ -285,8 +292,9 @@ theta_fr = model.transform(french_docs, multilingual_embed(french_docs))
 
 As with CombinedTM, we hand-code the encoder's forward and backward over the
 embedding-only first layer (finite-difference checked) and fit with Adam, so the
-path has no PyTorch and is bit-identical across reruns. The reference
-implementation is
+path has no PyTorch and is bit-identical across reruns. ZeroShotTM accepts the same
+shared `prior=` and `contrastive=` flags described under
+[ProdLDA](models.md#objective-and-prior-options). The reference implementation is
 [contextualized-topic-models](https://github.com/MilaNLProc/contextualized-topic-models)
 (Bianchi et al., MIT).
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -333,6 +333,41 @@ amortized, `transform` maps new documents with a single forward pass rather than
 re-running an optimizer. ProdLDA is bag-of-words (no embeddings); for the
 embedding-factored generative model see [`ETM`](embedding.md).
 
+### Objective and prior options
+
+`ProdLDA`, `CombinedTM`, `ZeroShotTM`, and `ETM(inference="vae")` share the same
+amortized-VAE core, so two optional flags apply across all four. Both default off,
+and the defaults reproduce the standard model exactly.
+
+- `prior=` chooses the document-topic prior. `"laplace"` (the default) is the
+  logistic-normal Laplace approximation to a Dirichlet from the AVITM paper.
+  `"dirichlet"` puts a true Dirichlet prior on `θ` through the Weibull
+  reparameterization (Zhang et al. 2018; Burkhardt & Kramer 2019): the encoder
+  parameterizes a Weibull variational posterior on each unnormalized topic weight,
+  a Weibull draw is normalized onto the simplex, and the analytic Weibull-to-Gamma
+  KL replaces the logistic-normal KL. We reuse the same reparameterization noise the
+  laplace path draws, so turning the flag off is bit-for-bit the original model.
+
+- `contrastive=True` adds a CLNTM-style (Nguyen & Luu 2021) InfoNCE term on the
+  topic vectors. For each document the *anchor* is its sampled topic vector and the
+  *positive view* is the deterministic no-noise topic vector (`softmax(μ)` on the
+  laplace path, the median Weibull on the dirichlet path); the other documents in
+  the minibatch are negatives, with cosine similarity at temperature
+  `contrastive_temp`. The term is scaled by `contrastive_weight` and added to the
+  per-batch loss. We document the positive-view choice because it is what makes the
+  term deterministic and finite-difference checkable; the TF-IDF salient-word
+  positive construction from CLNTM is a future refinement.
+
+```python
+m = topica.ProdLDA(num_topics=20, prior="dirichlet",
+                   contrastive=True, contrastive_weight=0.5, contrastive_temp=0.5)
+m.fit(docs)
+```
+
+The two flags are orthogonal and compose: the contrastive term operates on `θ`
+however `θ` was produced. Every new gradient path is hand-coded and checked against
+finite differences in the Rust unit tests.
+
 ## NMF
 
 Non-negative matrix factorization ([Lee & Seung 2001](https://papers.nips.cc/paper/1861-algorithms-for-non-negative-matrix-factorization)) factors the document-term matrix `X` (D x V, non-negative) as `X ≈ W H` with both factors non-negative, then reads each row of `H` as a topic's word distribution and each row of `W` as a document's topic mixture (both normalized to sum to 1). It is the fast, deterministic baseline familiar from scikit-learn: no sampling and no priors, just multiplicative updates that descend a reconstruction loss.

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2377,9 +2377,17 @@ class ETM:
         lr: float = 0.005,
         wdecay: float = 1.2e-6,
         seed: int = 42,
+        prior: str = "laplace",
+        contrastive: bool = False,
+        contrastive_weight: float = 0.5,
+        contrastive_temp: float = 0.5,
         em_tol: Optional[float] = None,
     ) -> None:
-        """em_tol is a deprecated alias for convergence_tol."""
+        """em_tol is a deprecated alias for convergence_tol. On the VAE path,
+        ``prior`` selects ``"laplace"`` (default) or ``"dirichlet"`` (Weibull
+        reparameterization), and ``contrastive`` adds an InfoNCE term on the topic
+        vectors scaled by ``contrastive_weight`` at temperature ``contrastive_temp``.
+        Both are ignored on the EM path."""
         ...
     def fit(
         self,
@@ -2471,10 +2479,21 @@ class ProdLDA:
         lr: float = 0.002,
         convergence_tol: float = 0.0,
         seed: int = 42,
+        prior: str = "laplace",
+        contrastive: bool = False,
+        contrastive_weight: float = 0.5,
+        contrastive_temp: float = 0.5,
         em_tol: Optional[float] = None,
     ) -> None:
-        """em_tol is a deprecated alias for convergence_tol."""
+        """em_tol is a deprecated alias for convergence_tol. ``prior`` selects
+        ``"laplace"`` (default) or ``"dirichlet"`` (Weibull reparameterization);
+        ``contrastive`` adds an InfoNCE term on the topic vectors scaled by
+        ``contrastive_weight`` at temperature ``contrastive_temp``."""
         ...
+    @property
+    def prior(self) -> str: ...
+    @property
+    def contrastive(self) -> bool: ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2548,7 +2567,19 @@ class CombinedTM:
         lr: float = 0.002,
         convergence_tol: float = 0.0,
         seed: int = 42,
-    ) -> None: ...
+        prior: str = "laplace",
+        contrastive: bool = False,
+        contrastive_weight: float = 0.5,
+        contrastive_temp: float = 0.5,
+    ) -> None:
+        """``prior`` selects ``"laplace"`` (default) or ``"dirichlet"`` (Weibull
+        reparameterization); ``contrastive`` adds an InfoNCE term on the topic vectors
+        scaled by ``contrastive_weight`` at temperature ``contrastive_temp``."""
+        ...
+    @property
+    def prior(self) -> str: ...
+    @property
+    def contrastive(self) -> bool: ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2631,7 +2662,19 @@ class ZeroShotTM:
         lr: float = 0.002,
         convergence_tol: float = 0.0,
         seed: int = 42,
-    ) -> None: ...
+        prior: str = "laplace",
+        contrastive: bool = False,
+        contrastive_weight: float = 0.5,
+        contrastive_temp: float = 0.5,
+    ) -> None:
+        """``prior`` selects ``"laplace"`` (default) or ``"dirichlet"`` (Weibull
+        reparameterization); ``contrastive`` adds an InfoNCE term on the topic vectors
+        scaled by ``contrastive_weight`` at temperature ``contrastive_temp``."""
+        ...
+    @property
+    def prior(self) -> str: ...
+    @property
+    def contrastive(self) -> bool: ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],

--- a/src/etm_vae.rs
+++ b/src/etm_vae.rs
@@ -26,7 +26,15 @@
 //! inference the sample is dropped (`z = mu`), so `theta = softmax(mu)`.
 
 use crate::etm::softmax_beta;
+use crate::prodlda::{
+    info_nce_backward, info_nce_loss, normal_cdf, weibull_gamma_kl, weibull_gamma_kl_grad,
+    weibull_weight, AvitmOptions, Prior, WEIBULL_FLOOR, WEIBULL_SHAPE_FLOOR,
+};
 use rand::Rng;
+
+/// The implicit symmetric Dirichlet concentration for the ETM Weibull prior. ETM
+/// exposes no `alpha`, so we use 1.0 (a uniform Dirichlet) on the dirichlet path.
+const ETM_DIR_ALPHA: f64 = 1.0;
 
 /// Kaiming-uniform initialization matching PyTorch's `nn.Linear` default:
 /// entries are uniform on `[-1/sqrt(fan_in), 1/sqrt(fan_in)]`.
@@ -167,10 +175,83 @@ fn softmax(v: &[f64]) -> Vec<f64> {
     exps.iter().map(|e| e / z).collect()
 }
 
+/// Logistic sigmoid, the derivative of softplus (used on the Weibull-Dirichlet path
+/// where the Weibull shape/scale are `softplus` of the encoder heads).
+fn sigmoid(x: f64) -> f64 {
+    if x >= 0.0 {
+        1.0 / (1.0 + (-x).exp())
+    } else {
+        let e = x.exp();
+        e / (1.0 + e)
+    }
+}
+
+/// Per-document reparameterization, depending on the prior. For [`Prior::Laplace`]
+/// (ETM's standard `theta = softmax(mu + s eps)`, KL to `N(0, I)`) the Weibull
+/// fields are unused. For [`Prior::Dirichlet`] the topic vector is the normalized
+/// Weibull `theta = g / S`, with the analytic Weibull-to-Gamma KL.
+struct Reparam {
+    theta: Vec<f64>,
+    // Weibull scratch (dirichlet path only).
+    kw: Vec<f64>,
+    lam: Vec<f64>,
+    ln_l: Vec<f64>,
+    g: Vec<f64>,
+    s: f64,
+}
+
+/// Compute `theta` for one document under the chosen prior, given the encoder cache
+/// and the per-topic reparameterization noise `eps`. On the dirichlet path the noise
+/// is turned into uniforms by `Phi(eps)`; passing `noise_free = true` builds the
+/// no-noise positive view (laplace: `softmax(mu)`; dirichlet: median `u = 0.5`).
+fn reparam_theta(cache: &Cache, eps: &[f64], prior: Prior, noise_free: bool) -> Reparam {
+    let k = cache.mu.len();
+    match prior {
+        Prior::Laplace => {
+            let theta = if noise_free {
+                softmax(&cache.mu)
+            } else {
+                let mut z = vec![0.0; k];
+                for t in 0..k {
+                    z[t] = cache.mu[t] + (0.5 * cache.logvar[t]).exp() * eps[t];
+                }
+                softmax(&z)
+            };
+            Reparam { theta, kw: vec![], lam: vec![], ln_l: vec![], g: vec![], s: 0.0 }
+        }
+        Prior::Dirichlet => {
+            let mut kw = vec![0.0; k];
+            let mut lam = vec![0.0; k];
+            let mut ln_l = vec![0.0; k];
+            let mut g = vec![0.0; k];
+            let mut s = 0.0;
+            for t in 0..k {
+                let l = if noise_free {
+                    (-(0.5f64).ln()).ln() // u = 0.5
+                } else {
+                    let u = normal_cdf(eps[t]).clamp(1e-6, 1.0 - 1e-6);
+                    (-(1.0 - u).ln()).ln()
+                };
+                let (kwt, lamt, gt) = weibull_weight(cache.mu[t], cache.logvar[t], l);
+                kw[t] = kwt;
+                lam[t] = lamt;
+                ln_l[t] = l;
+                g[t] = gt;
+                s += gt;
+            }
+            let theta: Vec<f64> = (0..k).map(|t| g[t] / s).collect();
+            Reparam { theta, kw, lam, ln_l, g, s }
+        }
+    }
+}
+
 /// Backprop one document through the decoder and encoder, accumulating into the
 /// encoder gradient, the beta gradient (`g_beta`, K×V), and returning the document's
-/// `(recon, kl)`. `eps` is the fixed reparameterization noise (per topic). `beta`
-/// and `theta` are precomputed for this document.
+/// `(recon, kl)`. `eps` is the fixed reparameterization noise (per topic). `rep`
+/// holds the precomputed `theta` (and Weibull scratch) for this document under the
+/// active prior. `dtheta_extra` is an optional additive gradient on `theta` (the
+/// contrastive anchor term), and `dtheta_pos` is an optional gradient routed through
+/// the no-noise positive view (the contrastive positive term). `beta` is precomputed.
 #[allow(clippy::too_many_arguments)]
 fn backward_doc(
     enc: &Encoder,
@@ -178,12 +259,16 @@ fn backward_doc(
     bow: &[(usize, f64)],
     cache: &Cache,
     eps: &[f64],
-    theta: &[f64],
+    rep: &Reparam,
+    prior: Prior,
+    dtheta_extra: Option<&[f64]>,
+    dtheta_pos: Option<&[f64]>,
     beta: &[Vec<f64>],
     g: &mut EncoderGrad,
     g_beta: &mut [Vec<f64>],
 ) -> (f64, f64) {
     let (h, k, v) = (enc.hidden, enc.k, enc.v);
+    let theta = &rep.theta;
 
     // Reconstruction over the document's words: m_v = sum_k theta_k beta_kv.
     let mut recon = 0.0f64;
@@ -201,24 +286,71 @@ fn backward_doc(
             g_beta[t][w] += g_m * theta[t];
         }
     }
+    // Contrastive anchor gradient acts on theta directly.
+    if let Some(dx) = dtheta_extra {
+        for t in 0..k {
+            g_theta[t] += dx[t];
+        }
+    }
 
-    // theta = softmax(z): g_z = theta .* (g_theta - <g_theta, theta>).
-    let dot: f64 = g_theta.iter().zip(theta).map(|(&g, &t)| g * t).sum();
-    let g_z: Vec<f64> = (0..k).map(|t| theta[t] * (g_theta[t] - dot)).collect();
-
-    // z = mu + s*eps, s = exp(logvar/2). Plus the KL gradients.
-    let mut kl = 0.0f64;
     let mut g_mu = vec![0.0f64; k];
     let mut g_logvar = vec![0.0f64; k];
-    for t in 0..k {
-        let s = (0.5 * cache.logvar[t]).exp();
-        // recon path
-        g_mu[t] += g_z[t];
-        g_logvar[t] += g_z[t] * eps[t] * 0.5 * s;
-        // KL = -0.5 (1 + logvar - mu^2 - exp logvar)
-        kl += -0.5 * (1.0 + cache.logvar[t] - cache.mu[t] * cache.mu[t] - cache.logvar[t].exp());
-        g_mu[t] += cache.mu[t];
-        g_logvar[t] += 0.5 * (cache.logvar[t].exp() - 1.0);
+    let mut kl = 0.0f64;
+
+    match prior {
+        Prior::Laplace => {
+            // theta = softmax(z): g_z = theta .* (g_theta - <g_theta, theta>).
+            let dot: f64 = g_theta.iter().zip(theta).map(|(&g, &t)| g * t).sum();
+            let g_z: Vec<f64> = (0..k).map(|t| theta[t] * (g_theta[t] - dot)).collect();
+            // z = mu + s*eps, s = exp(logvar/2). Plus the KL gradients.
+            for t in 0..k {
+                let s = (0.5 * cache.logvar[t]).exp();
+                g_mu[t] += g_z[t];
+                g_logvar[t] += g_z[t] * eps[t] * 0.5 * s;
+                // KL = -0.5 (1 + logvar - mu^2 - exp logvar)
+                kl += -0.5 * (1.0 + cache.logvar[t] - cache.mu[t] * cache.mu[t] - cache.logvar[t].exp());
+                g_mu[t] += cache.mu[t];
+                g_logvar[t] += 0.5 * (cache.logvar[t].exp() - 1.0);
+            }
+            // Contrastive positive view = softmax(mu): grad into mu only.
+            if let Some(dzp) = dtheta_pos {
+                let tp = softmax(&cache.mu);
+                let dot: f64 = (0..k).map(|t| dzp[t] * tp[t]).sum();
+                for t in 0..k {
+                    g_mu[t] += tp[t] * (dzp[t] - dot);
+                }
+            }
+        }
+        Prior::Dirichlet => {
+            // theta = g / S. dg_m = (g_theta_m - sum_t g_theta_t theta_t) / S.
+            let dot: f64 = (0..k).map(|t| g_theta[t] * theta[t]).sum();
+            for m in 0..k {
+                let dg = (g_theta[m] - dot) / rep.s;
+                let dg_dlam = if rep.lam[m] != 0.0 { rep.g[m] / rep.lam[m] } else { 0.0 };
+                let dg_dkw = rep.g[m] * (-rep.ln_l[m] / (rep.kw[m] * rep.kw[m]));
+                g_mu[m] += dg * dg_dkw * sigmoid(cache.mu[m]);
+                g_logvar[m] += dg * dg_dlam * sigmoid(cache.logvar[m]);
+            }
+            // KL( Weibull(kw, lam) || Gamma(alpha, 1) ).
+            for t in 0..k {
+                kl += weibull_gamma_kl(rep.kw[t], rep.lam[t], ETM_DIR_ALPHA);
+                let (dkw, dlam) = weibull_gamma_kl_grad(rep.kw[t], rep.lam[t], ETM_DIR_ALPHA);
+                g_mu[t] += dkw * sigmoid(cache.mu[t]);
+                g_logvar[t] += dlam * sigmoid(cache.logvar[t]);
+            }
+            // Contrastive positive view = normalized Weibull at u = 0.5.
+            if let Some(dzp) = dtheta_pos {
+                let pos = reparam_theta(cache, eps, Prior::Dirichlet, true);
+                let dot: f64 = (0..k).map(|t| dzp[t] * pos.theta[t]).sum();
+                for m in 0..k {
+                    let dg = (dzp[m] - dot) / pos.s;
+                    let dg_dlam = if pos.lam[m] != 0.0 { pos.g[m] / pos.lam[m] } else { 0.0 };
+                    let dg_dkw = pos.g[m] * (-pos.ln_l[m] / (pos.kw[m] * pos.kw[m]));
+                    g_mu[m] += dg * dg_dkw * sigmoid(cache.mu[m]);
+                    g_logvar[m] += dg * dg_dlam * sigmoid(cache.logvar[m]);
+                }
+            }
+        }
     }
 
     // Heads: mu = W_mu h2 + b_mu, logvar = W_ls h2 + b_ls.
@@ -272,13 +404,29 @@ pub struct EtmVaeModel {
     pub converged: bool,
     pub epochs_run: usize,
     pub encoder: Encoder,
+    /// The document-topic prior the model was fit under, so inference matches the
+    /// training reparameterization. `Laplace` (default) keeps `theta = softmax(mu)`.
+    pub prior: Prior,
 }
 
 impl EtmVaeModel {
     /// Topic proportions for new documents: one encoder forward pass per document,
-    /// `theta = softmax(mu)` (no sampling).
+    /// no sampling. Laplace uses `theta = softmax(mu)`; the Weibull-Dirichlet path
+    /// uses the normalized Weibull at the posterior median (`u = 0.5`), the
+    /// deterministic counterpart of its training reparameterization.
     pub fn transform(&self, docs: &[Vec<u32>]) -> Vec<Vec<f64>> {
-        docs.iter().map(|d| self.encoder.encode_mean(&normalized_bow(d))).collect()
+        docs.iter().map(|d| self.infer_theta(&normalized_bow(d))).collect()
+    }
+
+    fn infer_theta(&self, xn: &[(usize, f64)]) -> Vec<f64> {
+        match self.prior {
+            Prior::Laplace => self.encoder.encode_mean(xn),
+            Prior::Dirichlet => {
+                let cache = self.encoder.forward(xn);
+                let zeros = vec![0.0; self.num_topics];
+                reparam_theta(&cache, &zeros, Prior::Dirichlet, true).theta
+            }
+        }
     }
 }
 
@@ -370,6 +518,7 @@ pub fn fit_etm_vae<R: Rng>(
     lr: f64,
     wdecay: f64,
     em_tol: f64,
+    opts: AvitmOptions,
     rng: &mut R,
 ) -> EtmVaeModel {
     let k = num_topics;
@@ -413,16 +562,55 @@ pub fn fit_etm_vae<R: Rng>(
             let mut g_beta = vec![vec![0.0f64; v]; k];
             let mut batch_loss = 0.0f64;
 
+            // Forward every document first: caches, noise, theta (anchor) and the
+            // no-noise positive-view theta. The contrastive InfoNCE term couples the
+            // batch, so its gradient must be computed before the per-document backward.
+            let bsz = chunk.len();
+            let mut caches = Vec::with_capacity(bsz);
+            let mut epss = Vec::with_capacity(bsz);
+            let mut reps = Vec::with_capacity(bsz);
+            let mut thetas = Vec::with_capacity(bsz);
+            let mut thetas_pos = Vec::with_capacity(bsz);
             for &di in chunk {
                 let cache = enc.forward(&xn[di]);
                 let eps: Vec<f64> = (0..k).map(|_| randn(rng)).collect();
-                let mut z = vec![0.0f64; k];
-                for t in 0..k {
-                    z[t] = cache.mu[t] + (0.5 * cache.logvar[t]).exp() * eps[t];
+                let rep = reparam_theta(&cache, &eps, opts.prior, false);
+                thetas.push(rep.theta.clone());
+                if opts.contrastive {
+                    thetas_pos.push(reparam_theta(&cache, &eps, opts.prior, true).theta);
                 }
-                let theta = softmax(&z);
+                reps.push(rep);
+                caches.push(cache);
+                epss.push(eps);
+            }
+
+            // Contrastive InfoNCE gradients (anchor and positive views), scaled by
+            // the contrastive weight. Empty when the flag is off or the batch is < 2.
+            let (dz_c, dz_pos) = if opts.contrastive && bsz >= 2 {
+                let (mut dz, dzp) =
+                    info_nce_backward(&thetas, &thetas_pos, opts.contrastive_temp);
+                for row in &mut dz {
+                    for x in row.iter_mut() {
+                        *x *= opts.contrastive_weight;
+                    }
+                }
+                let dzp: Vec<Vec<f64>> = dzp
+                    .into_iter()
+                    .map(|row| row.into_iter().map(|x| x * opts.contrastive_weight).collect())
+                    .collect();
+                batch_loss +=
+                    opts.contrastive_weight * info_nce_loss(&thetas, &thetas_pos, opts.contrastive_temp);
+                (Some(dz), Some(dzp))
+            } else {
+                (None, None)
+            };
+
+            for (bi, &di) in chunk.iter().enumerate() {
+                let dx = dz_c.as_ref().map(|d| d[bi].as_slice());
+                let dxp = dz_pos.as_ref().map(|d| d[bi].as_slice());
                 let (recon, kl) = backward_doc(
-                    &enc, &xn[di], &bows[di], &cache, &eps, &theta, &beta, &mut g, &mut g_beta,
+                    &enc, &xn[di], &bows[di], &caches[bi], &epss[bi], &reps[bi], opts.prior,
+                    dx, dxp, &beta, &mut g, &mut g_beta,
                 );
                 batch_loss += recon + kl;
             }
@@ -464,20 +652,21 @@ pub fn fit_etm_vae<R: Rng>(
     }
 
     let beta = softmax_beta(rho, &alpha);
-    let doc_topic: Vec<Vec<f64>> = xn.iter().map(|x| enc.encode_mean(x)).collect();
-
-    EtmVaeModel {
+    let model_stub = EtmVaeModel {
         num_topics: k,
         num_types: v,
         beta,
         alpha,
-        doc_topic,
+        doc_topic: Vec::new(),
         bound: bound_history.last().copied().unwrap_or(f64::NAN),
         bound_history,
         converged,
         epochs_run,
         encoder: enc,
-    }
+        prior: opts.prior,
+    };
+    let doc_topic: Vec<Vec<f64>> = xn.iter().map(|x| model_stub.infer_theta(x)).collect();
+    EtmVaeModel { doc_topic, ..model_stub }
 }
 
 fn scaled(v: &[f64], s: f64) -> Vec<f64> {
@@ -522,10 +711,20 @@ mod tests {
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
 
-    // The full per-document loss (recon + kl) at a FIXED eps, as a function of every
-    // trainable parameter, checked against central finite differences.
-    #[test]
-    fn vae_gradients_match_fd() {
+    fn clone_encoder(e: &Encoder) -> Encoder {
+        Encoder {
+            v: e.v, hidden: e.hidden, k: e.k,
+            w1: e.w1.clone(), b1: e.b1.clone(),
+            w2: e.w2.clone(), b2: e.b2.clone(),
+            w_mu: e.w_mu.clone(), b_mu: e.b_mu.clone(),
+            w_ls: e.w_ls.clone(), b_ls: e.b_ls.clone(),
+        }
+    }
+
+    // Batch FD harness over a small multi-document batch (so the contrastive term is
+    // active), parameterized by `AvitmOptions`. Returns the max relative error over
+    // all encoder/alpha parameters; asserts each is within the 1e-4 absolute band.
+    fn etm_fd_check(opts: AvitmOptions) -> f64 {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let (v, hidden, k, e) = (6usize, 4usize, 3usize, 2usize);
         let enc0 = Encoder::new(v, hidden, k, &mut rng);
@@ -533,82 +732,109 @@ mod tests {
             (0..v).map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect()).collect();
         let alpha0: Vec<Vec<f64>> =
             (0..k).map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect()).collect();
-        let doc: Vec<u32> = vec![0, 0, 2, 3, 3, 5];
-        let xn = normalized_bow(&doc);
-        let bow = raw_bow(&doc);
-        let eps = [0.3f64, -0.7, 0.5];
+        let docs: Vec<Vec<u32>> = vec![vec![0, 0, 2, 3, 3, 5], vec![1, 4, 4, 5], vec![2, 2, 3, 0]];
+        let xns: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| normalized_bow(d)).collect();
+        let bows: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| raw_bow(d)).collect();
+        let n = docs.len();
+        let epss: Vec<Vec<f64>> = (0..n)
+            .map(|i| (0..k).map(|t| 0.2 * (i as f64 + 1.0) - 0.13 * t as f64).collect())
+            .collect();
 
-        // Closed-form loss + gradients.
-        let loss_grad = |enc: &Encoder, alpha: &[Vec<f64>]| {
-            let cache = enc.forward(&xn);
-            let mut z = vec![0.0f64; k];
-            for t in 0..k {
-                z[t] = cache.mu[t] + (0.5 * cache.logvar[t]).exp() * eps[t];
-            }
-            let theta = softmax(&z);
+        // Whole-batch loss as a function of the encoder and alpha.
+        let loss_only = |enc: &Encoder, alpha: &[Vec<f64>]| -> f64 {
             let beta = softmax_beta(&rho, alpha);
-            let mut g = EncoderGrad::zeros(enc);
-            let mut g_beta = vec![vec![0.0f64; v]; k];
-            let (recon, kl) =
-                backward_doc(enc, &xn, &bow, &cache, &eps, &theta, &beta, &mut g, &mut g_beta);
-            let g_alpha = alpha_grad(&g_beta, &beta, &rho, e);
-            (recon + kl, g, g_alpha)
+            let mut thetas = Vec::with_capacity(n);
+            let mut thetas_pos = Vec::with_capacity(n);
+            let mut total = 0.0;
+            for i in 0..n {
+                let cache = enc.forward(&xns[i]);
+                let rep = reparam_theta(&cache, &epss[i], opts.prior, false);
+                // recon
+                for &(w, c) in &bows[i] {
+                    let m: f64 = (0..k).map(|t| rep.theta[t] * beta[t][w]).sum::<f64>() + 1e-6;
+                    total -= c * m.ln();
+                }
+                // kl
+                match opts.prior {
+                    Prior::Laplace => {
+                        for t in 0..k {
+                            total += -0.5
+                                * (1.0 + cache.logvar[t] - cache.mu[t].powi(2) - cache.logvar[t].exp());
+                        }
+                    }
+                    Prior::Dirichlet => {
+                        for t in 0..k {
+                            total += weibull_gamma_kl(rep.kw[t], rep.lam[t], ETM_DIR_ALPHA);
+                        }
+                    }
+                }
+                if opts.contrastive {
+                    thetas_pos.push(reparam_theta(&cache, &epss[i], opts.prior, true).theta);
+                }
+                thetas.push(rep.theta);
+            }
+            if opts.contrastive && n >= 2 {
+                total += opts.contrastive_weight
+                    * info_nce_loss(&thetas, &thetas_pos, opts.contrastive_temp);
+            }
+            total
         };
 
-        // Loss only (for finite differences).
-        let loss_only = |enc: &Encoder, alpha: &[Vec<f64>]| {
-            let cache = enc.forward(&xn);
-            let mut z = vec![0.0f64; k];
-            for t in 0..k {
-                z[t] = cache.mu[t] + (0.5 * cache.logvar[t]).exp() * eps[t];
+        // Analytic gradients: forward the batch, contrastive backward, per-doc backward.
+        let mut g = EncoderGrad::zeros(&enc0);
+        let mut g_beta = vec![vec![0.0f64; v]; k];
+        let beta = softmax_beta(&rho, &alpha0);
+        let mut caches = Vec::new();
+        let mut reps = Vec::new();
+        let mut thetas = Vec::new();
+        let mut thetas_pos = Vec::new();
+        for i in 0..n {
+            let cache = enc0.forward(&xns[i]);
+            let rep = reparam_theta(&cache, &epss[i], opts.prior, false);
+            thetas.push(rep.theta.clone());
+            if opts.contrastive {
+                thetas_pos.push(reparam_theta(&cache, &epss[i], opts.prior, true).theta);
             }
-            let theta = softmax(&z);
-            let beta = softmax_beta(&rho, alpha);
-            let mut recon = 0.0;
-            for &(w, c) in &bow {
-                let m: f64 = (0..k).map(|t| theta[t] * beta[t][w]).sum::<f64>() + 1e-6;
-                recon -= c * m.ln();
-            }
-            let kl: f64 = (0..k)
-                .map(|t| -0.5 * (1.0 + cache.logvar[t] - cache.mu[t].powi(2) - cache.logvar[t].exp()))
-                .sum();
-            recon + kl
-        };
+            reps.push(rep);
+            caches.push(cache);
+        }
+        let (dz_c, dz_pos) = if opts.contrastive && n >= 2 {
+            let (mut dz, dzp) = info_nce_backward(&thetas, &thetas_pos, opts.contrastive_temp);
+            for row in &mut dz { for x in row.iter_mut() { *x *= opts.contrastive_weight; } }
+            let dzp: Vec<Vec<f64>> = dzp.into_iter()
+                .map(|r| r.into_iter().map(|x| x * opts.contrastive_weight).collect()).collect();
+            (Some(dz), Some(dzp))
+        } else { (None, None) };
+        for i in 0..n {
+            let dx = dz_c.as_ref().map(|d| d[i].as_slice());
+            let dxp = dz_pos.as_ref().map(|d| d[i].as_slice());
+            backward_doc(&enc0, &xns[i], &bows[i], &caches[i], &epss[i], &reps[i], opts.prior,
+                dx, dxp, &beta, &mut g, &mut g_beta);
+        }
+        let g_alpha = alpha_grad(&g_beta, &beta, &rho, e);
 
-        let (_, g, g_alpha) = loss_grad(&enc0, &alpha0);
         let eps_fd = 1e-6;
-
-        // Check each encoder block and alpha by perturbing one coordinate.
+        let mut max_rel = 0.0f64;
+        let mut chk = |analytic: f64, num: f64| {
+            let abs = (analytic - num).abs();
+            let denom = analytic.abs().max(num.abs());
+            if denom > 1e-3 { max_rel = max_rel.max(abs / denom); }
+            assert!(abs < 1e-4, "analytic {analytic} vs numeric {num}");
+        };
         macro_rules! check_block {
-            ($field:ident, $label:expr) => {
+            ($field:ident) => {
                 for idx in 0..enc0.$field.len() {
-                    let mut ep = Encoder {
-                        v, hidden, k,
-                        w1: enc0.w1.clone(), b1: enc0.b1.clone(),
-                        w2: enc0.w2.clone(), b2: enc0.b2.clone(),
-                        w_mu: enc0.w_mu.clone(), b_mu: enc0.b_mu.clone(),
-                        w_ls: enc0.w_ls.clone(), b_ls: enc0.b_ls.clone(),
-                    };
+                    let mut ep = clone_encoder(&enc0);
                     ep.$field[idx] += eps_fd;
                     let lp = loss_only(&ep, &alpha0);
                     ep.$field[idx] -= 2.0 * eps_fd;
                     let lm = loss_only(&ep, &alpha0);
-                    let num = (lp - lm) / (2.0 * eps_fd);
-                    assert!(
-                        (g.$field[idx] - num).abs() < 1e-4,
-                        "{} [{}]: {} vs {}", $label, idx, g.$field[idx], num
-                    );
+                    chk(g.$field[idx], (lp - lm) / (2.0 * eps_fd));
                 }
             };
         }
-        check_block!(w1, "w1");
-        check_block!(b1, "b1");
-        check_block!(w2, "w2");
-        check_block!(b2, "b2");
-        check_block!(w_mu, "w_mu");
-        check_block!(b_mu, "b_mu");
-        check_block!(w_ls, "w_ls");
-        check_block!(b_ls, "b_ls");
+        check_block!(w1); check_block!(b1); check_block!(w2); check_block!(b2);
+        check_block!(w_mu); check_block!(b_mu); check_block!(w_ls); check_block!(b_ls);
         for t in 0..k {
             for d in 0..e {
                 let mut ap = alpha0.clone();
@@ -616,10 +842,43 @@ mod tests {
                 let lp = loss_only(&enc0, &ap);
                 ap[t][d] -= 2.0 * eps_fd;
                 let lm = loss_only(&enc0, &ap);
-                let num = (lp - lm) / (2.0 * eps_fd);
-                assert!((g_alpha[t][d] - num).abs() < 1e-4, "alpha[{t}][{d}]: {} vs {}", g_alpha[t][d], num);
+                chk(g_alpha[t][d], (lp - lm) / (2.0 * eps_fd));
             }
         }
+        max_rel
+    }
+
+    #[test]
+    fn vae_gradients_match_fd() {
+        // Default options reproduce the original Gaussian-softmax / N(0,I) path.
+        etm_fd_check(AvitmOptions::default());
+    }
+
+    #[test]
+    fn etm_contrastive_gradients_match_fd() {
+        let opts = AvitmOptions {
+            contrastive: true, contrastive_weight: 0.7, contrastive_temp: 0.4,
+            ..AvitmOptions::default()
+        };
+        let max_rel = etm_fd_check(opts);
+        assert!(max_rel < 1e-4, "etm contrastive max relative error {max_rel}");
+    }
+
+    #[test]
+    fn etm_dirichlet_gradients_match_fd() {
+        let opts = AvitmOptions { prior: Prior::Dirichlet, ..AvitmOptions::default() };
+        let max_rel = etm_fd_check(opts);
+        assert!(max_rel < 1e-4, "etm dirichlet max relative error {max_rel}");
+    }
+
+    #[test]
+    fn etm_contrastive_and_dirichlet_compose_fd() {
+        let opts = AvitmOptions {
+            prior: Prior::Dirichlet, contrastive: true,
+            contrastive_weight: 0.6, contrastive_temp: 0.5,
+        };
+        let max_rel = etm_fd_check(opts);
+        assert!(max_rel < 1e-4, "etm contrastive+dirichlet max relative error {max_rel}");
     }
 
     // Planted blocks: K word-blocks, each document drawn from one block. The VAE
@@ -642,7 +901,7 @@ mod tests {
             })
             .collect();
 
-        let m = fit_etm_vae(&docs, k, v, &rho, 32, 200, 64, 0.01, 0.0, 0.0, &mut rng);
+        let m = fit_etm_vae(&docs, k, v, &rho, 32, 200, 64, 0.01, 0.0, 0.0, AvitmOptions::default(), &mut rng);
         assert_eq!(m.beta.len(), k);
         for row in &m.doc_topic {
             assert!((row.iter().sum::<f64>() - 1.0).abs() < 1e-9);
@@ -675,8 +934,9 @@ mod tests {
                 (0..12).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
             })
             .collect();
-        let m = fit_etm_vae(&docs, k, v, &rho, 32, 200, 64, 0.01, 0.0, 0.0, &mut rng);
+        let m = fit_etm_vae(&docs, k, v, &rho, 32, 200, 64, 0.01, 0.0, 0.0, AvitmOptions::default(), &mut rng);
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }
 }
+

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -365,6 +365,109 @@ fn laplace_prior(alpha: &[f64]) -> (Vec<f64>, Vec<f64>) {
     (mu1, var1)
 }
 
+/// Euler-Mascheroni constant, used in the Weibull-to-Gamma KL.
+const EULER_GAMMA: f64 = 0.577_215_664_901_532_9;
+
+/// Standard-normal CDF via `erf`, used on the Dirichlet path to turn the per-batch
+/// Gaussian reparameterization noise `eps` into uniform draws `u = Phi(eps)`. We
+/// reuse the *same* noise the laplace path draws so the RNG stream (and therefore
+/// the laplace path) is byte-identical; only the transform of that noise changes.
+pub(crate) fn normal_cdf(x: f64) -> f64 {
+    0.5 * (1.0 + erf(x / std::f64::consts::SQRT_2))
+}
+
+/// `erf` via the Abramowitz-Stegun 7.1.26 rational approximation (|err| < 1.5e-7),
+/// which is ample next to the 1e-4 FD tolerance. The noise transform it feeds is
+/// constant with respect to the trainable parameters, so it never enters a gradient.
+fn erf(x: f64) -> f64 {
+    let sign = if x < 0.0 { -1.0 } else { 1.0 };
+    let x = x.abs();
+    let t = 1.0 / (1.0 + 0.327_591_1 * x);
+    let y = 1.0
+        - (((((1.061_405_429 * t - 1.453_152_027) * t) + 1.421_413_741) * t - 0.284_496_736) * t
+            + 0.254_829_592)
+            * t
+            * (-x * x).exp();
+    sign * y
+}
+
+/// `ln Γ(x)` (Lanczos approximation, x > 0). Used in the Weibull-to-Gamma KL,
+/// where the prior's `ln Γ(α)` term is a constant offset but is kept for a true KL.
+fn lgamma(x: f64) -> f64 {
+    const G: f64 = 7.0;
+    const C: [f64; 9] = [
+        0.999_999_999_999_809_93,
+        676.520_368_121_885_1,
+        -1_259.139_216_722_402_8,
+        771.323_428_777_653_1,
+        -176.615_029_162_140_6,
+        12.507_343_278_686_905,
+        -0.138_571_095_265_720_12,
+        9.984_369_578_019_572e-6,
+        1.505_632_735_149_311_6e-7,
+    ];
+    if x < 0.5 {
+        // Reflection: Γ(x)Γ(1-x) = π / sin(πx).
+        let pi = std::f64::consts::PI;
+        (pi / (pi * x).sin()).ln() - lgamma(1.0 - x)
+    } else {
+        let x = x - 1.0;
+        let mut a = C[0];
+        let t = x + G + 0.5;
+        for (i, &c) in C.iter().enumerate().skip(1) {
+            a += c / (x + i as f64);
+        }
+        0.5 * (2.0 * std::f64::consts::PI).ln() + (x + 0.5) * t.ln() - t + a.ln()
+    }
+}
+
+/// Which prior the VAE path places on the document-topic vector.
+///
+/// - [`Prior::Laplace`] is the unchanged logistic-normal Laplace approximation to
+///   `Dirichlet(alpha)` in the softmax basis (Srivastava & Sutton 2017, eq. 6):
+///   `theta = softmax(mu + exp(logvar/2) * eps)` with the diagonal logistic-normal
+///   KL.
+/// - [`Prior::Dirichlet`] is a true `Dirichlet(alpha)` prior via the Weibull
+///   reparameterization (Zhang et al. 2018; Burkhardt & Kramer 2019): the two
+///   encoder heads parameterize a Weibull variational posterior on each
+///   unnormalized topic weight, a Weibull sample is normalized onto the simplex to
+///   give `theta`, and the analytic Weibull-to-Gamma KL replaces the
+///   logistic-normal KL. The Gaussian reparameterization is replaced too; we reuse
+///   the same Gaussian noise turned into uniforms by `Phi(eps)` so the laplace path
+///   is unaffected.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+pub enum Prior {
+    Laplace,
+    Dirichlet,
+}
+
+/// The two orthogonal `fit_avitm` options (#174, #176). Both default to the
+/// current code path: `Prior::Laplace` and `contrastive == false` reproduce the
+/// pre-change forward/backward exactly, so the defaults are bit-identical to the
+/// implementation before these flags existed.
+#[derive(Clone, Copy)]
+pub struct AvitmOptions {
+    pub prior: Prior,
+    /// InfoNCE contrastive regularization on the topic vectors (CLNTM-style,
+    /// Nguyen & Luu 2021). Off by default.
+    pub contrastive: bool,
+    /// Scale on the contrastive term added to the per-batch loss.
+    pub contrastive_weight: f64,
+    /// InfoNCE temperature.
+    pub contrastive_temp: f64,
+}
+
+impl Default for AvitmOptions {
+    fn default() -> Self {
+        AvitmOptions {
+            prior: Prior::Laplace,
+            contrastive: false,
+            contrastive_weight: 0.5,
+            contrastive_temp: 0.5,
+        }
+    }
+}
+
 /// Inputs and noise for one batch, gathered so the forward and the
 /// finite-difference loss can be recomputed identically.
 struct Batch<'a> {
@@ -388,11 +491,216 @@ struct BatchCache {
     theta: Vec<Vec<f64>>,   // N x K
     theta_do: Vec<Vec<f64>>, // N x K (post-dropout)
     recon: Vec<Vec<f64>>,   // N x V
+    // Dirichlet (Weibull) reparameterization scratch, empty on the laplace path.
+    // For each (doc, topic): Weibull shape `kw`, scale `lam`, the constant
+    // `L = -ln(1-u)` from the noise, and the unnormalized weight `g = lam * L^(1/kw)`.
+    dir: Option<DirCache>,
+    // Contrastive positive-view topic vectors (the no-noise / posterior-mean theta),
+    // and the per-doc softmax used to build them, retained so the backward can push
+    // the InfoNCE gradient through both views. Empty when `contrastive == false`.
+    contrast: Option<ContrastCache>,
+}
+
+/// Per-(doc, topic) Weibull reparameterization quantities for the Dirichlet prior.
+struct DirCache {
+    kw: Vec<Vec<f64>>,  // N x K Weibull shape  = softplus(mu) + floor
+    lam: Vec<Vec<f64>>, // N x K Weibull scale  = softplus(lv) + floor
+    ln_l: Vec<Vec<f64>>, // N x K  ln L, L = -ln(1-u), u = Phi(eps) (constant in params)
+    g: Vec<Vec<f64>>,   // N x K unnormalized weight g = lam * L^(1/kw)
+    s: Vec<f64>,        // N      normalizer sum_t g
+}
+
+/// The contrastive positive view: a second deterministic topic vector per document.
+/// On the laplace path it is `softmax(mu)` (the encoder mean, no sampling noise); on
+/// the Dirichlet path it is the normalized Weibull at the posterior median (`u=0.5`).
+struct ContrastCache {
+    theta_pos: Vec<Vec<f64>>, // N x K positive-view topic vectors
+    // Dirichlet-only positive-view weights, mirroring DirCache (empty on laplace).
+    g_pos: Vec<Vec<f64>>, // N x K
+    s_pos: Vec<f64>,      // N
 }
 
 /// Forward pass over a whole minibatch (batchnorm uses batch statistics). Returns
 /// the summed loss (reconstruction + KL) and the backward cache, plus the BN batch
 /// statistics so the running estimates can be updated by the caller.
+/// Floor added to the Weibull scale so it stays strictly positive.
+pub(crate) const WEIBULL_FLOOR: f64 = 1e-4;
+/// Floor on the Weibull *shape*. A Weibull with small shape has a very large
+/// coefficient of variation, so the reparameterized topic vector is too noisy to
+/// train; flooring the shape at 1 keeps the variational posterior concentrated
+/// enough to learn (a standard WHAI-style choice) while staying strictly positive.
+pub(crate) const WEIBULL_SHAPE_FLOOR: f64 = 1.0;
+
+/// Map a post-BN head pair `(a, b)` to a Weibull `(shape, scale)` and, given the
+/// constant `ln_l = ln(-ln(1-u))`, the unnormalized weight `g = scale * L^(1/shape)`.
+/// Returns `(kw, lam, g)`. Shared by the sampled and positive (median) views so the
+/// reparameterization is identical up to the noise.
+pub(crate) fn weibull_weight(a: f64, b: f64, ln_l: f64) -> (f64, f64, f64) {
+    let kw = softplus(a) + WEIBULL_SHAPE_FLOOR;
+    let lam = softplus(b) + WEIBULL_FLOOR;
+    let g = lam * (ln_l / kw).exp(); // lam * L^(1/kw) = lam * exp(ln_l / kw)
+    (kw, lam, g)
+}
+
+/// Analytic KL( Weibull(kw, lam) || Gamma(alpha, rate=1) ), the per-topic term of
+/// the Weibull-Dirichlet prior (Zhang et al. 2018, "WHAI", appendix; Burkhardt &
+/// Kramer 2019). A symmetric `Dirichlet(alpha)` prior on the simplex factorizes
+/// into independent `Gamma(alpha, 1)` priors on the unnormalized weights, so the KL
+/// sums these per-topic terms.
+pub(crate) fn weibull_gamma_kl(kw: f64, lam: f64, alpha: f64) -> f64 {
+    EULER_GAMMA * alpha / kw - alpha * lam.ln() + kw.ln()
+        + lam * lgamma(1.0 + 1.0 / kw).exp()
+        - EULER_GAMMA
+        - 1.0
+        + lgamma(alpha)
+}
+
+/// d/d(kw, lam) of [`weibull_gamma_kl`]. `Γ(1 + 1/kw)` enters through both its value
+/// and its derivative `-Γ(1+1/kw) ψ(1+1/kw) / kw^2` w.r.t. `kw` (chain rule on the
+/// `1/kw` argument), where `ψ` is the digamma function.
+pub(crate) fn weibull_gamma_kl_grad(kw: f64, lam: f64, alpha: f64) -> (f64, f64) {
+    let arg = 1.0 + 1.0 / kw;
+    let gam = lgamma(arg).exp();
+    let dgam_dkw = gam * digamma(arg) * (-1.0 / (kw * kw));
+    // d/dkw: -γα/kw^2 + 1/kw + lam * dΓ/dkw
+    let dkw = -EULER_GAMMA * alpha / (kw * kw) + 1.0 / kw + lam * dgam_dkw;
+    // d/dlam: -alpha/lam + Γ(1+1/kw)
+    let dlam = -alpha / lam + gam;
+    (dkw, dlam)
+}
+
+/// Digamma `ψ(x)` for `x > 0` (asymptotic series with recurrence shift). Accurate
+/// well within the 1e-4 FD tolerance.
+fn digamma(mut x: f64) -> f64 {
+    let mut result = 0.0;
+    while x < 6.0 {
+        result -= 1.0 / x;
+        x += 1.0;
+    }
+    let inv = 1.0 / x;
+    let inv2 = inv * inv;
+    result + x.ln() - 0.5 * inv
+        - inv2 * (1.0 / 12.0 - inv2 * (1.0 / 120.0 - inv2 / 252.0))
+}
+
+/// InfoNCE contrastive loss (CLNTM, Nguyen & Luu 2021) over a minibatch of topic
+/// vectors. The anchor for document `i` is its sampled topic vector `z[i]`; the
+/// positive is the second deterministic view `z_pos[i]`; the negatives are the other
+/// documents' sampled topic vectors. Similarity is cosine, scaled by `temp`:
+///   `L = -(1/N) Σ_i log[ exp(sim(z_i, z_i^+)/τ) / (exp(sim(z_i,z_i^+)/τ) + Σ_{j≠i} exp(sim(z_i,z_j)/τ)) ]`.
+pub(crate) fn info_nce_loss(z: &[Vec<f64>], z_pos: &[Vec<f64>], temp: f64) -> f64 {
+    let n = z.len();
+    let mut total = 0.0;
+    for i in 0..n {
+        let pos = cosine(&z[i], &z_pos[i]) / temp;
+        let mut max_logit = pos;
+        let mut negs = Vec::with_capacity(n - 1);
+        for j in 0..n {
+            if j != i {
+                let s = cosine(&z[i], &z[j]) / temp;
+                if s > max_logit {
+                    max_logit = s;
+                }
+                negs.push(s);
+            }
+        }
+        // log-sum-exp over {positive} ∪ {negatives}, stabilized.
+        let mut denom = (pos - max_logit).exp();
+        for &s in &negs {
+            denom += (s - max_logit).exp();
+        }
+        total += -(pos - max_logit - denom.ln());
+    }
+    total / n as f64
+}
+
+/// Cosine similarity of two K-vectors.
+fn cosine(a: &[f64], b: &[f64]) -> f64 {
+    let mut dot = 0.0;
+    let mut na = 0.0;
+    let mut nb = 0.0;
+    for t in 0..a.len() {
+        dot += a[t] * b[t];
+        na += a[t] * a[t];
+        nb += b[t] * b[t];
+    }
+    dot / (na.sqrt() * nb.sqrt() + 1e-12)
+}
+
+/// Gradient of `cosine(a, b)` w.r.t. `a` (returns a K-vector). By symmetry the
+/// gradient w.r.t. `b` is `cosine_grad_a(b, a)`.
+fn cosine_grad_a(a: &[f64], b: &[f64]) -> Vec<f64> {
+    let k = a.len();
+    let mut dot = 0.0;
+    let mut na2 = 0.0;
+    let mut nb2 = 0.0;
+    for t in 0..k {
+        dot += a[t] * b[t];
+        na2 += a[t] * a[t];
+        nb2 += b[t] * b[t];
+    }
+    let na = na2.sqrt();
+    let nb = nb2.sqrt();
+    let denom = na * nb + 1e-12;
+    // d/da [ dot / (|a||b| + e) ] = b/denom - dot * (|b| a/|a|) / denom^2.
+    let mut out = vec![0.0; k];
+    let coef = dot * nb / (na.max(1e-12)) / (denom * denom);
+    for t in 0..k {
+        out[t] = b[t] / denom - coef * a[t];
+    }
+    out
+}
+
+/// Backward of [`info_nce_loss`]. Returns `(dz, dz_pos)`, the gradients of the mean
+/// InfoNCE loss w.r.t. the anchor vectors `z` and the positive-view vectors `z_pos`.
+/// Each anchor `z_i` appears both as its own anchor and as a negative for every
+/// other document, so its gradient accumulates both contributions.
+pub(crate) fn info_nce_backward(z: &[Vec<f64>], z_pos: &[Vec<f64>], temp: f64) -> (Vec<Vec<f64>>, Vec<Vec<f64>>) {
+    let n = z.len();
+    let k = if n > 0 { z[0].len() } else { 0 };
+    let mut dz = vec![vec![0.0; k]; n];
+    let mut dz_pos = vec![vec![0.0; k]; n];
+    let scale = 1.0 / n as f64;
+    for i in 0..n {
+        // Logits sim/τ for the positive and each negative j; softmax probabilities.
+        let pos_sim = cosine(&z[i], &z_pos[i]) / temp;
+        let mut logits = vec![pos_sim];
+        let mut idx = vec![usize::MAX]; // MAX marks the positive
+        for j in 0..n {
+            if j != i {
+                logits.push(cosine(&z[i], &z[j]) / temp);
+                idx.push(j);
+            }
+        }
+        let max = logits.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+        let exps: Vec<f64> = logits.iter().map(|&l| (l - max).exp()).collect();
+        let sumexp: f64 = exps.iter().sum();
+        let probs: Vec<f64> = exps.iter().map(|&e| e / sumexp).collect();
+        // L_i = -log p_pos. dL/d logit_m = p_m - 1{m == positive}. Mean over batch.
+        for (m, &j) in idx.iter().enumerate() {
+            let d_logit = (probs[m] - if m == 0 { 1.0 } else { 0.0 }) * scale / temp;
+            if j == usize::MAX {
+                // positive: sim(z_i, z_pos_i)
+                let ga = cosine_grad_a(&z[i], &z_pos[i]);
+                let gb = cosine_grad_a(&z_pos[i], &z[i]);
+                for t in 0..k {
+                    dz[i][t] += d_logit * ga[t];
+                    dz_pos[i][t] += d_logit * gb[t];
+                }
+            } else {
+                // negative: sim(z_i, z_j)
+                let ga = cosine_grad_a(&z[i], &z[j]);
+                let gb = cosine_grad_a(&z[j], &z[i]);
+                for t in 0..k {
+                    dz[i][t] += d_logit * ga[t];
+                    dz[j][t] += d_logit * gb[t];
+                }
+            }
+        }
+    }
+    (dz, dz_pos)
+}
+
 #[allow(clippy::type_complexity)]
 fn batch_forward(
     w: &Weights,
@@ -401,6 +709,8 @@ fn batch_forward(
     bn_dec: &BatchNorm,
     prior_mu: &[f64],
     prior_var: &[f64],
+    alpha: &[f64],
+    opts: &AvitmOptions,
     batch: &Batch,
 ) -> (f64, BatchCache, [(Vec<f64>, Vec<f64>); 3]) {
     let (k, v) = (w.k, w.v);
@@ -416,20 +726,73 @@ fn batch_forward(
     let (mu, c_mu, mean_mu, var_mu) = bn_mu.forward_train(&mu_raw);
     let (lv, c_lv, mean_lv, var_lv) = bn_lv.forward_train(&lv_raw);
 
+    let dirichlet = opts.prior == Prior::Dirichlet;
+    let contrastive = opts.contrastive;
+
     // Reparameterize and decode.
     let mut theta = vec![vec![0.0; k]; n];
     let mut theta_do = vec![vec![0.0; k]; n];
     let mut logit_raw = vec![vec![0.0; v]; n];
+    // Dirichlet scratch.
+    let mut d_kw = vec![vec![0.0; k]; n];
+    let mut d_lam = vec![vec![0.0; k]; n];
+    let mut d_ln_l = vec![vec![0.0; k]; n];
+    let mut d_g = vec![vec![0.0; k]; n];
+    let mut d_s = vec![0.0; n];
+    // Contrastive positive-view scratch.
+    let mut theta_pos = vec![vec![0.0; k]; n];
+    let mut g_pos = vec![vec![0.0; k]; n];
+    let mut s_pos = vec![0.0; n];
+
     for i in 0..n {
-        let mut z = vec![0.0; k];
-        for t in 0..k {
-            z[t] = mu[i][t] + (0.5 * lv[i][t]).exp() * batch.eps[i][t];
-        }
-        let th = softmax(&z);
+        let th: Vec<f64> = if dirichlet {
+            // Weibull reparameterization: u = Phi(eps), L = -ln(1-u), constant in params.
+            let mut s = 0.0;
+            for t in 0..k {
+                let u = normal_cdf(batch.eps[i][t]).clamp(1e-6, 1.0 - 1e-6);
+                let ln_l = (-(1.0 - u).ln()).ln();
+                let (kw, lam, g) = weibull_weight(mu[i][t], lv[i][t], ln_l);
+                d_kw[i][t] = kw;
+                d_lam[i][t] = lam;
+                d_ln_l[i][t] = ln_l;
+                d_g[i][t] = g;
+                s += g;
+            }
+            d_s[i] = s;
+            (0..k).map(|t| d_g[i][t] / s).collect()
+        } else {
+            let mut z = vec![0.0; k];
+            for t in 0..k {
+                z[t] = mu[i][t] + (0.5 * lv[i][t]).exp() * batch.eps[i][t];
+            }
+            softmax(&z)
+        };
         for t in 0..k {
             theta_do[i][t] = th[t] * batch.masks_t[i][t];
         }
         theta[i] = th;
+
+        // Positive view for the contrastive term: same reparameterization without the
+        // noise. Laplace -> softmax(mu); Dirichlet -> normalized Weibull at the median
+        // (u = 0.5, so L = ln 2). Both are deterministic and smooth in the params.
+        if contrastive {
+            if dirichlet {
+                let ln_l = (-(0.5f64).ln()).ln(); // u = 0.5
+                let mut s = 0.0;
+                for t in 0..k {
+                    let (_, _, g) = weibull_weight(mu[i][t], lv[i][t], ln_l);
+                    g_pos[i][t] = g;
+                    s += g;
+                }
+                s_pos[i] = s;
+                for t in 0..k {
+                    theta_pos[i][t] = g_pos[i][t] / s;
+                }
+            } else {
+                theta_pos[i] = softmax(&mu[i]);
+            }
+        }
+
         // logit_raw = theta_do . beta  (product of experts, beta unnormalized).
         let row = &mut logit_raw[i];
         for t in 0..k {
@@ -453,14 +816,29 @@ fn batch_forward(
             loss -= c * (r[word] + 1e-10).ln();
         }
         recon[i] = r;
-        // KL( N(mu, e^lv) || N(mu1, var1) ), diagonal (eq. 7, first line).
-        let mut kl = 0.0;
-        for t in 0..k {
-            let s0 = lv[i][t].exp();
-            let dm = prior_mu[t] - mu[i][t];
-            kl += s0 / prior_var[t] + dm * dm / prior_var[t] - 1.0 + prior_var[t].ln() - lv[i][t];
+        if dirichlet {
+            // KL( Weibull(kw, lam) || Gamma(alpha, 1) ), summed over topics
+            // (Zhang et al. 2018). A Dirichlet(alpha) prior on theta factorizes into
+            // independent Gamma(alpha_t, 1) priors on the unnormalized weights.
+            for t in 0..k {
+                loss += weibull_gamma_kl(d_kw[i][t], d_lam[i][t], alpha[t]);
+            }
+        } else {
+            // KL( N(mu, e^lv) || N(mu1, var1) ), diagonal (eq. 7, first line).
+            let mut kl = 0.0;
+            for t in 0..k {
+                let s0 = lv[i][t].exp();
+                let dm = prior_mu[t] - mu[i][t];
+                kl += s0 / prior_var[t] + dm * dm / prior_var[t] - 1.0 + prior_var[t].ln() - lv[i][t];
+            }
+            loss += 0.5 * kl;
         }
-        loss += 0.5 * kl;
+    }
+
+    // Contrastive InfoNCE term on the sampled topic vectors (anchor) vs the
+    // positive view, with the other documents in the batch as negatives.
+    if contrastive && n >= 2 {
+        loss += opts.contrastive_weight * info_nce_loss(&theta, &theta_pos, opts.contrastive_temp);
     }
 
     let cache = BatchCache {
@@ -473,16 +851,68 @@ fn batch_forward(
         theta,
         theta_do,
         recon,
+        dir: if dirichlet {
+            Some(DirCache { kw: d_kw, lam: d_lam, ln_l: d_ln_l, g: d_g, s: d_s })
+        } else {
+            None
+        },
+        contrast: if contrastive {
+            Some(ContrastCache { theta_pos, g_pos, s_pos })
+        } else {
+            None
+        },
     };
     let stats = [(mean_mu, var_mu), (mean_lv, var_lv), (mean_dec, var_dec)];
     (loss, cache, stats)
 }
 
+/// Backward of the Dirichlet (Weibull) reparameterization for one document: given
+/// `dtheta` (grad w.r.t. the normalized topic vector), the unnormalized weights `g`,
+/// their sum `s`, the Weibull shape/scale `kw`/`lam`, and the noise constant `ln_l`,
+/// accumulate into `dmu`/`dlv` (the post-BN head gradients), where
+/// `kw = softplus(mu) + floor`, `lam = softplus(lv) + floor`, `g = lam L^(1/kw)`.
+#[allow(clippy::too_many_arguments)]
+fn weibull_reparam_backward(
+    dtheta: &[f64],
+    g: &[f64],
+    s: f64,
+    kw: &[f64],
+    lam: &[f64],
+    ln_l: &[f64],
+    mu_post: &[f64],
+    lv_post: &[f64],
+    dmu: &mut [f64],
+    dlv: &mut [f64],
+) {
+    let k = dtheta.len();
+    // theta = g / s  ->  dg_m = (dtheta_m - sum_t dtheta_t theta_t) / s.
+    let dot: f64 = (0..k).map(|t| dtheta[t] * (g[t] / s)).sum();
+    for m in 0..k {
+        let dg = (dtheta[m] - dot) / s;
+        // g = lam * exp(ln_l / kw).
+        let dg_dlam = if lam[m] != 0.0 { g[m] / lam[m] } else { 0.0 };
+        let dg_dkw = g[m] * (-ln_l[m] / (kw[m] * kw[m]));
+        // kw = softplus(mu)+f, lam = softplus(lv)+f.
+        dmu[m] += dg * dg_dkw * sigmoid(mu_post[m]);
+        dlv[m] += dg * dg_dlam * sigmoid(lv_post[m]);
+    }
+}
+
 /// Backward pass over the batch, accumulating into `g`. Returns gradients for the
 /// summed loss (the caller scales by 1/N).
-fn batch_backward(w: &Weights, prior_mu: &[f64], prior_var: &[f64], batch: &Batch, c: &BatchCache, g: &mut Grad) {
+fn batch_backward(
+    w: &Weights,
+    prior_mu: &[f64],
+    prior_var: &[f64],
+    alpha: &[f64],
+    opts: &AvitmOptions,
+    batch: &Batch,
+    c: &BatchCache,
+    g: &mut Grad,
+) {
     let (h, k, v) = (w.hidden, w.k, w.v);
     let n = batch.xns.len();
+    let dirichlet = opts.prior == Prior::Dirichlet;
 
     // --- Decoder: loss -> logit -> BN -> logit_raw -> (theta_do, beta). ---
     // d loss / d logit_iv = total_i * recon_iv - count_iv.
@@ -513,25 +943,88 @@ fn batch_backward(w: &Weights, prior_mu: &[f64], prior_var: &[f64], batch: &Batc
         }
     }
 
+    // Contrastive InfoNCE: gradients w.r.t. the sampled topic vectors (the anchor)
+    // and the positive-view vectors. The anchor grad joins the decoder path into
+    // `dtheta`; the positive-view grad routes only through the positive view.
+    let (dz_contrast, dz_pos) = if opts.contrastive && n >= 2 {
+        let cc = c.contrast.as_ref().unwrap();
+        let (mut dz, dzp) = info_nce_backward(&c.theta, &cc.theta_pos, opts.contrastive_temp);
+        for row in &mut dz {
+            for x in row.iter_mut() {
+                *x *= opts.contrastive_weight;
+            }
+        }
+        let dzp: Vec<Vec<f64>> = dzp
+            .into_iter()
+            .map(|row| row.into_iter().map(|x| x * opts.contrastive_weight).collect())
+            .collect();
+        (Some(dz), Some(dzp))
+    } else {
+        (None, None)
+    };
+
     // --- Per-document gradients into the BN-head outputs (mu, lv). ---
     let mut dmu = vec![vec![0.0; k]; n];
     let mut dlv = vec![vec![0.0; k]; n];
     for i in 0..n {
-        // Dropout on theta, then softmax.
+        // Decoder path: dropout on theta. Add the contrastive anchor gradient (which
+        // acts on theta directly, before dropout) to get the full grad w.r.t. theta.
         let mut dtheta = vec![0.0; k];
         for t in 0..k {
             dtheta[t] = dtheta_do[i][t] * batch.masks_t[i][t];
+            if let Some(dz) = &dz_contrast {
+                dtheta[t] += dz[i][t];
+            }
         }
-        let dot: f64 = (0..k).map(|t| dtheta[t] * c.theta[i][t]).sum();
-        let dz: Vec<f64> = (0..k).map(|t| c.theta[i][t] * (dtheta[t] - dot)).collect();
-        // z = mu + exp(lv/2) * eps.
-        for t in 0..k {
-            let s = (0.5 * c.lv[i][t]).exp();
-            dmu[i][t] += dz[t];
-            dlv[i][t] += dz[t] * batch.eps[i][t] * 0.5 * s;
-            // KL gradients (post-BN mu, lv).
-            dmu[i][t] += (c.mu[i][t] - prior_mu[t]) / prior_var[t];
-            dlv[i][t] += 0.5 * (c.lv[i][t].exp() / prior_var[t] - 1.0);
+
+        if dirichlet {
+            let dir = c.dir.as_ref().unwrap();
+            weibull_reparam_backward(
+                &dtheta, &dir.g[i], dir.s[i], &dir.kw[i], &dir.lam[i], &dir.ln_l[i],
+                &c.mu[i], &c.lv[i], &mut dmu[i], &mut dlv[i],
+            );
+            // KL( Weibull || Gamma ) gradients, through softplus on each head.
+            for t in 0..k {
+                let (dkw, dlam) = weibull_gamma_kl_grad(dir.kw[i][t], dir.lam[i][t], alpha[t]);
+                dmu[i][t] += dkw * sigmoid(c.mu[i][t]);
+                dlv[i][t] += dlam * sigmoid(c.lv[i][t]);
+            }
+        } else {
+            // theta = softmax(z): softmax backward.
+            let dot: f64 = (0..k).map(|t| dtheta[t] * c.theta[i][t]).sum();
+            let dz: Vec<f64> = (0..k).map(|t| c.theta[i][t] * (dtheta[t] - dot)).collect();
+            // z = mu + exp(lv/2) * eps.
+            for t in 0..k {
+                let s = (0.5 * c.lv[i][t]).exp();
+                dmu[i][t] += dz[t];
+                dlv[i][t] += dz[t] * batch.eps[i][t] * 0.5 * s;
+                // KL gradients (post-BN mu, lv).
+                dmu[i][t] += (c.mu[i][t] - prior_mu[t]) / prior_var[t];
+                dlv[i][t] += 0.5 * (c.lv[i][t].exp() / prior_var[t] - 1.0);
+            }
+        }
+
+        // Contrastive positive view routes its gradient through the no-noise path.
+        if let Some(dzp) = &dz_pos {
+            let cc = c.contrast.as_ref().unwrap();
+            if dirichlet {
+                // theta_pos via Weibull at u = 0.5 (L = ln 2), depends on mu and lv.
+                let ln2 = std::f64::consts::LN_2;
+                let ln_l_pos = vec![ln2.ln(); k]; // ln L, L = -ln(1-0.5) = ln 2
+                let kw_pos: Vec<f64> = (0..k).map(|t| softplus(c.mu[i][t]) + WEIBULL_SHAPE_FLOOR).collect();
+                let lam_pos: Vec<f64> = (0..k).map(|t| softplus(c.lv[i][t]) + WEIBULL_FLOOR).collect();
+                weibull_reparam_backward(
+                    &dzp[i], &cc.g_pos[i], cc.s_pos[i], &kw_pos, &lam_pos, &ln_l_pos,
+                    &c.mu[i], &c.lv[i], &mut dmu[i], &mut dlv[i],
+                );
+            } else {
+                // theta_pos = softmax(mu): softmax backward into mu only.
+                let tp = &cc.theta_pos[i];
+                let dot: f64 = (0..k).map(|t| dzp[i][t] * tp[t]).sum();
+                for t in 0..k {
+                    dmu[i][t] += tp[t] * (dzp[i][t] - dot);
+                }
+            }
         }
     }
 
@@ -768,7 +1261,7 @@ pub fn fit_prodlda<R: Rng>(
     let empty: Vec<Vec<f64>> = vec![Vec::new(); docs.len()];
     fit_avitm(
         docs, &empty, InputMode::BowOnly, num_topics, num_types, 0, hidden, alpha,
-        dropout, epochs, batch_size, lr, em_tol, rng,
+        dropout, epochs, batch_size, lr, em_tol, AvitmOptions::default(), rng,
     )
 }
 
@@ -793,6 +1286,7 @@ pub fn fit_avitm<R: Rng>(
     batch_size: usize,
     lr: f64,
     em_tol: f64,
+    opts: AvitmOptions,
     rng: &mut R,
 ) -> ProdldaModel {
     let (k, v) = (num_topics, num_types);
@@ -801,7 +1295,8 @@ pub fn fit_avitm<R: Rng>(
     let bows: Vec<Vec<(usize, f64)>> = docs.iter().map(|doc| raw_bow(doc)).collect();
     let totals: Vec<f64> = bows.iter().map(|b| b.iter().map(|&(_, c)| c).sum()).collect();
 
-    let (prior_mu, prior_var) = laplace_prior(&vec![alpha; k]);
+    let alpha_vec = vec![alpha; k];
+    let (prior_mu, prior_var) = laplace_prior(&alpha_vec);
     let keep = (1.0 - dropout).max(1e-6);
 
     let mut w = Weights::new(v, emb_dim, hidden, k, mode, rng);
@@ -855,14 +1350,15 @@ pub fn fit_avitm<R: Rng>(
                 masks_t: &masks_t,
             };
 
-            let (loss, cache, stats) =
-                batch_forward(&w, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &batch);
+            let (loss, cache, stats) = batch_forward(
+                &w, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha_vec, &opts, &batch,
+            );
             bn_mu.update_running(&stats[0].0, &stats[0].1);
             bn_lv.update_running(&stats[1].0, &stats[1].1);
             bn_dec.update_running(&stats[2].0, &stats[2].1);
 
             let mut g = Grad::zeros(&w);
-            batch_backward(&w, &prior_mu, &prior_var, &batch, &cache, &mut g);
+            batch_backward(&w, &prior_mu, &prior_var, &alpha_vec, &opts, &batch, &cache, &mut g);
             g.scale(1.0 / n as f64);
             opt.step(&mut w, &g);
 
@@ -942,23 +1438,26 @@ mod tests {
         w: &Weights,
         prior_mu: &[f64],
         prior_var: &[f64],
+        alpha: &[f64],
+        opts: &AvitmOptions,
         batch: &Batch,
     ) -> f64 {
         let bn_mu = BatchNorm::new(w.k);
         let bn_lv = BatchNorm::new(w.k);
         let bn_dec = BatchNorm::new(w.v);
-        batch_forward(w, &bn_mu, &bn_lv, &bn_dec, prior_mu, prior_var, batch).0
+        batch_forward(w, &bn_mu, &bn_lv, &bn_dec, prior_mu, prior_var, alpha, opts, batch).0
     }
 
-    // FD gradient check for a given encoder input mode. Every weight block is
-    // perturbed by central differences against the analytic batch gradient,
-    // including the new dense-embedding columns of `w1`. The maximum relative
-    // error across all parameters is returned for reporting.
-    fn fd_check_mode(mode: InputMode, emb_dim: usize) -> f64 {
+    // FD gradient check for a given encoder input mode and option set. Every weight
+    // block is perturbed by central differences against the analytic batch gradient,
+    // including the new dense-embedding columns of `w1`. The maximum relative error
+    // across all parameters is returned for reporting.
+    fn fd_check_mode_opts(mode: InputMode, emb_dim: usize, opts: AvitmOptions) -> f64 {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let (v, hidden, k) = (7usize, 5usize, 4usize);
         let w0 = Weights::new(v, emb_dim, hidden, k, mode, &mut rng);
-        let (prior_mu, prior_var) = laplace_prior(&vec![1.0; k]);
+        let alpha = vec![1.0; k];
+        let (prior_mu, prior_var) = laplace_prior(&alpha);
 
         // A small batch (>=2 docs so batchnorm statistics are well-defined).
         let docs: Vec<Vec<u32>> =
@@ -990,9 +1489,9 @@ mod tests {
         let bn_lv = BatchNorm::new(k);
         let bn_dec = BatchNorm::new(v);
         let (_, cache, _) =
-            batch_forward(&w0, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &batch);
+            batch_forward(&w0, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha, &opts, &batch);
         let mut g = Grad::zeros(&w0);
-        batch_backward(&w0, &prior_mu, &prior_var, &batch, &cache, &mut g);
+        batch_backward(&w0, &prior_mu, &prior_var, &alpha, &opts, &batch, &cache, &mut g);
 
         let fd = 1e-6;
         let mut max_rel = 0.0f64;
@@ -1001,9 +1500,9 @@ mod tests {
                 for idx in 0..w0.$field.len() {
                     let mut wp = w0.clone();
                     wp.$field[idx] += fd;
-                    let lp = batch_loss(&wp, &prior_mu, &prior_var, &batch);
+                    let lp = batch_loss(&wp, &prior_mu, &prior_var, &alpha, &opts, &batch);
                     wp.$field[idx] -= 2.0 * fd;
-                    let lm = batch_loss(&wp, &prior_mu, &prior_var, &batch);
+                    let lm = batch_loss(&wp, &prior_mu, &prior_var, &alpha, &opts, &batch);
                     let num = (lp - lm) / (2.0 * fd);
                     let analytic = g.$field[idx];
                     let abs_err = (analytic - num).abs();
@@ -1040,22 +1539,88 @@ mod tests {
 
     #[test]
     fn batch_gradients_match_fd() {
-        // Bow-only path (plain ProdLDA).
-        fd_check_mode(InputMode::BowOnly, 0);
+        // Bow-only path (plain ProdLDA), default options (laplace, no contrastive).
+        fd_check_mode_opts(InputMode::BowOnly, 0, AvitmOptions::default());
     }
 
     #[test]
     fn batch_gradients_match_fd_bow_emb() {
         // CombinedTM: BoW concatenated with a dense embedding block.
-        let max_rel = fd_check_mode(InputMode::BowEmb, 6);
+        let max_rel = fd_check_mode_opts(InputMode::BowEmb, 6, AvitmOptions::default());
         assert!(max_rel < 1e-4, "bow+emb max relative error {max_rel}");
     }
 
     #[test]
     fn batch_gradients_match_fd_emb_only() {
         // ZeroShotTM: dense embedding block only, no BoW in the encoder.
-        let max_rel = fd_check_mode(InputMode::EmbOnly, 6);
+        let max_rel = fd_check_mode_opts(InputMode::EmbOnly, 6, AvitmOptions::default());
         assert!(max_rel < 1e-4, "emb-only max relative error {max_rel}");
+    }
+
+    // --- #174 contrastive term FD checks (BowOnly + an embedding mode) ----------
+    #[test]
+    fn contrastive_gradients_match_fd_bow_only() {
+        let opts = AvitmOptions {
+            contrastive: true,
+            contrastive_weight: 0.7,
+            contrastive_temp: 0.4,
+            ..AvitmOptions::default()
+        };
+        let max_rel = fd_check_mode_opts(InputMode::BowOnly, 0, opts);
+        assert!(max_rel < 1e-4, "contrastive bow-only max relative error {max_rel}");
+    }
+
+    #[test]
+    fn contrastive_gradients_match_fd_bow_emb() {
+        let opts = AvitmOptions {
+            contrastive: true,
+            contrastive_weight: 0.7,
+            contrastive_temp: 0.4,
+            ..AvitmOptions::default()
+        };
+        let max_rel = fd_check_mode_opts(InputMode::BowEmb, 6, opts);
+        assert!(max_rel < 1e-4, "contrastive bow+emb max relative error {max_rel}");
+    }
+
+    // --- #176 Dirichlet (Weibull) prior FD checks (BowOnly + an embedding mode) --
+    #[test]
+    fn dirichlet_gradients_match_fd_bow_only() {
+        let opts = AvitmOptions { prior: Prior::Dirichlet, ..AvitmOptions::default() };
+        let max_rel = fd_check_mode_opts(InputMode::BowOnly, 0, opts);
+        assert!(max_rel < 1e-4, "dirichlet bow-only max relative error {max_rel}");
+    }
+
+    #[test]
+    fn dirichlet_gradients_match_fd_emb_only() {
+        let opts = AvitmOptions { prior: Prior::Dirichlet, ..AvitmOptions::default() };
+        let max_rel = fd_check_mode_opts(InputMode::EmbOnly, 6, opts);
+        assert!(max_rel < 1e-4, "dirichlet emb-only max relative error {max_rel}");
+    }
+
+    // --- composition: both flags on at once must still FD-check ------------------
+    #[test]
+    fn contrastive_and_dirichlet_compose_fd() {
+        let opts = AvitmOptions {
+            prior: Prior::Dirichlet,
+            contrastive: true,
+            contrastive_weight: 0.6,
+            contrastive_temp: 0.5,
+        };
+        let max_rel = fd_check_mode_opts(InputMode::BowEmb, 6, opts);
+        assert!(max_rel < 1e-4, "contrastive+dirichlet max relative error {max_rel}");
+    }
+
+    // The Weibull-to-Gamma KL gradient checked directly against finite differences.
+    #[test]
+    fn weibull_gamma_kl_grad_matches_fd() {
+        let fd = 1e-7;
+        for &(kw, lam, a) in &[(0.7, 1.3, 1.0), (2.0, 0.5, 0.8), (1.1, 2.2, 1.5)] {
+            let (dkw, dlam) = weibull_gamma_kl_grad(kw, lam, a);
+            let num_kw = (weibull_gamma_kl(kw + fd, lam, a) - weibull_gamma_kl(kw - fd, lam, a)) / (2.0 * fd);
+            let num_lam = (weibull_gamma_kl(kw, lam + fd, a) - weibull_gamma_kl(kw, lam - fd, a)) / (2.0 * fd);
+            assert!((dkw - num_kw).abs() < 1e-5, "dkw {dkw} vs {num_kw}");
+            assert!((dlam - num_lam).abs() < 1e-5, "dlam {dlam} vs {num_lam}");
+        }
     }
 
     #[test]
@@ -1169,7 +1734,8 @@ mod tests {
         let (docs, embs, k, block, v) = planted_emb_corpus(180, 1);
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let m = fit_avitm(
-            &docs, &embs, InputMode::BowEmb, k, v, k, 32, 1.0, 0.0, 250, 60, 0.01, 0.0, &mut rng,
+            &docs, &embs, InputMode::BowEmb, k, v, k, 32, 1.0, 0.0, 250, 60, 0.01, 0.0,
+            AvitmOptions::default(), &mut rng,
         );
         let tw = m.topic_word();
         for row in &tw {
@@ -1188,7 +1754,8 @@ mod tests {
         let (docs, embs, k, block, v) = planted_emb_corpus(180, 1);
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let m = fit_avitm(
-            &docs, &embs, InputMode::EmbOnly, k, v, k, 32, 1.0, 0.0, 250, 60, 0.01, 0.0, &mut rng,
+            &docs, &embs, InputMode::EmbOnly, k, v, k, 32, 1.0, 0.0, 250, 60, 0.01, 0.0,
+            AvitmOptions::default(), &mut rng,
         );
         let tw = m.topic_word();
         for row in &tw {
@@ -1206,10 +1773,76 @@ mod tests {
         for mode in [InputMode::BowEmb, InputMode::EmbOnly] {
             let mut r1 = ChaCha8Rng::seed_from_u64(11);
             let mut r2 = ChaCha8Rng::seed_from_u64(11);
-            let a = fit_avitm(&docs, &embs, mode, k, v, k, 16, 1.0, 0.0, 30, 30, 0.01, 0.0, &mut r1);
-            let b = fit_avitm(&docs, &embs, mode, k, v, k, 16, 1.0, 0.0, 30, 30, 0.01, 0.0, &mut r2);
+            let a = fit_avitm(&docs, &embs, mode, k, v, k, 16, 1.0, 0.0, 30, 30, 0.01, 0.0, AvitmOptions::default(), &mut r1);
+            let b = fit_avitm(&docs, &embs, mode, k, v, k, 16, 1.0, 0.0, 30, 30, 0.01, 0.0, AvitmOptions::default(), &mut r2);
             assert_eq!(a.topic_word(), b.topic_word(), "{mode:?} topic_word not bit-identical");
             assert_eq!(a.doc_topic, b.doc_topic, "{mode:?} doc_topic not bit-identical");
         }
     }
+
+    // Planted recovery with each flag on: topics still concentrate on single blocks.
+    #[test]
+    fn fit_recovers_planted_blocks_contrastive() {
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let (k, block) = (3usize, 8usize);
+        let v = k * block;
+        let docs: Vec<Vec<u32>> = (0..180)
+            .map(|d| {
+                let b = d % k;
+                (0..15).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+            })
+            .collect();
+        let opts = AvitmOptions { contrastive: true, ..AvitmOptions::default() };
+        let m = fit_avitm(
+            &docs, &vec![Vec::new(); docs.len()], InputMode::BowOnly, k, v, 0, 32, 1.0, 0.0,
+            250, 60, 0.01, 0.0, opts, &mut rng,
+        );
+        let tw = m.topic_word();
+        assert_eq!(top_blocks(&tw, k, v, block), k, "contrastive: topics did not cover all blocks");
+    }
+
+    #[test]
+    fn fit_recovers_planted_blocks_dirichlet() {
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let (k, block) = (3usize, 8usize);
+        let v = k * block;
+        let docs: Vec<Vec<u32>> = (0..180)
+            .map(|d| {
+                let b = d % k;
+                (0..15).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+            })
+            .collect();
+        let opts = AvitmOptions { prior: Prior::Dirichlet, ..AvitmOptions::default() };
+        let m = fit_avitm(
+            &docs, &vec![Vec::new(); docs.len()], InputMode::BowOnly, k, v, 0, 32, 0.5, 0.0,
+            400, 60, 0.005, 0.0, opts, &mut rng,
+        );
+        let tw = m.topic_word();
+        for row in &tw {
+            assert!((row.iter().sum::<f64>() - 1.0).abs() < 1e-9);
+        }
+        for row in &m.doc_topic {
+            assert!((row.iter().sum::<f64>() - 1.0).abs() < 1e-9);
+        }
+        // Each topic should be dominated by a single planted block (majority of its
+        // top-3 words from one block), and every block should be covered. The
+        // Weibull-Dirichlet path mixes a little more than the laplace path, so we use
+        // a majority rather than the strict "all top-4 in one block" helper.
+        let mut covered = std::collections::HashSet::new();
+        for row in tw.iter().take(k) {
+            let mut ord: Vec<usize> = (0..v).collect();
+            ord.sort_by(|&a, &b| row[b].total_cmp(&row[a]));
+            let mut counts = vec![0usize; k];
+            for &w in &ord[..3] {
+                counts[w / block] += 1;
+            }
+            let (dom, &cnt) = counts.iter().enumerate().max_by_key(|(_, &c)| c).unwrap();
+            assert!(cnt >= 2, "dirichlet topic top words do not concentrate in a block");
+            covered.insert(dom);
+        }
+        assert_eq!(covered.len(), k, "dirichlet: topics did not cover all blocks");
+    }
 }
+
+
+

--- a/src/python.rs
+++ b/src/python.rs
@@ -10956,6 +10956,11 @@ pub struct ETM {
     lr: f64,
     wdecay: f64,
     seed: u64,
+    // VAE-path flags (#174, #176); ignored on the EM path.
+    prior: String,
+    contrastive: bool,
+    contrastive_weight: f64,
+    contrastive_temp: f64,
     fitted: bool,
     topic_names: Vec<String>,
     model: Option<etm::EtmModel>,
@@ -10978,6 +10983,14 @@ struct EtmState {
     lr: f64,
     wdecay: f64,
     seed: u64,
+    #[serde(default = "default_prior")]
+    prior: String,
+    #[serde(default)]
+    contrastive: bool,
+    #[serde(default = "default_contrastive_weight")]
+    contrastive_weight: f64,
+    #[serde(default = "default_contrastive_temp")]
+    contrastive_temp: f64,
     fitted: bool,
     topic_names: Vec<String>,
     id_to_word: Vec<String>,
@@ -11095,7 +11108,9 @@ impl ETM {
     #[pyo3(signature = (num_topics, *, inference="em", convergence_tol=1e-4,
                         sigma_shrink=0.0, prior_variance=1e6, max_inner=25,
                         hidden_size=800, batch_size=1000, lr=0.005,
-                        wdecay=1.2e-6, seed=42, em_tol=None))]
+                        wdecay=1.2e-6, seed=42, prior="laplace".to_string(),
+                        contrastive=false, contrastive_weight=0.5, contrastive_temp=0.5,
+                        em_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         py: Python<'_>,
@@ -11110,6 +11125,10 @@ impl ETM {
         lr: f64,
         wdecay: f64,
         seed: u64,
+        prior: String,
+        contrastive: bool,
+        contrastive_weight: f64,
+        contrastive_temp: f64,
         em_tol: Option<f64>,
     ) -> PyResult<Self> {
         let convergence_tol = if let Some(old_val) = em_tol {
@@ -11132,6 +11151,8 @@ impl ETM {
         if inference != "em" && inference != "vae" {
             return Err(PyValueError::new_err("inference must be \"em\" or \"vae\""));
         }
+        // Validate the VAE flags eagerly (they only take effect on the vae path).
+        build_avitm_options(&prior, contrastive, contrastive_weight, contrastive_temp)?;
         Ok(ETM {
             num_topics,
             inference: inference.to_string(),
@@ -11144,6 +11165,10 @@ impl ETM {
             lr,
             wdecay,
             seed,
+            prior,
+            contrastive,
+            contrastive_weight,
+            contrastive_temp,
             fitted: false,
             topic_names: Vec::new(),
             model: None,
@@ -11209,12 +11234,15 @@ impl ETM {
 
         if self.inference == "vae" {
             let ep = iters.unwrap_or(150);
+            let opts = build_avitm_options(
+                &self.prior, self.contrastive, self.contrastive_weight, self.contrastive_temp,
+            )?;
             let (k, h, bs, lr, wd, et) = (
                 self.num_topics, self.hidden_size, self.batch_size,
                 self.lr, self.wdecay, tol,
             );
             let m = py.allow_threads(move || {
-                etm_vae::fit_etm_vae(&docs_ids, k, num_types, &rho, h, ep, bs, lr, wd, et, &mut rng)
+                etm_vae::fit_etm_vae(&docs_ids, k, num_types, &rho, h, ep, bs, lr, wd, et, opts, &mut rng)
             });
             self.vae = Some(m);
             self.model = None;
@@ -11391,6 +11419,10 @@ impl ETM {
             lr: self.lr,
             wdecay: self.wdecay,
             seed: self.seed,
+            prior: self.prior.clone(),
+            contrastive: self.contrastive,
+            contrastive_weight: self.contrastive_weight,
+            contrastive_temp: self.contrastive_temp,
             fitted: self.fitted,
             topic_names: self.topic_names.clone(),
             id_to_word: self.id_to_word.clone(),
@@ -11445,6 +11477,11 @@ impl ETM {
                     w_ls: s.enc_w_ls.unwrap_or_default(),
                     b_ls: s.enc_b_ls.unwrap_or_default(),
                 },
+                prior: if s.prior == "dirichlet" {
+                    prodlda::Prior::Dirichlet
+                } else {
+                    prodlda::Prior::Laplace
+                },
             })
         } else { None };
         Ok(ETM {
@@ -11459,6 +11496,10 @@ impl ETM {
             lr: s.lr,
             wdecay: s.wdecay,
             seed: s.seed,
+            prior: s.prior,
+            contrastive: s.contrastive,
+            contrastive_weight: s.contrastive_weight,
+            contrastive_temp: s.contrastive_temp,
             fitted: s.fitted,
             topic_names: s.topic_names,
             id_to_word: s.id_to_word,
@@ -11534,6 +11575,12 @@ pub struct ProdLDA {
     lr: f64,
     em_tol: f64,
     seed: u64,
+    // #176 prior: "laplace" (default) or "dirichlet" (Weibull-reparameterized).
+    prior: String,
+    // #174 contrastive (InfoNCE) regularization on the topic vectors.
+    contrastive: bool,
+    contrastive_weight: f64,
+    contrastive_temp: f64,
     fitted: bool,
     topic_names: Vec<String>,
     model: Option<prodlda::ProdldaModel>,
@@ -11541,6 +11588,17 @@ pub struct ProdLDA {
 }
 
 /// Serializable snapshot of a fitted ProdLDA.
+// Serde defaults for the VAE flags so pre-change saved models load unchanged.
+fn default_prior() -> String {
+    "laplace".to_string()
+}
+fn default_contrastive_weight() -> f64 {
+    0.5
+}
+fn default_contrastive_temp() -> f64 {
+    0.5
+}
+
 #[derive(serde::Serialize, serde::Deserialize)]
 struct ProdldaState {
     num_topics: usize,
@@ -11551,6 +11609,16 @@ struct ProdldaState {
     lr: f64,
     em_tol: f64,
     seed: u64,
+    // VAE objective/prior flags (#174, #176). `#[serde(default)]` so models saved
+    // before these fields existed still load with the pre-change behavior.
+    #[serde(default = "default_prior")]
+    prior: String,
+    #[serde(default)]
+    contrastive: bool,
+    #[serde(default = "default_contrastive_weight")]
+    contrastive_weight: f64,
+    #[serde(default = "default_contrastive_temp")]
+    contrastive_temp: f64,
     fitted: bool,
     topic_names: Vec<String>,
     corpus: Option<corpus::Corpus>,
@@ -11578,6 +11646,40 @@ struct ProdldaState {
     bn_running_var: Option<Vec<f64>>,
 }
 
+/// Validate the VAE-model flags (#174, #176) and build the [`prodlda::AvitmOptions`]
+/// passed into `fit_avitm`. With `prior == "laplace"` and `contrastive == false`
+/// (the defaults) this yields `AvitmOptions::default()`, the pre-flag code path.
+fn build_avitm_options(
+    prior: &str,
+    contrastive: bool,
+    contrastive_weight: f64,
+    contrastive_temp: f64,
+) -> PyResult<prodlda::AvitmOptions> {
+    let prior_enum = match prior {
+        "laplace" => prodlda::Prior::Laplace,
+        "dirichlet" => prodlda::Prior::Dirichlet,
+        other => {
+            return Err(PyValueError::new_err(format!(
+                "prior must be \"laplace\" or \"dirichlet\", got {other:?}"
+            )))
+        }
+    };
+    if contrastive {
+        if !(contrastive_weight >= 0.0 && contrastive_weight.is_finite()) {
+            return Err(PyValueError::new_err("contrastive_weight must be >= 0 and finite"));
+        }
+        if !(contrastive_temp > 0.0 && contrastive_temp.is_finite()) {
+            return Err(PyValueError::new_err("contrastive_temp must be > 0 and finite"));
+        }
+    }
+    Ok(prodlda::AvitmOptions {
+        prior: prior_enum,
+        contrastive,
+        contrastive_weight,
+        contrastive_temp,
+    })
+}
+
 impl ProdLDA {
     fn fitted_model(&self) -> PyResult<&prodlda::ProdldaModel> {
         self.model
@@ -11596,7 +11698,9 @@ impl ProdLDA {
     /// all epochs). Pass `iters` to :meth:`fit` to set the number of epochs.
     #[new]
     #[pyo3(signature = (num_topics, *, alpha=1.0, hidden_size=100, dropout=0.2,
-                        batch_size=200, lr=0.002, convergence_tol=0.0, seed=42, em_tol=None))]
+                        batch_size=200, lr=0.002, convergence_tol=0.0, seed=42,
+                        prior="laplace".to_string(), contrastive=false,
+                        contrastive_weight=0.5, contrastive_temp=0.5, em_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         py: Python<'_>,
@@ -11608,6 +11712,10 @@ impl ProdLDA {
         lr: f64,
         convergence_tol: f64,
         seed: u64,
+        prior: String,
+        contrastive: bool,
+        contrastive_weight: f64,
+        contrastive_temp: f64,
         em_tol: Option<f64>,
     ) -> PyResult<Self> {
         let convergence_tol = if let Some(old_val) = em_tol {
@@ -11631,6 +11739,8 @@ impl ProdLDA {
         if !(0.0..1.0).contains(&dropout) {
             return Err(PyValueError::new_err("dropout must be in [0, 1)"));
         }
+        // Validate the flags eagerly so a bad prior/weight fails at construction.
+        build_avitm_options(&prior, contrastive, contrastive_weight, contrastive_temp)?;
         Ok(ProdLDA {
             num_topics,
             hidden_size,
@@ -11640,6 +11750,10 @@ impl ProdLDA {
             lr,
             em_tol: convergence_tol,
             seed,
+            prior,
+            contrastive,
+            contrastive_weight,
+            contrastive_temp,
             fitted: false,
             topic_names: Vec::new(),
             model: None,
@@ -11669,14 +11783,19 @@ impl ProdLDA {
             return Err(PyValueError::new_err("vocabulary must have at least num_topics words"));
         }
         let ep = iters.unwrap_or(200);
+        let opts = build_avitm_options(
+            &self.prior, self.contrastive, self.contrastive_weight, self.contrastive_temp,
+        )?;
         let (k, h, a, dp, bs, lr, et) = (
             self.num_topics, self.hidden_size, self.alpha, self.dropout,
             self.batch_size, self.lr, tol,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let empty: Vec<Vec<f64>> = vec![Vec::new(); corpus.docs.len()];
         let (model, corpus) = py.allow_threads(move || {
-            let m = prodlda::fit_prodlda(
-                &corpus.docs, k, num_types, h, a, dp, ep, bs, lr, et, &mut rng,
+            let m = prodlda::fit_avitm(
+                &corpus.docs, &empty, prodlda::InputMode::BowOnly, k, num_types, 0, h, a, dp,
+                ep, bs, lr, et, opts, &mut rng,
             );
             (m, corpus)
         });
@@ -11810,6 +11929,10 @@ impl ProdLDA {
             lr: self.lr,
             em_tol: self.em_tol,
             seed: self.seed,
+            prior: self.prior.clone(),
+            contrastive: self.contrastive,
+            contrastive_weight: self.contrastive_weight,
+            contrastive_temp: self.contrastive_temp,
             fitted: self.fitted,
             topic_names: self.topic_names.clone(),
             corpus: self.corpus.clone(),
@@ -11879,11 +12002,26 @@ impl ProdLDA {
             lr: s.lr,
             em_tol: s.em_tol,
             seed: s.seed,
+            prior: s.prior,
+            contrastive: s.contrastive,
+            contrastive_weight: s.contrastive_weight,
+            contrastive_temp: s.contrastive_temp,
             fitted: s.fitted,
             topic_names: s.topic_names,
             model,
             corpus: s.corpus,
         })
+    }
+
+    /// The document-topic prior: ``"laplace"`` (default) or ``"dirichlet"``.
+    #[getter]
+    fn prior(&self) -> String {
+        self.prior.clone()
+    }
+    /// Whether contrastive (InfoNCE) regularization is enabled.
+    #[getter]
+    fn contrastive(&self) -> bool {
+        self.contrastive
     }
 
     fn __repr__(&self) -> String {
@@ -11916,6 +12054,14 @@ struct CtmEmbState {
     lr: f64,
     convergence_tol: f64,
     seed: u64,
+    #[serde(default = "default_prior")]
+    prior: String,
+    #[serde(default)]
+    contrastive: bool,
+    #[serde(default = "default_contrastive_weight")]
+    contrastive_weight: f64,
+    #[serde(default = "default_contrastive_temp")]
+    contrastive_temp: f64,
     fitted: bool,
     topic_names: Vec<String>,
     corpus: Option<corpus::Corpus>,
@@ -11989,6 +12135,10 @@ macro_rules! ctm_embedding_model {
             lr: f64,
             convergence_tol: f64,
             seed: u64,
+            prior: String,
+            contrastive: bool,
+            contrastive_weight: f64,
+            contrastive_temp: f64,
             fitted: bool,
             topic_names: Vec<String>,
             model: Option<prodlda::ProdldaModel>,
@@ -12015,7 +12165,9 @@ macro_rules! ctm_embedding_model {
             /// to :meth:`fit` to set the number of epochs.
             #[new]
             #[pyo3(signature = (num_topics, *, alpha=1.0, hidden_size=100, dropout=0.2,
-                                batch_size=200, lr=0.002, convergence_tol=0.0, seed=42))]
+                                batch_size=200, lr=0.002, convergence_tol=0.0, seed=42,
+                                prior="laplace".to_string(), contrastive=false,
+                                contrastive_weight=0.5, contrastive_temp=0.5))]
             #[allow(clippy::too_many_arguments)]
             fn new(
                 #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
@@ -12026,6 +12178,10 @@ macro_rules! ctm_embedding_model {
                 lr: f64,
                 convergence_tol: f64,
                 seed: u64,
+                prior: String,
+                contrastive: bool,
+                contrastive_weight: f64,
+                contrastive_temp: f64,
             ) -> PyResult<Self> {
                 if num_topics < 2 {
                     return Err(PyValueError::new_err("need at least 2 topics"));
@@ -12036,6 +12192,7 @@ macro_rules! ctm_embedding_model {
                 if !(0.0..1.0).contains(&dropout) {
                     return Err(PyValueError::new_err("dropout must be in [0, 1)"));
                 }
+                build_avitm_options(&prior, contrastive, contrastive_weight, contrastive_temp)?;
                 Ok($name {
                     num_topics,
                     hidden_size,
@@ -12045,6 +12202,10 @@ macro_rules! ctm_embedding_model {
                     lr,
                     convergence_tol,
                     seed,
+                    prior,
+                    contrastive,
+                    contrastive_weight,
+                    contrastive_temp,
                     fitted: false,
                     topic_names: Vec::new(),
                     model: None,
@@ -12097,6 +12258,10 @@ macro_rules! ctm_embedding_model {
                 }
                 self.emb_dim = emb_dim;
                 let ep = iters.unwrap_or(200);
+                let opts = build_avitm_options(
+                    &self.prior, self.contrastive, self.contrastive_weight,
+                    self.contrastive_temp,
+                )?;
                 let (k, h, a, dp, bs, lr) = (
                     self.num_topics, self.hidden_size, self.alpha, self.dropout,
                     self.batch_size, self.lr,
@@ -12105,7 +12270,7 @@ macro_rules! ctm_embedding_model {
                 let (model, corpus) = py.allow_threads(move || {
                     let m = prodlda::fit_avitm(
                         &corpus.docs, &embs, $mode, k, num_types, emb_dim, h, a, dp, ep, bs,
-                        lr, tol, &mut rng,
+                        lr, tol, opts, &mut rng,
                     );
                     (m, corpus)
                 });
@@ -12256,6 +12421,10 @@ macro_rules! ctm_embedding_model {
                     lr: self.lr,
                     convergence_tol: self.convergence_tol,
                     seed: self.seed,
+                    prior: self.prior.clone(),
+                    contrastive: self.contrastive,
+                    contrastive_weight: self.contrastive_weight,
+                    contrastive_temp: self.contrastive_temp,
                     fitted: self.fitted,
                     topic_names: self.topic_names.clone(),
                     corpus: self.corpus.clone(),
@@ -12335,12 +12504,27 @@ macro_rules! ctm_embedding_model {
                     lr: s.lr,
                     convergence_tol: s.convergence_tol,
                     seed: s.seed,
+                    prior: s.prior,
+                    contrastive: s.contrastive,
+                    contrastive_weight: s.contrastive_weight,
+                    contrastive_temp: s.contrastive_temp,
                     fitted: s.fitted,
                     topic_names: s.topic_names,
                     model,
                     corpus: s.corpus,
                     emb_dim: s.emb_dim,
                 })
+            }
+
+            /// The document-topic prior: ``"laplace"`` (default) or ``"dirichlet"``.
+            #[getter]
+            fn prior(&self) -> String {
+                self.prior.clone()
+            }
+            /// Whether contrastive (InfoNCE) regularization is enabled.
+            #[getter]
+            fn contrastive(&self) -> bool {
+                self.contrastive
             }
 
             fn __repr__(&self) -> String {

--- a/tests/test_combinedtm.py
+++ b/tests/test_combinedtm.py
@@ -175,3 +175,59 @@ def test_recovers_planted_blocks():
         # Each topic concentrates on few blocks; together they touch all blocks.
         all_blocks = {term.split("w")[0] for words in m.top_words(4) for term, _ in words}
         assert len(all_blocks) == 3, f"{cls.__name__}: blocks covered {all_blocks}"
+
+
+# --- VAE objective/prior flags (#174 contrastive, #176 prior) ----------------
+
+@pytest.mark.parametrize("cls", MODELS, ids=MODEL_IDS)
+def test_flags_accepted_and_exposed(cls):
+    m = cls(num_topics=3, prior="dirichlet", contrastive=True,
+            contrastive_weight=0.3, contrastive_temp=0.2)
+    assert m.prior == "dirichlet"
+    assert m.contrastive is True
+
+
+@pytest.mark.parametrize("cls", MODELS, ids=MODEL_IDS)
+def test_flag_validation(cls):
+    with pytest.raises(ValueError):
+        cls(num_topics=3, prior="nope")
+    with pytest.raises(ValueError):
+        cls(num_topics=3, contrastive=True, contrastive_weight=-0.1)
+    with pytest.raises(ValueError):
+        cls(num_topics=3, contrastive=True, contrastive_temp=-1.0)
+
+
+@pytest.mark.parametrize("cls", MODELS, ids=MODEL_IDS)
+def test_flags_change_results(cls):
+    docs, embs, _ = _planted(n=120)
+    base = _model(cls, seed=1); base.fit(docs, embs, iters=60)
+    dir_m = _model(cls, seed=1, prior="dirichlet"); dir_m.fit(docs, embs, iters=60)
+    con_m = _model(cls, seed=1, contrastive=True); con_m.fit(docs, embs, iters=60)
+    assert not np.allclose(base.topic_word, dir_m.topic_word)
+    assert not np.allclose(base.topic_word, con_m.topic_word)
+    for m in (dir_m, con_m):
+        assert np.allclose(m.topic_word.sum(axis=1), 1.0)
+        assert np.allclose(m.doc_topic.sum(axis=1), 1.0)
+
+
+@pytest.mark.parametrize("cls", MODELS, ids=MODEL_IDS)
+def test_flags_deterministic(cls):
+    docs, embs, _ = _planted(n=120)
+    a = _model(cls, seed=4, prior="dirichlet", contrastive=True); a.fit(docs, embs, iters=60)
+    b = _model(cls, seed=4, prior="dirichlet", contrastive=True); b.fit(docs, embs, iters=60)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+@pytest.mark.parametrize("cls", MODELS, ids=MODEL_IDS)
+def test_flags_save_load_roundtrip(cls, tmp_path):
+    docs, embs, _ = _planted(n=120)
+    m = _model(cls, seed=2, prior="dirichlet", contrastive=True, contrastive_weight=0.4)
+    m.fit(docs, embs, iters=60)
+    path = str(tmp_path / "ctm_flags.bin")
+    m.save(path)
+    loaded = cls.load(path)
+    assert loaded.prior == "dirichlet"
+    assert loaded.contrastive is True
+    assert np.array_equal(loaded.topic_word, m.topic_word)
+    assert np.array_equal(loaded.doc_topic, m.doc_topic)

--- a/tests/test_etm.py
+++ b/tests/test_etm.py
@@ -116,3 +116,51 @@ def test_etm_vae_determinism():
     b.fit(docs, word_emb, vocab, iters=200)
     assert np.allclose(a.topic_word, b.topic_word)
     assert np.allclose(a.doc_topic, b.doc_topic)
+
+
+# --- VAE objective/prior flags (#174 contrastive, #176 prior) ----------------
+
+def test_etm_vae_flags_accepted():
+    m = topica.ETM(num_topics=3, inference="vae", prior="dirichlet",
+                   contrastive=True, contrastive_weight=0.3, contrastive_temp=0.2)
+    assert m.inference == "vae"
+
+
+def test_etm_flag_validation():
+    with pytest.raises(ValueError):
+        topica.ETM(num_topics=3, inference="vae", prior="gaussian")
+    with pytest.raises(ValueError):
+        topica.ETM(num_topics=3, inference="vae", contrastive=True, contrastive_weight=-1.0)
+    with pytest.raises(ValueError):
+        topica.ETM(num_topics=3, inference="vae", contrastive=True, contrastive_temp=0.0)
+
+
+def test_etm_vae_flags_change_results():
+    docs, vocab, word_emb, _ = _planted()
+    base = _vae(seed=1); base.fit(docs, word_emb, vocab, iters=80)
+    dir_m = _vae(seed=1, prior="dirichlet"); dir_m.fit(docs, word_emb, vocab, iters=80)
+    con_m = _vae(seed=1, contrastive=True); con_m.fit(docs, word_emb, vocab, iters=80)
+    assert not np.allclose(base.topic_word, dir_m.topic_word)
+    assert not np.allclose(base.topic_word, con_m.topic_word)
+    for m in (dir_m, con_m):
+        assert np.allclose(m.topic_word.sum(axis=1), 1.0)
+        assert np.allclose(m.doc_topic.sum(axis=1), 1.0)
+
+
+def test_etm_vae_flags_deterministic():
+    docs, vocab, word_emb, _ = _planted()
+    a = _vae(seed=3, prior="dirichlet", contrastive=True); a.fit(docs, word_emb, vocab, iters=80)
+    b = _vae(seed=3, prior="dirichlet", contrastive=True); b.fit(docs, word_emb, vocab, iters=80)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+def test_etm_vae_flags_save_load_roundtrip(tmp_path):
+    docs, vocab, word_emb, _ = _planted()
+    m = _vae(seed=2, prior="dirichlet", contrastive=True)
+    m.fit(docs, word_emb, vocab, iters=80)
+    path = str(tmp_path / "etm_vae_flags.bin")
+    m.save(path)
+    loaded = topica.ETM.load(path)
+    assert np.array_equal(loaded.topic_word, m.topic_word)
+    assert np.array_equal(loaded.doc_topic, m.doc_topic)

--- a/tests/test_prodlda.py
+++ b/tests/test_prodlda.py
@@ -98,3 +98,63 @@ def test_prodlda_validation():
         topica.ProdLDA(num_topics=3, dropout=1.0)  # dropout in [0, 1)
     with pytest.raises(RuntimeError):
         topica.ProdLDA(num_topics=3).topic_word  # not fitted
+
+
+# --- VAE objective/prior flags (#174 contrastive, #176 prior) ----------------
+
+def test_prodlda_flags_accepted_and_exposed():
+    m = topica.ProdLDA(
+        num_topics=3, prior="dirichlet", contrastive=True,
+        contrastive_weight=0.3, contrastive_temp=0.2,
+    )
+    assert m.prior == "dirichlet"
+    assert m.contrastive is True
+    # Laplace, no contrastive is the default.
+    d = topica.ProdLDA(num_topics=3)
+    assert d.prior == "laplace" and d.contrastive is False
+
+
+def test_prodlda_flag_validation():
+    with pytest.raises(ValueError):
+        topica.ProdLDA(num_topics=3, prior="gaussian")  # unknown prior
+    with pytest.raises(ValueError):
+        topica.ProdLDA(num_topics=3, contrastive=True, contrastive_weight=-1.0)
+    with pytest.raises(ValueError):
+        topica.ProdLDA(num_topics=3, contrastive=True, contrastive_temp=0.0)
+
+
+def test_prodlda_flags_change_results_but_stay_valid():
+    docs, vocab, _ = _planted(n=120)
+    base = _model(seed=1); base.fit(docs, iters=60)
+    dir_m = _model(seed=1, prior="dirichlet"); dir_m.fit(docs, iters=60)
+    con_m = _model(seed=1, contrastive=True); con_m.fit(docs, iters=60)
+    # Each flag changes the fitted topics.
+    assert not np.allclose(base.topic_word, dir_m.topic_word)
+    assert not np.allclose(base.topic_word, con_m.topic_word)
+    # Outputs remain valid distributions.
+    for m in (dir_m, con_m):
+        assert np.allclose(m.topic_word.sum(axis=1), 1.0)
+        assert np.allclose(m.doc_topic.sum(axis=1), 1.0)
+
+
+def test_prodlda_flags_deterministic():
+    docs, _, _ = _planted(n=120)
+    for kw in ({"prior": "dirichlet"}, {"contrastive": True},
+               {"prior": "dirichlet", "contrastive": True}):
+        a = _model(seed=5, **kw); a.fit(docs, iters=60)
+        b = _model(seed=5, **kw); b.fit(docs, iters=60)
+        assert np.array_equal(a.topic_word, b.topic_word)
+        assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+def test_prodlda_flags_save_load_roundtrip(tmp_path):
+    docs, _, _ = _planted(n=120)
+    m = _model(seed=2, prior="dirichlet", contrastive=True, contrastive_weight=0.4)
+    m.fit(docs, iters=60)
+    path = str(tmp_path / "prodlda_flags.bin")
+    m.save(path)
+    loaded = topica.ProdLDA.load(path)
+    assert loaded.prior == "dirichlet"
+    assert loaded.contrastive is True
+    assert np.array_equal(loaded.topic_word, m.topic_word)
+    assert np.array_equal(loaded.doc_topic, m.doc_topic)


### PR DESCRIPTION
Closes #174 and #176.

## What

Adds two orthogonal, opt-in options to topica's amortized-VAE topic models (**ProdLDA, ETM `inference="vae"`, CombinedTM, ZeroShotTM**), both via the shared `fit_avitm` core. These are flags, not new classes.

- **`contrastive=False`** (+ `contrastive_weight=0.5`, `contrastive_temp=0.5`) — CLNTM-style InfoNCE contrastive regularization on the topic vectors (Nguyen & Luu 2021). Anchor = the sampled topic vector; positive = the deterministic no-noise topic vector (`softmax(mu)` on the laplace path, median Weibull on the dirichlet path); negatives = the other in-batch documents; cosine similarity at `contrastive_temp`. Deterministic and FD-checkable. The TF-IDF salient-word positive construction is a documented future refinement.
- **`prior="laplace"`** (default, unchanged) or **`"dirichlet"`** — a true Dirichlet(alpha) prior via the Weibull reparameterization (Burkhardt & Kramer 2019; Zhang et al. 2018), with the analytic Weibull-to-Gamma KL replacing the logistic-normal Laplace KL on that path. The Weibull shape is floored at 1.0 (WHAI-style) for stable training; this does not affect gradient correctness (FD-verified) or the laplace-path bit-identity.

## Defaults bit-identical to `main` (the key guarantee)

Both flags are fully gated. An independent agent built `main` and this branch and fit all four VAE models on a fixed corpus/seed with defaults: `topic_word` and `doc_topic` are **bit-identical, max abs diff 0.0** for ProdLDA, ETM-vae, CombinedTM, and ZeroShotTM. Touching the two shared cores (`fit_avitm`, `etm_vae`) did not perturb any merged model.

## Validation

The CLNTM/DVAE references are stochastic PyTorch, so exact parity is impossible; correctness is guaranteed by FD gradient checks (topica has no autodiff), independently reproduced:

| path | contrastive | dirichlet | both composed |
|---|---|---|---|
| prodlda core | 1.9e-7 / 8.8e-7 | 3.8e-7 / 2.6e-6 | 1.4e-6 |
| etm_vae | 1.9e-6 | 1.4e-7 | 1.4e-7 |

All ≪ 1e-4. Flags demonstrably change results and are deterministic (bit-identical reruns under a fixed seed); the two compose. With `prior="dirichlet"`, θ stays on the simplex (rows sum to 1, all ≥ 0). Planted-block recovery is preserved or improved (ProdLDA purity 0.958 default / 0.975 dirichlet at 300 epochs).

## Speed

**Overhead vs the default path** (fit-only, iters=50, 14 cores, median of 3):

| flag | overhead | note |
|---|---|---|
| `prior="dirichlet"` | +3-6% | negligible (1.03-1.06x across all sizes + embedding path) |
| `contrastive=True` | +44-54% (ProdLDA), +32% (CombinedTM) | the InfoNCE term is O(batch²) per minibatch at the default batch_size=200; per-batch, not per-document (constant across corpus size) |

Absolute (8000×500, K=25, 50 iters): 23.3s default → 24.7s dirichlet → 33.4s contrastive → 34.6s both. Practical with both flags on.

**Indicative vs the original implementations** (PyTorch-CPU vs no-torch Rust, apples-to-oranges, "same ballpark" only):
- Contrastive vs the official **CLNTM** (Nguyen & Luu): reference ~4.0s vs topica `contrastive=True` ~5.2s at a medium config (~1.3×). Same ballpark.
- Dirichlet: the faithful Weibull-DVAE reference (Burkhardt & Kramer) is TensorFlow 1.x with no Apple-Silicon/Py3.13 wheels, so it could not be installed; we did not substitute a PyTorch repo that implements the *Laplace-approx* Dirichlet VAE (the wrong method). topica's `prior="dirichlet"` runs ~3.7s standalone; no clean reference comparison available.

## Conventions, gates, credit

- `tests/test_naming_conventions.py` + `tests/test_registry.py` pass (canonical names; registry unchanged since the models/descriptions are identical). State structs gained `#[serde(default)]` fields so models saved before this change still load.
- `cargo test --lib` 127 passed; `pytest tests/ -q` 2397 passed, 38 skipped; `mkdocs build --strict` clean.
- CLNTM (Nguyen & Luu 2021) and the Weibull-Dirichlet VAE (Burkhardt & Kramer 2019; Zhang et al. 2018) added to the README acknowledgements.

Independent of the `feat/detm` work still in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
