### PR TITLE
Add llm_coherence + llm_intrusion (LLM-based topic evaluation; first cut of #197)

### DIFF
--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -53,6 +53,10 @@ and in the `topica.validation` module.
 
 ::: topica.document_intrusion
 
+::: topica.llm_coherence
+
+::: topica.llm_intrusion
+
 ::: topica.bootstrap_stability
 
 ::: topica.search_k

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -77,6 +77,33 @@ topica.word_intrusion(model, n_words=5, seed=0)           # top words + an intru
 topica.document_intrusion(model, texts=texts, n_docs=3)   # top docs + an intruder
 ```
 
+## LLM-based evaluation
+
+Automated coherence (NPMI, c_v) correlates only weakly with human judgment. Stammbach
+et al. (2023) show that an LLM, prompted with the *same* instructions the crowd-workers
+received, tracks human ratings more closely — especially the rating task. topica
+exposes two such diagnostics; both reuse the provider-agnostic `topica[llm]` backend.
+
+```python
+call = topica.llm_backend("gpt-4o-mini", temperature=0)    # or any provider / openrouter / ollama
+
+topica.llm_coherence(model, call=call, n_words=10)         # per-topic 1-3 rating (the headline)
+topica.llm_intrusion(model, call=call, n_words=5)          # LLM picks the intruder -> accuracy
+```
+
+`llm_coherence` is the one to lead with: in the paper it beats NPMI/c_v at tracking
+human topic *rankings* (and on the Hoyle 2021 gold, `parity/llm_coherence_compare.py`
+reproduces that here). `llm_intrusion` matches human accuracy on the *task* but is a
+weaker ranking signal, so report it alongside, not instead.
+
+!!! warning "These are `llm-bounded`, not bit-exact"
+    Unlike the rest of topica's diagnostics, these call an external model and are
+    **not** reproducible bit-for-bit. Use `temperature=0` (or `n_samples>1`, which
+    calls the model repeatedly and aggregates by mean/majority-vote) for stability,
+    and read the result as a measurement with model-dependent noise. The paper's
+    prompts are kept verbatim in the overridable `topica.LLM_EVAL_PROMPTS` dict. Cost
+    is O(K) LLM calls; pass a cheap model.
+
 ## Stability and model selection
 
 ```python

--- a/parity/llm_coherence_compare.py
+++ b/parity/llm_coherence_compare.py
@@ -1,0 +1,117 @@
+"""Human-correlation check for `llm_coherence` against the Hoyle et al. (2021) human
+topic-rating gold, replicating Stammbach et al. (2023).
+
+Stammbach et al. show an LLM prompted with the crowd-worker instructions correlates
+with human topic *ratings* better than NPMI / c_v. This script reproduces that on the
+public Hoyle 2021 data (300 topics: wikitext + nytimes, each fit by mallet / dvae /
+etm, 50 topics each, with mean human ratings and c_npmi already computed). For each
+topic it runs `topica.llm_coherence` and reports the Spearman correlation of the LLM
+ratings vs the mean human ratings, against the NPMI baseline.
+
+Skips cleanly when the data cannot be fetched or no LLM backend is configured. The
+LLM is `llm-bounded`, so this is a measurement (with model noise), not a bit-exact
+gate; it is NOT run in CI. Configure the model/limit via the constants below.
+
+Run:  VIRTUAL_ENV=.venv-dev .venv-dev/bin/python parity/llm_coherence_compare.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import urllib.request
+
+import numpy as np
+
+DATA_URL = "https://raw.githubusercontent.com/ahoho/topics/dev/data/human/all_data/all_data.json"
+CACHE = "/tmp/hoyle_human_all_data.json"
+MODEL = os.environ.get("LLM_EVAL_MODEL", "openrouter/qwen/qwen3-235b-a22b-2507")
+N_WORDS = 10
+PER_COMBO = int(os.environ.get("LLM_EVAL_LIMIT", "0")) or None  # None = all 50/combo
+
+
+def available() -> bool:
+    try:
+        import topica  # noqa: F401
+    except Exception:
+        return False
+    # an LLM backend must be reachable
+    if not (os.environ.get("OPENROUTER_API_KEY") or os.environ.get("OPENAI_API_KEY")
+            or os.environ.get("ANTHROPIC_API_KEY")):
+        return False
+    return True
+
+
+def _load():
+    if not os.path.exists(CACHE):
+        try:
+            urllib.request.urlretrieve(DATA_URL, CACHE)
+        except Exception:
+            return None
+    with open(CACHE) as f:
+        return json.load(f)
+
+
+def _spearman(a, b):
+    try:
+        from scipy.stats import spearmanr
+        return float(spearmanr(a, b).statistic)
+    except Exception:
+        # rank-correlation without scipy
+        ra = np.argsort(np.argsort(a)); rb = np.argsort(np.argsort(b))
+        ra = ra - ra.mean(); rb = rb - rb.mean()
+        denom = (np.sqrt((ra ** 2).sum()) * np.sqrt((rb ** 2).sum())) or 1.0
+        return float((ra * rb).sum() / denom)
+
+
+def run(verbose: bool = True) -> dict:
+    import topica
+
+    data = _load()
+    if data is None:
+        raise RuntimeError("could not fetch the Hoyle human data")
+    call = topica.llm_backend(MODEL, temperature=0)
+
+    llm_all, human_all, npmi_all = [], [], []
+    rows = []
+    for dataset in ("wikitext", "nytimes"):
+        for model_name in ("mallet", "dvae", "etm"):
+            entry = data[dataset][model_name]
+            topics = entry["topics"]
+            human = entry["metrics"]["ratings_scores_avg"]
+            npmi = entry["metrics"]["c_npmi_10_full"]
+            if PER_COMBO:
+                topics, human, npmi = topics[:PER_COMBO], human[:PER_COMBO], npmi[:PER_COMBO]
+            word_lists = [t[:N_WORDS] for t in topics]
+            llm = topica.llm_coherence(word_lists, call=call, n_words=N_WORDS)
+            ok = ~np.isnan(llm)
+            llm, human, npmi = llm[ok], np.array(human)[ok], np.array(npmi)[ok]
+            rows.append((f"{dataset}/{model_name}", _spearman(llm, human), _spearman(npmi, human), len(llm)))
+            llm_all += list(llm); human_all += list(human); npmi_all += list(npmi)
+
+    out = {
+        "llm_spearman": _spearman(llm_all, human_all),
+        "npmi_spearman": _spearman(npmi_all, human_all),
+        "n_topics": len(llm_all),
+        "per_combo": rows,
+    }
+    if verbose:
+        print(f"llm_coherence vs human ratings ({out['n_topics']} topics, model={MODEL}):")
+        print(f"  {'combo':18s} {'LLM':>7s} {'NPMI':>7s}  n")
+        for name, ls, ns, n in rows:
+            print(f"  {name:18s} {ls:7.3f} {ns:7.3f}  {n}")
+        print(f"  {'CONCAT':18s} {out['llm_spearman']:7.3f} {out['npmi_spearman']:7.3f}  {out['n_topics']}")
+        print(f"\n  llm_coherence Spearman {out['llm_spearman']:.3f} vs NPMI {out['npmi_spearman']:.3f} "
+              f"(paper: LLM ~0.6 > NPMI ~0.45)")
+    return out
+
+
+if __name__ == "__main__":
+    if not available():
+        print("topica / an LLM API key not available; skipping llm_coherence parity.")
+    else:
+        r = run()
+        assert r["llm_spearman"] > r["npmi_spearman"], (
+            f"llm_coherence ({r['llm_spearman']:.3f}) did not beat NPMI "
+            f"({r['npmi_spearman']:.3f})")
+        print("\nOK: llm_coherence correlates with human ratings better than NPMI.")

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -145,6 +145,9 @@ from .coherence import (  # noqa: E402
     exclusivity,
     word_intrusion,
     document_intrusion,
+    llm_coherence,
+    llm_intrusion,
+    LLM_EVAL_PROMPTS,
 )
 from .registry import list_models, ModelInfo, REGISTRY  # noqa: E402  model taxonomy / discovery
 
@@ -267,6 +270,9 @@ __all__ = [
     "exclusivity",
     "word_intrusion",
     "document_intrusion",
+    "llm_coherence",
+    "llm_intrusion",
+    "LLM_EVAL_PROMPTS",
     "frex",
     "label_topics",
     "topic_table",

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -25,6 +25,7 @@ These are pure-Python/numpy and work with any model here: pass a fitted model
 from __future__ import annotations
 
 import math
+import re
 from collections import Counter, defaultdict
 from itertools import combinations
 
@@ -590,3 +591,170 @@ def document_intrusion(model_or_theta, texts=None, *, n_docs=3, seed=0):
             entry["texts"] = [str(texts[i])[:120] for i in shuffled]
         out.append(entry)
     return out
+
+
+# ---------------------------------------------------------------------------
+# LLM-based topic evaluation (Stammbach, Zouhar, Hoyle, Sachan & Ash 2023,
+# "Revisiting Automated Topic Model Evaluation with Large Language Models",
+# EMNLP; arXiv:2305.12152). An LLM, prompted with the same instructions the
+# crowd-workers received, correlates with human judgment better than NPMI / c_v
+# -- especially the *rating* task (`llm_coherence`). These are `llm-bounded`: they
+# call an external model, so they are NOT bit-deterministic like the rest of the
+# coherence suite. Use `temperature=0` (or `n_samples>1` and aggregate) for
+# stability, and read the result as a measurement with model-dependent noise.
+# ---------------------------------------------------------------------------
+
+# The prompts ARE the method: kept verbatim from the paper for comparability, as a
+# module-level overridable dict (pass `prompts=` to override). `{dataset}` is an
+# optional dataset-description clause (small reported gains); `{words}` is the
+# comma-separated, shuffled word list.
+RATING_PROMPT = (
+    "You are a helpful assistant evaluating the top words of a topic model output "
+    "for a given topic. {dataset}Please rate how related the following words are to "
+    'each other on a scale from 1 to 3 ("1" = not very related, "2" = moderately '
+    'related, "3" = very related). Reply with a single number, indicating the '
+    "overall appropriateness of the topic.\n\n{words}"
+)
+INTRUSION_PROMPT = (
+    "You are a helpful assistant evaluating the top words of a topic model output "
+    "for a given topic. {dataset}Select which word is the least related to all other "
+    "words. If multiple words do not fit, choose the word that is most out of place. "
+    "Reply with a single word.\n\n{words}"
+)
+LLM_EVAL_PROMPTS: dict[str, str] = {"rating": RATING_PROMPT, "intrusion": INTRUSION_PROMPT}
+
+
+def _resolve_llm_call(call):
+    """Turn `call` into a callable ``str -> str``. Accepts a callable (used as-is)
+    or a model-name string (routed through :func:`topica.llm_backend`)."""
+    if callable(call):
+        return call
+    if isinstance(call, str):
+        from .labeling import llm_backend
+
+        return llm_backend(call)
+    raise TypeError(
+        "call must be a callable (str -> str) or a model-name string; pass e.g. "
+        'call=topica.llm_backend("gpt-4o-mini", temperature=0) or call="gpt-4o-mini".'
+    )
+
+
+def _dataset_clause(dataset_description):
+    if not dataset_description:
+        return ""
+    return f"The topics are from the following corpus: {dataset_description.strip()} "
+
+
+def _parse_rating(reply, lo, hi):
+    """The first integer in `reply` within ``[lo, hi]``, else None."""
+    for tok in re.findall(r"-?\d+", str(reply)):
+        v = int(tok)
+        if lo <= v <= hi:
+            return v
+    return None
+
+
+def _match_intruder(reply, words):
+    """Match the model's reply to one of `words` (case-insensitive, whole-word
+    first, then substring). Returns the matched word or None."""
+    r = str(reply).strip().lower()
+    lowered = {w.lower(): w for w in words}
+    if r in lowered:
+        return lowered[r]
+    # whole-word hit anywhere in the reply
+    toks = set(re.findall(r"[a-z0-9']+", r))
+    for w in words:
+        if w.lower() in toks:
+            return w
+    # last resort: substring
+    for w in words:
+        if w.lower() in r:
+            return w
+    return None
+
+
+def llm_coherence(model, *, call, n_words=10, scale=(1, 3), dataset_description=None,
+                  seed=0, n_samples=1, shuffle=True, prompts=None):
+    """LLM-rated topic coherence (Stammbach et al. 2023): the headline LLM metric.
+
+    For each topic, the top ``n_words`` words are shuffled and an LLM rates how
+    related they are on a ``scale`` (default 1-3). Returns a per-topic numpy array
+    of mean ratings (higher = more coherent). This is the metric that **beats
+    NPMI / c_v at tracking human judgment** in the paper; it sits beside
+    :func:`coherence`, :func:`topic_diversity`, and :func:`topic_semantic_diversity`,
+    but is ``llm-bounded`` -- it calls an external model and is not bit-deterministic.
+
+    Parameters
+    ----------
+    model : fitted model or list of word lists
+        Anything :func:`_extract_topics` accepts.
+    call : callable ``str -> str`` or model-name str
+        The LLM. Pass ``topica.llm_backend(name, temperature=0)`` or a model name.
+    n_words, scale : the number of top words shown and the rating range.
+    dataset_description : optional str
+        A one-line corpus description added to the prompt (small reported gains).
+    seed : int
+        Seeds the per-topic word shuffles (reproducible task; the *LLM* is not).
+    n_samples : int
+        Calls the LLM this many times per topic and averages (tames non-determinism;
+        the paper uses temperature=1 to mimic annotator variation).
+    prompts : optional dict
+        Override the editable templates (key ``"rating"``); defaults to
+        :data:`LLM_EVAL_PROMPTS`.
+    """
+    backend = _resolve_llm_call(call)
+    tmpl = (prompts or LLM_EVAL_PROMPTS)["rating"]
+    lo, hi = int(scale[0]), int(scale[1])
+    ds = _dataset_clause(dataset_description)
+    topics = _extract_topics(model, n_words)
+    out = []
+    for t, words in enumerate(topics):
+        scores = []
+        for s in range(max(1, n_samples)):
+            w = list(words)
+            if shuffle:
+                np.random.RandomState(seed + t * 1000 + s).shuffle(w)
+            prompt = tmpl.format(dataset=ds, words=", ".join(w))
+            val = _parse_rating(backend(prompt), lo, hi)
+            if val is not None:
+                scores.append(val)
+        out.append(float(np.mean(scores)) if scores else float("nan"))
+    return np.array(out, dtype=float)
+
+
+def llm_intrusion(model, vocabulary=None, *, call, n_words=5, dataset_description=None,
+                  seed=0, n_samples=1, prompts=None):
+    """LLM word-intrusion accuracy (Stammbach et al. 2023).
+
+    Builds the intrusion task with :func:`word_intrusion` (top ``n_words`` words plus
+    one intruder, shuffled), asks the LLM to pick the intruder, and scores it against
+    the answer key. Returns ``{"accuracy": float, "per_topic": [...]}`` where each
+    per-topic dict has ``topic``, ``intruder``, ``picked``, and ``correct``.
+
+    The paper finds an LLM matches human accuracy on this *task* (~72%), but rating
+    (:func:`llm_coherence`) tracks human topic *rankings* better -- lead with
+    ``llm_coherence`` and report this alongside. ``llm-bounded``; see
+    :func:`llm_coherence` for the shared ``call`` / ``n_samples`` semantics.
+    """
+    backend = _resolve_llm_call(call)
+    tmpl = (prompts or LLM_EVAL_PROMPTS)["intrusion"]
+    ds = _dataset_clause(dataset_description)
+    items = word_intrusion(model, vocabulary, n_words=n_words, seed=seed)
+    per_topic, correct = [], []
+    for item in items:
+        votes = []
+        for _ in range(max(1, n_samples)):
+            prompt = tmpl.format(dataset=ds, words=", ".join(item["words"]))
+            picked = _match_intruder(backend(prompt), item["words"])
+            if picked is not None:
+                votes.append(picked)
+        chosen = Counter(votes).most_common(1)
+        picked = chosen[0][0] if chosen else None
+        hit = picked == item["intruder"]
+        per_topic.append({
+            "topic": item["topic"], "intruder": item["intruder"],
+            "picked": picked, "correct": bool(hit),
+        })
+        correct.append(hit)
+    return {"accuracy": float(np.mean(correct)) if correct else float("nan"),
+            "per_topic": per_topic}

--- a/tests/test_llm_eval.py
+++ b/tests/test_llm_eval.py
@@ -1,0 +1,178 @@
+"""LLM-based topic evaluation (Stammbach et al. 2023): llm_coherence + llm_intrusion.
+
+Exercised offline with deterministic fake backends (no network), so the
+orchestration, parsing, aggregation, and scoring are CI-testable. The live behaviour
+is llm-bounded and validated separately (parity/llm_coherence_compare.py).
+"""
+
+import numpy as np
+import pytest
+
+import topica
+from topica import llm_coherence, llm_intrusion, LLM_EVAL_PROMPTS
+
+# Three topics with a clear theme each; the third is deliberately incoherent.
+TOPICS = [
+    ["water", "river", "lake", "ocean", "rain", "flood", "stream", "wave"],
+    ["senate", "election", "vote", "policy", "law", "congress", "budget", "party"],
+    ["banana", "telescope", "guitar", "asphalt", "penguin", "invoice", "comet", "yoga"],
+]
+
+
+class Rater:
+    """Rates by counting how many words share the first topic's theme. Coherent
+    topics (1, 2) get '3', the random topic (3) gets '1'. Records calls."""
+
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, prompt: str) -> str:
+        self.calls.append(prompt)
+        water = sum(w in prompt for w in ("water", "river", "lake", "ocean"))
+        gov = sum(w in prompt for w in ("senate", "vote", "law", "congress"))
+        if water >= 2 or gov >= 2:
+            return "I would rate these as very related: 3"
+        return "1"
+
+
+def test_llm_coherence_shape_and_discrimination():
+    rater = Rater()
+    out = llm_coherence(TOPICS, call=rater)
+    assert out.shape == (3,)
+    assert (out >= 1).all() and (out <= 3).all()
+    # coherent topics score higher than the random one
+    assert out[0] == 3.0 and out[1] == 3.0 and out[2] == 1.0
+    # one call per topic by default
+    assert len(rater.calls) == 3
+
+
+def test_llm_coherence_n_samples_averages():
+    # A backend that alternates 3,1,3 -> mean 2.33 over 3 samples.
+    seq = iter(["3", "1", "3"] * 10)
+    out = llm_coherence([TOPICS[0]], call=lambda p: next(seq), n_samples=3)
+    assert out.shape == (1,)
+    assert abs(out[0] - (7 / 3)) < 1e-9
+
+
+def test_llm_coherence_parses_prose_and_clamps():
+    # Replies with out-of-range or prose still parse the first in-range integer.
+    out = llm_coherence([TOPICS[0], TOPICS[1]], call=lambda p: "Score: 99? no, a 2 overall.")
+    assert np.allclose(out, 2.0)
+
+
+def test_llm_coherence_accepts_prompts_override():
+    seen = {}
+    def be(p):
+        seen["prompt"] = p
+        return "2"
+    custom = dict(LLM_EVAL_PROMPTS)
+    custom["rating"] = "RATE THESE {dataset}{words}"
+    llm_coherence([TOPICS[0]], call=be, prompts=custom, dataset_description="news")
+    assert seen["prompt"].startswith("RATE THESE")
+    assert "news" in seen["prompt"]
+
+
+def test_llm_coherence_dataset_description_in_prompt():
+    seen = {}
+    llm_coherence([TOPICS[0]], call=lambda p: seen.setdefault("p", p) or "3",
+                  dataset_description="Wikipedia articles")
+    assert "Wikipedia articles" in seen["p"]
+
+
+# ---------------------------------------------------------------------------
+# llm_intrusion (reuses word_intrusion's generated items)
+# ---------------------------------------------------------------------------
+
+def _planted_model(seed=0):
+    # A simple (K, V) topic-word matrix with three well-separated blocks.
+    rng = np.random.default_rng(seed)
+    V = 24
+    phi = np.full((3, V), 0.001)
+    for t in range(3):
+        phi[t, t * 8:(t + 1) * 8] = 1.0
+    phi = phi / phi.sum(1, keepdims=True)
+    vocab = [f"t{t}w{i}" for t in range(3) for i in range(8)]
+    return phi, vocab
+
+
+def test_llm_intrusion_perfect_detector_scores_one():
+    phi, vocab = _planted_model()
+    # An oracle backend that returns the true intruder for each item.
+    items = topica.word_intrusion(phi, vocab, n_words=5, seed=0)
+    answer = {", ".join(it["words"]): it["intruder"] for it in items}
+    def oracle(prompt):
+        for words, intr in answer.items():
+            if words in prompt:
+                return intr
+        return "?"
+    res = llm_intrusion(phi, vocab, call=oracle, n_words=5, seed=0)
+    assert res["accuracy"] == 1.0
+    assert all(e["correct"] for e in res["per_topic"])
+
+
+def test_llm_intrusion_wrong_picks_score_low():
+    phi, vocab = _planted_model()
+    # Always returns the first presented word (usually not the intruder).
+    res = llm_intrusion(phi, vocab, call=lambda p: p.rsplit("\n", 1)[-1].split(",")[0],
+                        n_words=5, seed=0)
+    assert 0.0 <= res["accuracy"] <= 1.0
+    assert len(res["per_topic"]) == 3
+
+
+def test_llm_intrusion_majority_vote_over_samples():
+    phi, vocab = _planted_model()
+    items = topica.word_intrusion(phi, vocab, n_words=5, seed=0)
+    intr0 = items[0]["intruder"]
+    # 2 of 3 votes are the true intruder -> majority correct for topic 0.
+    seq = {}
+    def be(prompt):
+        if items[0]["intruder"] in prompt and ", ".join(items[0]["words"]) in prompt:
+            seq.setdefault("t0", 0)
+            seq["t0"] += 1
+            return intr0 if seq["t0"] != 2 else items[0]["words"][0]
+        return "?"
+    res = llm_intrusion(phi, vocab, call=be, n_words=5, seed=0, n_samples=3)
+    assert res["per_topic"][0]["picked"] == intr0
+
+
+def test_match_intruder_is_robust():
+    from topica.coherence import _match_intruder
+    words = ["river", "lake", "senate", "ocean", "rain", "wave"]
+    assert _match_intruder("senate", words) == "senate"
+    assert _match_intruder("The intruder is 'senate'.", words) == "senate"
+    assert _match_intruder("SENATE", words) == "senate"
+    assert _match_intruder("none of these", words) is None
+
+
+# ---------------------------------------------------------------------------
+# Adversarial self-check (gold-free): a competent detector flags a planted outlier
+# ---------------------------------------------------------------------------
+
+def test_adversarial_planted_outlier_is_detectable():
+    # Topic of clearly-related words plus a blatant outlier; the task generator must
+    # be able to surface a detectable intruder, and an oracle must score it.
+    phi, vocab = _planted_model()
+    items = topica.word_intrusion(phi, vocab, n_words=5, seed=1)
+    # Each generated item has exactly one intruder from another block.
+    for it in items:
+        intr_block = it["intruder"][1]  # "t{block}w{i}"
+        topic_block = str(it["topic"])
+        assert intr_block != topic_block  # the intruder is genuinely out-of-block
+
+
+# ---------------------------------------------------------------------------
+# Backend resolution / errors
+# ---------------------------------------------------------------------------
+
+def test_call_must_be_callable_or_str():
+    with pytest.raises(TypeError):
+        llm_coherence(TOPICS, call=123)
+
+
+def test_accepts_fitted_model_surface():
+    # llm_coherence reads top_words / topic_word like the other diagnostics.
+    docs = [["water", "river", "lake"]] * 20 + [["senate", "vote", "law"]] * 20
+    m = topica.LDA(num_topics=2, seed=1)
+    m.fit(docs, iters=200)
+    out = llm_coherence(m, call=lambda p: "2", n_words=5)
+    assert out.shape == (2,) and np.allclose(out, 2.0)


### PR DESCRIPTION
## What

Adds the first two **LLM-based topic-evaluation diagnostics** from Stammbach, Zouhar, Hoyle, Sachan & Ash (2023), "Revisiting Automated Topic Model Evaluation with Large Language Models" (EMNLP; arXiv:2305.12152):

- **`llm_coherence(model, call=)`** — the headline. An LLM rates each topic's top-`n` shuffled words 1–3; returns a per-topic array. In the paper this **beats NPMI/c_v at tracking human judgment**.
- **`llm_intrusion(model, call=)`** — reuses `word_intrusion`'s generated items; the LLM picks the intruder, scored against the answer key. Per-topic accuracy + overall.

This is the **first cut of the #197 umbrella** (per the chosen scope). `llm_select_k` (doc-label purity) and the Tan & D'Souza dimensions (repetitiveness, LLM-diversity, topic-doc alignment) are deferred follow-ups; #197 stays open for them.

```python
call = topica.llm_backend("gpt-4o-mini", temperature=0)   # any provider / openrouter / ollama
topica.llm_coherence(model, call=call, n_words=10)        # per-topic 1-3 rating
topica.llm_intrusion(model, call=call, n_words=5)         # LLM picks the intruder -> accuracy
```

## Design

Mostly assembly — the plumbing already existed: both reuse `_extract_topics`, `word_intrusion`, and the provider-agnostic `llm_backend`. The paper's prompts are kept **verbatim** in an editable `topica.LLM_EVAL_PROMPTS` dict. `n_samples=` calls the model repeatedly and aggregates (mean for rating, majority-vote for intrusion) to tame the non-determinism. `call=` accepts a callable or a model-name string.

**Honest framing (documented):** these are **`llm-bounded`** — they call an external model and are **not** bit-deterministic like the rest of the diagnostics. The docs carry an explicit warning; lead with `llm_coherence` (rating tracks human *rankings*; intrusion is a weaker ranking signal, reported alongside).

## Validation

**Human correlation vs the Hoyle 2021 gold (reproduces the paper).** `parity/llm_coherence_compare.py` fetches the public Hoyle human topic-rating data and reports Spearman of `llm_coherence` vs mean human ratings against NPMI. Live result (qwen3-235b via OpenRouter, 150 topics across wikitext+nytimes × mallet/dvae/etm):

| | Spearman vs human |
|---|---|
| **`llm_coherence`** | **0.549** |
| NPMI (baseline) | 0.450 |

`llm_coherence` beats NPMI on the aggregate — the paper's headline finding (paper: LLM ~0.6 > NPMI ~0.45). Per-combo is mixed, as in the paper; the concat is the result.

**Offline (CI gate): 12 tests** with a deterministic FakeBackend — discrimination, n-sample averaging, prose parsing, prompt override, intrusion scoring + majority vote, robust intruder matching, an adversarial planted-outlier check, and error handling.

**Live spot-check:** coherent topics rated 3 vs a random topic 1; intrusion accuracy 1.0 on planted intruders.

## Docs
`docs/guides/diagnostics.md` LLM-evaluation section (the `llm-bounded` warning, lead-with-`llm_coherence`, editable prompts, cost) + API reference entries.

## Gates
`cargo test --lib` 143 (no Rust touched) · `pytest tests/` **2665 passed** · `mkdocs build --strict` clean. The parity script is `llm-bounded` and not run in CI.

Part of #197.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
