### PR TITLE
Faithful spectral recover() (reproduces R stm recoverL2) + beta_init warm-start (closes #234)

### DIFF
--- a/docs/replications/stm.md
+++ b/docs/replications/stm.md
@@ -68,6 +68,20 @@ that the two optimizers split differently, never a systematic offset — the
 expected behavior of a non-convex model, where there is no single STM fit to
 reproduce.
 
+### Spectral initialization reproduces R's recovery exactly
+
+The cosines above are EM optima of a non-convex objective, so they differ across
+optimizers. The *initialization* underneath them is the deterministic Arora
+anchor-word recovery, and topica reproduces R `stm`'s `recoverL2()` step exactly:
+on identical documents the spectral topic-word matrix matches R's reference
+recovery at a cosine of **1.0** (`parity/spectral_recover_stm.py`). (Earlier
+topica's recovery used a fixed, too-large exponentiated-gradient step that diverged
+to vertices rather than the constrained optimum; the step is now scale-adaptive and
+runs to convergence — issue #234.) For a guaranteed "replicate the original" mode,
+`STM.fit(..., beta_init=)` / `CTM.fit(..., beta_init=)` inject an externally
+computed base β (for example R `stm`'s exact spectral β), so a fit can start from
+R's initialization and reproduce that run.
+
 What replicates stably across optima is the substantive conclusion. Regressing
 topic prevalence on ideology, topica recovers R's effect coefficients with a
 Pearson correlation of 0.84, and the same sign and significance on 13 of 15

--- a/parity/spectral_recover_stm.py
+++ b/parity/spectral_recover_stm.py
@@ -1,0 +1,100 @@
+"""Parity: topica's spectral-init recovery vs R stm's recoverL2 (issue #234).
+
+topica's `recover()` (src/spectral.rs) is the Arora anchor-word recovery step. This
+checks it reproduces R `stm`'s reference recovery on an identical corpus: it drives
+R to tokenize gadarian, compute its spectral topic-word matrix via the QP reference
+path (`recoverEG=FALSE` — the converged optimum, not stm's non-converging default
+exponentiated-gradient), and emit the prepped documents; then it fits topica's
+spectral init (CTM, iters=0) on those same documents and reports the Hungarian-
+matched topic-word cosine. Pre-#234 this was ~0.37 (topica's EG diverged at the
+fixed eta=50); the fix targets ~1.0.
+
+Skips cleanly if Rscript or the stm/Matrix packages are unavailable.
+"""
+import json
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+
+import numpy as np
+
+
+R_SCRIPT = r"""
+ok <- requireNamespace("stm", quietly=TRUE) && requireNamespace("Matrix", quietly=TRUE)
+if (!ok) { cat("SKIP: stm/Matrix not installed\n"); quit(status=0) }
+suppressMessages({library(stm); library(Matrix)})
+args <- commandArgs(trailingOnly=TRUE); outdir <- args[1]; K <- as.integer(args[2])
+data("gadarian", package="stm")
+proc <- textProcessor(gadarian$open.ended.response, metadata=gadarian, verbose=FALSE)
+out  <- prepDocuments(proc$documents, proc$vocab, proc$meta, verbose=FALSE)
+docs <- out$documents; vocab <- out$vocab; V <- length(vocab)
+# documents as word-string lists (same tokens topica will see)
+lines <- vapply(docs, function(m) paste(rep(vocab[m[1,]], m[2,]), collapse=" "), character(1))
+writeLines(lines, file.path(outdir, "docs.txt"))
+# stm spectral topic-word via the QP reference path (the converged optimum)
+rows<-integer(0);cols<-integer(0);vals<-integer(0)
+for(i in seq_along(docs)){m<-docs[[i]];rows<-c(rows,rep(i,ncol(m)));cols<-c(cols,m[1,]);vals<-c(vals,m[2,])}
+mat <- sparseMatrix(i=rows,j=cols,x=vals,dims=c(length(docs),V))
+Q <- stm:::gram(mat); Qsums <- rowSums(Q); Qbar <- Q/Qsums
+anchors <- stm:::fastAnchor(Qbar, K, verbose=FALSE)
+beta <- stm:::recoverL2(Qbar, anchors, Qsums/sum(Qsums), verbose=FALSE, recoverEG=FALSE)$A
+writeLines(vocab, file.path(outdir, "vocab.txt"))
+write.table(beta, file.path(outdir, "beta.csv"), sep=",", row.names=FALSE, col.names=FALSE)
+cat("OK\n")
+"""
+
+
+def _hungarian_cosine(A, B):
+    from scipy.optimize import linear_sum_assignment
+    An = A / (np.linalg.norm(A, axis=1, keepdims=True) + 1e-12)
+    Bn = B / (np.linalg.norm(B, axis=1, keepdims=True) + 1e-12)
+    S = An @ Bn.T
+    r, c = linear_sum_assignment(-S)
+    return float(S[r, c].mean())
+
+
+def main():
+    if shutil.which("Rscript") is None:
+        print("SKIP: Rscript not found")
+        return 0
+    import topica
+    K = 5
+    with tempfile.TemporaryDirectory() as d:
+        rs = os.path.join(d, "gen.R")
+        with open(rs, "w") as f:
+            f.write(R_SCRIPT)
+        res = subprocess.run(["Rscript", rs, d, str(K)], capture_output=True, text=True)
+        if "SKIP" in res.stdout:
+            print(res.stdout.strip())
+            return 0
+        if res.returncode != 0 or not os.path.exists(os.path.join(d, "beta.csv")):
+            print("SKIP: R step failed\n" + res.stdout + res.stderr)
+            return 0
+        docs = [ln.split() for ln in open(os.path.join(d, "docs.txt")) if ln.strip()]
+        stm_vocab = [w.strip() for w in open(os.path.join(d, "vocab.txt"))]
+        stm_beta = np.loadtxt(os.path.join(d, "beta.csv"), delimiter=",")  # (K, V_stm)
+
+    m = topica.CTM(num_topics=K, seed=1, init="spectral")
+    m.fit(docs, iters=0)  # iters=0 returns the pure spectral-init topic-word
+    tb = np.asarray(m.topic_word)
+    tvocab = list(m.vocabulary)
+
+    # align both to the shared vocabulary
+    stm_idx = {w: i for i, w in enumerate(stm_vocab)}
+    shared = [w for w in tvocab if w in stm_idx]
+    tcols = [tvocab.index(w) for w in shared]
+    scols = [stm_idx[w] for w in shared]
+    A = tb[:, tcols]
+    B = stm_beta[:, scols]
+    cos = _hungarian_cosine(B, A)
+    print(f"shared vocab: {len(shared)} words | topica V={len(tvocab)} stm V={len(stm_vocab)}")
+    print(f"spectral recover() vs R stm recoverL2 (QP path): matched cosine = {cos:.4f}")
+    ok = cos >= 0.95
+    print("PASS" if ok else "FAIL (expected >= 0.95)")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -366,6 +366,7 @@ class CTM:
         batch_size: int = 256,
         tau: float = 64.0,
         kappa: float = 0.7,
+        beta_init: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
         em_tol: Optional[float] = None,
         keep_eta_cov: bool = True,
         num_threads: Optional[int] = None,
@@ -382,6 +383,11 @@ class CTM:
         Monro step rho_t = (tau + t)^(-kappa). tau (>= 0) and kappa in (0.5, 1] set
         the learning-rate schedule; convergence_tol is ignored. SVI does not retain a
         per-iteration bound trace.
+
+        beta_init (K x num_words) overrides the spectral/random topic-word
+        initialization with a caller-supplied base beta -- the warm-start hook for
+        reproducing an external fit (e.g. R stm's exact spectral beta). Batch only
+        (not supported with inference="svi").
 
         keep_eta_cov=False skips storing the per-document variational covariance (nu),
         saving O(N*K^2) memory. The fit is bit-identical. Use _recompute_eta_cov() or
@@ -512,6 +518,7 @@ class STM:
         convergence_tol: float = 1e-5,
         gamma_prior: str = "pooled",
         gamma_enet: float = 1.0,
+        beta_init: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
         em_tol: Optional[float] = None,
         covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
         keep_eta_cov: bool = True,
@@ -533,6 +540,10 @@ class STM:
         with AIC-selected penalty, recommended for high-dimensional prevalence
         designs. gamma_enet is the elastic-net mix (1.0 = pure lasso, values in
         (0,1) add ridge; R stm's gamma.enet). Ignored when gamma_prior="pooled".
+
+        beta_init (K x num_words) overrides the spectral/random topic-word
+        initialization with a caller-supplied base beta -- the warm-start hook for
+        reproducing an external fit (e.g. R stm's exact spectral beta).
 
         keep_eta_cov=False skips storing the per-document variational covariance (nu),
         saving O(N*K^2) memory. The fit is bit-identical. Use _recompute_eta_cov() or

--- a/src/ctm.rs
+++ b/src/ctm.rs
@@ -885,6 +885,7 @@ pub fn fit_ctm<R: Rng>(
     prevalence: Option<&[Vec<f64>]>,
     content: Option<(&[usize], usize)>,
     init_spectral: bool,
+    init_beta: Option<&[Vec<f64>]>,
     gamma_prior: GammaPrior,
     keep_nu: bool,
     diagonal: bool,
@@ -921,10 +922,15 @@ pub fn fit_ctm<R: Rng>(
     // content deviations κ at zero. Gating spectral off for content models left
     // the base β random, which is strongly multimodal — most seeds collapse to a
     // flat, no-group-content optimum (issue #216).
-    let mut beta = if init_spectral {
-        crate::spectral::spectral_init(docs, k, num_types).unwrap_or_else(|| random_beta(rng))
-    } else {
-        random_beta(rng)
+    // A caller-supplied `init_beta` (K×V) overrides spectral/random init — the
+    // warm-start hook that lets an STM-compatible front end inject an externally
+    // computed base β (e.g. R `stm`'s exact spectral β) and reproduce that fit.
+    let mut beta = match init_beta {
+        Some(b) => b.iter().map(|row| row.to_vec()).collect(),
+        None if init_spectral => {
+            crate::spectral::spectral_init(docs, k, num_types).unwrap_or_else(|| random_beta(rng))
+        }
+        None => random_beta(rng),
     };
 
     // Content covariate state: background m_v and SAGE deviations κ; per-group β.

--- a/src/ctm.rs
+++ b/src/ctm.rs
@@ -1579,7 +1579,7 @@ mod tests {
                 docs.push(vec![6, 7, 8, 6, 7, 8, 6, 7, 8, 6]);
             }
         }
-        let model = fit_ctm(&docs, 3, 9, 25, 0.0, 0.0, None, None, true, GammaPrior::Pooled, true, false, &mut rng);
+        let model = fit_ctm(&docs, 3, 9, 25, 0.0, 0.0, None, None, true, None, GammaPrior::Pooled, true, false, &mut rng);
         let theta = model.doc_topics();
         // Sanity: θ rows sum to 1 and are valid.
         for row in &theta {
@@ -1610,7 +1610,7 @@ mod tests {
             }
         }
         // K=2 (CTM needs >=2 topics); content groups = 2.
-        let model = fit_ctm(&docs, 2, 4, 30, 0.0, 0.0, None, Some((&groups, 2)), false, GammaPrior::Pooled, true, false, &mut rng);
+        let model = fit_ctm(&docs, 2, 4, 30, 0.0, 0.0, None, Some((&groups, 2)), false, None, GammaPrior::Pooled, true, false, &mut rng);
         let cb = model.content_beta.expect("content_beta present");
         // cb[group][topic][word]. The dominant topic for group 0 should favour
         // {0,1}; for group 1 {2,3}. Check that for each group some topic does.
@@ -1638,7 +1638,7 @@ mod tests {
             }
         }
 
-        let converged = fit_ctm(&docs, 2, 6, 100, 1e-5, 0.0, None, None, true, GammaPrior::Pooled, true, false, &mut rng);
+        let converged = fit_ctm(&docs, 2, 6, 100, 1e-5, 0.0, None, None, true, None, GammaPrior::Pooled, true, false, &mut rng);
         // The bound trajectory is (weakly) monotone increasing.
         let h = &converged.bound_history;
         assert!(h.len() >= 2);
@@ -1651,7 +1651,7 @@ mod tests {
 
         // em_tol = 0 disables early stopping: run the full cap.
         let mut rng2 = ChaCha8Rng::seed_from_u64(7);
-        let capped = fit_ctm(&docs, 2, 6, 8, 0.0, 0.0, None, None, true, GammaPrior::Pooled, true, false, &mut rng2);
+        let capped = fit_ctm(&docs, 2, 6, 8, 0.0, 0.0, None, None, true, None, GammaPrior::Pooled, true, false, &mut rng2);
         assert!(!capped.converged);
         assert_eq!(capped.em_iters_run, 8);
         assert_eq!(capped.bound_history.len(), 8);
@@ -1675,7 +1675,7 @@ mod tests {
             })
             .collect();
         let model = fit_ctm(
-            &docs, nb, v, 30, 0.0, 0.0, None, None, true, GammaPrior::Pooled, true, true, &mut rng,
+            &docs, nb, v, 30, 0.0, 0.0, None, None, true, None, GammaPrior::Pooled, true, true, &mut rng,
         );
         assert!(model.diagonal, "model should record diagonal mode");
 
@@ -1801,7 +1801,7 @@ mod tests {
             vec![1, 1, 2, 0, 1],
             vec![2, 2, 0, 1, 2],
         ];
-        let model = fit_ctm(&docs, 3, 3, 5, 0.0, 0.0, None, None, false, GammaPrior::Pooled, true, false, &mut rng);
+        let model = fit_ctm(&docs, 3, 3, 5, 0.0, 0.0, None, None, false, None, GammaPrior::Pooled, true, false, &mut rng);
 
         let base_violations = check_conformance(&model);
         assert!(

--- a/src/python.rs
+++ b/src/python.rs
@@ -3231,6 +3231,37 @@ fn parse_features(data: &Bound<'_, PyAny>) -> PyResult<Vec<Vec<f64>>> {
     })
 }
 
+/// Parse the optional caller-supplied base topic-word init (K×V) for the warm-start
+/// hook (issue #234): lets an STM-compatible front end inject an externally
+/// computed β (e.g. R `stm`'s exact spectral β) and reproduce that fit. Validates
+/// the shape and rejects it on the SVI path (batch only).
+fn parse_init_beta(
+    beta_init: Option<&Bound<'_, PyAny>>,
+    k: usize,
+    num_types: usize,
+    svi: bool,
+) -> PyResult<Option<Vec<Vec<f64>>>> {
+    match beta_init {
+        None => Ok(None),
+        Some(b) => {
+            if svi {
+                return Err(PyValueError::new_err(
+                    "beta_init is not supported with inference=\"svi\" (batch only)",
+                ));
+            }
+            let m = parse_features(b)?;
+            if m.len() != k || m.iter().any(|r| r.len() != num_types) {
+                return Err(PyValueError::new_err(format!(
+                    "beta_init must have shape (num_topics={k}, num_words={num_types}); got {}x{}",
+                    m.len(),
+                    m.first().map(|r| r.len()).unwrap_or(0)
+                )));
+            }
+            Ok(Some(m))
+        }
+    }
+}
+
 /// Map a per-document timestamp sequence to contiguous 0-based time-segment
 /// indices plus the sorted, distinct labels. Accepts numbers or strings; the
 /// distinct values are sorted to define the time order. Returns
@@ -5492,8 +5523,8 @@ impl CTM {
     /// sharply at large K; `posterior_theta_samples` / `estimate_effect` with
     /// draws transparently recompute it on demand when needed.
     #[pyo3(signature = (data, *, iters=500, convergence_tol=1e-5, inference="batch",
-                        batch_size=256, tau=64.0, kappa=0.7, em_tol=None, keep_eta_cov=true,
-                        num_threads=None))]
+                        batch_size=256, tau=64.0, kappa=0.7, beta_init=None, em_tol=None,
+                        keep_eta_cov=true, num_threads=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -5505,6 +5536,7 @@ impl CTM {
         batch_size: usize,
         tau: f64,
         kappa: f64,
+        beta_init: Option<&Bound<'_, PyAny>>,
         em_tol: Option<f64>,
         keep_eta_cov: bool,
         num_threads: Option<usize>,
@@ -5549,6 +5581,8 @@ impl CTM {
         let diagonal = self.variational == "diagonal";
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
 
+        let init_beta = parse_init_beta(beta_init, k, num_types, svi)?;
+
         let (model, corpus) = py.allow_threads(move || {
             let m = run_with_threads(num_threads, || {
                 if svi {
@@ -5559,7 +5593,8 @@ impl CTM {
                 } else {
                     ctm::fit_ctm(
                         &corpus.docs, k, num_types, iters, convergence_tol, shrink, None, None,
-                        spectral, ctm::GammaPrior::Pooled, keep_eta_cov, diagonal, &mut rng,
+                        spectral, init_beta.as_deref(), ctm::GammaPrior::Pooled, keep_eta_cov,
+                        diagonal, &mut rng,
                     )
                 }
             });
@@ -6136,8 +6171,8 @@ impl STM {
     /// lower-precision mean-field covariance).
     #[pyo3(signature = (data, prevalence=None, *, prevalence_names=None,
                         content=None, content_names=None, iters=500, convergence_tol=1e-5,
-                        gamma_prior="pooled", gamma_enet=1.0, em_tol=None, covariates=None,
-                        keep_eta_cov=true, num_threads=None))]
+                        gamma_prior="pooled", gamma_enet=1.0, beta_init=None, em_tol=None,
+                        covariates=None, keep_eta_cov=true, num_threads=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
@@ -6151,6 +6186,7 @@ impl STM {
         convergence_tol: f64,
         gamma_prior: &str,
         gamma_enet: f64,
+        beta_init: Option<&Bound<'_, PyAny>>,
         em_tol: Option<f64>,
         covariates: Option<&Bound<'_, PyAny>>,
         keep_eta_cov: bool,
@@ -6295,13 +6331,15 @@ impl STM {
         let diagonal = self.variational == "diagonal";
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
 
+        let init_beta = parse_init_beta(beta_init, k, num_types, false)?;
+
         let (model, corpus) = py.allow_threads(move || {
             let prev_ref = prevalence_x.as_deref();
             let cont_ref = content_groups.as_ref().map(|(g, n)| (g.as_slice(), *n));
             let m = run_with_threads(num_threads, || {
                 ctm::fit_ctm(
                     &corpus.docs, k, num_types, iters, convergence_tol, shrink, prev_ref, cont_ref,
-                    spectral, gprior, keep_eta_cov, diagonal, &mut rng,
+                    spectral, init_beta.as_deref(), gprior, keep_eta_cov, diagonal, &mut rng,
                 )
             });
             (m, corpus)

--- a/src/spectral.rs
+++ b/src/spectral.rs
@@ -152,30 +152,64 @@ fn recover(qbar: &[Vec<f64>], p: &[f64], anchors: &[usize], k: usize, v: usize) 
         }
     }
 
+    // Map each anchor word to its topic index, so anchor words get exact unit
+    // vectors (matching stm's recoverL2, which sets condprob[anchor] = e_topic).
+    let mut anchor_topic = vec![usize::MAX; v];
+    for (t, &a) in anchors.iter().enumerate() {
+        anchor_topic[a] = t;
+    }
+
     // A[word][topic] = C[word][topic] * p[word]; later normalized per topic.
+    // Per word, recover the simplex weights C by exponentiated gradient on the
+    // residual `b − G c`, with a max-subtracted multiplicative update
+    // `c ∝ c · exp(2η(b − Gc) − max)` run to `‖residual‖` convergence.
+    //
+    // The step `η` is adaptive: `1/(2L)` with `L` a Gershgorin bound on the largest
+    // eigenvalue of `G` (the gradient's Lipschitz constant). This is the mirror-
+    // descent stable step, so the iterate converges to the constrained optimum
+    // (Arora's recoverL2, == R stm's `recoverEG=FALSE` reference path) rather than
+    // overshooting to a vertex. The classic fixed `η=50` is far too large here —
+    // the gradients scale as ~1/V — so it diverged to (arbitrary, float-order-
+    // dependent) vertices and never converged (issue #234); the adaptive step
+    // reaches the optimum in ~70 iterations on gadarian.
+    let l: f64 = (0..k)
+        .map(|i| (0..k).map(|j| g[i][j].abs()).sum::<f64>())
+        .fold(0.0, f64::max);
+    let eta = 1.0 / (2.0 * l.max(1e-12));
+    const TOL: f64 = 1e-8;
+    const MAX_ITS: usize = 500;
     let mut a_mat = vec![vec![0.0f64; k]; v];
     for w in 0..v {
-        let bvec: Vec<f64> = (0..k).map(|t| dot(anchor_rows[t], &qbar[w])).collect();
-        // Exponentiated gradient on the simplex: min Cᵀ G C − 2 Cᵀ b.
         let mut c = vec![1.0 / k as f64; k];
-        let eta = 50.0;
-        for _ in 0..120 {
-            let gc: Vec<f64> = (0..k).map(|i| (0..k).map(|j| g[i][j] * c[j]).sum()).collect();
-            // grad_i = 2(gc_i − b_i)
-            let mut total = 0.0;
-            for i in 0..k {
-                c[i] *= (-eta * 2.0 * (gc[i] - bvec[i])).exp();
-                if !c[i].is_finite() {
-                    c[i] = 0.0;
+        if anchor_topic[w] != usize::MAX {
+            // Anchor word: exact unit vector, no solve.
+            c = vec![0.0f64; k];
+            c[anchor_topic[w]] = 1.0;
+        } else {
+            let bvec: Vec<f64> = (0..k).map(|t| dot(anchor_rows[t], &qbar[w])).collect();
+            let mut sse_old = f64::INFINITY;
+            for _ in 0..MAX_ITS {
+                let gc: Vec<f64> = (0..k).map(|i| (0..k).map(|j| g[i][j] * c[j]).sum()).collect();
+                // residual b − Gc and its squared norm (the convergence metric).
+                let resid: Vec<f64> = (0..k).map(|i| bvec[i] - gc[i]).collect();
+                let sse: f64 = resid.iter().map(|r| r * r).sum();
+                // Multiplicative exp-gradient step, max-subtracted for stability.
+                let grad: Vec<f64> = resid.iter().map(|r| 2.0 * eta * r).collect();
+                let maxd = grad.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+                let mut total = 0.0;
+                for i in 0..k {
+                    c[i] *= (grad[i] - maxd).exp();
+                    total += c[i];
                 }
-                total += c[i];
-            }
-            if total > 0.0 {
-                for ci in c.iter_mut() {
-                    *ci /= total;
+                if total > 0.0 {
+                    for ci in c.iter_mut() {
+                        *ci /= total;
+                    }
                 }
-            } else {
-                c = vec![1.0 / k as f64; k];
+                if (sse_old.sqrt() - sse.sqrt()).abs() < TOL {
+                    break;
+                }
+                sse_old = sse;
             }
         }
         for t in 0..k {

--- a/tests/test_ctm.py
+++ b/tests/test_ctm.py
@@ -513,3 +513,35 @@ def test_bad_inference_rejected():
     docs, nb, _ = _block_corpus(n=60)
     with pytest.raises(ValueError):
         CTM(num_topics=nb, seed=1).fit(docs, iters=5, inference="banana")
+
+
+# beta_init warm-start hook (issue #234) -----------------------------------
+
+def test_beta_init_overrides_initialization():
+    """iters=0 returns exactly the injected base beta (the warm-start hook)."""
+    docs, nb, _ = _block_corpus(n=200)
+    V = len({w for d in docs for w in d})
+    rng = np.random.default_rng(0)
+    custom = rng.random((nb, V)); custom /= custom.sum(1, keepdims=True)
+    m = CTM(num_topics=nb, seed=1); m.fit(docs, iters=0, beta_init=custom)
+    # vocab order is stable for iters=0; rows match up to the model's vocab order
+    _npt.assert_allclose(np.sort(m.topic_word, axis=1), np.sort(custom, axis=1), atol=1e-9)
+
+
+def test_beta_init_warm_start_reproduces_spectral_fit():
+    """Injecting the spectral-init beta reproduces the default spectral fit."""
+    docs, nb, _ = _block_corpus(n=300)
+    default = CTM(num_topics=nb, seed=1); default.fit(docs, iters=20)
+    spec = CTM(num_topics=nb, seed=1); spec.fit(docs, iters=0)  # the spectral init beta
+    warm = CTM(num_topics=nb, seed=1); warm.fit(docs, iters=20, beta_init=spec.topic_word)
+    _npt.assert_allclose(warm.topic_word, default.topic_word, atol=1e-9)
+
+
+def test_beta_init_validation():
+    docs, nb, _ = _block_corpus(n=60)
+    V = len({w for d in docs for w in d})
+    with pytest.raises(ValueError, match="beta_init must have shape"):
+        CTM(num_topics=nb, seed=1).fit(docs, iters=5, beta_init=np.ones((nb + 1, V)))
+    with pytest.raises(ValueError, match="not supported with inference"):
+        CTM(num_topics=nb, seed=1).fit(docs, iters=2, inference="svi",
+                                       beta_init=np.ones((nb, V)) / V)

--- a/tests/test_stm.py
+++ b/tests/test_stm.py
@@ -548,3 +548,19 @@ class TestSearchK:
         for row in search_k_results:
             assert isinstance(row["coherence"], float)
             assert isinstance(row["exclusivity"], float)
+
+
+def test_stm_beta_init_warm_start():
+    """STM accepts a caller-supplied base beta (the warm-start hook, issue #234B):
+    injecting the spectral init reproduces the default spectral fit."""
+    import topica
+    rng = np.random.default_rng(0)
+    docs, x = _make_synthetic_corpus(rng, n_per_class=60)
+    X = x.reshape(-1, 1)
+    spec = topica.STM(num_topics=2, seed=1)
+    spec.fit(docs, prevalence=X, iters=0)  # pure spectral-init topic-word
+    warm = topica.STM(num_topics=2, seed=1)
+    warm.fit(docs, prevalence=X, iters=10, beta_init=spec.topic_word)
+    default = topica.STM(num_topics=2, seed=1)
+    default.fit(docs, prevalence=X, iters=10)
+    np.testing.assert_allclose(warm.topic_word, default.topic_word, atol=1e-9)


### PR DESCRIPTION
Closes #234.

## (A) recover() now reproduces R stm's recoverL2

topica's Arora anchor-word recovery (`src/spectral.rs::recover`) used a fixed,
too-large exponentiated-gradient step (η=50, 120 iterations, no convergence check)
that **diverged to arbitrary vertices** instead of the constrained optimum. On
gadarian K=5 the recovered β matched R `stm`'s `recoverL2()` at only **~0.37
cosine** even with bit-identical Q̄ and anchors.

**Root cause** (found by decomposing against stm): the per-word gradients scale as
~1/V, so η=50 overshoots. stm's *own* default EG (`recoverEG=TRUE`) also fails to
converge — it disagrees with stm's quadprog reference at cosine 0.44. The true
Arora optimum is interior and reproducible.

**Fix**: a scale-adaptive mirror-descent step `η = 1/(2L)` (L a Gershgorin bound on
λmax(G)), run to `‖residual‖` convergence (tol 1e-8, max 500), with the
max-subtracted multiplicative update and anchor words set to exact unit vectors.
Converges to the true optimum (= stm `recoverEG=FALSE`) in ~70 iterations.

**Result**: built-topica vs R stm `recoverL2` on gadarian → matched cosine
**1.0000** (`parity/spectral_recover_stm.py`, skips cleanly without R/stm). This
also fixes topica's *own* init, which previously landed at an arbitrary
non-converged point under the entire logistic-normal family.

## (B) beta_init warm-start hook

`fit_ctm` gains `init_beta`; `STM.fit`/`CTM.fit` gain `beta_init=` (K × num_words)
to inject an externally computed base β (e.g. R `stm`'s exact spectral β) and
reproduce that fit deterministically — what the **STM-compatible R bindings** need
for a guaranteed "replicate the original" mode. Batch only (rejected with
`inference="svi"`); shape-validated.

## Scope note

The recover() fix changes the (now-correct) spectral initialization for the whole
logistic-normal family. Full suite is green, so no behavior test regressed. The
downstream Poliblog parity cosines in `docs/replications/stm.md` (0.97 @2k, 0.84
@5k) were measured pre-fix and are left unchanged here; refreshing them is a small
follow-up (refs #206).

## Tests / docs
- CTM + STM `beta_init` tests (override, warm-start reproduces the default fit,
  shape validation, SVI rejection); `parity/spectral_recover_stm.py`.
- `docs/replications/stm.md`: notes the exact init parity + the warm-start mode.
- cargo 148, full pytest **2777 passed**, `mkdocs --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)