### PR TITLE
Add Gaussian stick-breaking prior to the VAE models (completes #176)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Topica stands on a generation of open topic-modeling research and code. Each ent
 - [**contextualized-topic-models**](https://github.com/MilaNLProc/contextualized-topic-models) (Bianchi et al., MIT) — `CombinedTM` (Bianchi, Terragni & Hovy, 2021) and `ZeroShotTM` (Bianchi, Nozza & Hovy, 2021): ProdLDA encoders that read a contextual document embedding, alongside or in place of the bag of words
 - [**CLNTM**](https://arxiv.org/abs/2110.12764) (Nguyen & Luu, 2021) — the InfoNCE contrastive regularization on topic vectors offered by the `contrastive=` flag on the VAE models
 - [**WHAI / Weibull-Dirichlet VAE**](https://arxiv.org/abs/1803.01328) (Zhang et al., 2018; Burkhardt & Kramer, 2019) — the Weibull-reparameterized Dirichlet prior offered by `prior="dirichlet"` on the VAE models
+- [**Neural variational topic models with alternative priors**](https://arxiv.org/abs/1706.00359) (Miao, Grefenstette & Blunsom, 2017; Nalisnick & Smyth, 2017) — the Gaussian stick-breaking prior offered by `prior="stick_breaking"` on the VAE models
 - [**TopicGPT**](https://github.com/chtmp223/topicGPT) (Pham et al., NAACL 2024, MIT) — `TopicGPT`: the generate / refine / assign prompt flow for LLM-driven topic discovery
 
 The embedding-native models build on two pure-Rust crates: [**petal-clustering**](https://github.com/petabi/petal-clustering) for HDBSCAN and [**umap-rs**](https://github.com/wilsonzlin/umap-rs) for the optional UMAP reducer, both BLAS-free.

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -354,11 +354,20 @@ and the defaults reproduce the standard model exactly.
   a Weibull draw is normalized onto the simplex, and the analytic Weibull-to-Gamma
   KL replaces the logistic-normal KL. We reuse the same reparameterization noise the
   laplace path draws, so turning the flag off is bit-for-bit the original model.
+  `"stick_breaking"` is the Gaussian stick-breaking construction (Miao,
+  Grefenstette & Blunsom 2017; reparameterizable simplex map of Nalisnick & Smyth
+  2017): it keeps the same Gaussian latent and Gaussian KL as `"laplace"`, but maps
+  it onto the simplex by stick-breaking — `K-1` breaks `ηₜ = sigmoid(zₜ)` give
+  `θₜ = ηₜ ∏_{j<t}(1 - η_j)` with the last topic the remainder. The ordered sticks
+  let early topics claim most mass and later ones decay, a nonparametric-flavored
+  prior that softens the fixed-`K` assumption. Because only the simplex map changes,
+  the laplace default stays bit-identical.
 
 - `contrastive=True` adds a CLNTM-style (Nguyen & Luu 2021) InfoNCE term on the
   topic vectors. For each document the *anchor* is its sampled topic vector and the
   *positive view* is the deterministic no-noise topic vector (`softmax(μ)` on the
-  laplace path, the median Weibull on the dirichlet path); the other documents in
+  laplace path, the median Weibull on the dirichlet path, the no-noise stick-breaking
+  of `μ` on the stick-breaking path); the other documents in
   the minibatch are negatives, with cosine similarity at temperature
   `contrastive_temp`. The term is scaled by `contrastive_weight` and added to the
   per-batch loss. We document the positive-view choice because it is what makes the

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2519,8 +2519,9 @@ class ETM:
         em_tol: Optional[float] = None,
     ) -> None:
         """em_tol is a deprecated alias for convergence_tol. On the VAE path,
-        ``prior`` selects ``"laplace"`` (default) or ``"dirichlet"`` (Weibull
-        reparameterization), and ``contrastive`` adds an InfoNCE term on the topic
+        ``prior`` selects ``"laplace"`` (default), ``"dirichlet"`` (Weibull
+        reparameterization), or ``"stick_breaking"`` (Gaussian stick-breaking,
+        Miao et al. 2017), and ``contrastive`` adds an InfoNCE term on the topic
         vectors scaled by ``contrastive_weight`` at temperature ``contrastive_temp``.
         Both are ignored on the EM path."""
         ...
@@ -2621,7 +2622,8 @@ class ProdLDA:
         em_tol: Optional[float] = None,
     ) -> None:
         """em_tol is a deprecated alias for convergence_tol. ``prior`` selects
-        ``"laplace"`` (default) or ``"dirichlet"`` (Weibull reparameterization);
+        ``"laplace"`` (default), ``"dirichlet"`` (Weibull reparameterization), or
+        ``"stick_breaking"`` (Gaussian stick-breaking, Miao et al. 2017);
         ``contrastive`` adds an InfoNCE term on the topic vectors scaled by
         ``contrastive_weight`` at temperature ``contrastive_temp``."""
         ...
@@ -2707,8 +2709,9 @@ class CombinedTM:
         contrastive_weight: float = 0.5,
         contrastive_temp: float = 0.5,
     ) -> None:
-        """``prior`` selects ``"laplace"`` (default) or ``"dirichlet"`` (Weibull
-        reparameterization); ``contrastive`` adds an InfoNCE term on the topic vectors
+        """``prior`` selects ``"laplace"`` (default), ``"dirichlet"`` (Weibull
+        reparameterization), or ``"stick_breaking"`` (Gaussian stick-breaking, Miao
+        et al. 2017); ``contrastive`` adds an InfoNCE term on the topic vectors
         scaled by ``contrastive_weight`` at temperature ``contrastive_temp``."""
         ...
     @property
@@ -2802,8 +2805,9 @@ class ZeroShotTM:
         contrastive_weight: float = 0.5,
         contrastive_temp: float = 0.5,
     ) -> None:
-        """``prior`` selects ``"laplace"`` (default) or ``"dirichlet"`` (Weibull
-        reparameterization); ``contrastive`` adds an InfoNCE term on the topic vectors
+        """``prior`` selects ``"laplace"`` (default), ``"dirichlet"`` (Weibull
+        reparameterization), or ``"stick_breaking"`` (Gaussian stick-breaking, Miao
+        et al. 2017); ``contrastive`` adds an InfoNCE term on the topic vectors
         scaled by ``contrastive_weight`` at temperature ``contrastive_temp``."""
         ...
     @property

--- a/src/etm_vae.rs
+++ b/src/etm_vae.rs
@@ -27,8 +27,8 @@
 
 use crate::etm::softmax_beta;
 use crate::prodlda::{
-    info_nce_backward, info_nce_loss, normal_cdf, weibull_gamma_kl, weibull_gamma_kl_grad,
-    weibull_weight, AvitmOptions, Prior, WEIBULL_FLOOR, WEIBULL_SHAPE_FLOOR,
+    info_nce_backward, info_nce_loss, normal_cdf, stick_break, stick_break_dz, weibull_gamma_kl,
+    weibull_gamma_kl_grad, weibull_weight, AvitmOptions, Prior,
 };
 use rand::Rng;
 
@@ -198,6 +198,8 @@ struct Reparam {
     ln_l: Vec<f64>,
     g: Vec<f64>,
     s: f64,
+    // Stick-breaking scratch (the eta = sigmoid(z) breaks), empty off that path.
+    eta: Vec<f64>,
 }
 
 /// Compute `theta` for one document under the chosen prior, given the encoder cache
@@ -217,7 +219,17 @@ fn reparam_theta(cache: &Cache, eps: &[f64], prior: Prior, noise_free: bool) -> 
                 }
                 softmax(&z)
             };
-            Reparam { theta, kw: vec![], lam: vec![], ln_l: vec![], g: vec![], s: 0.0 }
+            Reparam { theta, kw: vec![], lam: vec![], ln_l: vec![], g: vec![], s: 0.0, eta: vec![] }
+        }
+        Prior::StickBreaking => {
+            // Gaussian latent (same as laplace), simplex via stick-breaking.
+            let z = if noise_free {
+                cache.mu.clone()
+            } else {
+                (0..k).map(|t| cache.mu[t] + (0.5 * cache.logvar[t]).exp() * eps[t]).collect()
+            };
+            let (eta, theta) = stick_break(&z);
+            Reparam { theta, kw: vec![], lam: vec![], ln_l: vec![], g: vec![], s: 0.0, eta }
         }
         Prior::Dirichlet => {
             let mut kw = vec![0.0; k];
@@ -240,7 +252,7 @@ fn reparam_theta(cache: &Cache, eps: &[f64], prior: Prior, noise_free: bool) -> 
                 s += gt;
             }
             let theta: Vec<f64> = (0..k).map(|t| g[t] / s).collect();
