### PR TITLE
Expose SAGE content-model κ coefficients on STM (closes #237)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   a between-group content divergence is real rather than a small-cell estimation
   artifact. (#230, #232)
 
+- **SAGE content-model κ coefficients on `STM`** — `STM.content_kappa` returns the
+  additive decomposition behind the per-group topic-word model as a dict: `m`
+  (num_words), `kappa_topic` (num_topics × num_words), `kappa_cov` (num_groups ×
+  num_words), and `kappa_interaction` (num_topics × num_groups × num_words), where
+  the per-group log-probabilities are `m + kappa_topic + kappa_cov +
+  kappa_interaction` (softmax over words). These were computed internally but
+  previously discarded; they are the identifying parts R `stm`'s `sageLabels()` /
+  `labelTopics()` rank words by (and cannot be recovered from the per-group β
+  alone). Persisted across save/load. (#237)
+
 ## [0.24.0] - 2026-06-18
 
 ### Added

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -615,6 +615,16 @@ class STM:
         RuntimeError if fit without content covariates."""
         ...
     @property
+    def content_kappa(self) -> dict[str, numpy.typing.NDArray[numpy.float64]]:
+        """The SAGE content-model kappa decomposition as a dict: 'm' (num_words,),
+        'kappa_topic' (num_topics, num_words), 'kappa_cov' (num_groups, num_words),
+        'kappa_interaction' (num_topics, num_groups, num_words). Per-group
+        log-probabilities are m + kappa_topic + kappa_cov + kappa_interaction
+        (softmax over words). These are the additive parts R stm's sageLabels()
+        ranks words by; the per-group beta alone does not identify them.
+        RuntimeError if fit without content covariates."""
+        ...
+    @property
     def groups(self) -> list[str]:
         """Content group names (axis-1 of topic_word_by_group). RuntimeError if
         fit without content covariates."""

--- a/src/ctm.rs
+++ b/src/ctm.rs
@@ -347,6 +347,25 @@ pub fn ctm_hpb(
     HpbResult { nu, phi: eb, bound }
 }
 
+/// The SAGE content-model κ decomposition (the additive parts of the per-group
+/// topic-word model): `log β_{k,a,v} = m_v + κ_topic_{k,v} + κ_cov_{a,v} +
+/// κ_interaction_{k,a,v}`, softmax-normalized over `v`. `content_beta` is derived
+/// from these; the κ pieces are the identifying information R `stm`'s
+/// `sageLabels()` / `labelTopics()` rank words by (and cannot be recovered from
+/// the per-group β alone).
+#[derive(Clone, serde::Serialize, serde::Deserialize)]
+pub struct ContentKappa {
+    /// Background log word-frequency `m`, length V.
+    pub m: Vec<f64>,
+    /// Topic deviations κ_topic, K × V.
+    pub kappa_topic: Vec<Vec<f64>>,
+    /// Covariate (group) deviations κ_cov, num_groups × V.
+    pub kappa_cov: Vec<Vec<f64>>,
+    /// Topic×group interaction deviations κ_interaction, (K·num_groups) × V,
+    /// indexed `topic * num_groups + group` (the layout `build_content_beta` uses).
+    pub kappa_interaction: Vec<Vec<f64>>,
+}
+
 /// A fitted CTM/STM model.
 pub struct CtmModel {
     pub num_topics: usize,
@@ -378,6 +397,9 @@ pub struct CtmModel {
     /// covariates were supplied (the SAGE content model inside STM). `beta` is
     /// then the group-averaged topic-word.
     pub content_beta: Option<Vec<Vec<Vec<f64>>>>,
+    /// SAGE κ decomposition behind `content_beta`, `Some` when content covariates
+    /// were supplied. See [`ContentKappa`].
+    pub content_kappa: Option<ContentKappa>,
     pub num_groups: usize,
     /// Corpus approximate evidence bound (ELBO) at the final E-step — the same
     /// quantity R `stm` reports as its convergence bound.
@@ -1195,6 +1217,16 @@ pub fn fit_ctm<R: Rng>(
     } else {
         None
     };
+    let content_kappa_out = if content.is_some() {
+        Some(ContentKappa {
+            m: m_bg.clone(),
+            kappa_topic: kappa_t.clone(),
+            kappa_cov: kappa_c.clone(),
+            kappa_interaction: kappa_i.clone(),
+        })
+    } else {
+        None
+    };
 
     CtmModel {
         num_topics: k,
@@ -1208,6 +1240,7 @@ pub fn fit_ctm<R: Rng>(
         nu: nu_store,
         gamma,
         content_beta: content_out,
+        content_kappa: content_kappa_out,
         num_groups,
         bound: bound_history.last().copied().unwrap_or(f64::NAN),
         bound_history,
@@ -1415,6 +1448,7 @@ pub fn fit_ctm_svi<R: Rng>(
         nu: nu_store,
         gamma: None,
         content_beta: None,
+        content_kappa: None,
         num_groups: 1,
         bound: total_bound,
         bound_history: vec![total_bound],

--- a/src/python.rs
+++ b/src/python.rs
@@ -402,6 +402,7 @@ struct StmState {
     #[serde(default)] converged: bool,
     #[serde(default)] topic_names: Vec<String>,
     #[serde(default = "default_variational")] variational: String,
+    #[serde(default)] content_kappa: Option<ctm::ContentKappa>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct EctmState {
@@ -5820,6 +5821,7 @@ impl CTM {
             nu: Vec::new(),
             gamma: None,
             content_beta: None,
+            content_kappa: None,
             num_groups: 1,
             bound: f64::NAN,
             bound_history: Vec::new(),
@@ -6041,6 +6043,7 @@ pub struct STM {
     gamma: Option<Array2<f64>>, // (num_features, num_topics-1); None if no prevalence
     feature_names: Vec<String>,
     content_beta: Option<Vec<Vec<Vec<f64>>>>, // G×K×V; None if no content
+    content_kappa: Option<ctm::ContentKappa>, // SAGE κ decomposition; None if no content
     group_names: Vec<String>,
     mu: Vec<f64>,    // K-1 logistic-normal prior mean (covariate-free baseline)
     sigma: Vec<f64>, // (K-1)² logistic-normal prior covariance
@@ -6128,6 +6131,7 @@ impl STM {
             gamma: None,
             feature_names: Vec::new(),
             content_beta: None,
+            content_kappa: None,
             group_names: Vec::new(),
             mu: Vec::new(),
             sigma: Vec::new(),
@@ -6427,6 +6431,7 @@ impl STM {
         }
         self.feature_names = feat_names;
         self.content_beta = model.content_beta;
+        self.content_kappa = model.content_kappa;
         self.group_names = group_vocab;
         self.mu = model.mu.clone();
         self.sigma = model.sigma.clone();
@@ -6575,6 +6580,7 @@ impl STM {
             nu: Vec::new(),
             gamma: None,
             content_beta: None,
+            content_kappa: None,
             num_groups: 1,
             bound: f64::NAN,
             bound_history: Vec::new(),
@@ -6648,6 +6654,53 @@ impl STM {
             }
         }
         Ok(arr.to_pyarray_bound(py))
+    }
+
+    /// The SAGE content-model κ decomposition behind the per-group topic-word
+    /// model, as a dict: ``m`` (num_words,), ``kappa_topic`` (num_topics,
+    /// num_words), ``kappa_cov`` (num_groups, num_words), and ``kappa_interaction``
+    /// (num_topics, num_groups, num_words). The per-group log-probabilities are
+    /// ``m + kappa_topic + kappa_cov + kappa_interaction`` (softmax over words).
+    /// Requires content covariates. These additive parts are what R ``stm``'s
+    /// ``sageLabels()`` / ``labelTopics()`` rank words by; the per-group β alone
+    /// does not identify them.
+    #[getter]
+    fn content_kappa<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        self.require_fitted()?;
+        let ck = self.content_kappa.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("model was fit without content covariates")
+        })?;
+        let k = self.num_topics;
+        let g = self.group_names.len();
+        let v = ck.m.len();
+        let mut kt = Array2::<f64>::zeros((k, v));
+        for t in 0..k {
+            for w in 0..v {
+                kt[[t, w]] = ck.kappa_topic[t][w];
+            }
+        }
+        let mut kc = Array2::<f64>::zeros((g, v));
+        for gg in 0..g {
+            for w in 0..v {
+                kc[[gg, w]] = ck.kappa_cov[gg][w];
+            }
+        }
+        // kappa_interaction is stored flat as (K*G, V) indexed topic*G + group;
+        // reshape to (K, G, V) for the Python view.
+        let mut ki = Array3::<f64>::zeros((k, g, v));
+        for t in 0..k {
+            for gg in 0..g {
+                for w in 0..v {
+                    ki[[t, gg, w]] = ck.kappa_interaction[t * g + gg][w];
+                }
+            }
+        }
+        let d = PyDict::new_bound(py);
+        d.set_item("m", PyArray1::from_vec_bound(py, ck.m.clone()))?;
+        d.set_item("kappa_topic", kt.to_pyarray_bound(py))?;
+        d.set_item("kappa_cov", kc.to_pyarray_bound(py))?;
+        d.set_item("kappa_interaction", ki.to_pyarray_bound(py))?;
+        Ok(d)
     }
 
     /// Content-covariate group names (axis-1 order of :attr:`topic_word_by_group`).
@@ -6849,6 +6902,7 @@ impl STM {
             converged: self.converged,
             topic_names: self.topic_names.clone(),
             variational: self.variational.clone(),
+            content_kappa: self.content_kappa.clone(),
         })
     }
 
@@ -6871,6 +6925,7 @@ impl STM {
             eta_mean: arr2_back(s.eta_mean), eta_cov,
             gamma: arr2_back(s.gamma), feature_names: s.feature_names,
             content_beta: s.content_beta,
+            content_kappa: s.content_kappa,
             mu: s.mu, sigma: s.sigma,
             sigma_estep: Vec::new(),  // not persisted; falls back to sigma in _recompute_eta_cov
             beta_estep: None,         // not persisted; falls back to self.beta

--- a/tests/test_stm.py
+++ b/tests/test_stm.py
@@ -564,3 +564,51 @@ def test_stm_beta_init_warm_start():
     default = topica.STM(num_topics=2, seed=1)
     default.fit(docs, prevalence=X, iters=10)
     np.testing.assert_allclose(warm.topic_word, default.topic_word, atol=1e-9)
+
+
+def test_content_kappa_reconstructs_content_beta():
+    """SAGE kappa decomposition (issue #237): m + kappa_topic + kappa_cov +
+    kappa_interaction, softmax over words, reproduces the per-group topic-word."""
+    import topica
+    rng = np.random.default_rng(0)
+    docs, x = _make_synthetic_corpus(rng, n_per_class=60)
+    groups = ["a" if xi == 1 else "b" for xi in x]
+    m = topica.STM(num_topics=2, seed=1)
+    m.fit(docs, content=groups, iters=40)
+    ck = m.content_kappa
+    K, V, G = m.num_topics, len(m.vocabulary), len(m.groups)
+    assert ck["m"].shape == (V,)
+    assert ck["kappa_topic"].shape == (K, V)
+    assert ck["kappa_cov"].shape == (G, V)
+    assert ck["kappa_interaction"].shape == (K, G, V)
+    tw = m.topic_word_by_group  # (K, G, V)
+    for k in range(K):
+        for g in range(G):
+            eta = (ck["m"] + ck["kappa_topic"][k] + ck["kappa_cov"][g]
+                   + ck["kappa_interaction"][k, g])
+            beta = np.exp(eta - eta.max()); beta /= beta.sum()
+            np.testing.assert_allclose(beta, tw[k, g], atol=1e-9)
+
+
+def test_content_kappa_requires_content():
+    import topica
+    rng = np.random.default_rng(0)
+    docs, x = _make_synthetic_corpus(rng, n_per_class=40)
+    m = topica.STM(num_topics=2, seed=1)
+    m.fit(docs, prevalence=x.reshape(-1, 1), iters=20)  # prevalence, no content
+    with pytest.raises(RuntimeError, match="without content"):
+        _ = m.content_kappa
+
+
+def test_content_kappa_save_load(tmp_path):
+    import topica
+    rng = np.random.default_rng(0)
+    docs, x = _make_synthetic_corpus(rng, n_per_class=50)
+    groups = ["a" if xi == 1 else "b" for xi in x]
+    m = topica.STM(num_topics=2, seed=1)
+    m.fit(docs, content=groups, iters=30)
+    p = str(tmp_path / "m.tt")
+    m.save(p)
+    loaded = topica.STM.load(p)
+    for key in ("m", "kappa_topic", "kappa_cov", "kappa_interaction"):
+        np.testing.assert_allclose(m.content_kappa[key], loaded.content_kappa[key])


### PR DESCRIPTION
Closes #237.

## What

`fit_ctm` computes the SAGE κ deviations for a content fit (`m`, `kappa_t`,
`kappa_c`, `kappa_i` in `optimize_content`) but `CtmModel` only exposed the
*derived* per-group `content_beta`, discarding the additive decomposition. R
`stm`'s `sageLabels()` / `labelTopics()` rank words by the topic / covariate /
interaction κ, which **cannot** be reconstructed from the per-group β alone — this
was the last blocker for stm-compatible content labels in
[faSTM](https://github.com/nealcaren/faSTM).

- New `ctm::ContentKappa { m, kappa_topic, kappa_cov, kappa_interaction }` and
  `CtmModel.content_kappa` (`Some` for content fits, `None` otherwise), built from
  the existing fit locals — no recomputation.
- `STM.content_kappa` returns a dict of numpy arrays: `m` (V), `kappa_topic`
  (K,V), `kappa_cov` (G,V), `kappa_interaction` (K,G,V). Raises if fit without
  content. Persisted across save/load.

## Acceptance

`m + kappa_topic + kappa_cov + kappa_interaction` (softmax over words) reproduces
`topic_word_by_group` **exactly** (test). Plus a requires-content guard test and a
save/load round-trip test.

cargo 148, full pytest **2782 passed**, `mkdocs --strict` clean.

Bundled with #232 (content_placebo) into the upcoming **0.24.1**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)