### PR TITLE
release: 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-06-15
+
+### Added
+
+- Five new models, each validated against its reference implementation:
+  - **`NMF`** — non-negative matrix factorization (multiplicative updates,
+    Frobenius or generalized-KL), validated against `sklearn.decomposition.NMF`.
+  - **`LSA`** — latent semantic analysis (truncated SVD), identical to
+    `sklearn.decomposition.TruncatedSVD` (cosine 1.000000).
+  - **`CombinedTM`** / **`ZeroShotTM`** — contextualized neural topic models
+    (Bianchi et al. 2021); ZeroShotTM is topica's first cross-lingual model.
+  - **`DETM`** — Dynamic Embedded Topic Model (Dieng, Ruiz & Blei 2019):
+    embedding-factored topics that drift across time slices, fit by structured
+    amortized variational inference (hand-coded LSTM), validated on the paper's
+    UN and ACL corpora at the reference's own seed-to-seed noise floor.
+- **Model registry + purpose taxonomy** — `topica.list_models(group=, brings=,
+  inference=, determinism=, tag=)` over a seven-group registry that is the single
+  source of truth for the README and docs roster.
+- **Opt-in VAE options** on the amortized-VAE models (ProdLDA, ETM-vae,
+  CombinedTM, ZeroShotTM), off by default: `contrastive=` (CLNTM-style InfoNCE
+  regularization) and `prior="dirichlet"` (a true Dirichlet prior via the Weibull
+  reparameterization).
+- **Two bundled skills** (shipped under `.claude/skills/`): `add-topic-model`
+  (the developer workflow for porting a model) and `topica-analysis` (the user
+  analysis guide, the canonical source for the generated `AGENTS.md`).
+
+### Fixed
+
+- Windows CI: repo text files (README, docs, generated tables) are now read and
+  written as UTF-8, fixing a `UnicodeDecodeError` under the Windows cp1252 default.
+
 ## [0.19.0] - 2026-06-15
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.19.0"
+version = "0.20.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.19.0"
+version = "0.20.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.19.0"
+version = "0.20.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.20.0**. Bumps `Cargo.toml`/`pyproject.toml`/`Cargo.lock` and adds the CHANGELOG entry.

## Headline

The roster grows from 23 to **28 models**, all added through the `add-topic-model` skill and each independently verified + CI-green:

- **NMF**, **LSA** (vs scikit-learn), **CombinedTM** / **ZeroShotTM** (first cross-lingual), **DETM** (validated on the paper's UN + ACL corpora at the reference's noise floor).
- **Model registry + taxonomy** (`list_models`), **opt-in contrastive / Dirichlet VAE flags**, two **bundled skills**, and the **Windows UTF-8 CI fix**.

Minor bump (new models + features; no breaking changes — every existing model's default path is bit-identical, verified per PR).

## Gates

- Full CI green on main (incl. windows-latest) across all the merged PRs; rebuilt locally `topica.__version__ == "0.20.0"`, 28 models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)