### PR TITLE
Add topica.datasets: bundled + fetch-on-demand example data (#204)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Dataset CSVs are data, not source text. Keep their bytes identical across
+# platforms: on Windows, git's autocrlf would rewrite LF to CRLF on checkout,
+# changing the file's SHA-256 and breaking the dataset checksums (the vendored
+# file is verified directly; the fetched files are pinned by hash).
+python/topica/datasets/_data/*.csv binary
+examples/*.csv binary

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,4 +58,7 @@ test = ["pytest>=7", "pandas>=1.3", "formulaic>=0.6", "matplotlib>=3.4", "scipy>
 python-source = "python"
 module-name = "topica._topica"
 features = ["python"]
+# Ship the small vendored example dataset (topica.datasets.load_gadarian); larger
+# datasets are fetched on demand, not bundled.
+include = ["python/topica/datasets/_data/*.csv"]
 # Build a single abi3 wheel per platform (works on CPython >=3.9).

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -249,6 +249,7 @@ from .stopwords import ENGLISH_STOPWORDS  # noqa: E402
 from .phrases import learn_phrases, apply_phrases, add_ngrams, Phrases  # noqa: E402
 from .frames import from_dataframe, align, prep_documents, plot_removed  # noqa: E402
 from .formulas import design_matrix  # noqa: E402
+from . import datasets  # noqa: E402  (bundled + fetch-on-demand example datasets)
 
 __all__ = [
     "list_models",
@@ -381,6 +382,7 @@ __all__ = [
     "add_ngrams",
     "Phrases",
     "align_corpus",
+    "datasets",
     "DEFAULT_TOKEN_REGEX",
     "__version__",
     "__citation__",

--- a/python/topica/datasets/__init__.py
+++ b/python/topica/datasets/__init__.py
@@ -1,0 +1,244 @@
+"""Bundled example datasets for quickstarts and worked examples.
+
+Small datasets ship inside the wheel and load instantly, offline. Larger ones
+are downloaded once from GitHub on first use and cached locally, so the wheel
+stays lean. Every loader returns a :mod:`pandas` DataFrame ready for
+:func:`topica.from_dataframe`::
+
+    import topica
+
+    df = topica.datasets.load_gadarian()           # vendored, instant, offline
+    corpus = topica.from_dataframe(
+        df, text_col="open.ended.response", stopwords=topica.ENGLISH_STOPWORDS
+    )
+    model = topica.STM(num_topics=10).fit(corpus, prevalence=corpus.metadata[["treatment"]])
+
+Pass ``return_path=True`` to get the cached CSV path instead of a DataFrame
+(no pandas required).
+
+The cache lives under ``~/.cache/topica/datasets`` by default; set the
+``TOPICA_DATA_HOME`` environment variable to relocate it. Downloads are pinned
+to an immutable commit and verified against a SHA-256 checksum, so a given
+topica version always fetches the same bytes.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+__all__ = [
+    "load_gadarian",
+    "load_poliblog",
+    "load_dubois",
+    "get_data_home",
+    "clear_cache",
+]
+
+# Immutable commit that holds the dataset files. Pinned (not ``main``) so a
+# given topica version always fetches the same bytes; override with the
+# TOPICA_DATA_REF environment variable for local development against a branch.
+_DATA_REF = "cbb6fe4adbfd19e4a2bca226f05e146c7a61080c"
+_RAW_BASE = "https://raw.githubusercontent.com/nealcaren/topica"
+
+# name -> dataset record. ``vendored`` files ship in the wheel; the rest carry a
+# repo-relative ``remote`` path fetched on first use. ``sha256`` is verified for
+# every fetched file.
+_REGISTRY = {
+    "gadarian": {
+        "vendored": "gadarian.csv",
+        "filename": "gadarian.csv",
+        "sha256": "de30697c6f42a8d32fca4bb6798679e4004afe16e9f3dbd06e7409afedb474d2",
+        "text_col": "open.ended.response",
+        "n_docs": 341,
+        "summary": (
+            "Gadarian & Albertson (2014) immigration open-ended responses; the "
+            "canonical stm prevalence example. Raw text in 'open.ended.response'; "
+            "covariates 'treatment' (anxiety prime) and 'pid_rep' (Republican id)."
+        ),
+    },
+    "poliblog": {
+        "remote": "examples/poliblog.csv",
+        "filename": "poliblog.csv",
+        "sha256": "4c26bd96b5ca57ae99a7a72835f2aa1a549d55178e8779e079cc0fb9ac498ff9",
+        "text_col": "text",
+        "n_docs": 2000,
+        "summary": (
+            "CMU 2008 political blog corpus (a 2,000-document sample). Text is "
+            "already tokenized and stemmed (space-separated). Covariates 'rating' "
+            "(Liberal/Conservative), 'day', and 'blog'."
+        ),
+    },
+    "dubois": {
+        "remote": "examples/dubois_crisis.csv",
+        "filename": "dubois_crisis.csv",
+        "sha256": "b38b8b22e96fb2f6a07b7983db05c72e6bc1cffb1c0c23ab9ff006cdcce7513e",
+        "text_col": "text",
+        "n_docs": 704,
+        "summary": (
+            "Du Bois-era articles from The Crisis (1910-1922). Raw text in 'text'; "
+            "covariates 'year', 'decade', 'volume', 'issue', 'author', 'subjects'."
+        ),
+    },
+}
+
+
+def get_data_home() -> Path:
+    """Return the directory where downloaded datasets are cached.
+
+    Defaults to ``~/.cache/topica/datasets``; override with the
+    ``TOPICA_DATA_HOME`` environment variable. The directory is created if it
+    does not exist.
+    """
+    env = os.environ.get("TOPICA_DATA_HOME")
+    home = Path(env).expanduser() if env else Path.home() / ".cache" / "topica" / "datasets"
+    home.mkdir(parents=True, exist_ok=True)
+    return home
+
+
+def clear_cache() -> None:
+    """Delete every cached (downloaded) dataset file. Vendored datasets are
+    unaffected; the next ``load_*`` call re-downloads what it needs."""
+    home = get_data_home()
+    for record in _REGISTRY.values():
+        if "remote" in record:
+            (home / record["filename"]).unlink(missing_ok=True)
+
+
+def _sha256(path: Path) -> str:
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1 << 20), b""):
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def _vendored_path(record: dict) -> Path:
+    # importlib.resources keeps this working from a wheel, a zip, or the source
+    # tree without assuming a filesystem layout.
+    from importlib.resources import as_file, files
+
+    resource = files(__name__).joinpath("_data", record["vendored"])
+    with as_file(resource) as p:
+        path = Path(p)
+    if not path.exists():
+        raise FileNotFoundError(
+            f"vendored dataset {record['vendored']!r} is missing from the install"
+        )
+    return path
+
+
+def _fetch(name: str, record: dict) -> Path:
+    dest = get_data_home() / record["filename"]
+    if dest.exists():
+        if _sha256(dest) == record["sha256"]:
+            return dest
+        dest.unlink()  # corrupt/partial cache; re-download
+
+    ref = os.environ.get("TOPICA_DATA_REF", _DATA_REF)
+    url = f"{_RAW_BASE}/{ref}/{record['remote']}"
+    tmp = dest.with_suffix(dest.suffix + ".part")
+    try:
+        with urllib.request.urlopen(url, timeout=60) as resp, open(tmp, "wb") as out:
+            while True:
+                chunk = resp.read(1 << 20)
+                if not chunk:
+                    break
+                out.write(chunk)
+    except (urllib.error.URLError, OSError) as exc:
+        tmp.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"could not download the {name!r} dataset from {url}\n"
+            f"({exc}). Check your network, or download the file manually to "
+            f"{dest} and retry. Set TOPICA_DATA_HOME to relocate the cache."
+        ) from exc
+
+    got = _sha256(tmp)
+    if got != record["sha256"]:
+        tmp.unlink(missing_ok=True)
+        raise RuntimeError(
+            f"checksum mismatch for {name!r}: expected {record['sha256']}, got "
+            f"{got}. The download may be corrupt or the pinned data ref changed."
+        )
+    tmp.replace(dest)
+    return dest
+
+
+def _resolve(name: str) -> Path:
+    record = _REGISTRY[name]
+    if "vendored" in record:
+        return _vendored_path(record)
+    return _fetch(name, record)
+
+
+def _read_csv(path: Path):
+    try:
+        import pandas as pd
+    except ImportError as exc:  # pragma: no cover - exercised via error path
+        raise ImportError(
+            "loading a dataset as a DataFrame needs pandas (pip install pandas). "
+            "Pass return_path=True to get the CSV path without pandas."
+        ) from exc
+    return pd.read_csv(path)
+
+
+def _load(name: str, return_path: bool):
+    path = _resolve(name)
+    if return_path:
+        return path
+    return _read_csv(path)
+
+
+def load_gadarian(*, return_path: bool = False):
+    """Load the Gadarian & Albertson immigration experiment (341 documents).
+
+    The canonical ``stm`` prevalence example. Open-ended survey responses with
+    an anxiety-prime ``treatment`` and ``pid_rep`` (Republican identification).
+    Raw, untokenized text lives in the ``open.ended.response`` column, so build a
+    corpus with stopword removal::
+
+        df = topica.datasets.load_gadarian()
+        corpus = topica.from_dataframe(
+            df, text_col="open.ended.response", stopwords=topica.ENGLISH_STOPWORDS
+        )
+
+    This dataset is bundled in the wheel and loads offline. Pass
+    ``return_path=True`` for the CSV path instead of a DataFrame.
+    """
+    return _load("gadarian", return_path)
+
+
+def load_poliblog(*, return_path: bool = False):
+    """Load the CMU 2008 political blog corpus (a 2,000-document sample).
+
+    The text in the ``text`` column is already tokenized and stemmed
+    (space-separated), as in the ``stm`` ``poliblog`` vignette, so no stopword
+    removal is needed::
+
+        df = topica.datasets.load_poliblog()
+        corpus = topica.from_dataframe(df, text_col="text")
+
+    Covariates: ``rating`` (Liberal/Conservative), ``day``, ``blog``. Downloaded
+    once and cached. Pass ``return_path=True`` for the CSV path.
+    """
+    return _load("poliblog", return_path)
+
+
+def load_dubois(*, return_path: bool = False):
+    """Load Du Bois-era articles from The Crisis, 1910-1922 (704 documents).
+
+    Raw text in the ``text`` column; covariates ``year``, ``decade``,
+    ``volume``, ``issue``, ``author``, ``subjects``. Build a corpus with
+    stopword removal::
+
+        df = topica.datasets.load_dubois()
+        corpus = topica.from_dataframe(
+            df, text_col="text", stopwords=topica.ENGLISH_STOPWORDS
+        )
+
+    Downloaded once and cached. Pass ``return_path=True`` for the CSV path.
+    """
+    return _load("dubois", return_path)

--- a/python/topica/datasets/_data/gadarian.csv
+++ b/python/topica/datasets/_data/gadarian.csv
@@ -1,0 +1,502 @@
+"MetaID","treatment","pid_rep","open.ended.response"
+0,1,1,"problems caused by the influx of illegal immigrants who are crowding our schools and hospitals, lowering the level of ducation and the quality of care in hospitals."
+0,1,1,"if you mean illegal immigration, i'm afraid of who might be getting into this country in unsecured borders."
+0,0,0.333,"that they should enter the same way my grandparents did, legally. learn english and pay taxes. i don't think that a lot of these asians and east indians should be getting a tax free ride. i'm tired of paying for everyone else."
+0,0,0.5,"legally entering the usa meeting the requirements is the law. entering the usa improperly is a crime. it is unfortunate that the american bar association has fought treating entering the usa as a crime. and our politicians from both parties have been so anxious to get the ""vote"" that they refuse to inforce the law. meanwhile, terorists can walk right in without any problem. no accountability on the part of politicians supported by the news media will bring our nation down eventually. and the normal person will wonder how it happened."
+0,1,0.66667002,"terror
+bombings
+killing us
+robbing america"
+0,1,0,"having criminals immigrate here"
+0,1,0.833,"illegal, draining our goverment resources and making no contibution to our society.  as long as they will do the menial labor, our lazy welfare bums will continue to rob, steal, and murder.  our jails are overcrowded!
+if welfare recipients, who are physically able, wont work then no welfare."
+0,1,0,"we are not the lower class people and that is not right"
+0,0,0,"i dont have a problem with it as long as they learn english and pay taxes"
+0,1,0.66667002,"i think that people  that come into the united states shouldn't be able to get more for help for living when the states don't even take care of the people that were born and raised here."
+0,1,0.16666999,"taking jobs from americans"
+0,1,0.833,"illegal immagrtants and social security"
+0,0,0.66667002,"when i think of immigration, i think of the people who legally come to this country and apply for the necessary citizenships so that they can get a job and have the benefits of being an american and all the freedoms that come with that."
+0,0,0.833,"illegal imigration is a pox on our society."
+0,0,1,"illegals"
+0,0,1,"the amount of illegal immigration, and exceptions to the legal immigration quotas that happen all the time.  i'm concerned that abuses will sink us soon."
+0,0,0.16666999,"send them all back"
+0,0,0.333,"that we have to many people from other countrys here"
+0,0,0.5,"unfair unattainable"
+0,1,0,"i'm really more worried about world population growth than about immigration per se.  i do feel that immigrants should learn english.  i do not like the idea of spanish being on an equal par with english.  speak what ever you want at home but learn enough english to function in this country."
+0,1,0,"loss of jobs for americans"
+0,1,0.66667002,"changing the basic makeup of the united states.  creating a population with more socialistic values.  mexico is largely an economic failure, so the immigrants from there may tend to have the values that created that failure."
+0,1,0.66667002,"i firmly believe that the u.s. is a melting pot of nationalities and races -- people of different ethnic backgrounds blending into one rich culture - without losing the distinctiveness of their own culture.  in order to accomplish this safely and effectively:  1)immigrants must be in our country legally  2)immigrants need to learn our language  3) immigrants need to obey our laws. fears about illegal immigrants: terrorism, criminal activities, heavy drain on social services & medical services, weighing down the public school systems esl & other special needs."
+0,0,0.833,"illegal immigration is a drain on the welfare system, although it seems to provide laborers for jobs americans don't want, legal immigration brings  technically skilled workers (h-1b), my great grandparents, and other people who can contribute to the country."
+0,1,0.5,"that all the silliness about immigration will alter the fundamental character of the us as the ""melting pot"" nation."
+0,1,1,"jobs crime taxes"
+0,0,0.333,"ellis island, illegal immigration, new world, fences"
+0,0,1,"illegals; social security; benefits"
+0,0,0.16666999,"i come from legal immigrant parents. i believe that at this point of war and the economy looking as it is going down, immigration is not a good idea. besides this immigration is what has made the us what it is today. you can experince and live so many cultures."
+0,0,0.16666999,"people who come to the us to take advantage of the american dream and opportunities. unfortunately, many come over and do not become us citizens but are able to use tax-payer money to pay for their healthcare and welfare."
+0,1,0.16666999,"i worry about the republican party doing something very stupid.  this country was built on immigration, to deny anyone access to citizenship is unconstitutional.  what happened to give me your poor, sick, and tired?"
+0,1,0.16666999,"-finding teachers with multi-cultural/multi-lingual skills"
+0,1,0.333,"wages being depressed. criminals coming into the us."
+0,1,0.66667002,"leaching on our social structure, hospitals, welfare, jails--all the things we pay taxes for that they do not
+more tererism"
+0,1,0,"conflicts between working class, illegal profits for companies hiring undocumented immigrants, low job wages, more immigration, overpopulation and competition for jobs."
+0,0,0.333,"people crossing the border illegally."
+0,0,1,"poor economy"
+0,0,0.333,"my parents were immigrants from ireland.  everyone has a right to apply for entrance.  we are a nation of immigrants - except for native americans!"
+0,0,0.16666999,"the mexican border
+illegal aliens from other countries
+people getting a chance to have a decent life
+people like our country better than theirs"
+0,0,0,"i don't think we should legalize aliens smuggled in to usa."
+0,0,0.333,"as an arizona resident who lives 18 miles from the mexican-us border, and who has also spoken to some of these illegals while hiking in the huachuca mtns., i know these people, mostly, come here out of sheer desperation.  sure, some are the same lazy, fat, undereducated jerks that lurk around our own mid-level businesses.  but most simply are people who want what we all do: a comfortable life with as little thinking and suffering as possible, while reproducing at will.  they have told me, babies in arms,that if they remain at home, they have no future but an early death.  that they, maybe, should reduce their birth rate and/or not have children at all, if they cannot support them, simply will never occur to citizens of a catholic country, living a day's walk from a rich country that can be easily milked for what they consider a fortune in life support.  there is no answer to this, so long as 95% of mexico's wealth is controlled by 5% of its people, and the only riches the others have lie in their children."
+0,1,0,"the only thing that makes me worry is the econany. immigration did not that happen yrars ago. i know all men are not equal. the rich get richer the poore get poorer. are we not all gods children?"
+0,1,0.5,"the strain on the taxpayer in terms of welfare programs."
+0,1,0,"english not being the common language."
+0,0,0.333,"if it legal im fine with it."
+0,1,0,"nothing"
+0,1,0.66667002,"immigrants who dont contribute to society or bring bad things to our country."
+0,1,0.5,"that they will take our jobs!"
+0,1,0,"increased poverty due to more people in the us and less jobs.
+increased death/robbery when the poor get desperate and turn to crime."
+0,0,0.333,"people from other countries trying to come here to live or work and they don't always have the proper paper work"
+0,1,0.66667002,"crime
+taxes"
+0,1,0.16666999,"how some of the illegal immigrants get more help from the government than the u.s. citizens who are paying taxes."
+0,1,1,"expenses to our country for health care, education, crime, language changes;  these are people most of whom are entering the united states illegally"
+0,0,0.833,"too many people, not enough jobs.  people that don't speak english."
+0,0,0.66667002,"a bible verse (send me your weak and hungry) and a one way door"
+0,0,0,"my ancestors came over as immigrants looking for a better life for their family--today's immigrants are doing the same.  there must be a solution that works for everyone."
+0,1,1,"illegals will take jobs, healthcare, and other benefits from legal citizens."
+0,1,0.333,"i feel like the united states is a giant bowl of a little bit of everything. ""americans"" are becoming a minority in our own country."
+0,1,0.333,"we need to allow immigration. people from foreign countries will do the jobs we arent willing to do."
+0,0,0.333,"an overwhelming amount of immigrants in our country and the new laws or bills tryin to cut down on the amount of immigrants."
+0,1,0.833,"violence, drugs, jobs lost"
+0,0,0.333,"poor people
+taking jobs"
+0,1,0,"undocumented immigration and how it affects our economy."
+0,0,0,"robbing americans of their social security; rising costs of social programs to cover illegals; rising costs of incarceration due to illegals; not being able to understand what they are saying (spanish and other languages); the fact that illegal immigrants are here with their children who go through our school systems then cannot get financial aid for college because their parents never filed for naturalization leaving the kids to work dead end jobs and never get naturalized; the fact that they are doing the work that americans don't want to do anyway, and then the americans complain about it; border walls; increasing amounts of drugs in america because it is so easy to get into our country"
+0,1,0.333,"too many people, not enough social service support, crowded prisons, gangs taking over the cities, unemployment, abuse of immigrants, terrorism"
+0,1,0.333,"i think of all the jobs americans will lose and the welfare will increase"
+0,1,0,"i worry about the strife that is being stirred up among the american people. how can building a giant fence between the usa and mexico possibly help the usa in any way. it is a tremendous waste of resources that could be used for developing alternative energy sources, providing health care or decreasing the increase in the national debt."
+0,0,0.16666999,"people coming to the us looking for work
+people looking to do the jobs that us citizens will not do"
+0,1,0.333,"we are letting too many immigrants into the country.
+too many immigrants insist on speaking their native language and do not learn english. that is a real problem in our schools and business.
+i do not believe immigrants should get social security....unless they work and pay into it.  
+immigrants should not be able to get all the freebies that they are getting."
+0,0,0.333,"illegal immigrants, people complaining about them getting govt. benefits, talk about building a wall on the mexico border. poor people who do the jobs that most of us wouldn't take anyway. if i lived somewhere else, facing poverty, i would want to come here to build a better life too."
+0,1,0.16666999,"crime
+lost jobs
+benefits paid to illegals
+health care and food....we cannot feed the world when we have americans starving, etc"
+0,1,0,"that the illegals are recieving all of our benefits"
+0,0,1,"i am fine with immigration."
+0,1,0.16666999,"the jobs, welfare, and community resources we as tax payers pay with our hard earned sweat to give it to someone who comes here just to send money back home. i don't think so!"
+0,0,0.66667002,"mexican people. illegal border crossing. us finincal assistance to imigerants."
+0,1,0.5,"drain on us social services and medical service.
+increased crime rates"
+0,0,0.16666999,"illegal
+mexicans"
+0,1,1,"too many illegal immigrates coming into our country will take our work for less pay and the language barrier."
+0,1,0.333,"i'm worried that people are coming to amercia against the law. they are not doing it the right way. they steal social security numbers of people who are citizens so they can work etc"
+0,0,0.66667002,"why their country is so poor"
+0,0,0.16666999,"we need to protect our borders more. not enough agents covering too much distance."
+0,1,1,"illegal immigrants using services paid for by legimate taxpayers."
+0,1,0.333,"not much worries me about immigration. i think people are making way too big of a deal about it."
+0,0,0.333,"the people against immigration"
+0,1,0.66667002,"that we let people break the law b/c we just don't want to take the time to inforce it."
+0,0,0.833,"criminals stealing our jobs, our money, our belongings. people who don't speak english in our public schools. babies being born into this country and becoming citizens on a daily basis. free health care. pigs and slobs on the jobsite. you asked the wrong person, i work in construction and could go on for days about these thieves."
+0,0,0.16666999,"illegal immigrants."
+0,1,0.16666999,"1. not being able to document them so we have a record for crime, taxes and terrorism
+2.  that they are recieving money that i pay taxes to provide and they dont pay any of it
+3.  they recieve many services from the states they are in that again they dont  pay towards and many people that are legally here are not getting because their isn't enough to go around.
+4 that our country is bending and stretching toaccomidate their cultures"
+0,0,1,"we need to seal the borders. both north and south. fine all the employers that hire illegals and also those who rent to them.  if they can't find an job nor a place to live they will go home."
+0,0,0.333,"illegal people in our country
+illegal people taking our jobs"
+0,1,0.66667002,"free welfare without paying into the tax base, spread of third-world disease, 1/3 of all criminals in our prison syst. are illegal aliens, refusal to assimilate and learn the language, virtual abolition of our borders, and therefore, our sovereignty"
+0,1,0,"job losses, threat of terrorism, property value decreasing, drug trafficing, becoming citizens and going on welfare"
+0,1,1,"social security
+crime
+welfare
+healthcare
+educating immigrants"
+0,1,0.333,"welfare, schools, medical expenses, jobs, crime, housing, driving no insurance or license,"
+0,0,1,"allour ancestors immigrated here.
+immigration should be done legally.
+we shouldn't subsidize illegal immigrants with government money."
+0,1,0.16666999,"loss of jobs"
+0,0,0.833,"legal vs. illegal"
+0,1,0.333,"what worries me is that even when people try to immigrate into us legally, they are out through very disrespectful process that often violates fundamental human rights.  i think if the legal process was easier, or there would be options for legal work inthe us for foreigners, less people would try to come here illegally."
+0,1,0,"they do not pay taxes"
+0,0,0.16666999,"-jobs going to lower paid people
+-english no longer being spoken in some places
+-us becoming over populated
+-more people for us to support on welfare"
+0,0,0.333,"need better border build a wall like china did"
+0,0,0.66667002,"loss of jobs, hospitals losing money, illegal hiring, cheap labor,"
+0,1,0.66667002,"illegal persons,not speaking english,drinking alcohol,illegal driving"
+0,1,0.66667002,"where i live immigration has over populated our city and it is no joke.  we have to many here taking over and getting aid."
+0,1,0,"what really makes me worried is that we are doing nothing to fix the system i agreed that we need to pay attention to our borders but at the same time there is people hard working people that are here illegaly and they are ancious to obtain some king of work permit so they can work legally, they did cross the border ok make them pay a fine of course criminals they must be deported"
+0,1,1,"draining our health care system, 
+criminals"
+0,0,1,"the borders should now be sealing, allowing no more immigrates."
+0,0,0,"take over, over crowding of our nation.  more people not enough welfare or jobs.  health insurance is at an altime low and we can take of our own people who is here so why allow other to come here and take away the aid that could go to the people who is already here."
+0,0,0,"very mess up problem"
+0,0,0.66667002,"that the ileagles who sneack over the border should be fined to the fullest extent.
+i worked most of my life for what little i get. i on't think it's right for them to receive everything free."
+0,1,0.833,"they take the jobs away from us because they take lower pay. they speak a different language and do not try to learn ours. they do not pay taxes. we have to punch in buttons on the phone etc. to speak to someone in our language."
+0,1,0,"large numbers of poor people coming to the us and making our communities dirty, unkempt and poor"
+0,1,0,"i often worry that united states will become over crowded and immigration will place a economical strain on the counyry."
+0,1,0,"building a wall on our border.
+spanish becoming a dominant language in the u.s.
+political bungling in dealing with immigration."
+0,1,0.16666999,"kneejerk american jingoism
+lou dobbs and his ilk
+mistreatment of immigrants"
+0,0,0.333,"i think if they come in to the country
+ileaglely they should be depored . do it the right way or stay the hell home
+and if you do get here the correct way learn the damn langwige(sp) and learn our trafic laws."
+0,0,0,"people comming over here from another country."
+0,1,0,"i think that it is a major issue for us today.  there are too many immigration problems withno taxing from them, taking jobs from the u.s. citizens.  things have to change so that it makes it harder for them to come in illeagally.  they do deserve a chance, but it has to be done the right way."
+0,0,0.333,"i think of people from other countries coming to america to live.  these days you can't help thinking about the mexicans coming across the border, as well as those that are already here."
+0,1,0.333,"lack of jobs for americans
+terrorist activity"
+0,1,1,"taking our jobs, not paying taxes, using public services for free"
+0,1,0.833,"over population
+too many new citizens on welfare
+extra strain on our schools"
+0,1,0.66667002,"jobs,my tax dollars going to fund this."
+0,1,1,"security
+jobs
+healthcare
+following the laws of our country"
+0,0,0.333,"an attitude amongst many americans fueled by some members of the media who use the term ""immigrant"" almost as a term of abuse and seem totally unable to differentiate between legal & illegal immigration.  i also see an incredible degree of racism - the assumption often being that anyone hispanic must be an illegal immigrant."
+0,0,0,"mexico, muslems, problembs, terrorist,
+cheep labor,"
+0,0,0,"people from all over the world coming here for a new life--opportunity, freedom, justice. a way of life/history for the u.s.; our country has always been a giant melting pot and still is."
+0,1,0,"the cost of living, cost of food, diseases, and jobs that are taken from americans."
+0,1,1,"they get all our stuff for free, and it isnt right"
+0,1,1,"costs to feed, house, educate, and provide medical care
+
+potential for enemies of the us to enter"
+0,0,0.333,"i think of new beginnings becoming a citizen adapting to a new country learning to be a citizen of that country....entering legally so you can do this"
+0,0,0.833,"illegal immigrants; increased crime; schools & hospitals overwhelmed taking care of illegal immigrants"
+0,0,0.66667002,"law breakers."
+0,0,0.833,"we need to find a reasonable and humane compromise on the issue"
+0,0,0.66667002,"close borders.
+fine employers who employ illegal immigrats (im).
+remove children of im from public schools.
+no ssa or welfare for ims.
+when picked up by police or any other government institution, they should be taken into custody and deported.
+if an im is deported and returns to the us, they should be jailed and the family or mexican government made to paid for the cost of upkeep."
+0,0,1,"job availability, visas, welfare system"
+0,0,0,"racism, bigotry, intolerance"
+0,1,0,"i didn't have to worrty about immingration when all our relation came over to these lands without an invitation  !"
+0,0,0.333,"first i think that it isn't fair for someone who is not a citizen to receive benefits of any kind without paying into the system.  then i think of 12 million people (especially the children) who could not be taken out of our economy without undue suffering on everyone's part.  then i hear about illegal aliens still able to get driver's licenses, start businesses, buy homes, etc. when so many people are waiting all over the world to come here legally.  it is a difficult problem."
+0,0,0.16666999,"its one of those things that you can't fix."
+0,1,1,"over population
+crime
+job shortage
+welfare increase"
+0,0,0.16666999,"illegal aliens"
+0,0,0.333,"we need to crack down on illegal immigration in this country"
+0,1,0.16666999,"i actually worry about the conditions in those countries the people are leaving."
+0,0,0.16666999,"when i think of immigration i think of people who enter this country legally, who go through the proper immigration process, no matter how long it takes.  i think of people who are willing to learn the english language, make an honest living, honor our country and pledge allegiance to our flag.  those who come to america by any other means, who sneak in here and file false paperwork, who think they have the right to drive and have a license, who manage to obtain false ssn's don't deserve to be here, and our borders need to be much, much more secure."
+0,1,0,"immigrants who have married an american but their spouses die are still sometimes kicked out of the country once they are widowed. i am also concerned about how difficult it is to get a green card."
+0,0,0.16666999,"fences across the southern us border, welfare payments, illegal citizens"
+0,1,0.833,"legal immigration does not concern me,  illegal immigration does- it could bring in disease, put a burden on schools and healthcare, it could lead to security concerns"
+0,1,0.66667002,"the rising sentiment against immigrants. people seem to forget that not all immigrants are illegal, and that our nation was born of immigrants."
+0,0,0.833,"i think of illeagal immigrants
+i think of immigrants that could be terroist"
+0,0,0.16666999,"opportunity for the immagrants
+higher burden on the taxed citizens
+founding fathers
+we're paying for their health costs
+illegal immagration is illegal."
+0,1,0.833,"i think about illegal immigrants.
+giving them services paid for by tax dollars paid for by residents and legal immigrants."
+0,0,0.66667002,"illegal immigration; hispanics; entitlements; not paying taxes, social security; requiring all manners of info tobe inspanish as well as english; borders to the south, texas, ca, etc; gangs; crime; drugs; but positive thoughts about legal alilens here with work visas...hard workers, good people trying to make a better life for their families,"
+0,1,0.66667002,"illegal immigration
+increasing cost to me for healthcare for illegals who come here and have babies."
+0,0,0.333,"nothing"
+0,1,0.66667002,"the number of illegal immigrants, the strain on our resources (including schools, hospitals, etc.)"
+0,1,0.16666999,"i worry that newer immigrants are not assimilated as easily into this country as in the past"
+0,0,0.833,"legals (desirable) vs. illegals (criminals)
+
+very complicated
+
+many do what is good for themselves, rather than what is fair and just."
+0,0,0.333,"border control, certain illegal immigrants tolerated, and others immediately deported."
+0,0,0,"illegals"
+0,1,0.333,"i am most worried about the conception that forms in the relation of the modern nation state to that of the foreigner.  a relation of same and other is established that marginalizes the other in such a way as to turn hospitality into slavery.  the largest worries of immigration manifest themselves as concerns over economic effects primarily because the nation state has communally devolved into a neoliberal capitalist organization.  it is the corporisation of the state that governs the question of immigration, the question that is then framed in terms of resources and production.  my worry is that capitalist democracy will continue to perpetuate itself and replace community with individualism, consumerism, and the great american freedom-the freedom to buy"
+0,0,0.16666999,"just have everyone come in legal"
+0,1,0.66667002,"all the illegals coming in to the country."
+0,1,0.66667002,"job avalability"
+0,1,0.833,"i'm concerned the immigrants might not understand that democracy, which provides many freedoms, requires we act responsibly toward others to allow them their freedoms."
+0,1,0.66667002,"i think any illegal alien should be deported with no questions. if they come here and break our laws they deserve no consideration and should be treated as criminals and actively persued.
+
+illegals should get no benefits at all in anyway. no welfare of any kind and again deported.
+
+legal immigrants should be required to learn english before becoming a citizen. a certain amount should be required in a set period of time. 
+
+ a criminal record should be reason for a visa to be denied."
+0,1,1,"border security is my major concerns. however, immigration needs to be better informed with screening of potential terrorists."
+0,0,0.16666999,"people from other countries coming to america for a chance at a better way of life.  people illegally entering this country."
+0,1,0.66667002,"too many non speaking english americans
+too many people that do not stand with what we were founded on.
+
+too much trouble wanting their ways and not becoming americanized"
+0,1,0.333,"the unemployment and health care issues of americans"
+0,0,1,"legal immigration is ok and needed in u.s.
+illegal immigration is very wrong for u.s.
+ - causes job loss for citizens
+ - drain on ""medical system""
+ - crime rises in communities where
+   illegals stay"
+0,0,0.333,"wall construction
+amnesty"
+0,0,0,"jobs that no one else will do for a low wage, people that are taken advantage of, and hated for wanting a better life."
+0,0,0.833,"non us citizens coming over to the us and taking our jobs."
+0,0,0.5,"the history of this country. this country has a strong history with immigration being a crutial part."
+0,1,1,"no one speaks english anymore.  we are giving immigrants free health care.  immigrants do not contribute anything to the economy.  the immigrants immediately send their earnings back home to their country.  i can go on and on and on ............."
+0,1,1,"illegals getting all the benefits that us americans can't.  they get free medical, which causes met to have to pay $125 and up to visit a doctor due to no insurance which i can't afford.  grandmother who gets less than $600 a month, can't even get food stamps and i see people who can't speak english with hundreds of dollars of groceries all the time.  can't speak english means didn't work here and put into the system like the rest of us."
+0,0,1,"college students, grad students, foreign motel owners,stolen technology, passports, migrant workers, landscape workers, legal and illegal immigration"
+0,0,0.833,"i think its a good thing bc the ones that live n the usa and is legal means we can now have more houses and job and dont have to worry bout them and problems they cause"
+0,0,1,"people from other countries coming to the usa to work"
+0,1,0.66667002,"i am not worried about immigration."
+0,1,0.66667002,"i am concerned with citizen benefits being given to illegal aliens who probably are not paying into the system.  this will bankrupt this nation sooner or later."
+0,1,0.66667002,"don't think illegal immagrates who have lived here for years should receive special treatment.  they should still go through the process and become citizens just like anyone else coming to this country.  they've had a free ride and we've paid for it."
+0,0,0,"i do not like the ifea of illegal immigration, but i also think it is too difficult to legally get residency in this country, especially if you are seeking asylum from religious persecution."
+0,0,0,"the construction of the fence along the border. the deaths of people smuggled into the us in unventilated trucks.  people starving or freezing to death in the desert"
+0,1,1,"schools, hospitals, total infrastructure of our communities"
+0,0,1,"illegal immigrants coming from mexico, border patrol around texas, california, etc,"
+0,1,1,"border security is lacking. 
+mexicans have no regard for our system of law.
+washington has let illegal immigration go on, too long"
+0,1,0.333,"that people who are violent might come over."
+0,1,0.833,"illegal, getting services they don't deserve, not learning to speaknglish e"
+0,0,1,"illegal immigration,cost of social services for illegals,cost of illegals without car insurance, lost jobs, crime,"
+0,0,0.5,"the current debate centers on illegal immigrants from mexico.  i think our immigration policy should be as stringent as the mexican policy, which makes it extremely difficult for americans to work or live in mexico."
+0,0,0.333,"taxes, public services, opportunity."
+0,1,0.833,"not well versed."
+0,1,1,"bad for  every thing,,"
+0,0,0.833,"we have laws on the books why dont we use them. illigals should be deported no exception."
+0,0,0.16666999,"people form many countries coming to the united states for a better life. learning to speak english;being self supporting and becoming a citizen of the usa. flying one flag,keeping their history a part of their lives,but not forcing their way on everyone else..there's apart of my town i was raised in, but now cannot go shopping on that side because no-one speaks 
+english..  when did i leave the usa?
+"
+0,1,0.16666999,"illegal immigrants getting health, social security and ssi benefits when they have paid nothing into the system.  we need to make english the language of usa."
+0,1,1,"that they are getting money that really could be used to help our poor here in the usa"
+0,1,0.66667002,"people entering without paperwork"
+0,0,0.333,"i think it is a double edged sword."
+0,1,0,"no control.  us has lost all control.  not only illegel but drugs etc., etc. enter each day."
+0,0,0,"i think of, first off, where i grew up. southern california is full of immigrants from much of south & central america."
+0,1,0.333,"could continue to be a major disagreement amongst americans."
+0,0,1,"close the borders"
+0,1,0.16666999,"english as primary language
+equality for all
+traditions and customs
+fear of the unknown"
+0,1,1,"bigger taxes
+larger deficits
+unfair amnesty
+no social security $"
+0,1,0.66667002,"crime, possible terrorists, taking jobs from citizens, not learning our language"
+0,0,0.66667002,"i think with our (us) needing more  help here ,and less over seas  ,i think there should be a complet stop of letting people in the us so anyone of them cant kill anyone of us anymore.and all of our men and woman shoud be brought back to the us , instead of fighting a war we dont belong in ..."
+0,0,1,"illegal immagrants, refugees from other contries seeking assilum, border patrol"
+0,0,0,"strain on health care and education systems"
+0,1,0.66667002,"jobs- healthcare- schools - gangs"
+0,0,1,"mexicans working here and not paying taxes,fences won't work we need to go to a flat tax with a discount rate for seniors."
+0,0,1,"expense.  why we are not enforcing the laws we already have on the books. possibility of terrorists getting in more easily. why are we accomodating the aliens by printing things in other languages and having to push buttons to hear things in our own language.  why do we give free medical services to them when we can even take care of our own first. insurances going up to cover immigrants.  it seems that they are better accomodated than our own citizens. they are given rights, which they have not earned. i'm retired and i'm tired of costs going up because they are able to use and abuse our system to our debtrement."
+0,1,0.66667002,"illegal immigrants and terrism"
+0,1,0.5,"i want illegals gone.  they cost my husband his business.  they come here undercut the americans, and then raise their prices after they've driven hard working americans out of their jobs."
+0,0,0.66667002,"poor people wanting a better life because their own country is so full of 
+corruption. they have found it too easy to slip accross the border and our government must have some reasons for wanting them here to keep our wages lower. it has kept pur young from summer jobs. they are a major drain on 
+our health care system as well as all the welfare that many get. i don't what the answer is to fixing the problem with the ones already here but amnesty as it was done the last time is not the answer either. i personally helped 3 women get their papers the last time and as far as i know only 1 became a citizen. i beleive they should all speak english and we shouldn't have to pay extra so they can learn. it should not be our job t learn spanish."
+0,0,0,"the government seems to think we need to give everybody a free ride even though they are here illegaly.  if all of the free medical care they recieve and all the other benefits they recieve was denieded them the legal americans like me could afford proper medical care, prescriptions amoung other things."
+0,0,1,"people coming from another country"
+0,0,0.333,"mexico, fences, death"
+0,1,1,"i'm a painting contractor and worry about lower painting wages which translates to cheaper costs overall.  i cannot do jobs as cheaply, while providing my own health care and day to day living expenses."
+0,0,0.833,"illegal aliens, national security, the border with mexico"
+0,1,0.16666999,"violence, social security, welfare"
+0,1,0.66667002,"illegal immigrants coming into our country.
+illegal immigrants being a artificially low wage earner which takes away jobs that could go to americans.
+illegal immigrants working here but not paying their fair share of taxes since it is in large part an underground ""cash based"" society"
+0,1,0,"the over-hyped concern over a relatively minor problem concerns me."
+0,0,0,"people should be allowed to come over here, but there should be some guidelines."
+0,0,0.66667002,"social security, jobs, health care."
+0,1,0.833,"crime rate, illegal immigration,"
+0,0,0.5,"we need to get the upper hand on immigration, and treat everyone equally.
+we don't need to just start handing out licenses. 
+and let's keep america's #1 language english!!!"
+0,0,1,"i donot like ethinic groups not learning our language. if they live here they should speak english. i believe they should get here legally."
+0,0,0.333,"mexico
+nazi
+illegal"
+0,0,0,"mexico
+difficult"
+0,0,0,"illegal immigrants
+job loss
+more crimes
+school cost for immigrants"
+0,1,0.333,"terrorists entering the u.s.  we have too many taxes as it is without supporting more people.  i don't like the fact the some immigrants don't have to pay taxes for the first 5 years they are here.  our schools are too crowded as it is."
+0,1,1,"illegals taking our jobs
+free health care
+free loaders
+other countries ""dumping"" their unwanteds in our country"
+0,0,0.833,"s.s. or the lack of it 
+all the money the gov. spends on them"
+0,1,0.5,"that there are different rules for people depending on the country they are coming from. westerns europeans and others from wealthy nations can easily enter the us but people from developing countries have a difficult time obtaining visas because too many  people have abused the system (sneaking into the country; using a tourist visa to enter and staying illegally)."
+0,1,0.66667002,"the confusion over ""illegal"" vs legal immigrants. illegal immigration: will dregrade our nation heritage, ulimately weaking our strengths. increased costs to the public, for all services. crime increases, cultural division."
+0,0,1,"i think legal immigrants are great. i think the us should help other countries become better economically and safer places to live. we should work out a sensible,humanitarian and fair solution for the people & children that are here illegally. it isn't wise or safe to allow illegal immigration to continue as is."
+0,1,1,"wide open borders that allow terrorists to enter at will
+increased costs of health care due to illegal immigrants taxing the hospital system
+talk of amnesty causing a greater influx of illegal immigrants
+on the other hand, tough immigration practices causing families to be torn apart when illegals are sent home
+prices rising dramatically due to the loss of inexpensive labor"
+0,1,1,"more cost to me and america
+safety"
+0,0,0.333,"drain on the economy,displacement of american workers"
+0,0,0.833,"people coming to this country without following the rules to do that"
+0,1,1,"taxes going up
+jobs being taken away from our workers
+i am tried of the new breed not learning our english!  when in  rome do as the romans do."
+0,0,1,"we need to stop illegal immigration"
+0,0,1,"it is out of control and nothing is really being done about it and im not sure anything can."
+0,0,0.333,"i think that people who are already in america and who work, pay taxes should be granted asylum."
+0,0,1,"illegal"
+0,1,0.66667002,"ilegal immigrants drwaing medical and social security benrfits."
+0,0,0.5,"there is a difference between legal and illegal immigration .
+stop the illegal."
+0,0,0.333,"i think immigration is fine as long as they do it legally."
+0,0,0.333,"i think they need to stop immigration in the us."
+0,0,0.333,"i
+dont
+know"
+0,1,0.333,"work taken away"
+0,0,0.16666999,"close the borders. come here legally. learn the language it's english!!"
+0,0,0.66667002,"1. boarders need to be secured. 2. illegals need to be deported. 3.legals need to be treated fairly"
+0,1,0.833,"job loss to those who would work for les pay."
+0,0,0.333,"that the fence is a ridiculous idea"
+0,1,1,"coming in illegally and staying
+increasing costs to those that do pay taxes"
+0,1,0.16666999,"over population, jobs, lowered wages. prejudice, violence, terrorist."
+0,0,0.5,"i believe we need to protect our borders.  we need to be sure people entering our country are doing so legally."
+0,0,0.333,"the us-mex border
+statue of liberty
+irish immigration
+chinese railroad"
+0,0,0.333,"people that do not speak english in the united states, that take jobs away from americans because they will work for pennies then send it back to their home land and not put it back into our economy that is taking care of them. etc."
+0,0,0.16666999,"illegal workers"
+0,1,1,"#1 is it legal , #2 if not legal are they criminals ,terrorists , are they taking my job away , will they bother to learn english , do they really want to become american citizens or just collect bennefit from the government and the tax payer ."
+0,0,0.333,"problems"
+0,1,1,"inflation
+illegals"
+0,1,0.16666999,"violence that may occur from people that are already here against immigrants and violence from immigrants because of frustration of unfulfilled dreams."
+0,0,0.66667002,"legality of immigrants; border security"
+0,1,0.16666999,"over crowding, jobs taken away from natural citizens"
+0,0,0.333,"dont care"
+0,0,0.333,"bad economy, crime rates, unemployment, money under the table..."
+0,1,0.833,"illegals coming over the mexico boarder in droves to infest the country like cockroaches"
+0,0,1,"who much of a waste of time it is"
+0,1,0.16666999,"loss of jobs for americans
+increase in crime
+challenge on services such as healthcare"
+0,0,0.5,"migrant workers, mexicans, green cards, passports, border security, people willing to do jobs most americans don't want, multi-lingual culture, ignorance, fear, hypocrisy of americans"
+0,0,0.833,"abuse of healthcare and welfare programs.
+potential workers for less desirable jobs."
+0,1,0.5,"dearth of creative ways to deal with problem; fact that large employers are getting a free ride with underpaid aliens; stupidity of govt. in erecting a fence; truckers from mexico using our roads and not paying taxes for the upkeep."
+0,1,1,"the impact of illegal imigration on our schools and health care system"
+0,0,0.16666999,"since my grandparents were immigrants from europe, i think of people who want to build a better life for themselves and their families by coming to the u.s. - legally."
+0,1,0.16666999,"i really dont know about immigration or what it means"
+0,1,1,"way to many
+they get benefits that i don't 
+they should go home and come back the right way"
+0,1,0.833,"social security
+health coverage
+job security
+poverty level"
+0,1,0,"americans are not receptive to speakers of other than english and people who live south of the rio grande. immigrants are treated poorly by average citizens."
+0,1,0.833,"the fact that congress doesn't have the balls to enforce the laws already on the books. i don't understand why they are debating new laws when there are enought get a hold on the issue. congress is mainly run by special interest groups and lobbyists and i don't foresee them ever doing anything substantial until the lobbyists are kicked out of washington."
+0,1,0.16666999,"illegal immigrants, what this means for u.s., tax dollars not being paid"
+0,1,0.833,"it's not so much a worry as it is annoying.  if you want to come in the usa, fine, but do it legally. i resent the fact that i pay taxes, they don't and they take jobs from the legal immigrants."
+0,0,0,"mexicans."
+0,0,1,"legal entry into a country
+that challenge of illegal entrants and how to eliminate them
+bring me your tired, your poor...."
+0,1,1,"individuals coming to america at the taxpayers expense."
+0,0,0.333,"i think that immigration is fine.  i mean we all are immigrants if you think about it.  the only one's who aren't are the native americans.  we all came over to the americas."
+0,1,0.333,"losing good paying jobs to illegal immigrants.
+illegal immigrants not paying taxes.
+the government not doing enough to take care of illegal immigrants."
+0,0,0.16666999,"illegals, slave trade, child workers, racism"
+0,0,0.16666999,"i think we need new immigration laws that restrict the amount of immigrants into this country. i also think that immigrants need to learn our language, we should not have to cater to theirs."
+0,0,0.66667002,"people coming through ellis island."
+0,1,0.16666999,"job security, wreckless driving, auto accidents."
+0,0,0.66667002,"confused.  i think that everyone should be a citizen so that we receive money from their for their portion of taxes.  i also think that our country needs the immigrants more than we think as they will do almost any job, which many american's don't want to do."
+0,0,1,"citizens of other nations entering the united states."
+0,1,0.66667002,"i am enthusiastic about legal immigrants willing to assimilate and be productive members of american society.
+
+i worry that illegal immigrants have no incentive, and often no desire to assimilate.
+
+i worry that illegal immigrants are disproportionally involved in violent crimes, as well as drug and property crimes.
+
+i worry that our culture and language may be diminished by those not willing to assimilate.
+
+i worry that that our our society devotes more and more of it's resources providing health care, education and other services to those not willing to assimilate.
+
+i worry that our careless attitude about enforcing our border and immigration policy will lead to another 9/11 style terrorist attack."
+0,1,0.333,"i wonder about the thoughts in the heads of the immigrants, if they just want to be free of their former lives, or if they want to take ours."
+0,0,0.16666999,"language barriers, low income, opportunity, jobs"
+0,1,0.333,"lost jobs, unpaid taxes, undercut wages, benefits to illegals, gang violence"
+0,0,1,"illegals"
+0,1,0.66667002,"illegal
+
+language"
+0,0,0.833,"is thier  legal i could deal with it"
+0,0,0.66667002,"legal = good, illegal = out of control, border agents wrongly jailed, fences, desperation,"
+0,1,0,"people getting more benefits and paying no taxes,when people who lived here all there lives get no breaks, immigrants come to this country working for less money"
+0,0,0.66667002,"send them back"
+0,1,0,"people becoming violent toward immigrants"
+0,0,0.833,"illegal immigrants
+mexico"
+0,0,1,"if there were not jobs available then they would not come"
+0,1,1,"our immigration system doesn't work. beauacrats are sitting on their duffs and letting undocummented aliens, often subversive ones, flood our country. i don't see any efforts to repair the situation."
+0,1,1,"the people who are having problems with immigration are immigratens them selves. we need the immigrents for a work force for aboration has killed the workforce."
+0,0,0.333,"i think we spend to much money on taking care of people that are no payin g taxes."
+0,0,0.333,"1,difficult for worker immigrants.
+2,process takes too long.
+3,high fees from government and hiring lawyer.
+4,too much paper work
+5,immigration laws favor certain countries."
+0,1,0.833,"more than one side: being over-run, drugs, lower-end jobs not being filled, families tramatized, people wanting a better life"
+0,0,0.833,"there's no problem with immigration, it's illegal immigration that's a problem"
+0,1,0,"very little"
+0,1,0.833,"i worry about the state of the economy and the strain the immigrants are putting on it. using systems that were put in place by tax payers, who will likely never be able to use them because the government is giving aid to people who have never paid into them."
+0,1,0,"excess population
+jobs
+gangs
+education system
+j"
+0,1,1,"increasd costs to our economic and government systems, i.e. welfare, healthcare, educational, criminal justice, social security, etc.
+
+lack of respect of the american way of life, i.e. refusal to learn english or do the things that people who have immigrated to this country have done for years to assimilate and began citizens of the us.  they want americans to learn their language, customs, etc."
+0,0,0.333,"controversy....political correctness....complex issue"
+0,1,0.16666999,"i'm worried about the fact that it's unfair as to who can get a visa to come live here and who can't."
+0,0,0.333,"something this country was built with. something the american population against immigrants coming into the country need to educate themsleves more in."
+0,0,0.16666999,"i think that we are country founded on immigration and we should definitely allow immigration, but with strict rules and regulations.  we need to be protected, physically and economically.  i think that if someone immigrates here and is a strain on society they should be removed."
+0,1,0.16666999,"immigration has been the life blood of this country and as long as we have jobs to be filled, people will be coming to fill them.  the lost of jobs is not due to  immigrants but to job outsourcing by large and small companies.  by making the crossing of the border with mexico so difficult, those workers who use to come to work for the season and then go home, are now bringing their families because they cannot risk going back and forth."
+0,1,0.833,"the benifits that are given to them,the schooling for the kids immigrents should all be registered,"
+0,0,0.833,"mexico, illegal workers, difficult immigration process"
+0,1,0.833,"loss of american culture.  loss of rights, money and services to americans.  lack of security.  double standards.  lack of unified english.  end of american way of life."
+0,0,0.16666999,"immigration is fine as long as it is done legally.  people that are here illegally should be sent back to their country"
+0,1,0,"diseases"
+0,0,0.5,"mexican illegals in america"
+0,0,1,"i think of the american born people, and how we've sacrificed to give them their freedom. i think a lot of people have becom frustrated with it all. when white people apply for a job (minimum wage) and they are told their salary is not negotiable, and yet the minority is able to negotiate a higher wage for the same job. it is discrimination against our own. i think of what andy rooney said a while ago about this very subject and agree completely. if you come to our country - speak english. respect our laws. our country doesn't owe you anything, work for it like the rest of us! simply, i am against illegal immigrants, and legal immigrants should adjust to our ways, not us - to theirs."
+0,0,0.333,"people moving from one place to another, mostly for a better economic future."
+0,0,0.833,"bringing down our education systems, using up our government resouses less opportunities for americans for jobs, etc"
+0,0,0.5,"those people that are here illegally should be sent back to their own country.  mexicans"
+0,1,0.5,"racism & xenophobia make me worried!  also, corporations using immigrant labor because it's cheaper for them and the ensuing loss of well-paying jobs worries me quite a bit. vigilantes taking the law into their own hands at the border worries me."
+0,0,0.5,"that immigrants are the heart and soul and the creative growth that america has always had--all immigrants. that although we focus on latinos there are illegals from many countries whose people we consider ""white"". that it would behoove us to find some way to tax any income from those who work here. it is wrong to take social security payments from people who will not receive it. immigrants must become citizens within 2 years of their visa issue date unless a student. students could get another 2 years until a degree is procured . thereafter they leave or become citizens. we will expect other countries to require that from our citizens who live abroad. there should be a heavy tarriff on any money that leaves the u.s. by any electronic transfer, bank draft or otherwise. that it would then be cheaper for an immigrant to bring his family here than to send money out. that we are the second largest  source of revenue for the government of mexico because immigrants send money home."
+0,1,0.5,"job security for our citizens"
+0,1,0.5,"public safety, effect on the economy, whether or not they're entering legally (and if not how unfair and upsetting that is), that they're not willing to learn english"
+0,1,0.5,"nothing"

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -1,0 +1,140 @@
+"""Tests for topica.datasets (bundled + fetch-on-demand example data).
+
+The vendored Gadarian dataset is exercised for real (it ships in the package).
+The fetch path is exercised hermetically by monkeypatching urllib so the suite
+never touches the network; the live URL/checksum is validated out of band.
+"""
+
+import hashlib
+import io
+
+import pytest
+
+import topica
+from topica import datasets
+
+
+def _sha256_bytes(b: bytes) -> str:
+    return hashlib.sha256(b).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Vendored dataset: gadarian (ships in the wheel, loads offline)
+# ---------------------------------------------------------------------------
+
+
+def test_load_gadarian_dataframe():
+    df = datasets.load_gadarian()
+    assert len(df) == 341
+    for col in ("MetaID", "treatment", "pid_rep", "open.ended.response"):
+        assert col in df.columns
+
+
+def test_load_gadarian_return_path():
+    path = datasets.load_gadarian(return_path=True)
+    assert path.exists()
+    assert path.name == "gadarian.csv"
+    # vendored checksum matches the registry record
+    expected = datasets._REGISTRY["gadarian"]["sha256"]
+    assert datasets._sha256(path) == expected
+
+
+def test_gadarian_feeds_from_dataframe_and_fits():
+    """The quickstart smoke test: dataset -> corpus -> model, fully offline."""
+    df = datasets.load_gadarian()
+    corpus = topica.from_dataframe(
+        df,
+        text_col="open.ended.response",
+        stopwords=topica.ENGLISH_STOPWORDS,
+        min_doc_freq=2,
+    )
+    model = topica.LDA(num_topics=4, seed=1)
+    model.fit(corpus, iters=20)
+    assert model.topic_word.shape[0] == 4
+
+
+# ---------------------------------------------------------------------------
+# Cache location
+# ---------------------------------------------------------------------------
+
+
+def test_data_home_respects_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOPICA_DATA_HOME", str(tmp_path / "cache"))
+    home = datasets.get_data_home()
+    assert home == (tmp_path / "cache")
+    assert home.is_dir()
+
+
+# ---------------------------------------------------------------------------
+# Fetch path (hermetic: no real network)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def fake_remote(tmp_path, monkeypatch):
+    """Point the cache at a temp dir and serve a known payload over a fake
+    urlopen, with the registry checksum patched to match it."""
+    monkeypatch.setenv("TOPICA_DATA_HOME", str(tmp_path / "cache"))
+    payload = b"text,rating\nfoo bar baz,Liberal\nqux quux,Conservative\n"
+    calls = {"n": 0}
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            self.close()
+            return False
+
+    def fake_urlopen(url, timeout=None):
+        calls["n"] += 1
+        return _Resp(payload)
+
+    monkeypatch.setattr(datasets.urllib.request, "urlopen", fake_urlopen)
+    monkeypatch.setitem(
+        datasets._REGISTRY["poliblog"], "sha256", _sha256_bytes(payload)
+    )
+    return payload, calls
+
+
+def test_fetch_downloads_then_caches(fake_remote):
+    payload, calls = fake_remote
+    path = datasets.load_poliblog(return_path=True)
+    assert path.exists()
+    assert path.read_bytes() == payload
+    assert calls["n"] == 1
+    # second call hits cache, no further download
+    datasets.load_poliblog(return_path=True)
+    assert calls["n"] == 1
+
+
+def test_fetch_rejects_bad_checksum(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOPICA_DATA_HOME", str(tmp_path / "cache"))
+
+    class _Resp(io.BytesIO):
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            self.close()
+            return False
+
+    monkeypatch.setattr(
+        datasets.urllib.request, "urlopen", lambda url, timeout=None: _Resp(b"wrong")
+    )
+    monkeypatch.setitem(datasets._REGISTRY["poliblog"], "sha256", "0" * 64)
+    with pytest.raises(RuntimeError, match="checksum mismatch"):
+        datasets.load_poliblog(return_path=True)
+    # nothing left behind in the cache
+    assert not (tmp_path / "cache" / "poliblog.csv").exists()
+
+
+def test_fetch_network_error_is_friendly(tmp_path, monkeypatch):
+    monkeypatch.setenv("TOPICA_DATA_HOME", str(tmp_path / "cache"))
+
+    def boom(url, timeout=None):
+        raise datasets.urllib.error.URLError("no network")
+
+    monkeypatch.setattr(datasets.urllib.request, "urlopen", boom)
+    with pytest.raises(RuntimeError, match="could not download"):
+        datasets.load_dubois(return_path=True)


### PR DESCRIPTION
Closes #204.

Gives `pip install topica` users data to run the quickstart on, without bloating the wheel. Unblocks the CSV-first onboarding work in #205.

## API

```python
import topica
df = topica.datasets.load_gadarian()        # vendored in the wheel, instant, offline
corpus = topica.from_dataframe(df, text_col="open.ended.response", stopwords=topica.ENGLISH_STOPWORDS)
```

- `load_gadarian()` — 341 docs, **vendored** in the wheel (49.8 KB), loads offline.
- `load_poliblog()` — 2000 docs (pre-stemmed), **fetched** once and cached.
- `load_dubois()` — 704 docs (raw text), **fetched** once and cached.
- `get_data_home()`, `clear_cache()` helpers. Every loader takes `return_path=True` for a pandas-free path.

## Design

- Fetch URLs pinned to an **immutable commit** (`cbb6fe4`), each download **SHA-256 verified** and cached under `~/.cache/topica/datasets` (override with `TOPICA_DATA_HOME`). A given topica version always fetches the same bytes.
- Atomic write (download to `.part`, verify, rename); friendly errors on network failure and checksum mismatch.
- Dropped `load_poliblog5k()` — that file is gitignored / not on the remote, so it can't be fetched. The 2000-doc `load_poliblog()` covers the quickstart need.
- `[tool.maturin] include` ships the vendored CSV in the wheel.

## Verification

- New `tests/test_datasets.py`: 7 tests (vendored load, return_path, checksum match, hermetic fetch + cache, checksum-mismatch rejection, friendly network error, quickstart smoke fit). All pass.
- Full suite: **2703 passed, 26 skipped**.
- `mkdocs build --strict` clean.
- Live fetch against the pinned commit (out of band): poliblog → 2000 rows, dubois → 704 rows, both checksum-verified.
- Built wheel confirmed to bundle `topica/datasets/_data/gadarian.csv`.

> Note: these loader names/signatures become part of the frozen API surface, so they're named to read cleanly the first time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)