### PR TITLE
release: 0.25.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.25.0] - 2026-06-18
+
+### Changed
+
+- Internal refactor (no public API change): the logistic-normal structural-topic
+  core — `corpus`, `spectral`, the shared `variational` kernels, `estimator`,
+  `ctm` (CTM/STM/SAGE), `cvb0`, and `linalg` — now lives in a new Cargo workspace
+  member, `topica-core`, which `topica` depends on and re-exports. `topica::ctm::*`
+  and the entire Python/Rust API are unchanged. The split lets downstream Rust
+  consumers (e.g. the faSTM R package, heading for CRAN) vendor a small,
+  dependency-light crate (`rand`, `rand_chacha`, `rayon`, `regex`; serde opt-in)
+  instead of all of `topica`. A golden parity test pins `fit_ctm` output so the two
+  crates stay in lock-step (#242).
+
+### Added
+
+- Paper appendix: a side-by-side validation appendix that fits both the reference
+  package and `topica` on the poliblog corpus for 15 models and shows the results
+  together, with a master validation map covering every model (#241).
+
 ## [0.24.1] - 2026-06-18
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.24.1
+version: 0.25.0
 date-released: 2026-06-18
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.24.1"
+version = "0.25.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.24.1"
+version = "0.25.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.24.1"
+version = "0.25.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Release **0.25.0**.

Bumps `Cargo.toml`, `pyproject.toml`, `CITATION.cff` to 0.25.0 and adds the CHANGELOG entry. On tag `v0.25.0`, CI publishes the wheels to PyPI and cuts the GitHub Release.

## Since 0.24.1

- **`topica-core` workspace extraction (#242)** — the logistic-normal STM/CTM core moved to a new `topica-core` workspace member that `topica` re-exports. No public API change (verified no-op: workspace tests, `maturin --features python`, pytest 2782, mkdocs --strict; golden parity test pins `fit_ctm`). Lets faSTM vendor a small crate for CRAN.
- **Side-by-side validation appendix (#241)** — paper Appendix A fits both the reference package and `topica` on poliblog for 15 models, plus a master validation map over every model.

No behavior change for Python users; this is a structural/foundation release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)