### PR TITLE
release: 0.24.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.24.1] - 2026-06-18
+
 ### Added
 
 - **`content_placebo` for ECTM** — `topica.ectm.content_placebo` is the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.24.0
+version: 0.24.1
 date-released: 2026-06-18
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.24.0"
+version = "0.24.1"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.24.0"
+version = "0.24.1"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.24.0"
+version = "0.24.1"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.24.1**. Bumps `Cargo.toml` / `pyproject.toml` / `CITATION.cff` and moves
the CHANGELOG `[Unreleased]` entries under `[0.24.1]`.

## Highlights (already merged to main)

- **`content_placebo` for ECTM** (#230/#232) — content-side counterpart of
  `permutation_test`; establishes a between-group content divergence is real, not
  a small-cell artifact.
- **SAGE content-model κ on `STM`** (#237) — `STM.content_kappa` exposes the
  `m`/`kappa_topic`/`kappa_cov`/`kappa_interaction` decomposition R `stm`'s
  `sageLabels()` ranks words by (the last faSTM content-labels blocker). Persisted
  across save/load.

After merge: tag `v0.24.1` to publish to PyPI (pre-authorized).

🤖 Generated with [Claude Code](https://claude.com/claude-code)