### PR TITLE
JSS review: conformance covers GDMR (+ document InfoCTM exclusion); reproduce.py --strict

### DIFF
--- a/paper/reproduce.py
+++ b/paper/reproduce.py
@@ -11,7 +11,11 @@ Each step runs as an isolated subprocess with its own timeout and unbuffered
 output, so one stalled reference toolchain cannot hang the whole run silently
 (it is marked TIMEOUT and the rest proceeds). Steps whose toolchain is absent
 (Rscript+stm/keyATM, the mallet CLI) skip themselves cleanly and are reported as
-SKIP rather than failure.
+SKIP rather than failure -- so a contributor without those tools still gets a
+useful run. For the archival run that backs the paper's numbers, pass --strict:
+then SKIP and TIMEOUT also count as failures (every toolchain must be present
+and every step must actually reproduce), so a green --strict run is the evidence
+the manuscript's Sections 5-6 cite.
 
 Usage (from the repo root):
 
@@ -19,6 +23,7 @@ Usage (from the repo root):
     ... --no-benchmarks    # Sections 5 + 7 only (deterministic, machine-independent)
     ... --only 6           # one section
     ... --stamp "2026-06-16"   # provenance date written into the report
+    ... --strict           # SKIP/TIMEOUT are failures (archival provenance run)
 
 Performance numbers (Section 6) are hardware-dependent. The report records the
 machine so the absolute timings are interpretable; relative speedups are the
@@ -158,6 +163,12 @@ def main():
     ap.add_argument("--no-benchmarks", action="store_true", help="skip Section 6")
     ap.add_argument("--only", type=int, choices=[5, 6, 7], help="run one section")
     ap.add_argument("--stamp", default="", help="provenance date for the report")
+    ap.add_argument(
+        "--strict",
+        action="store_true",
+        help="treat SKIP and TIMEOUT as failures too (for an archival "
+             "full-provenance run where every toolchain must be present)",
+    )
     args = ap.parse_args()
 
     GEN.mkdir(parents=True, exist_ok=True)
@@ -225,9 +236,24 @@ def main():
     report.write_text("\n".join(lines), encoding="utf-8")
     print(f"\nReport: {report.relative_to(ROOT)}")
 
-    # nonzero exit if anything hard-failed (SKIP/TIMEOUT are not failures)
-    hard = [r for r in results if r[2].startswith("FAIL")]
-    sys.exit(1 if hard else 0)
+    # Default: nonzero exit only on hard FAIL (SKIP/TIMEOUT are tolerated, since
+    # a contributor may not have R/MALLET installed). With --strict, a SKIP or
+    # TIMEOUT is also a failure — use it for the archival run that backs the
+    # paper's numbers, where every toolchain must be present and every step must
+    # actually reproduce.
+    def _bad(status):
+        if status.startswith("FAIL"):
+            return True
+        if args.strict and status in ("SKIP", "TIMEOUT"):
+            return True
+        return False
+
+    bad = [r for r in results if _bad(r[2])]
+    if bad:
+        kinds = ", ".join(sorted({r[2].split("(")[0] for r in bad}))
+        print(f"\n{len(bad)} step(s) not reproduced ({kinds})"
+              + (" — strict mode" if args.strict else ""))
+    sys.exit(1 if bad else 0)
 
 
 if __name__ == "__main__":