-            Reparam { theta, kw, lam, ln_l, g, s }
+            Reparam { theta, kw, lam, ln_l, g, s, eta: vec![] }
         }
     }
 }
@@ -318,6 +330,27 @@ fn backward_doc(
                 let dot: f64 = (0..k).map(|t| dzp[t] * tp[t]).sum();
                 for t in 0..k {
                     g_mu[t] += tp[t] * (dzp[t] - dot);
+                }
+            }
+        }
+        Prior::StickBreaking => {
+            // Gaussian latent (same reparam + N(0, I) KL as laplace); the simplex
+            // map is stick-breaking, so g_z routes through its Jacobian.
+            let g_z = stick_break_dz(&g_theta, &rep.eta, theta);
+            for t in 0..k {
+                let s = (0.5 * cache.logvar[t]).exp();
+                g_mu[t] += g_z[t];
+                g_logvar[t] += g_z[t] * eps[t] * 0.5 * s;
+                kl += -0.5 * (1.0 + cache.logvar[t] - cache.mu[t] * cache.mu[t] - cache.logvar[t].exp());
+                g_mu[t] += cache.mu[t];
+                g_logvar[t] += 0.5 * (cache.logvar[t].exp() - 1.0);
+            }
+            // Contrastive positive view = stick-breaking on mu: grad into mu only.
+            if let Some(dzp) = dtheta_pos {
+                let (eta_pos, theta_pos) = stick_break(&cache.mu);
+                let dz_pos = stick_break_dz(dzp, &eta_pos, &theta_pos);
+                for t in 0..k {
+                    g_mu[t] += dz_pos[t];
                 }
             }
         }
