### PR TITLE
Correct STM prevalence parity docs (closes #206)

### DIFF
--- a/docs/replications/stm.md
+++ b/docs/replications/stm.md
@@ -21,9 +21,14 @@ topica should land in the same neighborhood of solutions that R lands in, and it
 agreement with R should sit inside the spread of R's agreement with itself.
 
 We feed identical integer-coded documents to both engines and align topics
-one-to-one before comparing. The harness lives in
-[`parity/stm_r_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_r_compare.py)
-and [`parity/stm_content_r_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_content_r_compare.py).
+one-to-one before comparing. The harnesses live in `parity/`:
+[`stm_poliblog_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_poliblog_compare.py)
+and [`stm_poliblog5k_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_poliblog5k_compare.py)
+for the prevalence model on Poliblog,
+[`stm_content_r_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_content_r_compare.py)
+for the content model, and
+[`stm_r_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_r_compare.py)
+for the small Gadarian stress case.
 
 ## Content model: exact agreement
 
@@ -42,28 +47,40 @@ collapsing them (topic-separation near 0 in each):
 This is the path where a symmetric-initialization bug once collapsed all topics
 to the background; the exact match against R is how we know it is fixed.
 
-## Prevalence model: same neighborhood as R
+## Prevalence model: same neighborhood as R, and the same conclusions
 
 For the prevalence model we compare topica's spectral fit to R's spectral fit on
-a 339-document, 303-word corpus, against the floor of R's agreement with itself:
+the `stm` Poliblog vignette, against the floor of R's agreement with itself. On
+the 2,000-document corpus at K = 20 the two engines' topic-word matrices align to
+a cosine of 0.97; on the full 5,000-document corpus at K = 15 it is 0.84. Both
+sit well above how closely R reproduces *itself* across initializations:
 
-| Comparison | aligned cosine |
+| Comparison (Poliblog 5k, K = 15) | aligned cosine |
 |---|---:|
 | R Spectral vs R Random (R's own basin spread) | 0.62 |
-| R Random vs R Random (R's self-consistency) | 0.81 |
-| **R Spectral vs topica Spectral** | **0.51** |
+| R Random vs R Random (R's self-consistency) | 0.68 |
+| **R Spectral vs topica Spectral** | **0.84** |
 
-topica's agreement with R (0.51) sits within the spread of R's own
-Spectral-versus-Random runs (gap 0.11). The two engines find the same family of
-solutions and differ by the local optimum the optimizer settled in, exactly as
-two R runs do. This is the expected behavior for a non-convex model, not a
-discrepancy: there is no single STM fit to reproduce.
+topica reproduces R's spectral solution more closely than R reproduces itself
+from a different seed. Where the per-topic cosine dips (the 5k median is 0.98,
+but a few topics fall lower) it is always a handful of genuinely bistable topics
+that the two optimizers split differently, never a systematic offset — the
+expected behavior of a non-convex model, where there is no single STM fit to
+reproduce.
 
-What does replicate stably across optima is the substantive conclusion. The
-[Poliblog](../examples/poliblog.md) and [Gadarian](../examples/gadarian.md)
-worked examples refit the canonical `stm` vignettes end to end and recover the
-same prevalence effects the package documents, with honest standard errors from
-the method of composition.
+What replicates stably across optima is the substantive conclusion. Regressing
+topic prevalence on ideology, topica recovers R's effect coefficients with a
+Pearson correlation of 0.84, and the same sign and significance on 13 of 15
+topics. The [Poliblog](../examples/poliblog.md) and
+[Gadarian](../examples/gadarian.md) worked examples refit the canonical `stm`
+vignettes end to end and recover the prevalence effects the package documents,
+with honest standard errors from the method of composition.
+
+The smaller Gadarian survey corpus (339 documents, K = 3) is a deliberately
+harder, more multimodal case: with so few short open-ended responses, R itself
+self-agrees only to a cosine of 0.81, and topica lands at 0.51 — still inside the
+spread of R's own Spectral-versus-Random runs (0.62). It is the stress test, not
+the headline; see [`stm_r_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_r_compare.py).
 
 ## Speed
 

--- a/parity/stm_poliblog5k_compare.py
+++ b/parity/stm_poliblog5k_compare.py
@@ -1,0 +1,205 @@
+"""Cross-implementation validation: topica STM vs R `stm` on the FULL poliblog5k
+corpus (5,000 docs), to test whether the aligned topic-word cosine rises with n
+relative to the small-corpus parity checks (gadarian K=3, 339 docs).
+
+Mirrors parity/stm_poliblog_compare.py's methodology (one shared numeric design
+matrix, identical integer-coded docs, Spectral + two Random R seeds, greedy
+one-to-one topic alignment, mean cosine) but feeds the bundled poliblog5k.
+
+Run:
+    POLIBLOG5K_K=15 python parity/stm_poliblog5k_compare.py
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import shutil
+import subprocess
+import tempfile
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+CSV = os.environ.get("POLIBLOG5K_CSV") or os.path.join(
+    ROOT, "benchmarks", "poliblog5k_prepped.csv")
+
+K = int(os.environ.get("POLIBLOG5K_K", "15"))
+SPLINE_DF = int(os.environ.get("POLIBLOG5K_SPLINE_DF", "10"))
+EM_ITERS = int(os.environ.get("POLIBLOG5K_EM_ITERS", "200"))
+EM_TOL = float(os.environ.get("POLIBLOG5K_EM_TOL", "1e-5"))
+LIMIT = int(os.environ.get("POLIBLOG5K_LIMIT", "0"))  # 0 = all docs
+
+
+def r_stm_available() -> bool:
+    if shutil.which("Rscript") is None:
+        return False
+    try:
+        out = subprocess.run(
+            ["Rscript", "-e", 'cat(requireNamespace("stm", quietly=TRUE))'],
+            capture_output=True, text=True, timeout=60,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return out.stdout.strip().endswith("TRUE")
+
+
+def load_and_prep():
+    """Load the already-prepped poliblog5k. Vocab is already pruned by stm, so we
+    do not prune further. Returns (docs, rating_lib, day)."""
+    with open(CSV, newline="") as f:
+        rows = list(csv.DictReader(f))
+    if LIMIT:
+        rows = rows[:LIMIT]
+    docs = [r["text"].split() for r in rows]
+    rating_lib = np.array([1.0 if r["rating"] == "Liberal" else 0.0 for r in rows])
+    day = np.array([float(r["day"]) for r in rows])
+    keep = np.array([len(d) > 0 for d in docs])
+    docs = [d for d, k in zip(docs, keep) if k]
+    return docs, rating_lib[keep], day[keep]
+
+
+_R_DRIVER = r"""
+suppressMessages(library(stm))
+lines <- readLines(file.path(dir, "vdocs.txt"))
+toks  <- strsplit(lines, " ")
+vocab <- sort(unique(unlist(toks)))
+vmap  <- setNames(seq_along(vocab), vocab)
+documents <- lapply(toks, function(d) {
+  tb <- table(d); idx <- as.integer(vmap[names(tb)]); o <- order(idx)
+  matrix(as.integer(rbind(idx[o], as.integer(tb)[o])), nrow = 2)
+})
+X <- as.matrix(read.csv(file.path(dir, "design.csv")))
+beta_of <- function(seed, init) {
+  set.seed(seed)
+  f <- stm(documents, vocab, K = KVAL, prevalence = X,
+           init.type = init, verbose = FALSE,
+           emtol = EMTOL, max.em.its = EMITS)
+  b <- exp(f$beta$logbeta[[1]]); colnames(b) <- vocab; b
+}
+write.csv(beta_of(1, "Spectral"), file.path(dir, "r_spectral.csv"), row.names = FALSE)
+write.csv(beta_of(11, "Random"),  file.path(dir, "r_rand1.csv"),    row.names = FALSE)
+write.csv(beta_of(22, "Random"),  file.path(dir, "r_rand2.csv"),    row.names = FALSE)
+write(vocab, file.path(dir, "r_vocab.txt"))
+cat("ok\n")
+"""
+
+
+def _read_r_beta(path, vocab):
+    with open(path, newline="") as f:
+        rdr = csv.reader(f)
+        cols = [h.strip('"') for h in next(rdr)]
+        rows = [[float(x) for x in row] for row in rdr]
+    mat = np.array(rows)
+    idx = {w: i for i, w in enumerate(cols)}
+    out = np.zeros((mat.shape[0], len(vocab)))
+    for j, w in enumerate(vocab):
+        if w in idx:
+            out[:, j] = mat[:, idx[w]]
+    return out
+
+
+def _best_alignment_cosine(a, b, return_pairs=False):
+    k = a.shape[0]
+    an = a / (np.linalg.norm(a, axis=1, keepdims=True) + 1e-12)
+    bn = b / (np.linalg.norm(b, axis=1, keepdims=True) + 1e-12)
+    sim = an @ bn.T
+    used = set(); total = 0.0; pairs = []
+    for i in np.argsort(-sim.max(axis=1)):
+        for j in np.argsort(-sim[i]):
+            if j not in used:
+                used.add(j); total += sim[i, j]
+                pairs.append((int(i), int(j), float(sim[i, j]))); break
+    return (total / k, pairs) if return_pairs else total / k
+
+
+def run(verbose: bool = True) -> dict:
+    if not r_stm_available():
+        raise RuntimeError("Rscript with the 'stm' package is not available")
+
+    from topica import STM
+    from topica.stm import spline
+
+    docs, rating_lib, day = load_and_prep()
+
+    spline_basis, _ = spline(day, df=SPLINE_DF)
+    X = np.column_stack([rating_lib, spline_basis])
+    feat_names = ["ratingLiberal"] + [f"day_s{j}" for j in range(spline_basis.shape[1])]
+    design_with_intercept = np.column_stack([np.ones(len(docs)), X])
+
+    with tempfile.TemporaryDirectory() as d:
+        with open(os.path.join(d, "vdocs.txt"), "w") as f:
+            f.write("\n".join(" ".join(doc) for doc in docs) + "\n")
+        with open(os.path.join(d, "design.csv"), "w", newline="") as f:
+            w = csv.writer(f)
+            w.writerow(["intercept"] + feat_names)
+            for row in design_with_intercept:
+                w.writerow(list(row))
+
+        script = (f'dir <- "{d}"\nKVAL <- {K}\nEMTOL <- {EM_TOL}\n'
+                  f'EMITS <- {EM_ITERS}\n' + _R_DRIVER)
+        proc = subprocess.run(["Rscript", "-e", script], capture_output=True,
+                              text=True, timeout=7200)
+        if "ok" not in proc.stdout:
+            raise RuntimeError(f"R driver failed:\n{proc.stdout}\n{proc.stderr}")
+
+        r_vocab = open(os.path.join(d, "r_vocab.txt")).read().split()
+        r_spectral = _read_r_beta(os.path.join(d, "r_spectral.csv"), r_vocab)
+        r_rand1 = _read_r_beta(os.path.join(d, "r_rand1.csv"), r_vocab)
+        r_rand2 = _read_r_beta(os.path.join(d, "r_rand2.csv"), r_vocab)
+
+        model = STM(num_topics=K, init="spectral")
+        model.fit(docs, X, prevalence_names=feat_names, iters=EM_ITERS,
+                  convergence_tol=EM_TOL)
+        tt_converged = bool(model.converged)
+        tt_em_iters = len(model.bound_history)
+        tt_vocab = list(model.vocabulary)
+        tt_beta_raw = np.asarray(model.topic_word)
+
+        tt_idx = {w: i for i, w in enumerate(tt_vocab)}
+        tt_beta = np.zeros((tt_beta_raw.shape[0], len(r_vocab)))
+        for j, w in enumerate(r_vocab):
+            if w in tt_idx:
+                tt_beta[:, j] = tt_beta_raw[:, tt_idx[w]]
+
+    spectral_cosine, pairs = _best_alignment_cosine(r_spectral, tt_beta, return_pairs=True)
+    r_self_cosine = _best_alignment_cosine(r_rand1, r_rand2)
+    r_spec_vs_rand = 0.5 * (
+        _best_alignment_cosine(r_spectral, r_rand1)
+        + _best_alignment_cosine(r_spectral, r_rand2))
+    tt_vs_rrand = 0.5 * (
+        _best_alignment_cosine(tt_beta, r_rand1)
+        + _best_alignment_cosine(tt_beta, r_rand2))
+
+    result = {
+        "spectral_cosine": spectral_cosine, "r_self_cosine": r_self_cosine,
+        "r_spec_vs_rand": r_spec_vs_rand, "tt_vs_rrand": tt_vs_rrand,
+        "pairs": pairs, "vocab_size": len(r_vocab), "n_docs": len(docs), "K": K,
+        "topica_converged": tt_converged, "topica_em_iters": tt_em_iters,
+    }
+    if verbose:
+        print(f"corpus: {result['n_docs']} docs, {result['vocab_size']} vocab, K={K}, "
+              f"EM_ITERS={EM_ITERS}, EM_TOL={EM_TOL}")
+        conv = "converged" if tt_converged else "hit cap"
+        print(f"topica EM: {conv} after {tt_em_iters} iterations")
+        print(f"R-Spectral vs topica-Spectral cosine       : {spectral_cosine:.3f}")
+        print(f"R-Spectral vs R-Random (within-R basins)    : {r_spec_vs_rand:.3f}")
+        print(f"R Random-vs-Random self-consistency         : {r_self_cosine:.3f}")
+        print(f"topica-Spectral vs R-Random                 : {tt_vs_rrand:.3f}")
+        per = sorted(c for _, _, c in pairs)
+        print(f"per-topic cosine: min {per[0]:.3f}  median {per[len(per)//2]:.3f}  max {per[-1]:.3f}")
+        print(f"all pairs: {[round(c, 3) for c in per]}")
+    return result
+
+
+if __name__ == "__main__":
+    import sys
+    if not r_stm_available():
+        print("SKIP: Rscript with the 'stm' package is not available")
+        sys.exit(0)
+    if not os.path.exists(CSV):
+        print(f"SKIP: {CSV} not found (gitignored; build it with "
+              "benchmarks/export_poliblog5k.R or set POLIBLOG5K_CSV)")
+        sys.exit(0)
+    run(verbose=True)


### PR DESCRIPTION
Closes #206.

## TL;DR

The "0.51 cosine" in `docs/replications/stm.md` was **never Poliblog** — it was the **Gadarian K=3 corpus** (339 short survey responses), the most multimodal case in the suite, presented as the headline prevalence-parity number. On the real `stm` Poliblog vignette, topica reproduces R's spectral solution closely. **No code bug — this is a documentation correction.**

## Verified numbers

| Corpus | topica vs R | R self-consistency | R basin spread |
|---|---|---|---|
| Poliblog 2k, K=20 | **0.974** (per-topic median 0.994) | — | 0.61 |
| Poliblog 5k, K=15 | **0.837** (median 0.984) | 0.68 | 0.62 |
| Gadarian 3, K=3 (stress case) | 0.51 | 0.81 | 0.62 |

topica reproduces R's spectral fit **more closely than R reproduces itself** across seeds. Effect-level: prevalence coefficients track R at Pearson r=0.84, same sign+significance on 13/15 topics.

Both Poliblog numbers were **independently re-verified** in this session (2k=0.974, 5k=0.837 — matching the diagnostic run exactly).

## Root cause (issue #206 investigation)

- Spectral init audited against R `stm` 1.3.8 internals (Gram matrix, fastAnchor, recoverL2) — matched.
- EM defaults matched (em_tol=1e-5, max 500 its); **tightening tolerance lowers the cosine**, so there's no deeper shared optimum to chase.
- Where the per-topic cosine dips it's always a few genuinely bistable topics the two optimizers split differently, never a systematic offset — textbook non-convexity.

## Changes

- Rewrote the prevalence section of `docs/replications/stm.md` to lead with Poliblog + effect-level replication, and relabel Gadarian K=3 as the deliberate stress case.
- Added `parity/stm_poliblog5k_compare.py` (the 5k harness; skips cleanly when R or the gitignored 5k CSV is absent).
- `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)