--- a/python/topica/conformance.py
+++ b/python/topica/conformance.py
@@ -54,6 +54,7 @@ REGISTRY: list[tuple[str, object, str]] = [
     # collapsed-Gibbs / Dirichlet doc-topic posterior
     ("LDA",          lambda: _topica.LDA(2),                                     "dirichlet"),
     ("DMR",          lambda: _topica.DMR(2),                                     "dirichlet"),
+    ("GDMR",         lambda: _topica.GDMR(2, degrees=[2]),                        "dirichlet"),
     ("SAGE",         lambda: _topica.SAGE(2),                                    "dirichlet"),
     ("PA",           lambda: _topica.PA(num_super=2, num_sub=4),                 "dirichlet"),
     ("PT",           lambda: _topica.PT(num_topics=2, num_pseudo=10),            "dirichlet"),
@@ -84,6 +85,15 @@ REGISTRY: list[tuple[str, object, str]] = [
     ("Top2Vec",      lambda: _topica.Top2Vec(),                                  "none"),
     # llm-based — pure-Python prompting pipeline, no generative word distribution
     ("TopicGPT",     lambda: _topica.TopicGPT(backend=lambda p: ""),             "none"),
+    # InfoCTM is EXCLUDED: it is a cross-lingual model that fits TWO aligned
+    # ProdLDA sub-models (fit(data_a, data_b, dictionary=...)) and exposes a
+    # topic-word distribution PER LANGUAGE, not a single flat (K, V) surface. It
+    # therefore has no generic (D, K) doc_topic / single topic_word to check
+    # against the flat contract here; its per-language outputs are validated in
+    # parity/infoctm_compare.py, and the underlying ProdLDA (in this registry)
+    # covers the single-language contract. Treat InfoCTM like DTM/HLDA: a
+    # structurally different model outside the flat-K conformance surface.
+    #
     # EmbeddingLDA is EXCLUDED: it is a Python wrapper around SeededLDA (see
     # module-level note in python/topica/embedding.py). It delegates every
     # fitted-model getter to self._model via __getattr__, has no class-level

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -127,6 +127,9 @@ pub const RUST_ESTIMATORS: &[RegistryEntry] = &[
     // Collapsed-Gibbs / Dirichlet doc-topic posterior.
     RegistryEntry { name: "LDA", family: ModelFamily::Dirichlet, exempt: &[] },
     RegistryEntry { name: "DMR", family: ModelFamily::Dirichlet, exempt: &[] },
+    // GDMR shares the `TopicModel` struct with LDA/DMR, so it is covered by the
+    // same `topicmodel_conforms` test; listed here under its user-facing name.
+    RegistryEntry { name: "GDMR", family: ModelFamily::Dirichlet, exempt: &[] },
     RegistryEntry { name: "LabeledLDA", family: ModelFamily::Dirichlet, exempt: &[] },
     RegistryEntry { name: "SeededLDA", family: ModelFamily::Dirichlet, exempt: &[] },
     RegistryEntry { name: "KeyATM", family: ModelFamily::Dirichlet, exempt: &[] },
@@ -172,6 +175,6 @@ mod registry_tests {
         }
         // Mirror of the Python REGISTRY size (user-facing models with an
         // Estimator-backed Rust struct).
-        assert_eq!(RUST_ESTIMATORS.len(), 25, "registry size drifted from the Python REGISTRY");
+        assert_eq!(RUST_ESTIMATORS.len(), 26, "registry size drifted from the Python REGISTRY");
     }
 }

--- a/tests/test_convergence_interface.py
+++ b/tests/test_convergence_interface.py
@@ -82,6 +82,13 @@ def _fit_model(name: str, factory):
         model.fit(_TOY, features, iters=20, check_every=10)
         return model
 
+    # GDMR: like DMR but a smooth (Legendre) prior over a continuous covariate;
+    # the factory uses degrees=[2], i.e. one continuous covariate column.
+    if name == "GDMR":
+        features = np.linspace(0.0, 1.0, len(_TOY)).reshape(-1, 1)
+        model.fit(_TOY, features, iters=20, check_every=10)
+        return model
+
     # SAGE: positional `groups` is a per-document group label
     if name == "SAGE":
         groups = ["animal"] * 15 + ["space"] * 15


### PR DESCRIPTION
The two repo-actionable findings from the second JSS review note (`/Users/nealcaren/Documents/GitHub/random/topica-jss-review-note.md`).

## 1. Conformance registry alignment (makes "every model is checked" true)
- **GDMR** — a real gap. It conforms (Dirichlet family; shares the `TopicModel` struct with LDA/DMR) but was in neither registry. Added to the Python `REGISTRY` (which drives the parametrized `test_conformance.py` — GDMR now passes all cells) and the Rust `RUST_ESTIMATORS` doc table (25→26; no new Rust test needed — `topicmodel_conforms` already exercises the shared struct).
- **InfoCTM** — *not* a plain omission: it's cross-lingual, fits two aligned ProdLDA sub-models, and exposes a **per-language** `topic_word` with no single flat `(K,V)`/`(D,K)` surface. Documented as an explicit exclusion (like `EmbeddingLDA`), validated instead in `parity/infoctm_compare.py`; the underlying ProdLDA covers the single-language contract.
- **EmbeddingLDA** — already documented-excluded (the reviewer missed the comment); unchanged.

## 2. `paper/reproduce.py --strict`
By default `SKIP`/`TIMEOUT` are tolerated (a contributor may lack R/MALLET). `--strict` makes them count as failures too, so a green `--strict` run is the archival provenance the manuscript's Sections 5–6 cite. Header + `--help` updated.

`cargo test --lib` 148 pass (warning-free); conformance + standard-errors suites 433 passed / 14 skipped.

The remaining review items are paper-facing (version provenance 0.22.0→0.23.1, validation-language "same names ≠ same statistical object", Table 1 re-audit, archived report) and will be handled in the paper pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)