### PR TITLE
release: 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Changed
 
+- **pandas is now a core dependency** (alongside NumPy). The DataFrame-first
+  workflow (`from_dataframe`, `topica.datasets`, `topic_table`) is the default
+  on-ramp, so `pip install topica` now ships pandas and the quickstart runs with
+  no extras. Still no JVM and no PyTorch.
 - **Repo root slimmed** — `CONTRIBUTING.md` and `CONTRIBUTING-MODELS.md` moved
   under `.github/` (GitHub still surfaces the contributing guide from there).
   Dataset CSVs are marked `binary` in a new `.gitattributes` so their bytes (and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,25 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-06-16
+
 ### Added
 
+- **`topica.datasets`** — bundled example datasets for quickstarts and worked
+  examples: `load_gadarian` (vendored in the wheel, loads offline), `load_poliblog`
+  and `load_dubois` (downloaded once from a pinned commit, SHA-256 verified, cached
+  under `~/.cache/topica` or `TOPICA_DATA_HOME`). Each returns a pandas DataFrame
+  ready for `from_dataframe`, or the cached CSV path with `return_path=True`. (#204)
+- **InfoCTM** — topica's first cross-lingual topic model (Wu et al. 2023): two
+  ProdLDA models aligned by a bilingual dictionary through a topic-alignment
+  mutual-information term, so topics correspond across two languages. Brings
+  `text, dictionary`; validated against the reference. (#200)
+- **LLM-based topic evaluation** under the `topica.llm` namespace —
+  `topica.llm.coherence` and `topica.llm.intrusion` (Stammbach et al. 2023: have an
+  LLM rate a topic's word set or spot the intruder), `topica.llm.select_k` for
+  LLM-guided K selection, the Tan & D'Souza metric suite, and a pluggable
+  `topica.llm.backend` (OpenAI or local via ollama; the docs default to and
+  showcase open models). (#201, #202)
 - **ECTM content standard errors** — `topica.ectm.content_contrast_se` gives
   instant analytic per-word SEs for a group contrast (multinomial sampling
   variance from each cell's effective token count; conservative, ignores period
@@ -46,6 +63,25 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   (currently `ECTM`). Such models are kept out of the validated roster and refuse
   to construct or load until enabled (also via the `TOPICA_EXPERIMENTAL`
   environment variable). `topica.experimental_enabled()` reports the current state.
+
+### Changed
+
+- **Repo root slimmed** — `CONTRIBUTING.md` and `CONTRIBUTING-MODELS.md` moved
+  under `.github/` (GitHub still surfaces the contributing guide from there).
+  Dataset CSVs are marked `binary` in a new `.gitattributes` so their bytes (and
+  the dataset checksums) are identical across platforms. (#209)
+
+### Documentation
+
+- **CSV-first onboarding** — the README leads with a runnable `from_dataframe`
+  example on a bundled dataset and collapses the model roster behind a "start
+  here" teaser; the quickstart leads with the CSV path, the minimal `fit(corpus)`
+  call, and a choosing-K section. New `topica.datasets` API page. (#205, #207)
+- **STM prevalence parity corrected** — `docs/replications/stm.md` now leads with
+  the Poliblog results (aligned topic-word cosine 0.97 at 2k/K=20, 0.84 at
+  5k/K=15; prevalence effects track R at Pearson 0.84) instead of the mislabeled
+  Gadarian K=3 stress case (0.51). No code change; the parity was always there.
+  Adds the `parity/stm_poliblog5k_compare.py` harness. (#206)
 
 ## [0.21.0] - 2026-06-16
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,13 +1,13 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.16.2
-date-released: 2026-06-13
+version: 0.22.0
+date-released: 2026-06-16
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
-  numpy-native API, built for computational social scientists. More than a dozen
-  models (LDA, DMR, CTM, STM, SAGE, HDP, DTM, keyATM, SeededLDA, BERTopic,
-  Top2Vec, ETM, FASTopic, and more), each validated against its reference
+  numpy-native API, built for computational social scientists. More than two
+  dozen models (LDA, DMR, CTM, STM, SAGE, HDP, DTM, keyATM, SeededLDA, BERTopic,
+  Top2Vec, ETM, FASTopic, InfoCTM, and more), each validated against its reference
   implementation.
 type: software
 authors:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.21.0"
+version = "0.22.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.21.0"
+version = "0.22.0"
 edition = "2021"
 
 [lib]

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Docs](https://img.shields.io/badge/docs-mkdocs--material-blue.svg)](https://nealcaren.github.io/topica/)
 [![License: Apache-2.0](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 
-`topica` is a fast, all-purpose topic-modeling library for Python, built for computational social scientists who want to go from a column of text to publishable results in one workflow. It brings together models usually split across JVM tools like MALLET and R packages like `stm`, more than two dozen in all (LDA, STM, CTM, plus neural, dynamic, and embedding-based models), each paired with the validation, covariate-effect, and reporting tools reviewers expect. It installs as a single wheel that needs only NumPy: no JVM, no PyTorch.
+`topica` is a fast, all-purpose topic-modeling library for Python, built for computational social scientists who want to go from a column of text to publishable results in one workflow. It brings together models usually split across JVM tools like MALLET and R packages like `stm`, more than two dozen in all (LDA, STM, CTM, plus neural, dynamic, and embedding-based models), each paired with the validation, covariate-effect, and reporting tools reviewers expect. Where general toolkits like Gensim or BERTopic give you topics, topica is built around the question social scientists ask of them next: how topic prevalence and content relate to covariates, with reference-validated models and reproducible fits. It installs as a single wheel that needs only NumPy and pandas: no JVM, no PyTorch.
 
 ```bash
 pip install topica
@@ -44,7 +44,7 @@ Your own data is one line away: pass `pandas.read_csv("yours.csv")` to `from_dat
 
 Fits are reproducible and validated: the variational models are identical to the bit, the samplers reproduce from a fixed seed and thread count, and every model is checked against its reference implementation (R `stm`, MALLET, keyATM, and more).
 
-The core needs only NumPy. Optional extras add features without weighing it down: `topica[viz]` (matplotlib plots), `topica[formula]` (R-style formulas), `topica[polars]` (Polars frames), and `topica[llm]` (LLM labels and embeddings, OpenAI or local via ollama).
+The core needs only NumPy and pandas. Optional extras add features without weighing it down: `topica[viz]` (matplotlib plots), `topica[formula]` (R-style formulas), `topica[polars]` (Polars frames), and `topica[llm]` (LLM labels and embeddings, OpenAI or local via ollama).
 
 ## Models
 

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -12,8 +12,9 @@ or, with [uv](https://github.com/astral-sh/uv):
 uv pip install topica
 ```
 
-The only runtime dependency is **NumPy**. Everything else is an optional extra,
-so the core stays light. Install the ones you need:
+The runtime dependencies are **NumPy** and **pandas** (the DataFrame workflow,
+`from_dataframe`, and the bundled datasets all build on pandas). Everything else
+is an optional extra, so the core stays light. Install the ones you need:
 
 | Install | Enables |
 |---------|---------|

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Topica
 
-`topica` is a fast topic-modeling library for Python with more than a dozen
+`topica` is a fast topic-modeling library for Python with more than two dozen
 models, built for social scientists who want to move from text data to
 publishable results in a single workflow. It brings together models and tools
 usually split across JVM software like MALLET and R packages like `stm`, and
@@ -66,7 +66,7 @@ for i, words in enumerate(model.top_words(5)):
 
 ## Worked examples
 
-Three end-to-end analyses on real, redistributable corpora:
+End-to-end analyses on real, redistributable corpora:
 
 - [**W.E.B. Du Bois in *The Crisis***](examples/dubois.md): 704 articles,
   1910–1934, the full workflow from preprocessing to dynamic topics.
@@ -74,6 +74,10 @@ Three end-to-end analyses on real, redistributable corpora:
   vignette, reproduced.
 - [**Political blogs**](examples/poliblog.md): STM with ideology and time
   covariates.
+- [**Party platforms**](examples/ectm.md): how Democrats and Republicans word the
+  same topics, and how that contrast has shifted across 20 elections (ECTM).
+- [**LLM embeddings and labels**](examples/llm-topics.md): embedding-based topics
+  with contextual document vectors and LLM-generated topic labels.
 
 ---
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
     "Topic :: Scientific/Engineering :: Artificial Intelligence",
     "Topic :: Text Processing :: Linguistic",
 ]
-dependencies = ["numpy>=1.21"]
+dependencies = ["numpy>=1.21", "pandas>=1.3"]
 
 [project.urls]
 Homepage = "https://nealcaren.github.io/topica/"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.21.0"
+version = "0.22.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/tests/test_version_consistency.py
+++ b/tests/test_version_consistency.py
@@ -1,0 +1,43 @@
+"""Guard against version drift across the files that declare topica's version.
+
+``Cargo.toml`` (the Rust crate / what the built wheel reports), ``pyproject.toml``
+(the PyPI package), and ``CITATION.cff`` (the academic citation) must all agree.
+CITATION.cff in particular is hand-maintained and has silently drifted behind
+real releases before; this test fails the build when any of the three disagree.
+"""
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _section_version(path: Path, section: str) -> str:
+    """The ``version = "X"`` inside a TOML ``[section]`` (first match)."""
+    text = path.read_text(encoding="utf-8")
+    # Slice from the section header to the next top-level header.
+    start = text.index(f"[{section}]")
+    rest = text[start + len(section) + 2:]
+    end = rest.find("\n[")
+    block = rest if end == -1 else rest[:end]
+    m = re.search(r'^\s*version\s*=\s*"([^"]+)"', block, re.MULTILINE)
+    assert m, f"no version found in [{section}] of {path.name}"
+    return m.group(1)
+
+
+def _cff_version(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    m = re.search(r'^version:\s*"?([^"\s]+)"?\s*$', text, re.MULTILINE)
+    assert m, f"no version found in {path.name}"
+    return m.group(1)
+
+
+def test_versions_agree():
+    cargo = _section_version(ROOT / "Cargo.toml", "package")
+    pyproject = _section_version(ROOT / "pyproject.toml", "project")
+    citation = _cff_version(ROOT / "CITATION.cff")
+    versions = {"Cargo.toml": cargo, "pyproject.toml": pyproject, "CITATION.cff": citation}
+    assert len(set(versions.values())) == 1, (
+        "version drift across release files; bump them together: "
+        + ", ".join(f"{f}={v}" for f, v in versions.items())
+    )


### PR DESCRIPTION
Cuts **0.22.0** from main. Version bumped in `Cargo.toml`, `Cargo.lock`, and `pyproject.toml`; `CHANGELOG.md` `[Unreleased]` rolled into `[0.22.0] - 2026-06-16`.

## What's in it (everything since 0.21.0)

**New models**
- **InfoCTM** (#200) — first cross-lingual model: two ProdLDA models aligned by a bilingual dictionary.
- **ECTM** (#203, experimental) — Evolving Content Topic Model: group-by-time content.

**Evaluation**
- **`topica.llm`** (#201, #202) — LLM-based coherence/intrusion (Stammbach et al. 2023), `select_k`, the Tan & D'Souza suite, and a pluggable backend.

**Usability**
- **`topica.datasets`** (#204) — `load_gadarian` (vendored), `load_poliblog`/`load_dubois` (fetch-on-demand, checksum-verified).
- **CSV-first onboarding** (#205, #207) — README + quickstart lead with `from_dataframe`; model wall collapsed; choosing-K section.

**Docs / hygiene**
- **STM prevalence parity corrected** (#206) — leads with Poliblog (0.97 / 0.84) instead of the mislabeled Gadarian K=3 (0.51); adds the 5k harness. No code change.
- **Repo root slimmed** (#209) — CONTRIBUTING files → `.github/`; dataset CSVs pinned `binary`.

> Backfilled changelog entries for InfoCTM and the LLM-eval suite, which had merged after 0.21.0 without them.

## Verification
- Rebuilt at 0.22.0; `topica.__version__ == "0.22.0"`.
- Full suite: **2703 passed, 26 skipped**. `mkdocs build --strict` clean.

On merge, the `v0.22.0` tag drives the wheel-build + PyPI publish jobs (they skip on normal PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)