### PR TITLE
release: 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-06-18
+
+### Added
+
+- **Minibatch / stochastic VI for ECTM** — `ECTM.fit(inference="svi",
+  batch_size=, tau=, kappa=, content_every=)` fits the 10^5–10^6-document corpora
+  ECTM is built for without subsampling. Each step samples `batch_size` documents,
+  runs the warm-started Laplace E-step, scales the minibatch sufficient statistics
+  to corpus size, and moves the globals with a Robbins-Monro rate
+  `(tau + step)^(-kappa)`; the expensive content-κ M-step is amortized across
+  `content_every` minibatches (default once per epoch). Validated against the batch
+  fit on a 96k-speech congressional corpus (matched topic-word cosine 0.97,
+  between-group divergence-spectrum correlation 0.97, in a few minutes vs ~22 for
+  batch). SVI is **seed-reproducible** (not bit-exact); batch stays the default.
+  A content-convergence guard (`content_converged`, `content_shift_history`) warns
+  when a fit's content model has not settled, so an understated headline cannot
+  pass silently. SVI is ECTM-only: a size-ladder benchmark showed plain STM/CTM
+  batch EM converges in ~15–25 cheap iterations at every scale, so SVI offers no
+  benefit there. (#231, #233)
+
+- **`beta_init` warm-start hook** — `STM.fit(..., beta_init=)` and
+  `CTM.fit(..., beta_init=)` accept a caller-supplied `(num_topics, num_words)`
+  base topic-word matrix, overriding the spectral/random init. This lets an
+  external front end (e.g. an R `stm`-compatible wrapper) inject a precomputed β
+  and reproduce that fit deterministically. Batch only. (#234)
+
+### Fixed
+
+- **Spectral initialization now reproduces R `stm`'s `recoverL2`** — the
+  anchor-word recovery (`recover()`) solved the per-word simplex problem with a
+  fixed, too-large exponentiated-gradient step that diverged to arbitrary vertices
+  instead of the constrained optimum (matching R `stm` at only ~0.37 cosine even
+  on identical inputs). The step is now scale-adaptive (`1/(2L)`, L a Gershgorin
+  bound on λmax) and runs to convergence, with anchor words set to exact unit
+  vectors; it reaches R `stm`'s reference recovery at cosine **1.0** on gadarian
+  (`parity/spectral_recover_stm.py`) in ~70 iterations. This corrects the spectral
+  init under the whole logistic-normal family (CTM/STM/STS/ECTM/DTM). (#234)
+
 ## [0.23.1] - 2026-06-17
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.23.1
-date-released: 2026-06-17
+version: 0.24.0
+date-released: 2026-06-18
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.23.1"
+version = "0.24.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.23.1"
+version = "0.24.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.23.1"
+version = "0.24.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.24.0**. Bumps `Cargo.toml` / `pyproject.toml` / `CITATION.cff` and adds
the CHANGELOG entry.

## Highlights (already merged to main)

- **ECTM minibatch SVI** (`inference="svi"`, #231/#233) — fits 10^5–10^6-document
  corpora ECTM is built for; validated on a 96k congressional corpus (0.97 cosine
  vs batch, few minutes vs ~22). Seed-reproducible; batch stays default; a
  content-convergence guard prevents a silently-understated headline. ECTM-only
  (benchmark showed plain STM/CTM batch is already fast).
- **`beta_init` warm-start hook** (#234) — `STM.fit`/`CTM.fit` accept a
  caller-supplied base β, for an R `stm`-compatible front end to reproduce a fit.
- **Spectral init reproduces R `stm`'s `recoverL2`** (#234) — `recover()`'s
  diverging fixed-step EG replaced by a scale-adaptive, converged solve; matches
  stm at cosine 1.0 on gadarian. Corrects the init under the whole logistic-normal
  family.

## Not in this release

- **#232 `content_placebo`** is finished and green but conflicts with the merged
  ECTM SVI work (additive overlaps in `ectm.md` / `test_ectm.py`); it will land in
  0.24.1 after a quick rebase, before the paper re-pin.
- The Poliblog parity cosines in `docs/replications/stm.md` predate the spectral
  fix and are a follow-up re-measure (refs #206).

After merge: tag `v0.24.0` to publish to PyPI (held for explicit go-ahead).

🤖 Generated with [Claude Code](https://claude.com/claude-code)