### PR TITLE
chore: warning-free build (JSS referee minors #1/#2)

### DIFF
--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -13,7 +13,7 @@ use crate::variational::LogisticNormalModel;
 /// `LogisticNormalModel` trait by the typed helper [`check_logistic_normal`],
 /// since `&dyn Estimator` cannot be downcast to it; a registered logistic-normal
 /// model is wired through that helper in the conformance test.
-#[allow(dead_code)]
+#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
 pub fn check_conformance(m: &dyn Estimator) -> Vec<String> {
     let mut v = Vec::new();
     let k = m.num_topics();
@@ -36,7 +36,7 @@ pub fn check_conformance(m: &dyn Estimator) -> Vec<String> {
 
 /// Tier-2 shape check for Dirichlet (collapsed-Gibbs) models: alpha length,
 /// doc_lengths length, and theta_draws nesting.
-#[allow(dead_code)]
+#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
 pub fn check_dirichlet(m: &dyn DirichletModel) -> Vec<String> {
     let mut v = Vec::new();
     let k = m.num_topics();
@@ -67,7 +67,7 @@ pub fn check_dirichlet(m: &dyn DirichletModel) -> Vec<String> {
 
 /// Tier-2 shape check for logistic-normal models: eta_mean is (D, eta_dim) and
 /// eta_cov is (D, eta_dim²) with a consistent eta_dim.
-#[allow(dead_code)]
+#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
 pub fn check_logistic_normal(m: &dyn LogisticNormalModel) -> Vec<String> {
     let mut v = Vec::new();
     let dim = m.eta_dim();
@@ -95,7 +95,7 @@ pub fn check_logistic_normal(m: &dyn LogisticNormalModel) -> Vec<String> {
 /// its fitted struct reports from `Estimator::model_family`, and any Tier-0
 /// Estimator method it structurally cannot provide — returned empty by design,
 /// the Rust analog of `conformance.py`'s `EXEMPT`.
-#[allow(dead_code)]
+#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
 pub struct RegistryEntry {
     pub name: &'static str,
     pub family: ModelFamily,
@@ -117,7 +117,7 @@ pub struct RegistryEntry {
 /// match the Python registry. The embedding-cluster models (`BERTopic`,
 /// `Top2Vec`) carry a `topic_word`/`doc_topic` from their Rust struct and so
 /// participate here.
-#[allow(dead_code)]
+#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
 pub const RUST_ESTIMATORS: &[RegistryEntry] = &[
     // Logistic-normal variational (eta posterior).
     RegistryEntry { name: "STM", family: ModelFamily::LogisticNormal, exempt: &[] },

--- a/src/detm.rs
+++ b/src/detm.rs
@@ -464,16 +464,15 @@ impl EtaNet {
         }
 
         EtaForward {
-            map_out, layer_inputs,
+            layer_inputs,
             gates_i, gates_f, gates_g, gates_o, cell, tanh_c, hidden,
-            output, head_inp, mu, ls, etas,
+            head_inp, mu, ls, etas,
         }
     }
 }
 
 /// Cached q(eta) forward activations retained for BPTT.
 struct EtaForward {
-    map_out: Vec<Vec<f64>>,                 // T x eh
     layer_inputs: Vec<Vec<Vec<f64>>>,       // nlayers x T x eh (input seen by each layer)
     gates_i: Vec<Vec<Vec<f64>>>,            // nlayers x T x eh
     gates_f: Vec<Vec<Vec<f64>>>,
@@ -482,7 +481,6 @@ struct EtaForward {
     cell: Vec<Vec<Vec<f64>>>,
     tanh_c: Vec<Vec<Vec<f64>>>,
     hidden: Vec<Vec<Vec<f64>>>,             // nlayers x T x eh
-    output: Vec<Vec<f64>>,                  // T x eh (top-layer hidden)
     head_inp: Vec<Vec<f64>>,                // T x (eh + K)
     mu: Vec<Vec<f64>>,                      // T x K
     ls: Vec<Vec<f64>>,                      // T x K
@@ -1378,24 +1376,6 @@ fn step3d(opt: &mut Adam, p: &mut [Vec<Vec<f64>>], g: &[Vec<Vec<f64>>], t: usize
                 p[tt][kk][ll] = flat_p[idx];
                 idx += 1;
             }
-        }
-    }
-}
-
-/// Adam step over a flattened (T x K) parameter block.
-fn step2d(opt: &mut Adam, p: &mut [Vec<f64>], g: &[Vec<f64>], t: usize, k: usize) {
-    let mut flat_p = Vec::with_capacity(t * k);
-    let mut flat_g = Vec::with_capacity(t * k);
-    for tt in 0..t {
-        flat_p.extend_from_slice(&p[tt]);
-        flat_g.extend_from_slice(&g[tt]);
-    }
-    opt.step(&mut flat_p, &flat_g);
-    let mut idx = 0;
-    for tt in 0..t {
-        for kk in 0..k {
-            p[tt][kk] = flat_p[idx];
-            idx += 1;
         }
     }
 }

--- a/src/seeded.rs
+++ b/src/seeded.rs
@@ -536,22 +536,6 @@ mod tests {
         (docs, v)
     }
 
-    /// Return the block (0-indexed) that contributes most mass to `phi`.
-    fn dominant_block(phi: &[f64], block_size: usize) -> usize {
-        let num_blocks = phi.len() / block_size;
-        (0..num_blocks)
-            .max_by(|&a, &b| {
-                let sa: f64 = phi[a * block_size..(a + 1) * block_size]
-                    .iter()
-                    .sum();
-                let sb: f64 = phi[b * block_size..(b + 1) * block_size]
-                    .iter()
-                    .sum();
-                sa.partial_cmp(&sb).unwrap()
-            })
-            .unwrap()
-    }
-
     /// Seeds steer topics toward the planted vocabulary blocks.
     ///
     /// K=3 topics; topic 0 seeded with words from block A, topic 1 seeded with

--- a/src/variational/lbfgs.rs
+++ b/src/variational/lbfgs.rs
@@ -65,7 +65,10 @@ where
         // Backtracking Armijo line search.
         let mut step = 1.0;
         let mut x_new = x.clone();
-        let (mut fx_new, mut g_new) = (fx, g.clone());
+        // Assigned on every loop iteration before they are read; the line search
+        // always runs the body at least once, so no initial value is needed.
+        let mut fx_new: f64;
+        let mut g_new: Vec<f64>;
         loop {
             for j in 0..n {
                 x_new[j] = x[j] + step * d[j];


### PR DESCRIPTION
Addresses the **minor** hygiene items from the JSS referee report (`notes/jss-referee-report.md`) — the ones that actually apply to the repo.

## Minor #1 — clear the 4 dead-code warnings
`cargo build` and `cargo test` are now warning-free:
- `variational/lbfgs.rs`: drop the dead `(fx, g.clone())` line-search init (the Armijo loop always assigns before reading; declare uninitialized — also removes a wasteful gradient clone).
- `detm.rs`: remove the write-only `EtaForward` fields `map_out`/`output` (the *local* vars feed `layer_inputs[0]`/`head_inp` and stay) and the unused `step2d` function.
- `seeded.rs`: remove an unused `dominant_block` test helper (surfaced under `cargo test`).

## Minor #2 — conformance `#[allow(dead_code)]`
Changed to `#[cfg_attr(not(test), allow(dead_code))]` on the contract checkers. They **are** exercised under `cargo test` (ctm/detm/bertopic/fastopic + the `*_conforms` table); the allow only suppressed the non-test build. Re-tagging makes them provably live under test — resolving the referee's "is this actually invoked?" smell.

## Minor #3 — not applicable
The referee saw `.DS_Store`/`.venv`/`uv.lock` in the working dir, but `git ls-files` shows none are tracked — `.gitignore` already covers them (`.DS_Store`, `.venv/`, `.venv*/`, `uv.lock`); only `Cargo.lock` is tracked (intentional). No repo/sdist change needed.

No behavior change. `cargo build` + `cargo test --lib` warning-free; 148 Rust tests pass; DETM/seeded/gsdmm/conformance Python suites green (492 passed).

The report's **major** items (committed `replication_report.md` provenance; benchmark variance/environment) are paper-facing and tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)