### PR TITLE
release: 0.23.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.23.1] - 2026-06-17
+
+### Added
+
+- **Bundled multilingual stopwords** — `topica.stopwords(lang)` returns a
+  `frozenset` for any of **58 languages** (the [stopwords-iso](https://github.com/stopwords-iso/stopwords-iso)
+  lists, MIT licensed, bundled in the wheel), accepting an ISO 639-1 code
+  (`"fr"`) or an English name (`"french"`, case-insensitive) and raising with the
+  available codes on an unknown language; `topica.stopword_languages()` lists
+  them. This gives the cross-lingual models (`InfoCTM`, `ZeroShotTM`) and any
+  non-English corpus a ready stoplist. `ENGLISH_STOPWORDS` is unchanged (the
+  short, stable default); `stopwords("en")` is the larger stopwords-iso English
+  list. (#225)
+
 ## [0.23.0] - 2026-06-17
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.23.0
+version: 0.23.1
 date-released: 2026-06-17
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.23.0"
+version = "0.23.1"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.23.0"
+version = "0.23.1"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.23.0"
+version = "0.23.1"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Patch release bundling **multilingual stopwords** (#225) on top of 0.23.0.

- `topica.stopwords(lang)` — 58 languages (stopwords-iso, MIT), ISO code or English name, case-insensitive; `topica.stopword_languages()` lists them.
- `ENGLISH_STOPWORDS` unchanged; `stopwords("en")` is the fuller iso list.
- Additive, no change to existing API.

Version bumps → 0.23.1 (`Cargo.toml`, `pyproject.toml`, `CITATION.cff`); CHANGELOG 0.23.1 section.

On merge, tagging `v0.23.1` triggers the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)