@@ -425,6 +458,12 @@ impl EtmVaeModel {
                 let cache = self.encoder.forward(xn);
                 let zeros = vec![0.0; self.num_topics];
                 reparam_theta(&cache, &zeros, Prior::Dirichlet, true).theta
+            }
+            Prior::StickBreaking => {
+                // Noise-free stick-breaking on the encoder mean, matching training.
+                let cache = self.encoder.forward(xn);
+                let zeros = vec![0.0; self.num_topics];
+                reparam_theta(&cache, &zeros, Prior::StickBreaking, true).theta
             }
         }
     }
@@ -756,7 +795,8 @@ mod tests {
                 }
                 // kl
                 match opts.prior {
-                    Prior::Laplace => {
+                    Prior::Laplace | Prior::StickBreaking => {
+                        // Both keep the Gaussian latent, so the KL is N(q || N(0, I)).
                         for t in 0..k {
                             total += -0.5
                                 * (1.0 + cache.logvar[t] - cache.mu[t].powi(2) - cache.logvar[t].exp());
@@ -879,6 +919,23 @@ mod tests {
         };
         let max_rel = etm_fd_check(opts);
         assert!(max_rel < 1e-4, "etm contrastive+dirichlet max relative error {max_rel}");
+    }
+
+    #[test]
+    fn etm_stick_breaking_gradients_match_fd() {
+        let opts = AvitmOptions { prior: Prior::StickBreaking, ..AvitmOptions::default() };
+        let max_rel = etm_fd_check(opts);
+        assert!(max_rel < 1e-4, "etm stick-breaking max relative error {max_rel}");
+    }
+
+    #[test]
+    fn etm_contrastive_and_stick_breaking_compose_fd() {
+        let opts = AvitmOptions {
+            prior: Prior::StickBreaking, contrastive: true,
+            contrastive_weight: 0.6, contrastive_temp: 0.5,
+        };
+        let max_rel = etm_fd_check(opts);
+        assert!(max_rel < 1e-4, "etm contrastive+stick-breaking max relative error {max_rel}");
     }
 
     // Planted blocks: K word-blocks, each document drawn from one block. The VAE

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -435,10 +435,72 @@ fn lgamma(x: f64) -> f64 {
 ///   logistic-normal KL. The Gaussian reparameterization is replaced too; we reuse
 ///   the same Gaussian noise turned into uniforms by `Phi(eps)` so the laplace path
 ///   is unaffected.
+/// - [`Prior::StickBreaking`] is the Gaussian stick-breaking construction (Miao,
+///   Grefenstette & Blunsom 2017, "GSB"; the reparameterizable simplex map of
+///   Nalisnick & Smyth 2017). It keeps the *same* Gaussian latent and Gaussian KL
+///   as `Prior::Laplace` — only the map onto the simplex changes: instead of
+///   `softmax(z)`, the `K-1` breaks `eta_t = sigmoid(z_t)` are turned into topic
+///   proportions by stick-breaking (`theta_t = eta_t * prod_{j<t}(1 - eta_j)`, with
+///   the last stick the remainder). The construction is nonparametric-flavored: the
+///   ordered sticks let early topics claim most mass and later ones decay, softening
+///   the fixed-`K` assumption. Because the latent and KL are unchanged, the laplace
+///   path stays byte-identical.
 #[derive(Clone, Copy, PartialEq, Eq, Debug)]
 pub enum Prior {
     Laplace,
     Dirichlet,
+    StickBreaking,
+}
+
+/// Gaussian stick-breaking map: turn a latent vector `z` (length `K`) into topic
+/// proportions on the simplex. The first `K-1` entries are breaks
+/// `eta_t = sigmoid(z_t)`; `theta_t = eta_t * prod_{j<t}(1 - eta_j)` and the last
+/// topic takes the remaining stick. Returns `(eta, theta)`; `eta[K-1]` is unused
+/// (left 0) and `theta` sums to 1 by construction. Shared by `prodlda` and `etm_vae`.
+pub(crate) fn stick_break(z: &[f64]) -> (Vec<f64>, Vec<f64>) {
+    let k = z.len();
+    let mut eta = vec![0.0; k];
+    let mut theta = vec![0.0; k];
+    if k == 0 {
+        return (eta, theta);
+    }
+    let mut r = 1.0; // remaining stick R_t = prod_{j<t}(1 - eta_j)
+    for t in 0..k - 1 {
+        let e = sigmoid(z[t]);
+        eta[t] = e;
+        theta[t] = e * r;
+        r *= 1.0 - e;
+    }
+    theta[k - 1] = r;
+    (eta, theta)
+}
+
+/// Backward of [`stick_break`]: map `dtheta` (grad w.r.t. the proportions) to `dz`
+/// (grad w.r.t. the latent), folding in the `sigmoid` derivative. `eta` and `theta`
+/// are the forward values. With `R_j = prod_{i<j}(1 - eta_i)` and the suffix sum
+/// `S_j = sum_{t>j} dtheta_t * theta_t`, the break gradient is
+/// `deta_j = dtheta_j R_j - S_j / (1 - eta_j)`; multiplying by the sigmoid Jacobian
+/// `eta_j (1 - eta_j)` cancels the division, giving
+/// `dz_j = eta_j (1 - eta_j) dtheta_j R_j - eta_j S_j`. `dz[K-1] = 0` (unused break).
+pub(crate) fn stick_break_dz(dtheta: &[f64], eta: &[f64], theta: &[f64]) -> Vec<f64> {
+    let k = dtheta.len();
+    let mut dz = vec![0.0; k];
+    if k < 2 {
+        return dz;
+    }
+    // suffix[j] = sum_{t>=j} dtheta_t * theta_t, so S_j = suffix[j+1].
+    let mut suffix = vec![0.0; k + 1];
+    for t in (0..k).rev() {
+        suffix[t] = suffix[t + 1] + dtheta[t] * theta[t];
+    }
+    let mut r = 1.0;
+    for j in 0..k - 1 {
+        let e = eta[j];
+        let s_j = suffix[j + 1];
+        dz[j] = e * (1.0 - e) * dtheta[j] * r - e * s_j;
+        r *= 1.0 - e;
+    }
+    dz
 }
 
 /// The two orthogonal `fit_avitm` options (#174, #176). Both default to the
@@ -495,10 +557,19 @@ struct BatchCache {
     // For each (doc, topic): Weibull shape `kw`, scale `lam`, the constant
     // `L = -ln(1-u)` from the noise, and the unnormalized weight `g = lam * L^(1/kw)`.
     dir: Option<DirCache>,
+    // Stick-breaking scratch (the `eta = sigmoid(z)` breaks), empty off that path.
+    // Needed by the backward to recompute the stick-breaking Jacobian.
+    sb: Option<SbCache>,
     // Contrastive positive-view topic vectors (the no-noise / posterior-mean theta),
     // and the per-doc softmax used to build them, retained so the backward can push
     // the InfoNCE gradient through both views. Empty when `contrastive == false`.
     contrast: Option<ContrastCache>,
+}
+
+/// Per-(doc, topic) stick-breaking quantities: the `eta = sigmoid(z)` breaks for the
+/// Gaussian stick-breaking prior. `theta` lives in `BatchCache.theta`.
+struct SbCache {
+    eta: Vec<Vec<f64>>, // N x K (entry K-1 unused)
 }
 
 /// Per-(doc, topic) Weibull reparameterization quantities for the Dirichlet prior.
@@ -727,6 +798,7 @@ fn batch_forward(
     let (lv, c_lv, mean_lv, var_lv) = bn_lv.forward_train(&lv_raw);
 
     let dirichlet = opts.prior == Prior::Dirichlet;
+    let stick = opts.prior == Prior::StickBreaking;
     let contrastive = opts.contrastive;
 
     // Reparameterize and decode.
@@ -739,6 +811,8 @@ fn batch_forward(
     let mut d_ln_l = vec![vec![0.0; k]; n];
     let mut d_g = vec![vec![0.0; k]; n];
     let mut d_s = vec![0.0; n];
+    // Stick-breaking scratch (eta breaks).
+    let mut sb_eta = vec![vec![0.0; k]; n];
     // Contrastive positive-view scratch.
     let mut theta_pos = vec![vec![0.0; k]; n];
     let mut g_pos = vec![vec![0.0; k]; n];
@@ -761,11 +835,18 @@ fn batch_forward(
             d_s[i] = s;
             (0..k).map(|t| d_g[i][t] / s).collect()
         } else {
+            // Gaussian latent (shared by laplace and stick-breaking).
             let mut z = vec![0.0; k];
             for t in 0..k {
                 z[t] = mu[i][t] + (0.5 * lv[i][t]).exp() * batch.eps[i][t];
             }
-            softmax(&z)
+            if stick {
+                let (eta, th) = stick_break(&z);
+                sb_eta[i] = eta;
+                th
+            } else {
+                softmax(&z)
+            }
         };
         for t in 0..k {
             theta_do[i][t] = th[t] * batch.masks_t[i][t];
@@ -788,6 +869,10 @@ fn batch_forward(
                 for t in 0..k {
                     theta_pos[i][t] = g_pos[i][t] / s;
                 }
+            } else if stick {
+                // No-noise stick-breaking on z = mu.
+                let (_eta_pos, th_pos) = stick_break(&mu[i]);
+                theta_pos[i] = th_pos;
             } else {
                 theta_pos[i] = softmax(&mu[i]);
             }
@@ -856,6 +941,7 @@ fn batch_forward(
         } else {
             None
         },
+        sb: if stick { Some(SbCache { eta: sb_eta }) } else { None },
         contrast: if contrastive {
             Some(ContrastCache { theta_pos, g_pos, s_pos })
         } else {
@@ -913,6 +999,7 @@ fn batch_backward(
     let (h, k, v) = (w.hidden, w.k, w.v);
     let n = batch.xns.len();
     let dirichlet = opts.prior == Prior::Dirichlet;
+    let stick = opts.prior == Prior::StickBreaking;
 
     // --- Decoder: loss -> logit -> BN -> logit_raw -> (theta_do, beta). ---
     // d loss / d logit_iv = total_i * recon_iv - count_iv.
@@ -990,9 +1077,16 @@ fn batch_backward(
                 dlv[i][t] += dlam * sigmoid(c.lv[i][t]);
             }
         } else {
-            // theta = softmax(z): softmax backward.
-            let dot: f64 = (0..k).map(|t| dtheta[t] * c.theta[i][t]).sum();
-            let dz: Vec<f64> = (0..k).map(|t| c.theta[i][t] * (dtheta[t] - dot)).collect();
+            // Gaussian latent z = mu + exp(lv/2) * eps. The simplex map differs:
+            // laplace -> softmax(z); stick-breaking -> sigmoid + stick-breaking. Both
+            // share the same Gaussian reparameterization and Gaussian KL below.
+            let dz: Vec<f64> = if stick {
+                let sb = c.sb.as_ref().unwrap();
+                stick_break_dz(&dtheta, &sb.eta[i], &c.theta[i])
+            } else {
+                let dot: f64 = (0..k).map(|t| dtheta[t] * c.theta[i][t]).sum();
+                (0..k).map(|t| c.theta[i][t] * (dtheta[t] - dot)).collect()
+            };
             // z = mu + exp(lv/2) * eps.
             for t in 0..k {
                 let s = (0.5 * c.lv[i][t]).exp();
@@ -1017,6 +1111,13 @@ fn batch_backward(
                     &dzp[i], &cc.g_pos[i], cc.s_pos[i], &kw_pos, &lam_pos, &ln_l_pos,
                     &c.mu[i], &c.lv[i], &mut dmu[i], &mut dlv[i],
                 );
+            } else if stick {
+                // theta_pos via no-noise stick-breaking on z = mu; grad into mu only.
+                let (eta_pos, _) = stick_break(&c.mu[i]);
+                let dz_pos = stick_break_dz(&dzp[i], &eta_pos, &cc.theta_pos[i]);
+                for t in 0..k {
+                    dmu[i][t] += dz_pos[t];
+                }
             } else {
                 // theta_pos = softmax(mu): softmax backward into mu only.
                 let tp = &cc.theta_pos[i];
@@ -1179,6 +1280,10 @@ pub struct ProdldaModel {
     pub epochs_run: usize,
     pub weights: Weights,
     pub bn_mu: BatchNorm,
+    /// The prior the model was fit under, so `transform` applies the matching
+    /// noise-free simplex map (softmax for laplace/dirichlet, stick-breaking for
+    /// `Prior::StickBreaking`).
+    pub prior: Prior,
 }
 
 impl ProdldaModel {
@@ -1209,7 +1314,15 @@ impl ProdldaModel {
                 let no_drop = vec![1.0; self.weights.hidden];
                 let dc = self.weights.encode_raw(&xn, emb, &no_drop);
                 let mu = self.bn_mu.forward_eval_row(&dc.mu_raw);
-                softmax(&mu)
+                // Noise-free point estimate under the model's prior. Laplace and
+                // Dirichlet both use softmax(mu) as the cheap point estimate (the
+                // shipped behavior); stick-breaking uses its own simplex map so the
+                // proportions stay consistent with the decoder it was trained on.
+                if self.prior == Prior::StickBreaking {
+                    stick_break(&mu).1
+                } else {
+                    softmax(&mu)
+                }
             })
             .collect()
     }
@@ -1388,6 +1501,7 @@ pub fn fit_avitm<R: Rng>(
         epochs_run,
         weights: w,
         bn_mu,
+        prior: opts.prior,
     };
     let doc_topic = model.transform_with_emb(docs, embs);
     ProdldaModel { doc_topic, ..model }
@@ -1597,6 +1711,20 @@ mod tests {
         assert!(max_rel < 1e-4, "dirichlet emb-only max relative error {max_rel}");
     }
 
+    #[test]
+    fn stick_breaking_gradients_match_fd_bow_only() {
+        let opts = AvitmOptions { prior: Prior::StickBreaking, ..AvitmOptions::default() };
+        let max_rel = fd_check_mode_opts(InputMode::BowOnly, 0, opts);
+        assert!(max_rel < 1e-4, "stick-breaking bow-only max relative error {max_rel}");
+    }
+
+    #[test]
+    fn stick_breaking_gradients_match_fd_emb_only() {
+        let opts = AvitmOptions { prior: Prior::StickBreaking, ..AvitmOptions::default() };
+        let max_rel = fd_check_mode_opts(InputMode::EmbOnly, 6, opts);
+        assert!(max_rel < 1e-4, "stick-breaking emb-only max relative error {max_rel}");
+    }
+
     // --- composition: both flags on at once must still FD-check ------------------
     #[test]
     fn contrastive_and_dirichlet_compose_fd() {
@@ -1608,6 +1736,18 @@ mod tests {
         };
         let max_rel = fd_check_mode_opts(InputMode::BowEmb, 6, opts);
         assert!(max_rel < 1e-4, "contrastive+dirichlet max relative error {max_rel}");
+    }
+
+    #[test]
+    fn contrastive_and_stick_breaking_compose_fd() {
+        let opts = AvitmOptions {
+            prior: Prior::StickBreaking,
+            contrastive: true,
+            contrastive_weight: 0.6,
+            contrastive_temp: 0.5,
+        };
+        let max_rel = fd_check_mode_opts(InputMode::BowEmb, 6, opts);
+        assert!(max_rel < 1e-4, "contrastive+stick-breaking max relative error {max_rel}");
     }
 
     // The Weibull-to-Gamma KL gradient checked directly against finite differences.
@@ -1841,6 +1981,48 @@ mod tests {
             covered.insert(dom);
         }
         assert_eq!(covered.len(), k, "dirichlet: topics did not cover all blocks");
+    }
+
+    #[test]
+    fn fit_recovers_planted_blocks_stick_breaking() {
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let (k, block) = (3usize, 8usize);
+        let v = k * block;
+        let docs: Vec<Vec<u32>> = (0..180)
+            .map(|d| {
+                let b = d % k;
+                (0..15).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+            })
+            .collect();
+        let opts = AvitmOptions { prior: Prior::StickBreaking, ..AvitmOptions::default() };
+        let m = fit_avitm(
+            &docs, &vec![Vec::new(); docs.len()], InputMode::BowOnly, k, v, 0, 32, 0.5, 0.0,
+            400, 60, 0.005, 0.0, opts, &mut rng,
+        );
+        let tw = m.topic_word();
+        for row in &tw {
+            assert!((row.iter().sum::<f64>() - 1.0).abs() < 1e-9);
+        }
+        // Stick-breaking proportions live on the simplex by construction.
+        for row in &m.doc_topic {
+            assert!((row.iter().sum::<f64>() - 1.0).abs() < 1e-9);
+            assert!(row.iter().all(|&x| x >= 0.0));
+        }
+        // Each topic dominated by a single planted block; every block covered. The
+        // ordered sticks mix a little more, so use the same majority criterion.
+        let mut covered = std::collections::HashSet::new();
+        for row in tw.iter().take(k) {
+            let mut ord: Vec<usize> = (0..v).collect();
+            ord.sort_by(|&a, &b| row[b].total_cmp(&row[a]));
+            let mut counts = vec![0usize; k];
+            for &w in &ord[..3] {
+                counts[w / block] += 1;
+            }
+            let (dom, &cnt) = counts.iter().enumerate().max_by_key(|(_, &c)| c).unwrap();
+            assert!(cnt >= 2, "stick-breaking topic top words do not concentrate in a block");
+            covered.insert(dom);
+        }
+        assert_eq!(covered.len(), k, "stick-breaking: topics did not cover all blocks");
     }
 }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -11480,11 +11480,7 @@ impl ETM {
                     w_ls: s.enc_w_ls.unwrap_or_default(),
                     b_ls: s.enc_b_ls.unwrap_or_default(),
                 },
-                prior: if s.prior == "dirichlet" {
-                    prodlda::Prior::Dirichlet
-                } else {
-                    prodlda::Prior::Laplace
-                },
+                prior: prior_from_str(&s.prior),
             })
         } else { None };
         Ok(ETM {
@@ -12211,6 +12207,17 @@ struct ProdldaState {
 /// Validate the VAE-model flags (#174, #176) and build the [`prodlda::AvitmOptions`]
 /// passed into `fit_avitm`. With `prior == "laplace"` and `contrastive == false`
 /// (the defaults) this yields `AvitmOptions::default()`, the pre-flag code path.
+/// Map a stored/validated prior string to the enum. Lenient (unknown -> laplace);
+/// used on the `load` path where the string was already validated at construction.
+/// Construction itself validates strictly via [`build_avitm_options`].
+fn prior_from_str(prior: &str) -> prodlda::Prior {
+    match prior {
+        "dirichlet" => prodlda::Prior::Dirichlet,
+        "stick_breaking" => prodlda::Prior::StickBreaking,
+        _ => prodlda::Prior::Laplace,
+    }
+}
+
 fn build_avitm_options(
     prior: &str,
     contrastive: bool,
@@ -12220,9 +12227,10 @@ fn build_avitm_options(
     let prior_enum = match prior {
         "laplace" => prodlda::Prior::Laplace,
         "dirichlet" => prodlda::Prior::Dirichlet,
+        "stick_breaking" => prodlda::Prior::StickBreaking,
         other => {
             return Err(PyValueError::new_err(format!(
-                "prior must be \"laplace\" or \"dirichlet\", got {other:?}"
+                "prior must be \"laplace\", \"dirichlet\", or \"stick_breaking\", got {other:?}"
             )))
         }
     };
@@ -12553,6 +12561,7 @@ impl ProdLDA {
                     running_var: s.bn_running_var.unwrap_or_else(|| vec![1.0; k]),
                     momentum: 0.1,
                 },
+                prior: prior_from_str(&s.prior),
             })
         } else { None };
         Ok(ProdLDA {
@@ -13053,6 +13062,7 @@ macro_rules! ctm_embedding_model {
                             running_var: s.bn_running_var.unwrap_or_else(|| vec![1.0; k]),
                             momentum: 0.1,
                         },
+                        prior: prior_from_str(&s.prior),
                     })
                 } else {
                     None

--- a/tests/test_combinedtm.py
+++ b/tests/test_combinedtm.py
@@ -231,3 +231,23 @@ def test_flags_save_load_roundtrip(cls, tmp_path):
     assert loaded.contrastive is True
     assert np.array_equal(loaded.topic_word, m.topic_word)
     assert np.array_equal(loaded.doc_topic, m.doc_topic)
+
+
+@pytest.mark.parametrize("cls", MODELS, ids=MODEL_IDS)
+def test_stick_breaking_valid_deterministic_roundtrip(cls, tmp_path):
+    docs, embs, _ = _planted(n=120)
+    base = _model(cls, seed=1); base.fit(docs, embs, iters=60)
+    sb = _model(cls, seed=1, prior="stick_breaking"); sb.fit(docs, embs, iters=60)
+    assert sb.prior == "stick_breaking"
+    assert not np.allclose(base.topic_word, sb.topic_word)
+    assert np.allclose(sb.topic_word.sum(axis=1), 1.0)
+    assert np.allclose(sb.doc_topic.sum(axis=1), 1.0)
+    # deterministic
+    sb2 = _model(cls, seed=1, prior="stick_breaking"); sb2.fit(docs, embs, iters=60)
+    assert np.array_equal(sb.topic_word, sb2.topic_word)
+    # save/load
+    path = str(tmp_path / "ctm_sb.bin")
+    sb.save(path)
+    loaded = cls.load(path)
+    assert loaded.prior == "stick_breaking"
+    assert np.array_equal(loaded.doc_topic, sb.doc_topic)

--- a/tests/test_etm.py
+++ b/tests/test_etm.py
@@ -164,3 +164,28 @@ def test_etm_vae_flags_save_load_roundtrip(tmp_path):
     loaded = topica.ETM.load(path)
     assert np.array_equal(loaded.topic_word, m.topic_word)
     assert np.array_equal(loaded.doc_topic, m.doc_topic)
+
+
+def test_etm_stick_breaking_valid_and_deterministic():
+    docs, vocab, word_emb, _ = _planted()
+    base = _vae(seed=1); base.fit(docs, word_emb, vocab, iters=80)
+    sb = _vae(seed=1, prior="stick_breaking"); sb.fit(docs, word_emb, vocab, iters=80)
+    # The prior changes the fit but the outputs stay on the simplex.
+    assert not np.allclose(base.topic_word, sb.topic_word)
+    assert np.allclose(sb.topic_word.sum(axis=1), 1.0)
+    assert np.allclose(sb.doc_topic.sum(axis=1), 1.0)
+    # determinism
+    sb2 = _vae(seed=1, prior="stick_breaking"); sb2.fit(docs, word_emb, vocab, iters=80)
+    assert np.array_equal(sb.topic_word, sb2.topic_word)
+    assert np.array_equal(sb.doc_topic, sb2.doc_topic)
+
+
+def test_etm_stick_breaking_save_load_roundtrip(tmp_path):
+    docs, vocab, word_emb, _ = _planted()
+    m = _vae(seed=2, prior="stick_breaking"); m.fit(docs, word_emb, vocab, iters=80)
+    path = str(tmp_path / "etm_sb.bin")
+    m.save(path)
+    loaded = topica.ETM.load(path)
+    # The stick-breaking map survives the round-trip (doc_topic matches exactly).
+    assert np.array_equal(loaded.topic_word, m.topic_word)
+    assert np.array_equal(loaded.doc_topic, m.doc_topic)

--- a/tests/test_prodlda.py
+++ b/tests/test_prodlda.py
@@ -158,3 +158,56 @@ def test_prodlda_flags_save_load_roundtrip(tmp_path):
     assert loaded.contrastive is True
     assert np.array_equal(loaded.topic_word, m.topic_word)
     assert np.array_equal(loaded.doc_topic, m.doc_topic)
+
+
+# --- stick-breaking prior (#176) ---------------------------------------------
+
+def test_prodlda_stick_breaking_exposed_and_valid():
+    docs, _, _ = _planted(n=120)
+    base = _model(seed=1); base.fit(docs, iters=60)
+    sb = _model(seed=1, prior="stick_breaking"); sb.fit(docs, iters=60)
+    assert sb.prior == "stick_breaking"
+    # The prior changes the fitted topics but the outputs stay on the simplex.
+    assert not np.allclose(base.topic_word, sb.topic_word)
+    assert np.allclose(sb.topic_word.sum(axis=1), 1.0)
+    assert np.allclose(sb.doc_topic.sum(axis=1), 1.0)
+    assert (sb.doc_topic >= 0).all()
+
+
+def test_prodlda_stick_breaking_deterministic():
+    docs, _, _ = _planted(n=120)
+    for kw in ({"prior": "stick_breaking"},
+               {"prior": "stick_breaking", "contrastive": True}):
+        a = _model(seed=5, **kw); a.fit(docs, iters=60)
+        b = _model(seed=5, **kw); b.fit(docs, iters=60)
+        assert np.array_equal(a.topic_word, b.topic_word)
+        assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+def test_prodlda_stick_breaking_recovers_planted():
+    docs, vocab, truth = _planted(n=240)
+    m = _model(seed=0, prior="stick_breaking"); m.fit(docs, iters=200)
+    # Each planted block should dominate some topic's top words (majority of top-3).
+    tw = m.topic_word
+    blocks = {w: int(w[1]) for w in vocab}  # "b{block}w{i}"
+    covered = set()
+    voc = m.vocabulary
+    for t in range(m.num_topics):
+        top = np.argsort(tw[t])[::-1][:3]
+        b = [blocks[voc[j]] for j in top]
+        covered.add(max(set(b), key=b.count))
+    assert len(covered) == 3
+
+
+def test_prodlda_stick_breaking_save_load_roundtrip(tmp_path):
+    docs, _, _ = _planted(n=120)
+    m = _model(seed=2, prior="stick_breaking"); m.fit(docs, iters=60)
+    path = str(tmp_path / "prodlda_sb.bin")
+    m.save(path)
+    loaded = topica.ProdLDA.load(path)
+    assert loaded.prior == "stick_breaking"
+    assert np.array_equal(loaded.topic_word, m.topic_word)
+    assert np.array_equal(loaded.doc_topic, m.doc_topic)
+    # transform after load uses the stick-breaking map (matches the fitted doc_topic).
+    dt = loaded.transform(docs[:5])
+    assert np.allclose(dt.sum(axis=1), 1.0)


### PR DESCRIPTION
## What

Adds a third document-topic **`prior="stick_breaking"`** to the four amortized-VAE
models — **ProdLDA, CombinedTM, ZeroShotTM, and `ETM(inference="vae")`** — the
Gaussian stick-breaking construction (Miao, Grefenstette & Blunsom 2017, "GSB";
reparameterizable simplex map of Nalisnick & Smyth 2017).

This **completes #176**. That issue asked for "alternative-prior VAE models
(Dirichlet / stick-breaking)"; the Weibull-**Dirichlet** half (its self-described
"highest-value" route) already shipped in #191 as `prior="dirichlet"`. This PR adds
the remaining stick-breaking prior.

## How it works

Stick-breaking keeps the **same Gaussian latent and Gaussian KL** as the `"laplace"`
default — only the map onto the simplex changes. Instead of `softmax(z)`, the `K-1`
breaks `ηₜ = sigmoid(zₜ)` are turned into proportions by stick-breaking:

```
θₜ = ηₜ · ∏_{j<t} (1 − η_j),   with the last topic the remainder.
```

The ordered sticks let early topics claim most mass and later ones decay — a
nonparametric-flavored prior that softens the fixed-`K` assumption. Because only the
simplex map changes, **the `"laplace"` default stays bit-identical** (verified).

## Validation

- **Hand-coded gradients, FD-checked < 1e-4** on both VAE cores:
  - `prodlda.rs`: bow-only, emb-only, and **composed with the `contrastive` flag**.
  - `etm_vae.rs`: the same, via its FD harness.
  - The backward is division-free (the `1/(1-η)` term cancels against the sigmoid
    Jacobian), so it stays stable as breaks saturate.
- **Planted-block recovery** (Rust + Python): a 3-block synthetic corpus recovers
  one dominant block per topic, covering all blocks.
- **Valid distributions, determinism, save/load** across all four classes.
- Rust `cargo test --lib`: 140 passed. `pytest tests/`: 2637 passed, 26 skipped.
  `mkdocs build --strict`: clean.

## Surface

```python
m = topica.ProdLDA(num_topics=20, prior="stick_breaking", seed=42)
# also CombinedTM, ZeroShotTM, ETM(inference="vae")
```

Strict validation at construction (unknown priors raise); lenient on load. Docs
(`docs/guides/models.md`, README reference list) and the `.pyi` stubs updated.

Closes #176.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
