### PR TITLE
Add topic_semantic_diversity (TSD) diagnostic

### DIFF
--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -17,6 +17,8 @@ and in the `topica.validation` module.
 
 ::: topica.topic_diversity
 
+::: topica.topic_semantic_diversity
+
 ::: topica.exclusivity
 
 ::: topica.quality_frontier

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -15,10 +15,17 @@ model.coherence(10)                                   # per-topic UMass (built i
 topica.coherence(model, texts, coherence_type="c_v")      # windowed, human-aligned
 topica.exclusivity(model, n=10)                           # per topic
 topica.topic_diversity(model, topn=25)                    # fraction of unique top words
+topica.topic_semantic_diversity(model, topn=25)           # fraction of unique top-word *pairs*
 
 qf = topica.quality_frontier(model, n=10)                 # coherence, exclusivity, prevalence
 # qf["coherence"], qf["exclusivity"] -> the canonical STM quality scatter
 ```
+
+`topic_diversity` counts unique single words; `topic_semantic_diversity` counts
+unique word *pairs* (Wu, Nguyen & Luu 2024). We reach for the pair version when
+single-word overlap understates redundancy: two topics can share few exact words
+yet co-locate the same word pairs, and a pair pins down word sense without any
+embeddings. Both range over `[0, 1]`, and higher means more diverse.
 
 !!! tip "Coherence is fast, even at large K"
     `topica.coherence` runs its co-occurrence counting in the Rust core, scoring only

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -140,6 +140,7 @@ from . import phrases  # noqa: E402
 from .coherence import (  # noqa: E402
     coherence,
     topic_diversity,
+    topic_semantic_diversity,
     exclusivity,
     word_intrusion,
     document_intrusion,
@@ -260,6 +261,7 @@ __all__ = [
     "phrases",
     "coherence",
     "topic_diversity",
+    "topic_semantic_diversity",
     "exclusivity",
     "word_intrusion",
     "document_intrusion",

--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -115,6 +115,10 @@ def topic_diversity(topics: Any, topn: int = 25) -> float:
     """Fraction of unique words across all topics' top-`topn` words."""
     ...
 
+def topic_semantic_diversity(topics: Any, topn: int = 25) -> float:
+    """Fraction of unique top-word *pairs* across all topics (Wu, Nguyen & Luu 2024)."""
+    ...
+
 
 def exclusivity(model_or_phi: Any, *, n: int = 10) -> numpy.typing.NDArray[numpy.float64]:
     """Per-topic exclusivity of the top-n words, shape (num_topics,). Pair with
@@ -411,6 +415,7 @@ __all__ = [
     "stm",
     "coherence",
     "topic_diversity",
+    "topic_semantic_diversity",
     "exclusivity",
     "word_intrusion",
     "document_intrusion",

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -25,7 +25,8 @@ These are pure-Python/numpy and work with any model here: pass a fitted model
 from __future__ import annotations
 
 import math
-from collections import defaultdict
+from collections import Counter, defaultdict
+from itertools import combinations
 
 import numpy as np
 
@@ -371,6 +372,40 @@ def topic_diversity(topics, topn=25):
             seen.add(w)
             total += 1
     return len(seen) / total if total else float("nan")
+
+
+def topic_semantic_diversity(topics, topn=25):
+    """Fraction of unique top-word *pairs* across all topics (Wu, Nguyen & Luu
+    2024, "A Survey on Neural Topic Models", Eq. 18). Where `topic_diversity`
+    counts unique single words, this counts unique *pairs* drawn from each
+    topic's top-`topn` words: a pair occurrence is "unique" when that unordered
+    pair appears in exactly one topic's top words. 1.0 means every top-word pair
+    is unique to its topic; higher = more diverse. A pair disambiguates word
+    sense, so this is "semantic-aware" — no embeddings are needed.
+
+    `topics` is a fitted model or a list of word lists. `topn` must be an
+    integer >= 2 (pairs require at least two words).
+    """
+    if not isinstance(topn, (int, np.integer)) or topn < 2:
+        raise ValueError(f"topn must be an integer >= 2, got {topn!r}")
+    tops = _extract_topics(topics, topn)
+    # Per-topic unordered pairs (top words within a topic are distinct).
+    topic_pairs = [
+        {frozenset(p) for p in combinations(t[:topn], 2)} for t in tops
+    ]
+    # How many topics contain each unordered pair.
+    global_count = Counter()
+    for pairs in topic_pairs:
+        for p in pairs:
+            global_count[p] += 1
+    total = 0
+    unique = 0
+    for pairs in topic_pairs:
+        for p in pairs:
+            total += 1
+            if global_count[p] == 1:
+                unique += 1
+    return unique / total if total else float("nan")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -105,6 +105,54 @@ class TestDiversity:
         assert 0.0 < d <= 1.0
 
 
+class TestSemanticDiversity:
+    """topic_semantic_diversity (Wu, Nguyen & Luu 2024, Eq. 18): fraction of
+    top-word *pairs* that are unique to a single topic."""
+
+    def test_disjoint_is_one(self):
+        # No shared words → no shared pairs → every pair unique.
+        tsd = topica.topic_semantic_diversity(
+            [["a", "b", "c"], ["d", "e", "f"]], topn=3
+        )
+        assert tsd == 1.0
+
+    def test_identical_is_zero(self):
+        # Two identical topics: every pair appears in BOTH topics, so no pair
+        # occurrence has global count 1 → 0.0. (Note: unlike topic_diversity,
+        # which counts unique *words* and gives 0.5 here.)
+        tsd = topica.topic_semantic_diversity(
+            [["a", "b", "c"], ["a", "b", "c"]], topn=3
+        )
+        assert tsd == 0.0
+
+    def test_partial_overlap_exact(self):
+        # A = {a,b,c,d}, B = {a,b,e,f}, topn=4 → 6 pairs each, 12 total.
+        # The only shared pair is {a,b} (count 2); it occurs once in A and once
+        # in B → 2 non-unique occurrences. Unique = 10 → TSD = 10/12.
+        tsd = topica.topic_semantic_diversity(
+            [["a", "b", "c", "d"], ["a", "b", "e", "f"]], topn=4
+        )
+        assert tsd == 10 / 12
+
+    def test_topn_two_edge(self):
+        # topn=2 → exactly one pair per topic; disjoint pairs → 1.0.
+        tsd = topica.topic_semantic_diversity(
+            [["a", "b"], ["c", "d"]], topn=2
+        )
+        assert tsd == 1.0
+
+    def test_accepts_model(self):
+        docs = [["cat", "dog", "pet"]] * 20 + [["star", "moon", "sky"]] * 20
+        m = LDA(num_topics=2, seed=1)
+        m.fit(docs, iters=300)
+        tsd = topica.topic_semantic_diversity(m, topn=3)
+        assert 0.0 <= tsd <= 1.0
+
+    def test_topn_below_two_raises(self):
+        with pytest.raises(ValueError):
+            topica.topic_semantic_diversity([["a", "b", "c"]], topn=1)
+
+
 class TestAnalysisContract:
     """Any object exposing the analysis contract -- ``topic_word`` /
     ``doc_topic`` / ``vocabulary`` -- works with the model-agnostic diagnostics,


### PR DESCRIPTION
Closes #173.

## What

Adds **`topic_semantic_diversity`** (TSD), a model-agnostic diagnostic from Wu, Nguyen & Luu 2024 ("A Survey on Neural Topic Models", Eq. 18). Where `topic_diversity` counts unique single *words* across topics, TSD counts unique top-word *pairs*: a pair occurrence is unique when that unordered pair appears in exactly one topic's top-`topn` words.

`TSD = (unique per-topic pair-occurrences) / (total per-topic pair-occurrences)`, range [0, 1], higher = more diverse. It is "semantic-aware" because a word *pair* disambiguates sense (e.g. `{bank, river}` vs `{bank, money}`) — **no embeddings are involved**. (The #173 issue originally mis-described it as embedding-based; corrected there.)

It sits beside `topic_diversity` in `coherence.py`, is pure Python, and operates on any fitted model or a list of word lists via the shared `_extract_topics`.

```python
from topica import topic_semantic_diversity
topic_semantic_diversity(model, topn=25)
```

## Validation (hand-computed exact values)

- Disjoint topics (`[a,b,c]`, `[d,e,f]`, topn=3) → **1.0**.
- Identical topics → **0.0** (contrast: `topic_diversity` gives 0.5 — TSD is the stricter, pair-level view, which is the point).
- Partial overlap (`[a,b,c,d]`, `[a,b,e,f]`, topn=4): 12 pair-occurrences, only `{a,b}` shared → **10/12**.
- topn=2 edge → 1.0; accepts a fitted model; `topn < 2` raises `ValueError`.

## Gates

- `cargo test --lib`: 127 passed (no Rust touched).
- `pytest tests/ -q`: 2403 passed, 38 skipped (incl. `test_naming_conventions.py`, `test_registry.py`).
- `mkdocs build --strict`: clean.

Pure-Python diagnostic; no model, no Rust, no embeddings. Independent of the `feat/detm` work in flight.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
