### PR TITLE
parity: consolidate the ProdLDA-family AVITM reference + add CombinedTM/ZeroShotTM harnesses

### DIFF
--- a/parity/combinedtm_compare.py
+++ b/parity/combinedtm_compare.py
@@ -1,0 +1,302 @@
+"""Cross-implementation check for topica's CombinedTM against a faithful PyTorch
+reference of the contextualized topic model (Bianchi, Terragni & Hovy 2021).
+
+CombinedTM is ProdLDA (AVITM; Srivastava & Sutton 2017) with one change: the
+encoder reads the normalized bag of words *concatenated with* a caller-supplied
+document embedding. The decoder is unchanged -- a product-of-experts
+``softmax(beta . theta)`` reconstructing the bag of words over the V-vocabulary.
+The embedding is only an encoder input; it is never reconstructed.
+
+The reference here reuses the shared AVITM backbone in ``refs.avitm`` (softplus
+encoder built ``fc1, fc2, mu, lv`` with affine-free batchnorm heads, the Laplace
+approximation to the Dirichlet prior, the reparameterization trick, and the
+Dirichlet-Laplace KL) and the same ProdLDA decoder + training loop as
+``prodlda_compare.py``. The only difference from ProdLDA is the encoder input
+width and what it is fed: ``build_encoder(v_in = V + E, ...)`` fed
+``concat([norm_bow, doc_emb], dim=1)``. topica's network is hand-coded in Rust
+with no autograd; PyTorch differentiates the same graph. Initialization, RNG, and
+autograd-vs-hand-coded backward differ, so exact agreement is impossible -- we
+hold them to a statistical-equivalence bar on a shared task: the SAME planted
+token corpus, the SAME per-document embeddings, the same topic count and
+optimizer schedule.
+
+Metrics, computed identically for both with topica's own coherence:
+  - topic coherence (c_v, c_npmi) over the shared token corpus
+  - topic diversity (TU): fraction of distinct words across the top lists
+  - doc-topic agreement: NMI of the argmax topic vs the true planted block, and
+    cross-NMI between the two implementations
+
+Skips cleanly when torch is unavailable. Run directly:
+
+    python parity/combinedtm_compare.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from refs.avitm import (  # noqa: E402
+    build_encoder,
+    dirichlet_laplace_kl,
+    laplace_prior,
+    reparameterize,
+)
+
+# --- Shared task and optimizer schedule --------------------------------------
+#
+# Planted-block synthetic corpus (mirrors tests/test_combinedtm.py): K word
+# blocks; each document draws its tokens from one block and carries an embedding
+# that one-hot-encodes its block (plus small noise), so the contextual signal is
+# clean and CombinedTM can recover the planted structure.
+
+NUM_BLOCKS = 5
+BLOCK = 10           # words per block -> vocab = NUM_BLOCKS * BLOCK
+NUM_DOCS = 600
+DOC_LEN = 25
+EMB_DIM = NUM_BLOCKS  # one-hot over blocks (+ noise)
+NUM_TOPICS = NUM_BLOCKS
+TOP_N = 10
+
+# Shared optimizer schedule (kept modest so the parity run finishes in minutes).
+ALPHA = 1.0
+HIDDEN = 100
+DROPOUT = 0.2
+EPOCHS = 150
+BATCH = 200
+LR = 0.002
+
+SEEDS = (0, 1, 2)
+
+
+def available() -> bool:
+    try:
+        import sklearn  # noqa: F401
+        import torch  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def load(seed: int = 0):
+    """Build a planted-block token corpus and per-document embeddings. The
+    embedding one-hot-encodes the document's dominant block (plus small Gaussian
+    noise), so it cleanly carries the planted topic structure. Returns
+    ``(token_docs, embeddings, labels, vocab)``; data is fixed across fit seeds so
+    topica and the reference see exactly the same task each run."""
+    rng = np.random.default_rng(seed)
+    vocab = [f"b{b}w{i}" for b in range(NUM_BLOCKS) for i in range(BLOCK)]
+    token_docs, embs, labels = [], [], []
+    for d in range(NUM_DOCS):
+        b = d % NUM_BLOCKS
+        token_docs.append(
+            [f"b{b}w{int(rng.integers(BLOCK))}" for _ in range(DOC_LEN)]
+        )
+        e = np.zeros(EMB_DIM)
+        e[b] = 3.0
+        e = e + rng.normal(0.0, 0.1, EMB_DIM)
+        embs.append(e)
+        labels.append(b)
+    return (
+        token_docs,
+        np.asarray(embs, dtype=np.float64),
+        np.asarray(labels),
+        vocab,
+    )
+
+
+# --- PyTorch reference: CombinedTM --------------------------------------------
+#
+# Identical to the ProdLDA reference (prodlda_compare.py) except the encoder is
+# built at ``v_in = V + E`` and fed ``concat([norm_bow, emb])``. The decoder,
+# Laplace-Dirichlet prior, reparameterization, KL, and batchnorm are unchanged
+# and come from ``refs.avitm``; nothing is re-implemented here.
+
+
+def _build_reference(v: int, e: int, k: int):
+    import torch
+    import torch.nn as nn
+
+    class CombinedTMRef(nn.Module):
+        def __init__(self):
+            super().__init__()
+            # CombinedTM: encoder input is [norm_bow (V) | doc_emb (E)].
+            self.enc = build_encoder(v + e, k, HIDDEN, dropout=DROPOUT)
+            self.drop = nn.Dropout(DROPOUT)
+            self.beta = nn.Linear(k, v, bias=False)  # weight V x K; logits = theta @ W^T
+            self.bn_dec = nn.BatchNorm1d(v, affine=False, eps=1e-5, momentum=0.1)
+
+        def encode(self, xn, emb):
+            return self.enc.encode(torch.cat([xn, emb], dim=1))
+
+        def forward(self, xn, emb):
+            mu, lv = self.encode(xn, emb)
+            z = reparameterize(mu, lv)
+            theta = self.drop(torch.softmax(z, dim=1))
+            logits = self.bn_dec(self.beta(theta))
+            return torch.log_softmax(logits, dim=1), mu, lv
+
+    return CombinedTMRef()
+
+
+def _train_reference(counts: np.ndarray, emb: np.ndarray, k: int, seed: int):
+    import torch
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    v = counts.shape[1]
+    e = emb.shape[1]
+    model = _build_reference(v, e, k)
+    prior_mu, prior_var = laplace_prior(k, ALPHA)
+
+    cnt = torch.tensor(counts, dtype=torch.float32)
+    norm = cnt / cnt.sum(1, keepdim=True).clamp_min(1.0)
+    em = torch.tensor(emb, dtype=torch.float32)
+    n = cnt.shape[0]
+    opt = torch.optim.Adam(model.parameters(), lr=LR, betas=(0.99, 0.999))
+
+    for _ in range(EPOCHS):
+        model.train()
+        perm = torch.randperm(n)
+        for s in range(0, n, BATCH):
+            idx = perm[s : s + BATCH]
+            if len(idx) < 2:
+                continue
+            opt.zero_grad()
+            recon, mu, lv = model(norm[idx], em[idx])
+            rl = -(cnt[idx] * recon).sum(1)
+            kl = dirichlet_laplace_kl(mu, lv, prior_mu, prior_var, k)
+            (rl + kl).mean().backward()
+            opt.step()
+
+    model.eval()
+    with torch.no_grad():
+        beta = model.beta.weight.detach().t()  # K x V
+        topic_word = torch.softmax(beta, dim=1).numpy()
+        mu, _ = model.encode(norm, em)
+        assign = torch.softmax(mu, dim=1).argmax(1).numpy()
+    return topic_word, assign
+
+
+# --- Shared metrics ----------------------------------------------------------
+
+
+def _coherence(topics, token_docs, measure):
+    import topica
+
+    return float(
+        np.mean(topica.coherence(topics, token_docs, coherence_type=measure, topn=TOP_N))
+    )
+
+
+def _diversity(topics):
+    words = [w for t in topics for w in t[:TOP_N]]
+    return len(set(words)) / max(1, len(words))
+
+
+def _counts_matrix(token_docs, vocab):
+    index = {w: i for i, w in enumerate(vocab)}
+    m = np.zeros((len(token_docs), len(vocab)), dtype=np.float32)
+    for d, toks in enumerate(token_docs):
+        for t in toks:
+            j = index.get(t)
+            if j is not None:
+                m[d, j] += 1.0
+    return m
+
+
+def _topica_fit(token_docs, embs, seed):
+    import topica
+
+    tm = topica.CombinedTM(
+        num_topics=NUM_TOPICS, alpha=ALPHA, hidden_size=HIDDEN, dropout=DROPOUT,
+        batch_size=BATCH, lr=LR, seed=seed,
+    )
+    tm.fit(token_docs, embs, iters=EPOCHS)
+    theta = np.asarray(tm.transform(token_docs, embs))
+    topics = [[w for w, _ in tm.top_words(TOP_N, topic=t)] for t in range(tm.num_topics)]
+    return topics, theta.argmax(1)
+
+
+def _ref_fit(counts, embs, vocab, seed):
+    tw, assign = _train_reference(counts, embs, NUM_TOPICS, seed)
+    topics = [[vocab[j] for j in row.argsort()[::-1][:TOP_N]] for row in tw]
+    return topics, assign
+
+
+def run(verbose: bool = True) -> dict:
+    from sklearn.metrics import normalized_mutual_info_score
+
+    token_docs, embs, labels, vocab = load()
+    counts = _counts_matrix(token_docs, vocab)
+
+    # Bit-exact agreement is impossible across frameworks; a single seed is also
+    # misleading (both models swing topic-to-topic). Average over seeds and report
+    # the spread, so the verdict reflects the model, not one lucky/unlucky draw.
+    rows = {k: [] for k in ("t_cv", "r_cv", "t_npmi", "r_npmi", "t_div", "r_div",
+                            "t_nmi", "r_nmi", "cross_nmi")}
+    for seed in SEEDS:
+        t_topics, t_assign = _topica_fit(token_docs, embs, seed)
+        r_topics, r_assign = _ref_fit(counts, embs, vocab, seed)
+        rows["t_cv"].append(_coherence(t_topics, token_docs, "c_v"))
+        rows["r_cv"].append(_coherence(r_topics, token_docs, "c_v"))
+        rows["t_npmi"].append(_coherence(t_topics, token_docs, "c_npmi"))
+        rows["r_npmi"].append(_coherence(r_topics, token_docs, "c_npmi"))
+        rows["t_div"].append(_diversity(t_topics))
+        rows["r_div"].append(_diversity(r_topics))
+        rows["t_nmi"].append(float(normalized_mutual_info_score(labels, t_assign)))
+        rows["r_nmi"].append(float(normalized_mutual_info_score(labels, r_assign)))
+        rows["cross_nmi"].append(float(normalized_mutual_info_score(t_assign, r_assign)))
+
+    def ms(key):
+        a = np.array(rows[key])
+        return float(a.mean()), float(a.std())
+
+    metrics = {
+        "num_docs": len(token_docs),
+        "vocab": len(vocab),
+        "emb_dim": EMB_DIM,
+        "seeds": list(SEEDS),
+        "topica_c_v": ms("t_cv"),
+        "reference_c_v": ms("r_cv"),
+        "topica_c_npmi": ms("t_npmi"),
+        "reference_c_npmi": ms("r_npmi"),
+        "topica_diversity": ms("t_div"),
+        "reference_diversity": ms("r_div"),
+        "topica_label_nmi": ms("t_nmi"),
+        "reference_label_nmi": ms("r_nmi"),
+        "cross_nmi": ms("cross_nmi"),
+    }
+    if verbose:
+        print(f"  CombinedTM parity: {metrics['num_docs']} docs, "
+              f"V={metrics['vocab']}, E={metrics['emb_dim']}, K={NUM_TOPICS}")
+        print(f"  {'metric':22s} {'topica (mean±sd)':>22s} {'reference (mean±sd)':>22s}")
+        for label, tk, rk in [
+            ("c_v coherence", "topica_c_v", "reference_c_v"),
+            ("c_npmi coherence", "topica_c_npmi", "reference_c_npmi"),
+            ("diversity (TU)", "topica_diversity", "reference_diversity"),
+            ("label NMI", "topica_label_nmi", "reference_label_nmi"),
+        ]:
+            tm_, ts = metrics[tk]
+            rm_, rs = metrics[rk]
+            print(f"  {label:22s} {tm_:>13.3f} ±{ts:.3f} {rm_:>13.3f} ±{rs:.3f}")
+        cm, cs = metrics["cross_nmi"]
+        print(f"  {'cross-NMI (topica<->ref)':22s} {cm:>13.3f} ±{cs:.3f}")
+        gap = metrics["topica_c_npmi"][0] - metrics["reference_c_npmi"][0]
+        print(
+            f"\n  c_npmi gap {gap:+.4f} vs reference seed-to-seed sd "
+            f"{metrics['reference_c_npmi'][1]:.4f}: "
+            f"{'within noise' if abs(gap) <= 2 * metrics['reference_c_npmi'][1] else 'systematic'}"
+        )
+    return metrics
+
+
+if __name__ == "__main__":
+    if not available():
+        print("SKIP: torch / sklearn not installed.")
+    else:
+        run(verbose=True)

--- a/parity/infoctm_compare.py
+++ b/parity/infoctm_compare.py
@@ -22,7 +22,19 @@ Skips cleanly when torch is unavailable.
 
 from __future__ import annotations
 
+import os
+import sys
+
 import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from refs.avitm import (  # noqa: E402
+    build_encoder,
+    dirichlet_laplace_kl,
+    laplace_prior,
+    reparameterize,
+)
 
 K = 5
 PER = 6                 # words per block per language
@@ -78,12 +90,12 @@ def _counts(docs, vocab):
 # ---------------------------------------------------------------------------
 # Paper-derived PyTorch reference
 # ---------------------------------------------------------------------------
-
-def _laplace_prior(k, a=1.0):
-    a = a * np.ones((1, k), dtype=np.float32)
-    mu = (np.log(a).T - np.mean(np.log(a), 1)).T
-    var = (((1.0 / a) * (1 - 2.0 / k)).T + (1.0 / (k * k)) * np.sum(1.0 / a, 1)).T
-    return mu.astype(np.float32), var.astype(np.float32)
+#
+# The two per-language encoder backbones (fc1, fc2, mu, lv + affine-free
+# batchnorm heads), the Laplace-Dirichlet prior, the reparameterization trick,
+# and the KL are shared with the ProdLDA parity reference via ``refs.avitm``.
+# The decoder (a ``phi`` matmul + decoder batchnorm + softmax recon, x2) and the
+# TAMI cross-lingual alignment term below are InfoCTM-specific.
 
 
 def _train_reference(counts_a, counts_b, trans_ab, seed):
@@ -92,8 +104,7 @@ def _train_reference(counts_a, counts_b, trans_ab, seed):
 
     torch.manual_seed(seed)
     va, vb = counts_a.shape[1], counts_b.shape[1]
-    mu2, var2 = _laplace_prior(K)
-    mu2 = torch.tensor(mu2); var2 = torch.tensor(var2)
+    mu2, var2 = laplace_prior(K, 1.0)
     trans = torch.tensor(trans_ab)              # Va x Vb (identity mono-mask -> dict pairs)
     trans_t = trans.T
     neg_ab = (trans <= 0).float()
@@ -101,24 +112,14 @@ def _train_reference(counts_a, counts_b, trans_ab, seed):
     pos_sum = trans.sum() + trans_t.sum()
     temp, weight = 0.2, 30.0
 
-    def encoder(v):
-        return torch.nn.Sequential(
-            torch.nn.Linear(v, HIDDEN), torch.nn.Softplus(),
-            torch.nn.Linear(HIDDEN, HIDDEN), torch.nn.Softplus(),
-        )
-
-    enc_a, enc_b = encoder(va), encoder(vb)
-    head_mu_a, head_lv_a = torch.nn.Linear(HIDDEN, K), torch.nn.Linear(HIDDEN, K)
-    head_mu_b, head_lv_b = torch.nn.Linear(HIDDEN, K), torch.nn.Linear(HIDDEN, K)
-    bn_mu_a, bn_lv_a = torch.nn.BatchNorm1d(K, affine=False), torch.nn.BatchNorm1d(K, affine=False)
-    bn_mu_b, bn_lv_b = torch.nn.BatchNorm1d(K, affine=False), torch.nn.BatchNorm1d(K, affine=False)
+    enc_a = build_encoder(va, K, HIDDEN)
+    enc_b = build_encoder(vb, K, HIDDEN)
     dec_bn_a = torch.nn.BatchNorm1d(va, affine=False)
     dec_bn_b = torch.nn.BatchNorm1d(vb, affine=False)
     phi_a = torch.nn.Parameter(torch.nn.init.xavier_uniform_(torch.empty(K, va)))
     phi_b = torch.nn.Parameter(torch.nn.init.xavier_uniform_(torch.empty(K, vb)))
 
-    mods = [enc_a, enc_b, head_mu_a, head_lv_a, head_mu_b, head_lv_b,
-            bn_mu_a, bn_lv_a, bn_mu_b, bn_lv_b, dec_bn_a, dec_bn_b]
+    mods = [enc_a, enc_b, dec_bn_a, dec_bn_b]
     params = [phi_a, phi_b]
     for m in mods:
         params += list(m.parameters())
@@ -126,15 +127,13 @@ def _train_reference(counts_a, counts_b, trans_ab, seed):
 
     xa = torch.tensor(counts_a); xb = torch.tensor(counts_b)
 
-    def elbo(x, enc, hmu, hlv, bmu, blv, dbn, phi):
-        h = enc(x)
-        mu = bmu(hmu(h)); lv = blv(hlv(h))
-        z = mu + torch.randn_like(lv) * (0.5 * lv).exp()
+    def elbo(x, enc, dbn, phi):
+        mu, lv = enc.encode(x)
+        z = reparameterize(mu, lv)
         theta = F.softmax(z, dim=1)
         recon = F.softmax(dbn(theta @ phi), dim=1)
         rec = -(x * (recon + 1e-10).log()).sum(1)
-        var = lv.exp()
-        kld = 0.5 * ((var / var2 + (mu - mu2) ** 2 / var2 + var2.log() - lv).sum(1) - K)
+        kld = dirichlet_laplace_kl(mu, lv, mu2, var2, K)
         return (rec + kld).mean()
 
     def mutual_info(fa, fb, pos, neg):
@@ -148,8 +147,8 @@ def _train_reference(counts_a, counts_b, trans_ab, seed):
 
     for _ in range(ITERS):
         opt.zero_grad()
-        la = elbo(xa, enc_a, head_mu_a, head_lv_a, bn_mu_a, bn_lv_a, dec_bn_a, phi_a)
-        lb = elbo(xb, enc_b, head_mu_b, head_lv_b, bn_mu_b, bn_lv_b, dec_bn_b, phi_b)
+        la = elbo(xa, enc_a, dec_bn_a, phi_a)
+        lb = elbo(xb, enc_b, dec_bn_b, phi_b)
         tami = mutual_info(phi_a.T, phi_b.T, trans, neg_ab)
         tami = tami + mutual_info(phi_b.T, phi_a.T, trans_t, neg_ba)
         loss = la + lb + weight * tami / pos_sum

--- a/parity/prodlda_compare.py
+++ b/parity/prodlda_compare.py
@@ -27,7 +27,19 @@ fetched. Run directly:
 
 from __future__ import annotations
 
+import os
+import sys
+
 import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from refs.avitm import (  # noqa: E402
+    build_encoder,
+    dirichlet_laplace_kl,
+    laplace_prior,
+    reparameterize,
+)
 
 GROUPS = [
     "rec.sport.baseball",
@@ -87,17 +99,12 @@ def load():
 
 
 # --- PyTorch reference: AVITM / ProdLDA --------------------------------------
-
-
-def _laplace_prior(k: int, alpha: float):
-    """Diagonal logistic-normal Laplace approximation to a symmetric Dirichlet
-    prior in the softmax basis (eq. 6)."""
-    import torch
-
-    a = np.full(k, alpha)
-    mu1 = np.log(a) - np.mean(np.log(a))
-    var1 = (1.0 / a) * (1.0 - 2.0 / k) + (1.0 / (k * k)) * np.sum(1.0 / a)
-    return torch.tensor(mu1, dtype=torch.float32), torch.tensor(var1, dtype=torch.float32)
+#
+# The encoder backbone (fc1, fc2, mu, lv + affine-free batchnorm heads), the
+# Laplace-Dirichlet prior, the reparameterization trick, and the KL are shared
+# with the InfoCTM parity reference via ``refs.avitm``. The decoder and training
+# loop below are ProdLDA-specific. The encoder submodule is constructed before
+# ``beta``, so the RNG draw order (fc1, fc2, mu, lv, beta) is unchanged.
 
 
 def _build_reference(v: int, k: int):
@@ -107,26 +114,17 @@ def _build_reference(v: int, k: int):
     class ProdLDARef(nn.Module):
         def __init__(self):
             super().__init__()
-            self.fc1 = nn.Linear(v, HIDDEN)
-            self.fc2 = nn.Linear(HIDDEN, HIDDEN)
+            self.enc = build_encoder(v, k, HIDDEN, dropout=DROPOUT)
             self.drop = nn.Dropout(DROPOUT)
-            self.mu = nn.Linear(HIDDEN, k)
-            self.lv = nn.Linear(HIDDEN, k)
-            # affine-free batchnorm, eps/momentum matching the Rust core
-            self.bn_mu = nn.BatchNorm1d(k, affine=False, eps=1e-5, momentum=0.1)
-            self.bn_lv = nn.BatchNorm1d(k, affine=False, eps=1e-5, momentum=0.1)
             self.beta = nn.Linear(k, v, bias=False)  # weight is V x K; logits = theta @ W^T
             self.bn_dec = nn.BatchNorm1d(v, affine=False, eps=1e-5, momentum=0.1)
 
         def encode(self, xn):
-            h = torch.nn.functional.softplus(self.fc1(xn))
-            h = torch.nn.functional.softplus(self.fc2(h))
-            h = self.drop(h)
-            return self.bn_mu(self.mu(h)), self.bn_lv(self.lv(h))
+            return self.enc.encode(xn)
 
         def forward(self, xn):
             mu, lv = self.encode(xn)
-            z = mu + torch.exp(0.5 * lv) * torch.randn_like(mu)
+            z = reparameterize(mu, lv)
             theta = self.drop(torch.softmax(z, dim=1))
             logits = self.bn_dec(self.beta(theta))
             return torch.log_softmax(logits, dim=1), mu, lv
@@ -141,7 +139,7 @@ def _train_reference(counts: np.ndarray, k: int, seed: int):
     np.random.seed(seed)
     v = counts.shape[1]
     model = _build_reference(v, k)
-    prior_mu, prior_var = _laplace_prior(k, ALPHA)
+    prior_mu, prior_var = laplace_prior(k, ALPHA)
 
     cnt = torch.tensor(counts, dtype=torch.float32)
     norm = cnt / cnt.sum(1, keepdim=True).clamp_min(1.0)
@@ -158,14 +156,7 @@ def _train_reference(counts: np.ndarray, k: int, seed: int):
             opt.zero_grad()
             recon, mu, lv = model(norm[idx])
             rl = -(cnt[idx] * recon).sum(1)
-            var0 = lv.exp()
-            kl = 0.5 * (
-                (var0 / prior_var).sum(1)
-                + ((prior_mu - mu) ** 2 / prior_var).sum(1)
-                - k
-                + prior_var.log().sum()
-                - lv.sum(1)
-            )
+            kl = dirichlet_laplace_kl(mu, lv, prior_mu, prior_var, k)
             (rl + kl).mean().backward()
             opt.step()
 
@@ -211,9 +202,10 @@ def _topica_fit(token_docs, seed):
 
     tm = topica.ProdLDA(
         num_topics=NUM_TOPICS, alpha=ALPHA, hidden_size=HIDDEN, dropout=DROPOUT,
-        epochs=EPOCHS, batch_size=BATCH, lr=LR, seed=seed,
+        batch_size=BATCH, lr=LR, seed=seed,
     )
-    theta = np.asarray(tm.fit_transform(token_docs))
+    tm.fit(token_docs, iters=EPOCHS)
+    theta = np.asarray(tm.transform(token_docs))
     topics = [[w for w, _ in tm.top_words(TOP_N, topic=t)] for t in range(tm.num_topics)]
     return topics, theta.argmax(1)
 

--- a/parity/refs/avitm.py
+++ b/parity/refs/avitm.py
@@ -1,0 +1,106 @@
+"""Shared PyTorch primitives for the AVITM / ProdLDA reference encoders used by
+topica's parity scripts (``prodlda_compare.py``, ``infoctm_compare.py``).
+
+Both scripts build the *same* autoencoding-variational LDA encoder backbone --
+softplus MLP, separate mean/logvar heads, affine-free batch normalization on the
+heads, the Laplace approximation to the Dirichlet prior (Srivastava & Sutton 2017,
+eq. 6), the reparameterization trick, and the Dirichlet-Laplace KL. Only those
+pieces live here; each script keeps its own decoder and training loop (ProdLDA: a
+``Linear(k, v, bias=False)`` + decoder batchnorm + log-softmax reconstruction with
+dropout on theta; InfoCTM: a ``phi`` matmul + decoder batchnorm + softmax recon,
+two languages, plus the TAMI alignment term).
+
+torch is imported lazily inside each function so the scripts still import (and skip
+cleanly) when torch is unavailable.
+
+**Layer construction order is load-bearing.** torch consumes its RNG stream in the
+order ``nn.Linear`` layers are constructed, so to keep each reference's output
+byte-identical to its pre-refactor form the backbone builder must construct
+``fc1, fc2, mu, lv`` in exactly that order. ``BatchNorm1d(affine=False)`` and
+``Dropout`` have no learnable parameters and consume no RNG, so they do not affect
+the stream -- matching both original scripts.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+
+def laplace_prior(k: int, alpha: float):
+    """Diagonal logistic-normal Laplace approximation to a symmetric Dirichlet
+    prior in the softmax basis (Srivastava & Sutton 2017, eq. 6).
+
+    Returns ``(mu, var)`` as float32 tensors of shape ``(k,)``. They broadcast
+    against batched ``(batch, k)`` mean/logvar exactly as both originals relied on.
+    """
+    import torch
+
+    a = np.full(k, alpha)
+    mu1 = np.log(a) - np.mean(np.log(a))
+    var1 = (1.0 / a) * (1.0 - 2.0 / k) + (1.0 / (k * k)) * np.sum(1.0 / a)
+    return (
+        torch.tensor(mu1, dtype=torch.float32),
+        torch.tensor(var1, dtype=torch.float32),
+    )
+
+
+def build_encoder(v_in: int, k: int, hidden: int, dropout: float = 0.0):
+    """Construct an AVITM encoder backbone module.
+
+    Layers are built in the order ``fc1, fc2, mu, lv`` (RNG-stream critical), with
+    affine-free ``BatchNorm1d(k)`` on each head and an optional ``Dropout`` between
+    the second hidden layer and the heads. The returned module exposes
+    ``encode(x) -> (mu, lv)`` applying ``softplus(fc1) -> softplus(fc2) -> dropout
+    -> (bn_mu(mu), bn_lv(lv))``.
+    """
+    import torch
+    import torch.nn as nn
+    import torch.nn.functional as F
+
+    class _Encoder(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.fc1 = nn.Linear(v_in, hidden)
+            self.fc2 = nn.Linear(hidden, hidden)
+            self.mu = nn.Linear(hidden, k)
+            self.lv = nn.Linear(hidden, k)
+            self.drop = nn.Dropout(dropout)
+            self.bn_mu = nn.BatchNorm1d(k, affine=False, eps=1e-5, momentum=0.1)
+            self.bn_lv = nn.BatchNorm1d(k, affine=False, eps=1e-5, momentum=0.1)
+
+        def encode(self, x):
+            h = F.softplus(self.fc1(x))
+            h = F.softplus(self.fc2(h))
+            h = self.drop(h)
+            return self.bn_mu(self.mu(h)), self.bn_lv(self.lv(h))
+
+        def forward(self, x):
+            return self.encode(x)
+
+    return _Encoder()
+
+
+def reparameterize(mu, lv):
+    """Gaussian reparameterization trick: ``mu + exp(0.5*lv) * randn_like(mu)``."""
+    import torch
+
+    return mu + torch.exp(0.5 * lv) * torch.randn_like(mu)
+
+
+def dirichlet_laplace_kl(mu, lv, prior_mu, prior_var, k: int):
+    """Per-doc KL between the diagonal-Gaussian posterior and the Laplace-Dirichlet
+    prior:
+
+        0.5 * ( (var/prior_var).sum + ((prior_mu-mu)^2/prior_var).sum
+                - k + prior_var.log().sum() - lv.sum() )
+
+    where ``var = lv.exp()``. Returns a per-doc tensor (shape ``(batch,)``).
+    """
+    var = lv.exp()
+    return 0.5 * (
+        (var / prior_var).sum(1)
+        + ((prior_mu - mu) ** 2 / prior_var).sum(1)
+        - k
+        + prior_var.log().sum()
+        - lv.sum(1)
+    )

--- a/parity/zeroshot_compare.py
+++ b/parity/zeroshot_compare.py
@@ -1,0 +1,306 @@
+"""Cross-implementation check for topica's ZeroShotTM against a faithful PyTorch
+reference of the contextualized topic model (Bianchi, Nozza & Hovy 2021).
+
+ZeroShotTM is ProdLDA (AVITM; Srivastava & Sutton 2017) with one change: the
+encoder reads *only* a caller-supplied document embedding -- no bag of words at
+all. The decoder is unchanged -- a product-of-experts ``softmax(beta . theta)``
+reconstructing the bag of words over the V-vocabulary. Because topics are inferred
+from the embedding alone, a document embedded with a multilingual encoder maps to
+the trained topics without any bag of words; the embedding is only an encoder
+input and is never reconstructed.
+
+The reference here reuses the shared AVITM backbone in ``refs.avitm`` (softplus
+encoder built ``fc1, fc2, mu, lv`` with affine-free batchnorm heads, the Laplace
+approximation to the Dirichlet prior, the reparameterization trick, and the
+Dirichlet-Laplace KL) and the same ProdLDA decoder + training loop as
+``prodlda_compare.py``. The only difference from ProdLDA is that the encoder is
+built at ``build_encoder(v_in = E, ...)`` and fed the document embedding alone --
+no normalized bag of words enters the encoder. topica's network is hand-coded in
+Rust with no autograd; PyTorch differentiates the same graph. Initialization,
+RNG, and autograd-vs-hand-coded backward differ, so exact agreement is
+impossible -- we hold them to a statistical-equivalence bar on a shared task: the
+SAME planted token corpus, the SAME per-document embeddings, the same topic count
+and optimizer schedule.
+
+Metrics, computed identically for both with topica's own coherence:
+  - topic coherence (c_v, c_npmi) over the shared token corpus
+  - topic diversity (TU): fraction of distinct words across the top lists
+  - doc-topic agreement: NMI of the argmax topic vs the true planted block, and
+    cross-NMI between the two implementations
+
+Skips cleanly when torch is unavailable. Run directly:
+
+    python parity/zeroshot_compare.py
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from refs.avitm import (  # noqa: E402
+    build_encoder,
+    dirichlet_laplace_kl,
+    laplace_prior,
+    reparameterize,
+)
+
+# --- Shared task and optimizer schedule --------------------------------------
+#
+# Planted-block synthetic corpus (mirrors tests/test_combinedtm.py): K word
+# blocks; each document draws its tokens from one block and carries an embedding
+# that one-hot-encodes its block (plus small noise). The embedding is the only
+# encoder signal ZeroShotTM gets, so it must carry the block structure cleanly
+# for either implementation to recover the planted topics.
+
+NUM_BLOCKS = 5
+BLOCK = 10           # words per block -> vocab = NUM_BLOCKS * BLOCK
+NUM_DOCS = 600
+DOC_LEN = 25
+EMB_DIM = NUM_BLOCKS  # one-hot over blocks (+ noise)
+NUM_TOPICS = NUM_BLOCKS
+TOP_N = 10
+
+# Shared optimizer schedule (kept modest so the parity run finishes in minutes).
+ALPHA = 1.0
+HIDDEN = 100
+DROPOUT = 0.2
+EPOCHS = 150
+BATCH = 200
+LR = 0.002
+
+SEEDS = (0, 1, 2)
+
+
+def available() -> bool:
+    try:
+        import sklearn  # noqa: F401
+        import torch  # noqa: F401
+    except Exception:
+        return False
+    return True
+
+
+def load(seed: int = 0):
+    """Build a planted-block token corpus and per-document embeddings. The
+    embedding one-hot-encodes the document's dominant block (plus small Gaussian
+    noise); it is the only signal the encoder sees. Returns
+    ``(token_docs, embeddings, labels, vocab)``; data is fixed across fit seeds so
+    topica and the reference see exactly the same task each run."""
+    rng = np.random.default_rng(seed)
+    vocab = [f"b{b}w{i}" for b in range(NUM_BLOCKS) for i in range(BLOCK)]
+    token_docs, embs, labels = [], [], []
+    for d in range(NUM_DOCS):
+        b = d % NUM_BLOCKS
+        token_docs.append(
+            [f"b{b}w{int(rng.integers(BLOCK))}" for _ in range(DOC_LEN)]
+        )
+        e = np.zeros(EMB_DIM)
+        e[b] = 3.0
+        e = e + rng.normal(0.0, 0.1, EMB_DIM)
+        embs.append(e)
+        labels.append(b)
+    return (
+        token_docs,
+        np.asarray(embs, dtype=np.float64),
+        np.asarray(labels),
+        vocab,
+    )
+
+
+# --- PyTorch reference: ZeroShotTM --------------------------------------------
+#
+# Identical to the ProdLDA reference (prodlda_compare.py) except the encoder is
+# built at ``v_in = E`` and fed the document embedding alone -- no bag of words
+# enters the encoder. The decoder still reconstructs the V-vocabulary. The
+# Laplace-Dirichlet prior, reparameterization, KL, and batchnorm are unchanged
+# and come from ``refs.avitm``; nothing is re-implemented here.
+
+
+def _build_reference(v: int, e: int, k: int):
+    import torch
+    import torch.nn as nn
+
+    class ZeroShotTMRef(nn.Module):
+        def __init__(self):
+            super().__init__()
+            # ZeroShotTM: encoder input is the document embedding alone (E).
+            self.enc = build_encoder(e, k, HIDDEN, dropout=DROPOUT)
+            self.drop = nn.Dropout(DROPOUT)
+            self.beta = nn.Linear(k, v, bias=False)  # weight V x K; logits = theta @ W^T
+            self.bn_dec = nn.BatchNorm1d(v, affine=False, eps=1e-5, momentum=0.1)
+
+        def encode(self, emb):
+            return self.enc.encode(emb)
+
+        def forward(self, emb):
+            mu, lv = self.encode(emb)
+            z = reparameterize(mu, lv)
+            theta = self.drop(torch.softmax(z, dim=1))
+            logits = self.bn_dec(self.beta(theta))
+            return torch.log_softmax(logits, dim=1), mu, lv
+
+    return ZeroShotTMRef()
+
+
+def _train_reference(counts: np.ndarray, emb: np.ndarray, k: int, seed: int):
+    import torch
+
+    torch.manual_seed(seed)
+    np.random.seed(seed)
+    v = counts.shape[1]
+    e = emb.shape[1]
+    model = _build_reference(v, e, k)
+    prior_mu, prior_var = laplace_prior(k, ALPHA)
+
+    cnt = torch.tensor(counts, dtype=torch.float32)
+    em = torch.tensor(emb, dtype=torch.float32)
+    n = cnt.shape[0]
+    opt = torch.optim.Adam(model.parameters(), lr=LR, betas=(0.99, 0.999))
+
+    for _ in range(EPOCHS):
+        model.train()
+        perm = torch.randperm(n)
+        for s in range(0, n, BATCH):
+            idx = perm[s : s + BATCH]
+            if len(idx) < 2:
+                continue
+            opt.zero_grad()
+            # Encoder sees only the embedding; the decoder still reconstructs BoW.
+            recon, mu, lv = model(em[idx])
+            rl = -(cnt[idx] * recon).sum(1)
+            kl = dirichlet_laplace_kl(mu, lv, prior_mu, prior_var, k)
+            (rl + kl).mean().backward()
+            opt.step()
+
+    model.eval()
+    with torch.no_grad():
+        beta = model.beta.weight.detach().t()  # K x V
+        topic_word = torch.softmax(beta, dim=1).numpy()
+        mu, _ = model.encode(em)
+        assign = torch.softmax(mu, dim=1).argmax(1).numpy()
+    return topic_word, assign
+
+
+# --- Shared metrics ----------------------------------------------------------
+
+
+def _coherence(topics, token_docs, measure):
+    import topica
+
+    return float(
+        np.mean(topica.coherence(topics, token_docs, coherence_type=measure, topn=TOP_N))
+    )
+
+
+def _diversity(topics):
+    words = [w for t in topics for w in t[:TOP_N]]
+    return len(set(words)) / max(1, len(words))
+
+
+def _counts_matrix(token_docs, vocab):
+    index = {w: i for i, w in enumerate(vocab)}
+    m = np.zeros((len(token_docs), len(vocab)), dtype=np.float32)
+    for d, toks in enumerate(token_docs):
+        for t in toks:
+            j = index.get(t)
+            if j is not None:
+                m[d, j] += 1.0
+    return m
+
+
+def _topica_fit(token_docs, embs, seed):
+    import topica
+
+    tm = topica.ZeroShotTM(
+        num_topics=NUM_TOPICS, alpha=ALPHA, hidden_size=HIDDEN, dropout=DROPOUT,
+        batch_size=BATCH, lr=LR, seed=seed,
+    )
+    tm.fit(token_docs, embs, iters=EPOCHS)
+    theta = np.asarray(tm.transform(token_docs, embs))
+    topics = [[w for w, _ in tm.top_words(TOP_N, topic=t)] for t in range(tm.num_topics)]
+    return topics, theta.argmax(1)
+
+
+def _ref_fit(counts, embs, vocab, seed):
+    tw, assign = _train_reference(counts, embs, NUM_TOPICS, seed)
+    topics = [[vocab[j] for j in row.argsort()[::-1][:TOP_N]] for row in tw]
+    return topics, assign
+
+
+def run(verbose: bool = True) -> dict:
+    from sklearn.metrics import normalized_mutual_info_score
+
+    token_docs, embs, labels, vocab = load()
+    counts = _counts_matrix(token_docs, vocab)
+
+    # Bit-exact agreement is impossible across frameworks; a single seed is also
+    # misleading (both models swing topic-to-topic). Average over seeds and report
+    # the spread, so the verdict reflects the model, not one lucky/unlucky draw.
+    rows = {k: [] for k in ("t_cv", "r_cv", "t_npmi", "r_npmi", "t_div", "r_div",
+                            "t_nmi", "r_nmi", "cross_nmi")}
+    for seed in SEEDS:
+        t_topics, t_assign = _topica_fit(token_docs, embs, seed)
+        r_topics, r_assign = _ref_fit(counts, embs, vocab, seed)
+        rows["t_cv"].append(_coherence(t_topics, token_docs, "c_v"))
+        rows["r_cv"].append(_coherence(r_topics, token_docs, "c_v"))
+        rows["t_npmi"].append(_coherence(t_topics, token_docs, "c_npmi"))
+        rows["r_npmi"].append(_coherence(r_topics, token_docs, "c_npmi"))
+        rows["t_div"].append(_diversity(t_topics))
+        rows["r_div"].append(_diversity(r_topics))
+        rows["t_nmi"].append(float(normalized_mutual_info_score(labels, t_assign)))
+        rows["r_nmi"].append(float(normalized_mutual_info_score(labels, r_assign)))
+        rows["cross_nmi"].append(float(normalized_mutual_info_score(t_assign, r_assign)))
+
+    def ms(key):
+        a = np.array(rows[key])
+        return float(a.mean()), float(a.std())
+
+    metrics = {
+        "num_docs": len(token_docs),
+        "vocab": len(vocab),
+        "emb_dim": EMB_DIM,
+        "seeds": list(SEEDS),
+        "topica_c_v": ms("t_cv"),
+        "reference_c_v": ms("r_cv"),
+        "topica_c_npmi": ms("t_npmi"),
+        "reference_c_npmi": ms("r_npmi"),
+        "topica_diversity": ms("t_div"),
+        "reference_diversity": ms("r_div"),
+        "topica_label_nmi": ms("t_nmi"),
+        "reference_label_nmi": ms("r_nmi"),
+        "cross_nmi": ms("cross_nmi"),
+    }
+    if verbose:
+        print(f"  ZeroShotTM parity: {metrics['num_docs']} docs, "
+              f"V={metrics['vocab']}, E={metrics['emb_dim']}, K={NUM_TOPICS}")
+        print(f"  {'metric':22s} {'topica (mean±sd)':>22s} {'reference (mean±sd)':>22s}")
+        for label, tk, rk in [
+            ("c_v coherence", "topica_c_v", "reference_c_v"),
+            ("c_npmi coherence", "topica_c_npmi", "reference_c_npmi"),
+            ("diversity (TU)", "topica_diversity", "reference_diversity"),
+            ("label NMI", "topica_label_nmi", "reference_label_nmi"),
+        ]:
+            tm_, ts = metrics[tk]
+            rm_, rs = metrics[rk]
+            print(f"  {label:22s} {tm_:>13.3f} ±{ts:.3f} {rm_:>13.3f} ±{rs:.3f}")
+        cm, cs = metrics["cross_nmi"]
+        print(f"  {'cross-NMI (topica<->ref)':22s} {cm:>13.3f} ±{cs:.3f}")
+        gap = metrics["topica_c_npmi"][0] - metrics["reference_c_npmi"][0]
+        print(
+            f"\n  c_npmi gap {gap:+.4f} vs reference seed-to-seed sd "
+            f"{metrics['reference_c_npmi'][1]:.4f}: "
+            f"{'within noise' if abs(gap) <= 2 * metrics['reference_c_npmi'][1] else 'systematic'}"
+        )
+    return metrics
+
+
+if __name__ == "__main__":
+    if not available():
+        print("SKIP: torch / sklearn not installed.")
+    else:
+        run(verbose=True)


### PR DESCRIPTION
Cleans up the ProdLDA family's parity infrastructure (the AVITM torch reference was reimplemented across scripts) and fills two reference-parity gaps from the audit.

## Stage 1 — consolidate the duplicated reference
The PyTorch AVITM reference (Laplace-Dirichlet prior, softplus MLP encoder with affine-free batchnorm mean/logvar heads, reparameterization, Dirichlet-Laplace KL) was written twice: in `prodlda_compare.py` and again in `infoctm_compare.py`. Extracted it once into **`parity/refs/avitm.py`** (`laplace_prior`, `build_encoder`, `reparameterize`, `dirichlet_laplace_kl`); each script keeps its own decoder + train loop.

- `build_encoder` constructs `fc1,fc2,mu,lv` in that order, preserving the reference RNG stream → **`prodlda_compare` reference output is byte-identical** to before.
- **Fixed a dead bug**: `prodlda_compare` was *crashing* — it passed a nonexistent `epochs=` constructor arg and used `fit_transform` (which takes no iters). Now `ProdLDA(...).fit(docs, iters=EPOCHS)` + `transform`.
- `infoctm_compare`: reported alignment/purity and verdict unchanged (internal init shifts negligibly, within the script's designed noise).

## Stage 2 — new harnesses for the two uncovered models
`CombinedTM` and `ZeroShotTM` were tagged `bit-exact` but had **no parity script**. Added `parity/combinedtm_compare.py` and `parity/zeroshot_compare.py` on the shared reference, faithful to `src/prodlda.rs`:
- CombinedTM (`BowEmb`): encoder fed `concat([norm_bow, doc_emb])`, `v_in=V+E`.
- ZeroShotTM (`EmbOnly`): encoder fed the document embedding alone, `v_in=E`.
- Both decoders = the unchanged ProdLDA decoder over the V-vocabulary.

Both land **within noise** vs the reference:
| Model | c_npmi gap | ref seed sd | cross-NMI |
|---|---|---|---|
| CombinedTM | −0.025 | 0.132 | 0.90 |
| ZeroShotTM | +0.065 | 0.110 | 0.96 |

## Verification
All four scripts run to a verdict from the repo root; `prodlda`/`infoctm` numbers match their pre-refactor baseline; diff touches only `parity/` (no `src`, no models).

## Follow-ups (not in this PR)
- These harnesses give the baseline to settle the **`bit-exact` mislabel** for CombinedTM/ZeroShotTM/ETM/FASTopic (seed-dependent → likely `seed-reproducible`) from the determinism sweep.
- The broader parity-matrix audit (DTM/DETM/SAGE/HDP/… still have no reference) continues incrementally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)