### PR TITLE
ci: bump JS actions to Node 24 majors (clear Node 20 deprecation)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -39,7 +39,7 @@ jobs:
         os: [ubuntu-latest, macos-latest, windows-latest]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # Install stable Rust toolchain (required for maturin/pyo3 compilation).
       - name: Install Rust (stable)
@@ -51,7 +51,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -95,7 +95,7 @@ jobs:
     name: docs (mkdocs --strict)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
@@ -104,7 +104,7 @@ jobs:
         uses: Swatinem/rust-cache@v2
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -167,13 +167,13 @@ jobs:
             manylinux: ""
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       # maturin-action provides Rust toolchain internally; explicit install not
       # needed here, but setup-python IS needed so maturin can find an interpreter
       # for the abi3 wheel stub.
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -192,7 +192,7 @@ jobs:
       # Upload each leg's wheel as a separate artifact so the release job can
       # download them all cleanly.
       - name: Upload wheel artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: wheel-${{ matrix.target }}-${{ matrix.os }}
           path: dist/*.whl
@@ -210,13 +210,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust (stable)
         uses: dtolnay/rust-toolchain@stable
 
       - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: "3.12"
 
@@ -227,7 +227,7 @@ jobs:
         run: maturin sdist --out dist
 
       - name: Upload sdist artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: sdist
           path: dist/*.tar.gz
@@ -263,7 +263,7 @@ jobs:
 
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v7
         with:
           # Download every artifact produced above into dist/.
           path: dist

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,9 +18,9 @@ jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.11"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
             archive: zip
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
@@ -71,7 +71,7 @@ jobs:
           echo "ASSET=$staging.zip" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload to GitHub Release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           files: ${{ env.ASSET }}
           generate_release_notes: true


### PR DESCRIPTION
Clears the **Node.js 20 deprecation** warnings GitHub now emits on every run (seen on the v0.22.0 release). Each `actions/*` JS action and `action-gh-release` declared Node 20; bumped each to its **first Node 24 major** (verified via each action's `action.yml` `using:` field, so this is the minimal version that clears the warning):

| Action | Before | After |
|---|---|---|
| actions/checkout | v4 | **v5** |
| actions/setup-python | v5 | **v6** |
| actions/upload-artifact | v4 | **v6** (v4 and v5 are still Node 20) |
| actions/download-artifact | v4 | **v7** (v4–v6 are Node 20) |
| softprops/action-gh-release | v2 | **v3** |

Left unchanged (already Node 24 or non-JS): `Swatinem/rust-cache@v2`, `PyO3/maturin-action@v1`, `dtolnay/rust-toolchain@stable`, `pypa/gh-action-pypi-publish@release/v1` (Docker).

The artifact backend is compatible from v4 onward, so `upload-artifact@v6` ↔ `download-artifact@v7` pair correctly.

**Note on coverage:** this PR's CI exercises `checkout@v5` + `setup-python@v6` (test/docs jobs). The `upload-artifact`/`download-artifact`/`action-gh-release` bumps only run in the tag-gated build-wheels/publish/release jobs, so they'll first execute on the next release tag — the bumps are within-backend-compatible, but flagging that they aren't exercised by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)