### PR TITLE
style: apply rustfmt to the workspace + gate fmt/workspace-tests in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -65,13 +65,20 @@ jobs:
       # build, and the suite is dominated by model fits, so an optimized build
       # turns a ~20-minute debug run into a few minutes. The extra compile time is
       # repaid many times over (and cached by rust-cache above).
+      # Formatting gate: the whole workspace must be rustfmt-clean. Mechanical,
+      # so it catches drift without depending on reviewer discipline.
+      - name: cargo fmt --check
+        run: cargo fmt --all --check
+
       # Rust unit tests. Run without the `python` feature: pyo3's
       # extension-module mode does not link libpython into a standalone test
-      # binary, so the bindings crate cannot be unit-tested that way. This
-      # covers the core/model/saveformat tests. Cheap and cached; part of the
-      # test contract in CONTRIBUTING.md, so it gates PRs here too.
+      # binary, so the bindings crate cannot be unit-tested that way. `--workspace`
+      # so the extracted `topica-core` member is tested too, not just the root
+      # crate (otherwise the core can regress while CI stays green). Covers the
+      # core/model/saveformat tests. Cheap and cached; part of the test contract
+      # in CONTRIBUTING.md, so it gates PRs here too.
       - name: cargo test
-        run: cargo test --lib
+        run: cargo test --workspace --lib
 
       - name: Build extension and run tests
         shell: bash

--- a/src/bertopic.rs
+++ b/src/bertopic.rs
@@ -48,7 +48,14 @@ impl BertopicModel {
         window: usize,
         stride: usize,
     ) -> Vec<Vec<f64>> {
-        approximate_distribution(docs, &self.ctfidf_raw, &self.idf, self.num_topics, window, stride)
+        approximate_distribution(
+            docs,
+            &self.ctfidf_raw,
+            &self.idf,
+            self.num_topics,
+            window,
+            stride,
+        )
     }
 
     /// Merge each group of topics into one and rebuild the representation.
@@ -95,7 +102,8 @@ impl BertopicModel {
         stride: usize,
     ) {
         self.num_topics = topic_count(&self.labels);
-        self.ctfidf_raw = represent::ctfidf_weighted(docs, &self.labels, vocab_size, bm25, reduce_frequent);
+        self.ctfidf_raw =
+            represent::ctfidf_weighted(docs, &self.labels, vocab_size, bm25, reduce_frequent);
         self.idf = idf_weights(docs, &self.labels, vocab_size);
         self.topic_word = self
             .ctfidf_raw
@@ -109,8 +117,14 @@ impl BertopicModel {
                 }
             })
             .collect();
-        self.doc_topic =
-            approximate_distribution(docs, &self.ctfidf_raw, &self.idf, self.num_topics, window, stride);
+        self.doc_topic = approximate_distribution(
+            docs,
+            &self.ctfidf_raw,
+            &self.idf,
+            self.num_topics,
+            window,
+            stride,
+        );
     }
 }
 
@@ -147,14 +161,20 @@ pub fn fit_bertopic(
         doc_embeddings.to_vec()
     };
     let mut labels = cluster::cluster_points(
-        &reduced, clusterer, num_clusters, min_cluster_size, min_samples, seed,
+        &reduced,
+        clusterer,
+        num_clusters,
+        min_cluster_size,
+        min_samples,
+        seed,
     );
     let mut num_topics = topic_count(&labels);
 
     // (3) optional topic reduction: merge the most c-TF-IDF-similar topics.
     if let Some(target) = nr_topics {
         while num_topics > target.max(1) {
-            let ctfidf = represent::ctfidf_weighted(docs, &labels, vocab_size, bm25, reduce_frequent);
+            let ctfidf =
+                represent::ctfidf_weighted(docs, &labels, vocab_size, bm25, reduce_frequent);
             let (a, b) = most_similar_pair(&ctfidf);
             if a == b {
                 break;
@@ -183,11 +203,23 @@ pub fn fit_bertopic(
     }
     let doc_topic = approximate_distribution(docs, &ctfidf_raw, &idf, num_topics, window, stride);
 
-    BertopicModel { num_topics, labels, topic_word, doc_topic, ctfidf_raw, idf }
+    BertopicModel {
+        num_topics,
+        labels,
+        topic_word,
+        doc_topic,
+        ctfidf_raw,
+        idf,
+    }
 }
 
 fn topic_count(labels: &[i64]) -> usize {
-    labels.iter().filter(|&&l| l >= 0).map(|&l| l as usize + 1).max().unwrap_or(0)
+    labels
+        .iter()
+        .filter(|&&l| l >= 0)
+        .map(|&l| l as usize + 1)
+        .max()
+        .unwrap_or(0)
 }
 
 /// idf factor `ln(1 + A / f_t)` per term, matching `represent::ctfidf` (A is the
@@ -209,8 +241,14 @@ fn idf_weights(docs: &[Vec<u32>], labels: &[i64], vocab_size: usize) -> Vec<f64>
             }
         }
     }
-    let a = if k > 0 { class_size.iter().sum::<f64>() / k as f64 } else { 0.0 };
-    f.iter().map(|&ft| if ft > 0.0 { (1.0 + a / ft).ln() } else { 0.0 }).collect()
+    let a = if k > 0 {
+        class_size.iter().sum::<f64>() / k as f64
+    } else {
+        0.0
+    };
+    f.iter()
+        .map(|&ft| if ft > 0.0 { (1.0 + a / ft).ln() } else { 0.0 })
+        .collect()
 }
 
 /// The most cosine-similar pair of topics by their c-TF-IDF rows, `(keep, drop)`
@@ -368,10 +406,16 @@ mod tests {
         let mut emb = Vec::new();
         for d in 0..(n_clusters * per) {
             let c = d % n_clusters;
-            let toks: Vec<u32> =
-                (0..8).map(|_| (c * block + rng.gen_range(0..block)) as u32).collect();
+            let toks: Vec<u32> = (0..8)
+                .map(|_| (c * block + rng.gen_range(0..block)) as u32)
+                .collect();
             docs.push(toks);
-            emb.push(centers[c].iter().map(|&v| v + rng.gen::<f64>() * 0.5).collect());
+            emb.push(
+                centers[c]
+                    .iter()
+                    .map(|&v| v + rng.gen::<f64>() * 0.5)
+                    .collect(),
+            );
         }
         (docs, emb, vocab_size)
     }
@@ -379,8 +423,14 @@ mod tests {
     #[test]
     fn recovers_topics_via_ctfidf() {
         let (docs, emb, vocab) = planted(3, 40, 1);
-        let m = fit_bertopic(&docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 1);
-        assert!(m.num_topics >= 3, "expected >=3 topics, got {}", m.num_topics);
+        let m = fit_bertopic(
+            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 1,
+        );
+        assert!(
+            m.num_topics >= 3,
+            "expected >=3 topics, got {}",
+            m.num_topics
+        );
         // Each topic's top words come from a single planted block (block = ids 0..5,
         // 5..10, 10..15).
         for t in 0..m.num_topics {
@@ -398,16 +448,37 @@ mod tests {
     #[test]
     fn nr_topics_reduces_to_target() {
         let (docs, emb, vocab) = planted(4, 40, 2);
-        let full = fit_bertopic(&docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 2);
+        let full = fit_bertopic(
+            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 2,
+        );
         assert!(full.num_topics >= 3);
-        let reduced = fit_bertopic(&docs, &emb, vocab, 5, false, 15, 15, 2, Some(2), 4, 1, false, false, "hdbscan", None, 2);
+        let reduced = fit_bertopic(
+            &docs,
+            &emb,
+            vocab,
+            5,
+            false,
+            15,
+            15,
+            2,
+            Some(2),
+            4,
+            1,
+            false,
+            false,
+            "hdbscan",
+            None,
+            2,
+        );
         assert_eq!(reduced.num_topics, 2, "should reduce to 2 topics");
     }
 
     #[test]
     fn approximate_distribution_favors_own_topic() {
         let (docs, emb, vocab) = planted(3, 40, 3);
-        let m = fit_bertopic(&docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 3);
+        let m = fit_bertopic(
+            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 3,
+        );
         // A document made only of block-0 words should put its largest mass on the
         // topic whose top words are block 0.
         let block0_topic = (0..m.num_topics)
@@ -415,14 +486,18 @@ mod tests {
             .expect("a block-0 topic exists");
         let doc0: Vec<u32> = vec![0, 1, 2, 3, 4, 0, 1, 2];
         let dist = m.approximate_distribution(&[doc0], 4, 1);
-        let argmax = (0..m.num_topics).max_by(|&a, &b| dist[0][a].total_cmp(&dist[0][b])).unwrap();
+        let argmax = (0..m.num_topics)
+            .max_by(|&a, &b| dist[0][a].total_cmp(&dist[0][b]))
+            .unwrap();
         assert_eq!(argmax, block0_topic, "dist: {:?}", dist[0]);
     }
 
     #[test]
     fn bertopic_conforms() {
         let (docs, emb, vocab) = planted(3, 40, 1);
-        let m = fit_bertopic(&docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 1);
+        let m = fit_bertopic(
+            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 1,
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/bin/analyze.rs
+++ b/src/bin/analyze.rs
@@ -1,8 +1,8 @@
-use topica::corpus;
 use std::collections::HashSet;
 use std::fs;
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
+use topica::corpus;
 
 fn print_usage() {
     eprintln!(
@@ -48,19 +48,42 @@ impl Default for Args {
 
 fn parse_args() -> Option<Args> {
     let raw: Vec<String> = std::env::args().skip(1).collect();
-    if raw.is_empty() { return None; }
+    if raw.is_empty() {
+        return None;
+    }
     let mut args = Args::default();
     let mut i = 0;
     while i < raw.len() {
         match raw[i].as_str() {
-            "--corpus"            => { i += 1; args.corpus = Some(raw[i].clone()); }
-            "--max-doc-fraction"  => { i += 1; args.max_doc_fraction = raw[i].parse().ok()?; }
-            "--max-word-length"   => { i += 1; args.max_word_length  = raw[i].parse().ok()?; }
-            "--min-doc-freq"      => { i += 1; args.min_doc_freq     = raw[i].parse().ok()?; }
-            "--num-candidates"    => { i += 1; args.num_candidates   = raw[i].parse().ok()?; }
-            "--output-stoplist"   => { i += 1; args.output_stoplist  = Some(raw[i].clone()); }
-            "--help" | "-h"       => return None,
-            other => { eprintln!("Unknown argument: {}", other); return None; }
+            "--corpus" => {
+                i += 1;
+                args.corpus = Some(raw[i].clone());
+            }
+            "--max-doc-fraction" => {
+                i += 1;
+                args.max_doc_fraction = raw[i].parse().ok()?;
+            }
+            "--max-word-length" => {
+                i += 1;
+                args.max_word_length = raw[i].parse().ok()?;
+            }
+            "--min-doc-freq" => {
+                i += 1;
+                args.min_doc_freq = raw[i].parse().ok()?;
+            }
+            "--num-candidates" => {
+                i += 1;
+                args.num_candidates = raw[i].parse().ok()?;
+            }
+            "--output-stoplist" => {
+                i += 1;
+                args.output_stoplist = Some(raw[i].clone());
+            }
+            "--help" | "-h" => return None,
+            other => {
+                eprintln!("Unknown argument: {}", other);
+                return None;
+            }
         }
         i += 1;
     }
@@ -76,7 +99,9 @@ fn is_numeric(word: &str) -> bool {
 }
 
 fn is_mostly_non_alpha(word: &str) -> bool {
-    if word.is_empty() { return false; }
+    if word.is_empty() {
+        return false;
+    }
     let alpha = word.chars().filter(|c| c.is_alphabetic()).count();
     alpha == 0 || (alpha as f64 / word.len() as f64) < 0.5
 }
@@ -84,16 +109,20 @@ fn is_mostly_non_alpha(word: &str) -> bool {
 // All report helpers write to stderr so stdout stays clean for the word list.
 
 fn report_table_header() {
-    eprintln!("{:<6}  {:<24}  {:>8}  {:>8}  {:>7}  {:>10}",
-        "rank", "word", "doc_freq", "% docs", "idf", "total_freq");
+    eprintln!(
+        "{:<6}  {:<24}  {:>8}  {:>8}  {:>7}  {:>10}",
+        "rank", "word", "doc_freq", "% docs", "idf", "total_freq"
+    );
     eprintln!("{}", "-".repeat(70));
 }
 
 fn report_word_row(rank: usize, word: &str, df: u32, num_docs: usize, tf: u32) {
-    let pct     = df as f64 / num_docs as f64 * 100.0;
+    let pct = df as f64 / num_docs as f64 * 100.0;
     let idf_val = idf(df, num_docs);
-    eprintln!("{:>6}  {:<24}  {:>8}  {:>7.2}%  {:>7.4}  {:>10}",
-        rank, word, df, pct, idf_val, tf);
+    eprintln!(
+        "{:>6}  {:<24}  {:>8}  {:>7.2}%  {:>7.4}  {:>10}",
+        rank, word, df, pct, idf_val, tf
+    );
 }
 
 fn run_heuristic(
@@ -115,7 +144,13 @@ fn run_heuristic(
     } else {
         report_table_header();
         for (rank, &id) in candidates.iter().take(num_candidates).enumerate() {
-            report_word_row(rank + 1, &id_to_word[id], doc_freqs[id], num_docs, total_freqs[id]);
+            report_word_row(
+                rank + 1,
+                &id_to_word[id],
+                doc_freqs[id],
+                num_docs,
+                total_freqs[id],
+            );
             all_suggested.insert(id_to_word[id].clone());
         }
         // Words beyond num_candidates are still added to the suggested set.
@@ -123,7 +158,10 @@ fn run_heuristic(
             all_suggested.insert(id_to_word[id].clone());
         }
         if candidates.len() > num_candidates {
-            eprintln!("  ... and {} more (all added to suggested list)", candidates.len() - num_candidates);
+            eprintln!(
+                "  ... and {} more (all added to suggested list)",
+                candidates.len() - num_candidates
+            );
         }
     }
     eprintln!();
@@ -132,21 +170,31 @@ fn run_heuristic(
 fn main() {
     let args = match parse_args() {
         Some(a) => a,
-        None => { print_usage(); std::process::exit(1); }
+        None => {
+            print_usage();
+            std::process::exit(1);
+        }
     };
 
     let corpus_path = match &args.corpus {
         Some(p) => p.clone(),
-        None => { eprintln!("Error: --corpus is required"); print_usage(); std::process::exit(1); }
+        None => {
+            eprintln!("Error: --corpus is required");
+            print_usage();
+            std::process::exit(1);
+        }
     };
 
     let c = match corpus::load_corpus(Path::new(&corpus_path)) {
         Ok(c) => c,
-        Err(e) => { eprintln!("Error loading corpus: {}", e); std::process::exit(1); }
+        Err(e) => {
+            eprintln!("Error loading corpus: {}", e);
+            std::process::exit(1);
+        }
     };
 
-    let num_docs   = c.num_docs();
-    let num_types  = c.num_types();
+    let num_docs = c.num_docs();
+    let num_types = c.num_types();
     let max_doc_thresh = (num_docs as f64 * args.max_doc_fraction).ceil() as u32;
 
     eprintln!("=== Corpus Statistics ===");
@@ -164,15 +212,22 @@ fn main() {
     );
     eprintln!(
         "Words appearing in more than {:.1}% of documents ({} docs):",
-        args.max_doc_fraction * 100.0, max_doc_thresh
+        args.max_doc_fraction * 100.0,
+        max_doc_thresh
     );
     eprintln!();
     run_heuristic(
         "High Document Frequency (continued)",
-        (0..num_types).filter(|&id| c.doc_freqs[id] > max_doc_thresh).collect(),
+        (0..num_types)
+            .filter(|&id| c.doc_freqs[id] > max_doc_thresh)
+            .collect(),
         |id| c.doc_freqs[id],
-        &c.id_to_word, &c.doc_freqs, &c.total_freqs,
-        num_docs, args.num_candidates, &mut all_suggested,
+        &c.id_to_word,
+        &c.doc_freqs,
+        &c.total_freqs,
+        num_docs,
+        args.num_candidates,
+        &mut all_suggested,
     );
 
     // --- Heuristic 2: Short tokens ---
@@ -185,46 +240,69 @@ fn main() {
             })
             .collect(),
         |id| c.doc_freqs[id],
-        &c.id_to_word, &c.doc_freqs, &c.total_freqs,
-        num_docs, args.num_candidates, &mut all_suggested,
+        &c.id_to_word,
+        &c.doc_freqs,
+        &c.total_freqs,
+        num_docs,
+        args.num_candidates,
+        &mut all_suggested,
     );
 
     // --- Heuristic 3: Numeric tokens ---
     run_heuristic(
         "Numeric Tokens",
-        (0..num_types).filter(|&id| is_numeric(&c.id_to_word[id])).collect(),
+        (0..num_types)
+            .filter(|&id| is_numeric(&c.id_to_word[id]))
+            .collect(),
         |id| c.total_freqs[id],
-        &c.id_to_word, &c.doc_freqs, &c.total_freqs,
-        num_docs, args.num_candidates, &mut all_suggested,
+        &c.id_to_word,
+        &c.doc_freqs,
+        &c.total_freqs,
+        num_docs,
+        args.num_candidates,
+        &mut all_suggested,
     );
 
     // --- Heuristic 4: Non-alphabetic tokens ---
     run_heuristic(
         "Non-Alphabetic Tokens",
-        (0..num_types).filter(|&id| is_mostly_non_alpha(&c.id_to_word[id])).collect(),
+        (0..num_types)
+            .filter(|&id| is_mostly_non_alpha(&c.id_to_word[id]))
+            .collect(),
         |id| c.total_freqs[id],
-        &c.id_to_word, &c.doc_freqs, &c.total_freqs,
-        num_docs, args.num_candidates, &mut all_suggested,
+        &c.id_to_word,
+        &c.doc_freqs,
+        &c.total_freqs,
+        num_docs,
+        args.num_candidates,
+        &mut all_suggested,
     );
 
     // --- Heuristic 5: Rare words (report only, not added to suggested list) ---
-    let rare_count = (0..num_types).filter(|&id| c.doc_freqs[id] < args.min_doc_freq).count();
-    eprintln!("=== Rare Words (fewer than {} documents) ===", args.min_doc_freq);
+    let rare_count = (0..num_types)
+        .filter(|&id| c.doc_freqs[id] < args.min_doc_freq)
+        .count();
+    eprintln!(
+        "=== Rare Words (fewer than {} documents) ===",
+        args.min_doc_freq
+    );
     eprintln!(
         "  {} words ({:.1}% of vocabulary) appear in fewer than {} documents.",
-        rare_count, rare_count as f64 / num_types as f64 * 100.0, args.min_doc_freq
+        rare_count,
+        rare_count as f64 / num_types as f64 * 100.0,
+        args.min_doc_freq
     );
-    eprintln!("  Consider removing with --min-doc-freq {} in preprocess.", args.min_doc_freq);
+    eprintln!(
+        "  Consider removing with --min-doc-freq {} in preprocess.",
+        args.min_doc_freq
+    );
     eprintln!();
 
     // --- Emit the word list ---
     let mut words: Vec<&String> = all_suggested.iter().collect();
     words.sort();
 
-    eprintln!(
-        "=== Summary: {} suggested stopwords ===",
-        words.len()
-    );
+    eprintln!("=== Summary: {} suggested stopwords ===", words.len());
 
     // stdout: one word per line, suitable for use directly with --stoplist
     let stdout = io::stdout();
@@ -238,7 +316,10 @@ fn main() {
     if let Some(ref out_path) = args.output_stoplist {
         let file = match fs::File::create(out_path) {
             Ok(f) => f,
-            Err(e) => { eprintln!("Error creating stoplist file: {}", e); std::process::exit(1); }
+            Err(e) => {
+                eprintln!("Error creating stoplist file: {}", e);
+                std::process::exit(1);
+            }
         };
         let mut writer = BufWriter::new(file);
         for word in &words {

--- a/src/bin/preprocess.rs
+++ b/src/bin/preprocess.rs
@@ -1,5 +1,5 @@
-use topica::corpus::{self, InputFormat, LoadOptions, DEFAULT_TOKEN_REGEX};
 use std::path::Path;
+use topica::corpus::{self, InputFormat, LoadOptions, DEFAULT_TOKEN_REGEX};
 
 fn print_usage() {
     eprintln!(
@@ -28,36 +28,36 @@ Output:
 }
 
 struct Args {
-    input:            Option<String>,
-    output:           Option<String>,
-    stoplist:         Option<String>,
+    input: Option<String>,
+    output: Option<String>,
+    stoplist: Option<String>,
     // Format selection
-    tsv_mode:         bool,
-    id_field:         bool,   // plain-mode: first whitespace token is name
+    tsv_mode: bool,
+    id_field: bool, // plain-mode: first whitespace token is name
     // TSV column indices
-    id_column:        usize,
-    label_column:     Option<usize>,  // None = no label column
-    text_column:      usize,
+    id_column: usize,
+    label_column: Option<usize>, // None = no label column
+    text_column: usize,
     // Tokenisation
-    token_regex:      String,
+    token_regex: String,
     // Frequency filters
-    min_doc_freq:     u32,
+    min_doc_freq: u32,
     max_doc_fraction: f64,
 }
 
 impl Default for Args {
     fn default() -> Self {
         Args {
-            input:            None,
-            output:           None,
-            stoplist:         None,
-            tsv_mode:         false,
-            id_field:         false,
-            id_column:        0,
-            label_column:     Some(1),
-            text_column:      2,
-            token_regex:      DEFAULT_TOKEN_REGEX.to_string(),
-            min_doc_freq:     1,
+            input: None,
+            output: None,
+            stoplist: None,
+            tsv_mode: false,
+            id_field: false,
+            id_column: 0,
+            label_column: Some(1),
+            text_column: 2,
+            token_regex: DEFAULT_TOKEN_REGEX.to_string(),
+            min_doc_freq: 1,
             max_doc_fraction: 1.0,
         }
     }
@@ -65,32 +65,71 @@ impl Default for Args {
 
 fn parse_args() -> Option<Args> {
     let raw: Vec<String> = std::env::args().skip(1).collect();
-    if raw.is_empty() { return None; }
+    if raw.is_empty() {
+        return None;
+    }
     let mut args = Args::default();
     let mut i = 0;
     while i < raw.len() {
         match raw[i].as_str() {
-            "--input"            => { i += 1; args.input = Some(raw[i].clone()); }
-            "--output"           => { i += 1; args.output = Some(raw[i].clone()); }
-            "--stoplist"         => { i += 1; args.stoplist = Some(raw[i].clone()); }
-            "--format"           => {
+            "--input" => {
+                i += 1;
+                args.input = Some(raw[i].clone());
+            }
+            "--output" => {
+                i += 1;
+                args.output = Some(raw[i].clone());
+            }
+            "--stoplist" => {
+                i += 1;
+                args.stoplist = Some(raw[i].clone());
+            }
+            "--format" => {
                 i += 1;
                 match raw[i].as_str() {
-                    "tsv"   => args.tsv_mode = true,
+                    "tsv" => args.tsv_mode = true,
                     "plain" => args.tsv_mode = false,
-                    other   => { eprintln!("Unknown format: {} (use 'plain' or 'tsv')", other); return None; }
+                    other => {
+                        eprintln!("Unknown format: {} (use 'plain' or 'tsv')", other);
+                        return None;
+                    }
                 }
             }
-            "--id-field"         => { args.id_field = true; }
-            "--id-column"        => { i += 1; args.id_column    = raw[i].parse().ok()?; }
-            "--label-column"     => { i += 1; args.label_column = Some(raw[i].parse().ok()?); }
-            "--no-label"         => { args.label_column = None; }
-            "--text-column"      => { i += 1; args.text_column  = raw[i].parse().ok()?; }
-            "--token-regex"      => { i += 1; args.token_regex  = raw[i].clone(); }
-            "--min-doc-freq"     => { i += 1; args.min_doc_freq     = raw[i].parse().ok()?; }
-            "--max-doc-fraction" => { i += 1; args.max_doc_fraction = raw[i].parse().ok()?; }
-            "--help" | "-h"      => return None,
-            other => { eprintln!("Unknown argument: {}", other); return None; }
+            "--id-field" => {
+                args.id_field = true;
+            }
+            "--id-column" => {
+                i += 1;
+                args.id_column = raw[i].parse().ok()?;
+            }
+            "--label-column" => {
+                i += 1;
+                args.label_column = Some(raw[i].parse().ok()?);
+            }
+            "--no-label" => {
+                args.label_column = None;
+            }
+            "--text-column" => {
+                i += 1;
+                args.text_column = raw[i].parse().ok()?;
+            }
+            "--token-regex" => {
+                i += 1;
+                args.token_regex = raw[i].clone();
+            }
+            "--min-doc-freq" => {
+                i += 1;
+                args.min_doc_freq = raw[i].parse().ok()?;
+            }
+            "--max-doc-fraction" => {
+                i += 1;
+                args.max_doc_fraction = raw[i].parse().ok()?;
+            }
+            "--help" | "-h" => return None,
+            other => {
+                eprintln!("Unknown argument: {}", other);
+                return None;
+            }
         }
         i += 1;
     }
@@ -100,16 +139,27 @@ fn parse_args() -> Option<Args> {
 fn main() {
     let args = match parse_args() {
         Some(a) => a,
-        None => { print_usage(); std::process::exit(1); }
+        None => {
+            print_usage();
+            std::process::exit(1);
+        }
     };
 
     let input_path = match &args.input {
         Some(p) => p.clone(),
-        None => { eprintln!("Error: --input is required"); print_usage(); std::process::exit(1); }
+        None => {
+            eprintln!("Error: --input is required");
+            print_usage();
+            std::process::exit(1);
+        }
     };
     let output_path = match &args.output {
         Some(p) => p.clone(),
-        None => { eprintln!("Error: --output is required"); print_usage(); std::process::exit(1); }
+        None => {
+            eprintln!("Error: --output is required");
+            print_usage();
+            std::process::exit(1);
+        }
     };
 
     let format = if args.tsv_mode {
@@ -122,20 +172,22 @@ fn main() {
             args.text_column
         );
         InputFormat::Tsv {
-            id_column:    args.id_column,
+            id_column: args.id_column,
             label_column: args.label_column,
-            text_column:  args.text_column,
+            text_column: args.text_column,
         }
     } else {
-        InputFormat::Plain { id_field: args.id_field }
+        InputFormat::Plain {
+            id_field: args.id_field,
+        }
     };
 
     eprintln!("Token regex: {}", args.token_regex);
 
     let mut opts = LoadOptions {
         format,
-        token_regex:      args.token_regex.clone(),
-        min_doc_freq:     args.min_doc_freq,
+        token_regex: args.token_regex.clone(),
+        min_doc_freq: args.min_doc_freq,
         max_doc_fraction: args.max_doc_fraction,
         ..Default::default()
     };
@@ -146,20 +198,32 @@ fn main() {
                 eprintln!("Loaded {} stopwords from {}", words.len(), sl_path);
                 opts.stopwords = words;
             }
-            Err(e) => { eprintln!("Error reading stoplist: {}", e); std::process::exit(1); }
+            Err(e) => {
+                eprintln!("Error reading stoplist: {}", e);
+                std::process::exit(1);
+            }
         }
     }
 
     eprintln!("Reading: {}", input_path);
     let c = match corpus::load_text_file(Path::new(&input_path), &opts) {
         Ok(c) => c,
-        Err(e) => { eprintln!("Error: {}", e); std::process::exit(1); }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
     };
 
     eprintln!(
         "Corpus: {} documents, {} word types, {} tokens{}",
-        c.num_docs(), c.num_types(), c.total_tokens(),
-        if c.has_labels() { ", labels present" } else { "" }
+        c.num_docs(),
+        c.num_types(),
+        c.total_tokens(),
+        if c.has_labels() {
+            ", labels present"
+        } else {
+            ""
+        }
     );
 
     if c.num_docs() == 0 {

--- a/src/bin/show.rs
+++ b/src/bin/show.rs
@@ -21,20 +21,20 @@ Options:
 
 struct Args {
     topic_word: String,
-    doc_topic:  String,
-    words:      usize,
+    doc_topic: String,
+    words: usize,
     doc_topics: usize,
-    threshold:  f64,
+    threshold: f64,
 }
 
 impl Default for Args {
     fn default() -> Self {
         Args {
             topic_word: "topic_word.tsv".to_string(),
-            doc_topic:  "doc_topic.tsv".to_string(),
-            words:      10,
+            doc_topic: "doc_topic.tsv".to_string(),
+            words: 10,
             doc_topics: 0,
-            threshold:  0.1,
+            threshold: 0.1,
         }
     }
 }
@@ -45,13 +45,31 @@ fn parse_args() -> Option<Args> {
     let mut i = 0;
     while i < raw.len() {
         match raw[i].as_str() {
-            "--topic-word"  => { i += 1; args.topic_word  = raw[i].clone(); }
-            "--doc-topic"   => { i += 1; args.doc_topic   = raw[i].clone(); }
-            "--words"       => { i += 1; args.words       = raw[i].parse().ok()?; }
-            "--doc-topics"  => { i += 1; args.doc_topics  = raw[i].parse().ok()?; }
-            "--threshold"   => { i += 1; args.threshold   = raw[i].parse().ok()?; }
+            "--topic-word" => {
+                i += 1;
+                args.topic_word = raw[i].clone();
+            }
+            "--doc-topic" => {
+                i += 1;
+                args.doc_topic = raw[i].clone();
+            }
+            "--words" => {
+                i += 1;
+                args.words = raw[i].parse().ok()?;
+            }
+            "--doc-topics" => {
+                i += 1;
+                args.doc_topics = raw[i].parse().ok()?;
+            }
+            "--threshold" => {
+                i += 1;
+                args.threshold = raw[i].parse().ok()?;
+            }
             "--help" | "-h" => return None,
-            other => { eprintln!("Unknown argument: {}", other); return None; }
+            other => {
+                eprintln!("Unknown argument: {}", other);
+                return None;
+            }
         }
         i += 1;
     }
@@ -65,9 +83,13 @@ fn load_topic_word(path: &Path) -> io::Result<BTreeMap<usize, Vec<(String, f64)>
 
     for (line_idx, line) in reader.lines().enumerate() {
         let line = line?;
-        if line_idx == 0 { continue; } // skip header
+        if line_idx == 0 {
+            continue;
+        } // skip header
         let cols: Vec<&str> = line.splitn(3, '\t').collect();
-        if cols.len() < 3 { continue; }
+        if cols.len() < 3 {
+            continue;
+        }
         let topic: usize = match cols[0].parse() {
             Ok(t) => t,
             Err(_) => continue,
@@ -91,7 +113,11 @@ fn show_topics(topics: &BTreeMap<usize, Vec<(String, f64)>>, n_words: usize) {
 
     for (&topic_idx, words) in topics {
         print!("Topic {:>width$}: ", topic_idx, width = width);
-        let top: Vec<&str> = words.iter().take(n_words).map(|(w, _)| w.as_str()).collect();
+        let top: Vec<&str> = words
+            .iter()
+            .take(n_words)
+            .map(|(w, _)| w.as_str())
+            .collect();
         println!("{}", top.join("  "));
     }
 }
@@ -129,7 +155,7 @@ fn show_doc_topics(path: &Path, n_topics: usize, threshold: f64) -> io::Result<(
         }
 
         let doc_name = fields[0];
-        let label    = if has_label { Some(fields[1]) } else { None };
+        let label = if has_label { Some(fields[1]) } else { None };
 
         // Collect (topic_idx, probability) pairs.
         let mut probs: Vec<(usize, f64)> = fields[first_topic_col..]
@@ -156,7 +182,7 @@ fn show_doc_topics(path: &Path, n_topics: usize, threshold: f64) -> io::Result<(
 
         match label {
             Some(lbl) => println!("{} [{}]:  {}", doc_name, lbl, top.join(", ")),
-            None       => println!("{}:  {}", doc_name, top.join(", ")),
+            None => println!("{}:  {}", doc_name, top.join(", ")),
         }
     }
 
@@ -166,7 +192,10 @@ fn show_doc_topics(path: &Path, n_topics: usize, threshold: f64) -> io::Result<(
 fn main() {
     let args = match parse_args() {
         Some(a) => a,
-        None => { print_usage(); std::process::exit(1); }
+        None => {
+            print_usage();
+            std::process::exit(1);
+        }
     };
 
     let tw_path = Path::new(&args.topic_word);
@@ -180,7 +209,10 @@ fn main() {
 
     let topics = match load_topic_word(tw_path) {
         Ok(t) => t,
-        Err(e) => { eprintln!("Error reading {}: {}", args.topic_word, e); std::process::exit(1); }
+        Err(e) => {
+            eprintln!("Error reading {}: {}", args.topic_word, e);
+            std::process::exit(1);
+        }
     };
 
     show_topics(&topics, args.words);

--- a/src/bin/train.rs
+++ b/src/bin/train.rs
@@ -1,9 +1,9 @@
-use topica::{corpus, model, optimize, output, sampler};
 use std::path::Path;
 use std::time::Instant;
+use topica::{corpus, model, optimize, output, sampler};
 
-use rand_pcg::Pcg64Mcg;
 use rand::SeedableRng;
+use rand_pcg::Pcg64Mcg;
 
 fn print_usage() {
     eprintln!(
@@ -38,66 +38,113 @@ Output:
 }
 
 struct Args {
-    corpus:                Option<String>,
-    num_topics:            usize,
-    iterations:            usize,
-    burn_in:               usize,
-    optimize_interval:     usize,
-    num_samples:           usize,
-    sample_interval:       usize,
-    topic_word_output:     String,
-    doc_topic_output:      String,
-    alpha_sum:             Option<f64>,
-    beta:                  f64,
-    seed:                  u64,
-    show_topics_interval:  usize,
-    words_per_topic:       usize,
+    corpus: Option<String>,
+    num_topics: usize,
+    iterations: usize,
+    burn_in: usize,
+    optimize_interval: usize,
+    num_samples: usize,
+    sample_interval: usize,
+    topic_word_output: String,
+    doc_topic_output: String,
+    alpha_sum: Option<f64>,
+    beta: f64,
+    seed: u64,
+    show_topics_interval: usize,
+    words_per_topic: usize,
 }
 
 impl Default for Args {
     fn default() -> Self {
         Args {
-            corpus:               None,
-            num_topics:           10,
-            iterations:           1000,
-            burn_in:              200,
-            optimize_interval:    50,
-            num_samples:          5,
-            sample_interval:      25,
-            topic_word_output:    "topic_word.tsv".to_string(),
-            doc_topic_output:     "doc_topic.tsv".to_string(),
-            alpha_sum:            None,
-            beta:                 0.01,
-            seed:                 42,
+            corpus: None,
+            num_topics: 10,
+            iterations: 1000,
+            burn_in: 200,
+            optimize_interval: 50,
+            num_samples: 5,
+            sample_interval: 25,
+            topic_word_output: "topic_word.tsv".to_string(),
+            doc_topic_output: "doc_topic.tsv".to_string(),
+            alpha_sum: None,
+            beta: 0.01,
+            seed: 42,
             show_topics_interval: 50,
-            words_per_topic:      7,
+            words_per_topic: 7,
         }
     }
 }
 
 fn parse_args() -> Option<Args> {
     let raw: Vec<String> = std::env::args().skip(1).collect();
-    if raw.is_empty() { return None; }
+    if raw.is_empty() {
+        return None;
+    }
     let mut args = Args::default();
     let mut i = 0;
     while i < raw.len() {
         match raw[i].as_str() {
-            "--corpus"               => { i += 1; args.corpus = Some(raw[i].clone()); }
-            "--num-topics"           => { i += 1; args.num_topics        = raw[i].parse().ok()?; }
-            "--iterations"           => { i += 1; args.iterations        = raw[i].parse().ok()?; }
-            "--burn-in"              => { i += 1; args.burn_in           = raw[i].parse().ok()?; }
-            "--optimize-interval"    => { i += 1; args.optimize_interval = raw[i].parse().ok()?; }
-            "--num-samples"          => { i += 1; args.num_samples       = raw[i].parse().ok()?; }
-            "--sample-interval"      => { i += 1; args.sample_interval   = raw[i].parse().ok()?; }
-            "--topic-word"           => { i += 1; args.topic_word_output = raw[i].clone(); }
-            "--doc-topic"            => { i += 1; args.doc_topic_output  = raw[i].clone(); }
-            "--alpha-sum"            => { i += 1; args.alpha_sum = Some(raw[i].parse().ok()?); }
-            "--beta"                 => { i += 1; args.beta              = raw[i].parse().ok()?; }
-            "--seed"                 => { i += 1; args.seed              = raw[i].parse().ok()?; }
-            "--show-topics-interval" => { i += 1; args.show_topics_interval = raw[i].parse().ok()?; }
-            "--words-per-topic"      => { i += 1; args.words_per_topic   = raw[i].parse().ok()?; }
-            "--help" | "-h"          => return None,
-            other => { eprintln!("Unknown argument: {}", other); return None; }
+            "--corpus" => {
+                i += 1;
+                args.corpus = Some(raw[i].clone());
+            }
+            "--num-topics" => {
+                i += 1;
+                args.num_topics = raw[i].parse().ok()?;
+            }
+            "--iterations" => {
+                i += 1;
+                args.iterations = raw[i].parse().ok()?;
+            }
+            "--burn-in" => {
+                i += 1;
+                args.burn_in = raw[i].parse().ok()?;
+            }
+            "--optimize-interval" => {
+                i += 1;
+                args.optimize_interval = raw[i].parse().ok()?;
+            }
+            "--num-samples" => {
+                i += 1;
+                args.num_samples = raw[i].parse().ok()?;
+            }
+            "--sample-interval" => {
+                i += 1;
+                args.sample_interval = raw[i].parse().ok()?;
+            }
+            "--topic-word" => {
+                i += 1;
+                args.topic_word_output = raw[i].clone();
+            }
+            "--doc-topic" => {
+                i += 1;
+                args.doc_topic_output = raw[i].clone();
+            }
+            "--alpha-sum" => {
+                i += 1;
+                args.alpha_sum = Some(raw[i].parse().ok()?);
+            }
+            "--beta" => {
+                i += 1;
+                args.beta = raw[i].parse().ok()?;
+            }
+            "--seed" => {
+                i += 1;
+                args.seed = raw[i].parse().ok()?;
+            }
+            "--show-topics-interval" => {
+                i += 1;
+                args.show_topics_interval = raw[i].parse().ok()?;
+            }
+            "--words-per-topic" => {
+                i += 1;
+                args.words_per_topic = raw[i].parse().ok()?;
+            }
+            "--help" | "-h" => return None,
+            other => {
+                eprintln!("Unknown argument: {}", other);
+                return None;
+            }
         }
         i += 1;
     }
@@ -105,14 +152,20 @@ fn parse_args() -> Option<Args> {
 }
 
 fn format_elapsed(total_secs: u64) -> String {
-    let days    = total_secs / 86400;
-    let hours   = (total_secs % 86400) / 3600;
+    let days = total_secs / 86400;
+    let hours = (total_secs % 86400) / 3600;
     let minutes = (total_secs % 3600) / 60;
     let seconds = total_secs % 60;
     let mut s = String::new();
-    if days > 0    { s.push_str(&format!("{} days ", days)); }
-    if hours > 0   { s.push_str(&format!("{} hours ", hours)); }
-    if minutes > 0 { s.push_str(&format!("{} minutes ", minutes)); }
+    if days > 0 {
+        s.push_str(&format!("{} days ", days));
+    }
+    if hours > 0 {
+        s.push_str(&format!("{} hours ", hours));
+    }
+    if minutes > 0 {
+        s.push_str(&format!("{} minutes ", minutes));
+    }
     s.push_str(&format!("{} seconds", seconds));
     s
 }
@@ -129,18 +182,18 @@ fn accumulate_phi(m: &model::TopicModel, acc: &mut Vec<Vec<f64>>) {
 }
 
 /// Snapshot the current smoothed document-topic distribution into acc_theta.
-fn accumulate_theta(
-    m: &model::TopicModel,
-    c: &corpus::Corpus,
-    acc: &mut Vec<Vec<f64>>,
-) {
+fn accumulate_theta(m: &model::TopicModel, c: &corpus::Corpus, acc: &mut Vec<Vec<f64>>) {
     let mut counts = vec![0u32; m.num_topics];
     for doc_idx in 0..c.num_docs() {
-        for t in 0..m.num_topics { counts[t] = 0; }
-        for &t in &m.doc_topics[doc_idx] { counts[t as usize] += 1; }
+        for t in 0..m.num_topics {
+            counts[t] = 0;
+        }
+        for &t in &m.doc_topics[doc_idx] {
+            counts[t as usize] += 1;
+        }
 
         let doc_len = c.docs[doc_idx].len() as f64;
-        let denom   = doc_len + m.alpha_sum;
+        let denom = doc_len + m.alpha_sum;
         for t in 0..m.num_topics {
             acc[doc_idx][t] += (counts[t] as f64 + m.alpha[t]) / denom;
         }
@@ -150,17 +203,27 @@ fn accumulate_theta(
 fn main() {
     let args = match parse_args() {
         Some(a) => a,
-        None => { print_usage(); std::process::exit(1); }
+        None => {
+            print_usage();
+            std::process::exit(1);
+        }
     };
 
     let corpus_path = match &args.corpus {
         Some(p) => p.clone(),
-        None => { eprintln!("Error: --corpus is required"); print_usage(); std::process::exit(1); }
+        None => {
+            eprintln!("Error: --corpus is required");
+            print_usage();
+            std::process::exit(1);
+        }
     };
 
     let c = match corpus::load_corpus(Path::new(&corpus_path)) {
         Ok(c) => c,
-        Err(e) => { eprintln!("Error loading corpus: {}", e); std::process::exit(1); }
+        Err(e) => {
+            eprintln!("Error loading corpus: {}", e);
+            std::process::exit(1);
+        }
     };
 
     if c.num_docs() == 0 {
@@ -175,7 +238,10 @@ fn main() {
         "Mallet LDA: {} topics, {} topic bits, {:b} topic mask",
         m.num_topics, m.topic_bits, m.topic_mask
     );
-    eprintln!("max tokens: {}", c.docs.iter().map(|d| d.len()).max().unwrap_or(0));
+    eprintln!(
+        "max tokens: {}",
+        c.docs.iter().map(|d| d.len()).max().unwrap_or(0)
+    );
     eprintln!("total tokens: {}", c.total_tokens());
     if args.optimize_interval > 0 {
         eprintln!(
@@ -188,7 +254,7 @@ fn main() {
     m.initialize(&c, &mut rng);
 
     let total_tokens = c.total_tokens();
-    let train_start  = Instant::now();
+    let train_start = Instant::now();
 
     // -----------------------------------------------------------------------
     // Main training loop
@@ -197,20 +263,17 @@ fn main() {
         sampler::run_iteration(&mut m, &c, &mut rng);
 
         // Hyperparameter optimization after burn-in
-        if args.optimize_interval > 0
-            && iter > args.burn_in
-            && iter % args.optimize_interval == 0
-        {
+        if args.optimize_interval > 0 && iter > args.burn_in && iter % args.optimize_interval == 0 {
             optimize::optimize_alpha(&mut m, &c);
             optimize::optimize_beta(&mut m);
-            eprintln!(
-                "[O] alpha_sum={:.5}  beta={:.5}",
-                m.alpha_sum, m.beta
-            );
+            eprintln!("[O] alpha_sum={:.5}  beta={:.5}", m.alpha_sum, m.beta);
         }
 
         if args.show_topics_interval > 0 && iter % args.show_topics_interval == 0 {
-            eprint!("\n{}", output::display_top_words(&m, &c, args.words_per_topic));
+            eprint!(
+                "\n{}",
+                output::display_top_words(&m, &c, args.words_per_topic)
+            );
         }
 
         if iter % 10 == 0 {
@@ -219,13 +282,16 @@ fn main() {
         }
     }
 
-    eprintln!("\nTotal time: {}", format_elapsed(train_start.elapsed().as_secs()));
+    eprintln!(
+        "\nTotal time: {}",
+        format_elapsed(train_start.elapsed().as_secs())
+    );
 
     // -----------------------------------------------------------------------
     // Sampling phase: collect num_samples samples separated by sample_interval
     // iterations each, then average for final distribution estimates.
     // -----------------------------------------------------------------------
-    let num_samples     = args.num_samples;
+    let num_samples = args.num_samples;
     let sample_interval = args.sample_interval;
 
     eprintln!(
@@ -233,7 +299,7 @@ fn main() {
         num_samples, sample_interval
     );
 
-    let mut acc_phi   = vec![vec![0.0f64; m.num_topics]; m.num_types];
+    let mut acc_phi = vec![vec![0.0f64; m.num_topics]; m.num_types];
     let mut acc_theta = vec![vec![0.0f64; m.num_topics]; c.num_docs()];
 
     for s in 0..num_samples {
@@ -247,23 +313,37 @@ fn main() {
 
     // Normalise by sample count
     let n = num_samples as f64;
-    for row in acc_phi.iter_mut()   { for v in row.iter_mut() { *v /= n; } }
-    for row in acc_theta.iter_mut() { for v in row.iter_mut() { *v /= n; } }
+    for row in acc_phi.iter_mut() {
+        for v in row.iter_mut() {
+            *v /= n;
+        }
+    }
+    for row in acc_theta.iter_mut() {
+        for v in row.iter_mut() {
+            *v /= n;
+        }
+    }
 
     // -----------------------------------------------------------------------
     // Write output
     // -----------------------------------------------------------------------
-    eprintln!("Writing topic-word probabilities to: {}", args.topic_word_output);
-    if let Err(e) = output::write_topic_word_matrix(
-        &acc_phi, &c, Path::new(&args.topic_word_output),
-    ) {
+    eprintln!(
+        "Writing topic-word probabilities to: {}",
+        args.topic_word_output
+    );
+    if let Err(e) =
+        output::write_topic_word_matrix(&acc_phi, &c, Path::new(&args.topic_word_output))
+    {
         eprintln!("Error writing topic-word file: {}", e);
     }
 
-    eprintln!("Writing document-topic probabilities to: {}", args.doc_topic_output);
-    if let Err(e) = output::write_doc_topic_matrix(
-        &acc_theta, &c, Path::new(&args.doc_topic_output),
-    ) {
+    eprintln!(
+        "Writing document-topic probabilities to: {}",
+        args.doc_topic_output
+    );
+    if let Err(e) =
+        output::write_doc_topic_matrix(&acc_theta, &c, Path::new(&args.doc_topic_output))
+    {
         eprintln!("Error writing doc-topic file: {}", e);
     }
 }

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -18,7 +18,11 @@ use rand_chacha::ChaCha8Rng;
 /// HDBSCAN / BERTopic outlier convention. `min_cluster_size` is the smallest
 /// group that counts as a topic; `min_samples` controls how conservative the
 /// density estimate is (larger = more points called noise).
-pub fn hdbscan_labels(points: &[Vec<f64>], min_cluster_size: usize, min_samples: usize) -> Vec<i64> {
+pub fn hdbscan_labels(
+    points: &[Vec<f64>],
+    min_cluster_size: usize,
+    min_samples: usize,
+) -> Vec<i64> {
     let n = points.len();
     if n == 0 {
         return Vec::new();
@@ -74,9 +78,7 @@ pub fn cluster_points(
 ) -> Vec<i64> {
     match clusterer {
         "kmeans" => kmeans_labels(points, num_clusters.unwrap_or(min_cluster_size), seed),
-        "agglomerative" => {
-            agglomerative_labels(points, num_clusters.unwrap_or(min_cluster_size))
-        }
+        "agglomerative" => agglomerative_labels(points, num_clusters.unwrap_or(min_cluster_size)),
         _ => hdbscan_labels(points, min_cluster_size, min_samples),
     }
 }
@@ -270,7 +272,10 @@ mod tests {
             pts.push(vec![rng.gen::<f64>() * 0.3, rng.gen::<f64>() * 0.3]); // near origin
         }
         for _ in 0..30 {
-            pts.push(vec![5.0 + rng.gen::<f64>() * 0.3, 5.0 + rng.gen::<f64>() * 0.3]); // near (5,5)
+            pts.push(vec![
+                5.0 + rng.gen::<f64>() * 0.3,
+                5.0 + rng.gen::<f64>() * 0.3,
+            ]); // near (5,5)
         }
         let labels = hdbscan_labels(&pts, 5, 2);
 
@@ -281,7 +286,10 @@ mod tests {
                     *counts.entry(l).or_insert(0) += 1;
                 }
             }
-            counts.into_iter().max_by_key(|&(_, c)| c).map(|(l, c)| (l, c))
+            counts
+                .into_iter()
+                .max_by_key(|&(_, c)| c)
+                .map(|(l, c)| (l, c))
         };
         let (a, na) = majority(&labels[..30]).expect("blob 1 has a cluster");
         let (b, nb) = majority(&labels[30..]).expect("blob 2 has a cluster");
@@ -315,7 +323,10 @@ mod tests {
             pts.push(vec![rng.gen::<f64>() * 0.3, rng.gen::<f64>() * 0.3]);
         }
         for _ in 0..30 {
-            pts.push(vec![5.0 + rng.gen::<f64>() * 0.3, 5.0 + rng.gen::<f64>() * 0.3]);
+            pts.push(vec![
+                5.0 + rng.gen::<f64>() * 0.3,
+                5.0 + rng.gen::<f64>() * 0.3,
+            ]);
         }
         pts
     }

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -3,7 +3,7 @@
 //! layer or a release. The full multi-model registry and EXEMPT set are populated
 //! in a later step; this file establishes the check.
 
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 use crate::variational::LogisticNormalModel;
 
 /// Check a fitted model against the Tier-0 contract and its family's Tier-2
@@ -13,15 +13,22 @@ use crate::variational::LogisticNormalModel;
 /// `LogisticNormalModel` trait by the typed helper [`check_logistic_normal`],
 /// since `&dyn Estimator` cannot be downcast to it; a registered logistic-normal
 /// model is wired through that helper in the conformance test.
-#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
+#[cfg_attr(not(test), allow(dead_code))] // test-only contract checker; live under `cargo test`
 pub fn check_conformance(m: &dyn Estimator) -> Vec<String> {
     let mut v = Vec::new();
     let k = m.num_topics();
     let tw = m.topic_word();
     if tw.len() != k {
-        v.push(format!("topic_word has {} rows but num_topics is {}", tw.len(), k));
+        v.push(format!(
+            "topic_word has {} rows but num_topics is {}",
+            tw.len(),
+            k
+        ));
     }
-    if matches!(m.model_family(), ModelFamily::Dirichlet | ModelFamily::LogisticNormal) {
+    if matches!(
+        m.model_family(),
+        ModelFamily::Dirichlet | ModelFamily::LogisticNormal
+    ) {
         let theta = m.doc_topic();
         for (d, row) in theta.iter().enumerate() {
             let s: f64 = row.iter().sum();
@@ -36,27 +43,41 @@ pub fn check_conformance(m: &dyn Estimator) -> Vec<String> {
 
 /// Tier-2 shape check for Dirichlet (collapsed-Gibbs) models: alpha length,
 /// doc_lengths length, and theta_draws nesting.
-#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
+#[cfg_attr(not(test), allow(dead_code))] // test-only contract checker; live under `cargo test`
 pub fn check_dirichlet(m: &dyn DirichletModel) -> Vec<String> {
     let mut v = Vec::new();
     let k = m.num_topics();
     let d = m.doc_topic().len();
     if m.alpha().len() != k {
-        v.push(format!("alpha has len {} but num_topics is {}", m.alpha().len(), k));
+        v.push(format!(
+            "alpha has len {} but num_topics is {}",
+            m.alpha().len(),
+            k
+        ));
     }
     if m.doc_lengths().len() != d {
-        v.push(format!("doc_lengths has len {} but doc_topic has {} rows", m.doc_lengths().len(), d));
+        v.push(format!(
+            "doc_lengths has len {} but doc_topic has {} rows",
+            m.doc_lengths().len(),
+            d
+        ));
     }
     let draws = m.theta_draws();
     if !draws.is_empty() {
         for (s, draw) in draws.iter().enumerate() {
             if draw.len() != d {
-                v.push(format!("theta_draws[{s}] has {} rows but doc_topic has {d}", draw.len()));
+                v.push(format!(
+                    "theta_draws[{s}] has {} rows but doc_topic has {d}",
+                    draw.len()
+                ));
                 break;
             }
             for (di, row) in draw.iter().enumerate() {
                 if row.len() != k {
-                    v.push(format!("theta_draws[{s}][{di}] has len {} but num_topics is {k}", row.len()));
+                    v.push(format!(
+                        "theta_draws[{s}][{di}] has len {} but num_topics is {k}",
+                        row.len()
+                    ));
                     break;
                 }
             }
@@ -67,19 +88,26 @@ pub fn check_dirichlet(m: &dyn DirichletModel) -> Vec<String> {
 
 /// Tier-2 shape check for logistic-normal models: eta_mean is (D, eta_dim) and
 /// eta_cov is (D, eta_dim²) with a consistent eta_dim.
-#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
+#[cfg_attr(not(test), allow(dead_code))] // test-only contract checker; live under `cargo test`
 pub fn check_logistic_normal(m: &dyn LogisticNormalModel) -> Vec<String> {
     let mut v = Vec::new();
     let dim = m.eta_dim();
     for (d, row) in m.eta_mean().iter().enumerate() {
         if row.len() != dim {
-            v.push(format!("eta_mean row {d} has len {} != eta_dim {dim}", row.len()));
+            v.push(format!(
+                "eta_mean row {d} has len {} != eta_dim {dim}",
+                row.len()
+            ));
             break;
         }
     }
     for (d, row) in m.eta_cov().iter().enumerate() {
         if row.len() != dim * dim {
-            v.push(format!("eta_cov row {d} has len {} != eta_dim² {}", row.len(), dim * dim));
+            v.push(format!(
+                "eta_cov row {d} has len {} != eta_dim² {}",
+                row.len(),
+                dim * dim
+            ));
             break;
         }
     }
@@ -95,7 +123,7 @@ pub fn check_logistic_normal(m: &dyn LogisticNormalModel) -> Vec<String> {
 /// its fitted struct reports from `Estimator::model_family`, and any Tier-0
 /// Estimator method it structurally cannot provide — returned empty by design,
 /// the Rust analog of `conformance.py`'s `EXEMPT`.
-#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
+#[cfg_attr(not(test), allow(dead_code))] // test-only contract checker; live under `cargo test`
 pub struct RegistryEntry {
     pub name: &'static str,
     pub family: ModelFamily,
@@ -117,43 +145,147 @@ pub struct RegistryEntry {
 /// match the Python registry. The embedding-cluster models (`BERTopic`,
 /// `Top2Vec`) carry a `topic_word`/`doc_topic` from their Rust struct and so
 /// participate here.
-#[cfg_attr(not(test), allow(dead_code))]  // test-only contract checker; live under `cargo test`
+#[cfg_attr(not(test), allow(dead_code))] // test-only contract checker; live under `cargo test`
 pub const RUST_ESTIMATORS: &[RegistryEntry] = &[
     // Logistic-normal variational (eta posterior).
-    RegistryEntry { name: "STM", family: ModelFamily::LogisticNormal, exempt: &[] },
-    RegistryEntry { name: "CTM", family: ModelFamily::LogisticNormal, exempt: &[] },
-    RegistryEntry { name: "STS", family: ModelFamily::LogisticNormal, exempt: &[] },
-    RegistryEntry { name: "ECTM", family: ModelFamily::LogisticNormal, exempt: &[] },
+    RegistryEntry {
+        name: "STM",
+        family: ModelFamily::LogisticNormal,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "CTM",
+        family: ModelFamily::LogisticNormal,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "STS",
+        family: ModelFamily::LogisticNormal,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "ECTM",
+        family: ModelFamily::LogisticNormal,
+        exempt: &[],
+    },
     // Collapsed-Gibbs / Dirichlet doc-topic posterior.
-    RegistryEntry { name: "LDA", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "DMR", family: ModelFamily::Dirichlet, exempt: &[] },
+    RegistryEntry {
+        name: "LDA",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "DMR",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
     // GDMR shares the `TopicModel` struct with LDA/DMR, so it is covered by the
     // same `topicmodel_conforms` test; listed here under its user-facing name.
-    RegistryEntry { name: "GDMR", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "LabeledLDA", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "SeededLDA", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "KeyATM", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "PA", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "PT", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "SAGE", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "HDP", family: ModelFamily::Dirichlet, exempt: &[] },
-    RegistryEntry { name: "SupervisedLDA", family: ModelFamily::Dirichlet, exempt: &[] },
+    RegistryEntry {
+        name: "GDMR",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "LabeledLDA",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "SeededLDA",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "KeyATM",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "PA",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "PT",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "SAGE",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "HDP",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "SupervisedLDA",
+        family: ModelFamily::Dirichlet,
+        exempt: &[],
+    },
     // Neural / embedding / nonparametric — no theta posterior.
-    RegistryEntry { name: "ProdLDA", family: ModelFamily::None_, exempt: &[] },
+    RegistryEntry {
+        name: "ProdLDA",
+        family: ModelFamily::None_,
+        exempt: &[],
+    },
     // Matrix factorization — signed latent coordinates, no theta posterior.
-    RegistryEntry { name: "NMF", family: ModelFamily::None_, exempt: &[] },
+    RegistryEntry {
+        name: "NMF",
+        family: ModelFamily::None_,
+        exempt: &[],
+    },
     // LSA/LSI: doc_topic is signed coordinates (U Sigma), not a (D,K) simplex;
     // the SVD is a direct solve, so there is no fit_history trajectory.
-    RegistryEntry { name: "LSA", family: ModelFamily::None_, exempt: &["fit_history"] },
-    RegistryEntry { name: "ETM", family: ModelFamily::None_, exempt: &[] },
-    RegistryEntry { name: "DETM", family: ModelFamily::None_, exempt: &[] },
-    RegistryEntry { name: "FASTopic", family: ModelFamily::None_, exempt: &[] },
-    RegistryEntry { name: "GSDMM", family: ModelFamily::None_, exempt: &[] },
-    RegistryEntry { name: "BERTopic", family: ModelFamily::None_, exempt: &[] },
-    RegistryEntry { name: "Top2Vec", family: ModelFamily::None_, exempt: &[] },
+    RegistryEntry {
+        name: "LSA",
+        family: ModelFamily::None_,
+        exempt: &["fit_history"],
+    },
+    RegistryEntry {
+        name: "ETM",
+        family: ModelFamily::None_,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "DETM",
+        family: ModelFamily::None_,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "FASTopic",
+        family: ModelFamily::None_,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "GSDMM",
+        family: ModelFamily::None_,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "BERTopic",
+        family: ModelFamily::None_,
+        exempt: &[],
+    },
+    RegistryEntry {
+        name: "Top2Vec",
+        family: ModelFamily::None_,
+        exempt: &[],
+    },
     // Time-sliced and tree-structured — flat doc_topic is structurally undefined.
-    RegistryEntry { name: "DTM", family: ModelFamily::None_, exempt: &["doc_topic", "fit_history"] },
-    RegistryEntry { name: "HLDA", family: ModelFamily::None_, exempt: &["doc_topic"] },
+    RegistryEntry {
+        name: "DTM",
+        family: ModelFamily::None_,
+        exempt: &["doc_topic", "fit_history"],
+    },
+    RegistryEntry {
+        name: "HLDA",
+        family: ModelFamily::None_,
+        exempt: &["doc_topic"],
+    },
 ];
 
 #[cfg(test)]
@@ -164,18 +296,31 @@ mod registry_tests {
     /// real Estimator method. Catches a typo or a duplicate when a model is added.
     #[test]
     fn registry_is_well_formed() {
-        const METHODS: &[&str] =
-            &["num_topics", "topic_word", "doc_topic", "fit_history", "converged"];
+        const METHODS: &[&str] = &[
+            "num_topics",
+            "topic_word",
+            "doc_topic",
+            "fit_history",
+            "converged",
+        ];
         let mut seen = std::collections::HashSet::new();
         for e in RUST_ESTIMATORS {
             assert!(seen.insert(e.name), "duplicate registry entry: {}", e.name);
             for &req in e.exempt {
-                assert!(METHODS.contains(&req), "{}: unknown exempt method {req:?}", e.name);
+                assert!(
+                    METHODS.contains(&req),
+                    "{}: unknown exempt method {req:?}",
+                    e.name
+                );
             }
         }
         // Mirror of the Python REGISTRY size (user-facing models with an
         // Estimator-backed Rust struct).
-        assert_eq!(RUST_ESTIMATORS.len(), 26, "registry size drifted from the Python REGISTRY");
+        assert_eq!(
+            RUST_ESTIMATORS.len(),
+            26,
+            "registry size drifted from the Python REGISTRY"
+        );
     }
 }
 
@@ -200,8 +345,22 @@ mod ctm_conformance_tests {
             vec![1, 1, 2, 0, 1],
             vec![2, 2, 0, 1, 2],
         ];
-        let model = fit_ctm(&docs, 3, 3, 5, 0.0, 0.0, None, None, false, None,
-                            GammaPrior::Pooled, true, false, &mut rng);
+        let model = fit_ctm(
+            &docs,
+            3,
+            3,
+            5,
+            0.0,
+            0.0,
+            None,
+            None,
+            false,
+            None,
+            GammaPrior::Pooled,
+            true,
+            false,
+            &mut rng,
+        );
 
         let base_violations = check_conformance(&model);
         assert!(

--- a/src/cvb0_ext.rs
+++ b/src/cvb0_ext.rs
@@ -19,8 +19,7 @@ pub trait Cvb0ToModel {
 
 impl Cvb0ToModel for Cvb0 {
     fn to_topic_model(&self, corpus: &Corpus) -> TopicModel {
-        let mut model =
-            TopicModel::new(self.num_topics, self.alpha_sum, self.beta, self.num_types);
+        let mut model = TopicModel::new(self.num_topics, self.alpha_sum, self.beta, self.num_types);
         model.alpha.copy_from_slice(&self.alpha);
         model.alpha_sum = self.alpha_sum;
         model.beta = self.beta;

--- a/src/detm.rs
+++ b/src/detm.rs
@@ -83,7 +83,9 @@ fn logvar_clamped(x: f64) -> bool {
 /// entries uniform on `[-1/sqrt(fan_in), 1/sqrt(fan_in)]`.
 fn kaiming<R: Rng>(len: usize, fan_in: usize, rng: &mut R) -> Vec<f64> {
     let bound = 1.0 / (fan_in.max(1) as f64).sqrt();
-    (0..len).map(|_| (rng.gen::<f64>() * 2.0 - 1.0) * bound).collect()
+    (0..len)
+        .map(|_| (rng.gen::<f64>() * 2.0 - 1.0) * bound)
+        .collect()
 }
 
 /// A standard-normal sample via Box-Muller.
@@ -94,7 +96,11 @@ fn randn<R: Rng>(rng: &mut R) -> f64 {
 }
 
 fn relu(x: f64) -> f64 {
-    if x > 0.0 { x } else { 0.0 }
+    if x > 0.0 {
+        x
+    } else {
+        0.0
+    }
 }
 
 fn sigmoid(x: f64) -> f64 {
@@ -106,7 +112,9 @@ fn sigmoid(x: f64) -> f64 {
 /// regardless of the per-tensor fan-in. This helper draws that block.
 fn lstm_init<R: Rng>(len: usize, hidden: usize, rng: &mut R) -> Vec<f64> {
     let bound = 1.0 / (hidden.max(1) as f64).sqrt();
-    (0..len).map(|_| (rng.gen::<f64>() * 2.0 - 1.0) * bound).collect()
+    (0..len)
+        .map(|_| (rng.gen::<f64>() * 2.0 - 1.0) * bound)
+        .collect()
 }
 
 fn softmax(v: &[f64]) -> Vec<f64> {
@@ -141,10 +149,10 @@ pub struct ThetaEncoder {
     pub v: usize,
     pub k: usize,
     pub hidden: usize,
-    pub w1: Vec<f64>, // hidden x (V + K)
-    pub b1: Vec<f64>, // hidden
-    pub w2: Vec<f64>, // hidden x hidden
-    pub b2: Vec<f64>, // hidden
+    pub w1: Vec<f64>,   // hidden x (V + K)
+    pub b1: Vec<f64>,   // hidden
+    pub w2: Vec<f64>,   // hidden x hidden
+    pub b2: Vec<f64>,   // hidden
     pub w_mu: Vec<f64>, // K x hidden
     pub b_mu: Vec<f64>, // K
     pub w_ls: Vec<f64>, // K x hidden
@@ -215,7 +223,14 @@ impl ThetaEncoder {
             // reparameterization std and the theta-KL); see [`clamp_logvar`].
             ls[c] = clamp_logvar(sl);
         }
-        ThetaCache { pre1, h1, pre2, h2, mu, ls }
+        ThetaCache {
+            pre1,
+            h1,
+            pre2,
+            h2,
+            mu,
+            ls,
+        }
     }
 }
 
@@ -276,8 +291,8 @@ impl EncGrad {
 pub struct EtaNet {
     pub v: usize,
     pub k: usize,
-    pub eh: usize,       // eta_hidden_size
-    pub nlayers: usize,  // eta_nlayers
+    pub eh: usize,      // eta_hidden_size
+    pub nlayers: usize, // eta_nlayers
     // q_eta_map: Linear(V -> eh).
     pub map_w: Vec<f64>, // eh x V
     pub map_b: Vec<f64>, // eh
@@ -313,9 +328,16 @@ impl EtaNet {
         // Heads: nn.Linear(eh + K -> K), fan_in = eh + K.
         let inp = eh + k;
         EtaNet {
-            v, k, eh, nlayers,
-            map_w, map_b,
-            w_ih, w_hh, b_ih, b_hh,
+            v,
+            k,
+            eh,
+            nlayers,
+            map_w,
+            map_b,
+            w_ih,
+            w_hh,
+            b_ih,
+            b_hh,
             mu_w: kaiming(k * inp, inp, rng),
             mu_b: kaiming(k, inp, rng),
             ls_w: kaiming(k * inp, inp, rng),
@@ -329,12 +351,7 @@ impl EtaNet {
     /// `mu` directly (reference `reparameterize` in eval mode). Returns the sampled
     /// (or mean) `eta` (T x K), the per-slice head `mu`/`logsigma` (for the KL), and
     /// a cache holding every activation BPTT needs.
-    fn forward(
-        &self,
-        rnn_input: &[Vec<f64>],
-        eps: &[Vec<f64>],
-        sample: bool,
-    ) -> EtaForward {
+    fn forward(&self, rnn_input: &[Vec<f64>], eps: &[Vec<f64>], sample: bool) -> EtaForward {
         let (k, eh, nl) = (self.k, self.eh, self.nlayers);
         let t = rnn_input.len();
 
@@ -361,10 +378,10 @@ impl EtaNet {
         let mut gates_f = vec![vec![vec![0.0f64; eh]; t]; nl];
         let mut gates_g = vec![vec![vec![0.0f64; eh]; t]; nl];
         let mut gates_o = vec![vec![vec![0.0f64; eh]; t]; nl];
-        let mut cell = vec![vec![vec![0.0f64; eh]; t]; nl];     // c_t per layer/step
-        let mut tanh_c = vec![vec![vec![0.0f64; eh]; t]; nl];   // tanh(c_t)
-        let mut hidden = vec![vec![vec![0.0f64; eh]; t]; nl];   // h_t per layer/step
-        // Inputs each layer saw (needed for the input-weight gradient).
+        let mut cell = vec![vec![vec![0.0f64; eh]; t]; nl]; // c_t per layer/step
+        let mut tanh_c = vec![vec![vec![0.0f64; eh]; t]; nl]; // tanh(c_t)
+        let mut hidden = vec![vec![vec![0.0f64; eh]; t]; nl]; // h_t per layer/step
+                                                              // Inputs each layer saw (needed for the input-weight gradient).
         let mut layer_inputs: Vec<Vec<Vec<f64>>> = Vec::with_capacity(nl);
 
         for layer in 0..nl {
@@ -465,26 +482,35 @@ impl EtaNet {
 
         EtaForward {
             layer_inputs,
-            gates_i, gates_f, gates_g, gates_o, cell, tanh_c, hidden,
-            head_inp, mu, ls, etas,
+            gates_i,
+            gates_f,
+            gates_g,
+            gates_o,
+            cell,
+            tanh_c,
+            hidden,
+            head_inp,
+            mu,
+            ls,
+            etas,
         }
     }
 }
 
 /// Cached q(eta) forward activations retained for BPTT.
 struct EtaForward {
-    layer_inputs: Vec<Vec<Vec<f64>>>,       // nlayers x T x eh (input seen by each layer)
-    gates_i: Vec<Vec<Vec<f64>>>,            // nlayers x T x eh
+    layer_inputs: Vec<Vec<Vec<f64>>>, // nlayers x T x eh (input seen by each layer)
+    gates_i: Vec<Vec<Vec<f64>>>,      // nlayers x T x eh
     gates_f: Vec<Vec<Vec<f64>>>,
     gates_g: Vec<Vec<Vec<f64>>>,
     gates_o: Vec<Vec<Vec<f64>>>,
     cell: Vec<Vec<Vec<f64>>>,
     tanh_c: Vec<Vec<Vec<f64>>>,
-    hidden: Vec<Vec<Vec<f64>>>,             // nlayers x T x eh
-    head_inp: Vec<Vec<f64>>,                // T x (eh + K)
-    mu: Vec<Vec<f64>>,                      // T x K
-    ls: Vec<Vec<f64>>,                      // T x K
-    etas: Vec<Vec<f64>>,                    // T x K
+    hidden: Vec<Vec<Vec<f64>>>, // nlayers x T x eh
+    head_inp: Vec<Vec<f64>>,    // T x (eh + K)
+    mu: Vec<Vec<f64>>,          // T x K
+    ls: Vec<Vec<f64>>,          // T x K
+    etas: Vec<Vec<f64>>,        // T x K
 }
 
 /// Gradient accumulators mirroring [`EtaNet`].
@@ -632,15 +658,19 @@ impl EtaNet {
                     let d_tc = d_h[j] * o[j];
                     let d_ct = d_tc * (1.0 - tc[j] * tc[j]) + d_c_next[j];
                     d_c[j] = d_ct;
-                    let cprev = if tt > 0 { fwd.cell[layer][tt - 1][j] } else { 0.0 };
+                    let cprev = if tt > 0 {
+                        fwd.cell[layer][tt - 1][j]
+                    } else {
+                        0.0
+                    };
                     let d_f = d_ct * cprev;
                     let d_i = d_ct * gt[j];
                     let d_g = d_ct * it[j];
                     // Gate pre-activation gradients (sigmoid' = s(1-s); tanh' = 1-g^2).
-                    d_pre[0][j] = d_i * it[j] * (1.0 - it[j]);  // input gate
-                    d_pre[1][j] = d_f * ft[j] * (1.0 - ft[j]);  // forget gate
-                    d_pre[2][j] = d_g * (1.0 - gt[j] * gt[j]);  // cell gate (tanh)
-                    d_pre[3][j] = d_o * o[j] * (1.0 - o[j]);     // output gate
+                    d_pre[0][j] = d_i * it[j] * (1.0 - it[j]); // input gate
+                    d_pre[1][j] = d_f * ft[j] * (1.0 - ft[j]); // forget gate
+                    d_pre[2][j] = d_g * (1.0 - gt[j] * gt[j]); // cell gate (tanh)
+                    d_pre[3][j] = d_o * o[j] * (1.0 - o[j]); // output gate
                 }
                 // Accumulate weight/bias grads and propagate to x_t and h_{t-1}.
                 let x = &inp_seq[tt];
@@ -720,7 +750,13 @@ struct Adam {
 
 impl Adam {
     fn new(len: usize, lr: f64, wd: f64) -> Self {
-        Adam { m: vec![0.0; len], v: vec![0.0; len], t: 0, lr, wd }
+        Adam {
+            m: vec![0.0; len],
+            v: vec![0.0; len],
+            t: 0,
+            lr,
+            wd,
+        }
     }
     fn step(&mut self, p: &mut [f64], grad: &[f64]) {
         const B1: f64 = 0.9;
@@ -729,8 +765,9 @@ impl Adam {
         self.t += 1;
         let bc1 = 1.0 - B1.powi(self.t as i32);
         let bc2 = 1.0 - B2.powi(self.t as i32);
-        for (pi, (&g0, (mi, vi))) in
-            p.iter_mut().zip(grad.iter().zip(self.m.iter_mut().zip(self.v.iter_mut())))
+        for (pi, (&g0, (mi, vi))) in p
+            .iter_mut()
+            .zip(grad.iter().zip(self.m.iter_mut().zip(self.v.iter_mut())))
         {
             let g = g0 + self.wd * *pi;
             *mi = B1 * *mi + (1.0 - B1) * g;
@@ -864,9 +901,11 @@ pub fn fit_detm<R: Rng>(
     let log_delta = delta.max(1e-12).ln();
 
     // Precompute the per-document sparse raw and normalized bags of words.
-    let bows: Vec<Vec<(usize, f64)>> =
-        (0..d).map(|i| raw_bow(&tokens[i], &counts[i])).collect();
-    let totals: Vec<f64> = bows.iter().map(|b| b.iter().map(|&(_, c)| c).sum::<f64>()).collect();
+    let bows: Vec<Vec<(usize, f64)>> = (0..d).map(|i| raw_bow(&tokens[i], &counts[i])).collect();
+    let totals: Vec<f64> = bows
+        .iter()
+        .map(|b| b.iter().map(|&(_, c)| c).sum::<f64>())
+        .collect();
     let nbows: Vec<Vec<(usize, f64)>> = bows
         .iter()
         .zip(&totals)
@@ -920,10 +959,26 @@ pub fn fit_detm<R: Rng>(
     // q(eta) LSTM-network optimizers (one Adam per parameter block).
     let mut a_eta_map_w = Adam::new(eta_net.map_w.len(), lr, wdecay);
     let mut a_eta_map_b = Adam::new(eta_net.map_b.len(), lr, wdecay);
-    let mut a_eta_w_ih: Vec<Adam> = eta_net.w_ih.iter().map(|w| Adam::new(w.len(), lr, wdecay)).collect();
-    let mut a_eta_w_hh: Vec<Adam> = eta_net.w_hh.iter().map(|w| Adam::new(w.len(), lr, wdecay)).collect();
-    let mut a_eta_b_ih: Vec<Adam> = eta_net.b_ih.iter().map(|b| Adam::new(b.len(), lr, wdecay)).collect();
-    let mut a_eta_b_hh: Vec<Adam> = eta_net.b_hh.iter().map(|b| Adam::new(b.len(), lr, wdecay)).collect();
+    let mut a_eta_w_ih: Vec<Adam> = eta_net
+        .w_ih
+        .iter()
+        .map(|w| Adam::new(w.len(), lr, wdecay))
+        .collect();
+    let mut a_eta_w_hh: Vec<Adam> = eta_net
+        .w_hh
+        .iter()
+        .map(|w| Adam::new(w.len(), lr, wdecay))
+        .collect();
+    let mut a_eta_b_ih: Vec<Adam> = eta_net
+        .b_ih
+        .iter()
+        .map(|b| Adam::new(b.len(), lr, wdecay))
+        .collect();
+    let mut a_eta_b_hh: Vec<Adam> = eta_net
+        .b_hh
+        .iter()
+        .map(|b| Adam::new(b.len(), lr, wdecay))
+        .collect();
     let mut a_eta_mu_w = Adam::new(eta_net.mu_w.len(), lr, wdecay);
     let mut a_eta_mu_b = Adam::new(eta_net.mu_b.len(), lr, wdecay);
     let mut a_eta_ls_w = Adam::new(eta_net.ls_w.len(), lr, wdecay);
@@ -1172,23 +1227,27 @@ pub fn fit_detm<R: Rng>(
                 for ll in 0..l {
                     let dm = mu_alpha[0][kk][ll];
                     g_mu_alpha[0][kk][ll] += dm / (1.0 + 1e-6);
-                    g_ls_alpha[0][kk][ll] += 0.5 * (lsc_alpha[0][kk][ll].exp() / (1.0 + 1e-6) - 1.0);
+                    g_ls_alpha[0][kk][ll] +=
+                        0.5 * (lsc_alpha[0][kk][ll].exp() / (1.0 + 1e-6) - 1.0);
                 }
                 for tt in 1..t {
                     let prior_mean = alpha[tt - 1][kk].clone(); // sampled alpha_{t-1}
                     let plv: Vec<f64> = vec![log_delta; l];
-                    batch_loss += kl_gauss(&mu_alpha[tt][kk], &lsc_alpha[tt][kk], &prior_mean, &plv);
+                    batch_loss +=
+                        kl_gauss(&mu_alpha[tt][kk], &lsc_alpha[tt][kk], &prior_mean, &plv);
                     let inv_pv = 1.0 / (delta + 1e-6);
                     for ll in 0..l {
                         let dm = mu_alpha[tt][kk][ll] - prior_mean[ll];
                         g_mu_alpha[tt][kk][ll] += inv_pv * dm;
-                        g_ls_alpha[tt][kk][ll] += 0.5 * (lsc_alpha[tt][kk][ll].exp() * inv_pv - 1.0);
+                        g_ls_alpha[tt][kk][ll] +=
+                            0.5 * (lsc_alpha[tt][kk][ll].exp() * inv_pv - 1.0);
                         // The prior mean is the sample alpha_{t-1}, so KL pushes a
                         // gradient back onto alpha_{t-1} (its mu/ls via the eps).
                         let dprior = -inv_pv * dm;
                         let std = (0.5 * lsc_alpha[tt - 1][kk][ll]).exp();
                         g_mu_alpha[tt - 1][kk][ll] += dprior;
-                        g_ls_alpha[tt - 1][kk][ll] += dprior * eps_alpha[tt - 1][kk][ll] * 0.5 * std;
+                        g_ls_alpha[tt - 1][kk][ll] +=
+                            dprior * eps_alpha[tt - 1][kk][ll] * 0.5 * std;
                     }
                 }
             }
@@ -1245,38 +1304,108 @@ pub fn fit_detm<R: Rng>(
             if let Some(max_norm) = grad_clip {
                 if max_norm > 0.0 {
                     let mut sumsq = 0.0f64;
-                    for a in &g_mu_alpha { for b in a { for &x in b { sumsq += x * x; } } }
-                    for a in &g_ls_alpha { for b in a { for &x in b { sumsq += x * x; } } }
+                    for a in &g_mu_alpha {
+                        for b in a {
+                            for &x in b {
+                                sumsq += x * x;
+                            }
+                        }
+                    }
+                    for a in &g_ls_alpha {
+                        for b in a {
+                            for &x in b {
+                                sumsq += x * x;
+                            }
+                        }
+                    }
                     let eta_blocks: [&[f64]; 4] =
                         [&g_eta.map_w, &g_eta.map_b, &g_eta.mu_w, &g_eta.mu_b];
-                    for blk in eta_blocks { for &x in blk { sumsq += x * x; } }
-                    for &x in &g_eta.ls_w { sumsq += x * x; }
-                    for &x in &g_eta.ls_b { sumsq += x * x; }
-                    for layer in [&g_eta.w_ih, &g_eta.w_hh, &g_eta.b_ih, &g_eta.b_hh] {
-                        for a in layer { for &x in a { sumsq += x * x; } }
+                    for blk in eta_blocks {
+                        for &x in blk {
+                            sumsq += x * x;
+                        }
                     }
-                    for blk in [&g_enc.w1, &g_enc.b1, &g_enc.w2, &g_enc.b2,
-                                &g_enc.w_mu, &g_enc.b_mu, &g_enc.w_ls, &g_enc.b_ls] {
-                        for &x in blk { sumsq += x * x; }
+                    for &x in &g_eta.ls_w {
+                        sumsq += x * x;
+                    }
+                    for &x in &g_eta.ls_b {
+                        sumsq += x * x;
+                    }
+                    for layer in [&g_eta.w_ih, &g_eta.w_hh, &g_eta.b_ih, &g_eta.b_hh] {
+                        for a in layer {
+                            for &x in a {
+                                sumsq += x * x;
+                            }
+                        }
+                    }
+                    for blk in [
+                        &g_enc.w1,
+                        &g_enc.b1,
+                        &g_enc.w2,
+                        &g_enc.b2,
+                        &g_enc.w_mu,
+                        &g_enc.b_mu,
+                        &g_enc.w_ls,
+                        &g_enc.b_ls,
+                    ] {
+                        for &x in blk {
+                            sumsq += x * x;
+                        }
                     }
                     let norm = sumsq.sqrt();
                     if norm > max_norm {
                         let s = max_norm / norm;
-                        for a in g_mu_alpha.iter_mut() { for b in a { for x in b { *x *= s; } } }
-                        for a in g_ls_alpha.iter_mut() { for b in a { for x in b { *x *= s; } } }
-                        for blk in [&mut g_eta.map_w, &mut g_eta.map_b,
-                                    &mut g_eta.mu_w, &mut g_eta.mu_b,
-                                    &mut g_eta.ls_w, &mut g_eta.ls_b] {
-                            for x in blk { *x *= s; }
+                        for a in g_mu_alpha.iter_mut() {
+                            for b in a {
+                                for x in b {
+                                    *x *= s;
+                                }
+                            }
                         }
-                        for layer in [&mut g_eta.w_ih, &mut g_eta.w_hh,
-                                      &mut g_eta.b_ih, &mut g_eta.b_hh] {
-                            for a in layer { for x in a { *x *= s; } }
+                        for a in g_ls_alpha.iter_mut() {
+                            for b in a {
+                                for x in b {
+                                    *x *= s;
+                                }
+                            }
                         }
-                        for blk in [&mut g_enc.w1, &mut g_enc.b1, &mut g_enc.w2, &mut g_enc.b2,
-                                    &mut g_enc.w_mu, &mut g_enc.b_mu,
-                                    &mut g_enc.w_ls, &mut g_enc.b_ls] {
-                            for x in blk { *x *= s; }
+                        for blk in [
+                            &mut g_eta.map_w,
+                            &mut g_eta.map_b,
+                            &mut g_eta.mu_w,
+                            &mut g_eta.mu_b,
+                            &mut g_eta.ls_w,
+                            &mut g_eta.ls_b,
+                        ] {
+                            for x in blk {
+                                *x *= s;
+                            }
+                        }
+                        for layer in [
+                            &mut g_eta.w_ih,
+                            &mut g_eta.w_hh,
+                            &mut g_eta.b_ih,
+                            &mut g_eta.b_hh,
+                        ] {
+                            for a in layer {
+                                for x in a {
+                                    *x *= s;
+                                }
+                            }
+                        }
+                        for blk in [
+                            &mut g_enc.w1,
+                            &mut g_enc.b1,
+                            &mut g_enc.w2,
+                            &mut g_enc.b2,
+                            &mut g_enc.w_mu,
+                            &mut g_enc.b_mu,
+                            &mut g_enc.w_ls,
+                            &mut g_enc.b_ls,
+                        ] {
+                            for x in blk {
+                                *x *= s;
+                            }
                         }
                     }
                 }
@@ -1311,7 +1440,11 @@ pub fn fit_detm<R: Rng>(
             batches += 1;
         }
 
-        let avg = if batches > 0 { epoch_loss / batches as f64 } else { f64::NAN };
+        let avg = if batches > 0 {
+            epoch_loss / batches as f64
+        } else {
+            f64::NAN
+        };
         bound_history.push(-avg); // ELBO == negative loss
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
@@ -1331,7 +1464,11 @@ pub fn fit_detm<R: Rng>(
     let zero_eps = vec![vec![0.0f64; k]; t];
     let eta_mean = eta_net.forward(&rnn_input, &zero_eps, false).etas;
     let beta_over_time: Vec<Vec<Vec<f64>>> = (0..t)
-        .map(|tt| (0..k).map(|kk| beta_row(rho, &alpha_mean[tt][kk])).collect())
+        .map(|tt| {
+            (0..k)
+                .map(|kk| beta_row(rho, &alpha_mean[tt][kk]))
+                .collect()
+        })
         .collect();
 
     // doc_topic from the encoder mean (theta = softmax(mu)), as in main.py's get_theta.
@@ -1359,7 +1496,14 @@ pub fn fit_detm<R: Rng>(
 }
 
 /// Adam step over a flattened (T x K x L) parameter block.
-fn step3d(opt: &mut Adam, p: &mut [Vec<Vec<f64>>], g: &[Vec<Vec<f64>>], t: usize, k: usize, l: usize) {
+fn step3d(
+    opt: &mut Adam,
+    p: &mut [Vec<Vec<f64>>],
+    g: &[Vec<Vec<f64>>],
+    t: usize,
+    k: usize,
+    l: usize,
+) {
     let mut flat_p = Vec::with_capacity(t * k * l);
     let mut flat_g = Vec::with_capacity(t * k * l);
     for tt in 0..t {
@@ -1396,7 +1540,11 @@ impl Estimator for DetmModel {
     }
 
     fn fit_history(&self) -> Vec<(usize, f64)> {
-        self.bound_history.iter().enumerate().map(|(i, &b)| (i + 1, b)).collect()
+        self.bound_history
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| (i + 1, b))
+            .collect()
     }
 
     fn converged(&self) -> Option<bool> {
@@ -1423,7 +1571,13 @@ mod tests {
         block: usize,
         t: usize,
         d_per_t: usize,
-    ) -> (Vec<Vec<u32>>, Vec<Vec<u32>>, Vec<usize>, Vec<Vec<f64>>, usize) {
+    ) -> (
+        Vec<Vec<u32>>,
+        Vec<Vec<u32>>,
+        Vec<usize>,
+        Vec<Vec<f64>>,
+        usize,
+    ) {
         let v = k * block;
         let l = k + 2;
         let rho: Vec<Vec<f64>> = (0..v)
@@ -1490,7 +1644,10 @@ mod tests {
         // Not exactly zero: the reference's get_kl adds 1e-6 to the prior variance
         // for numerical safety, so KL(q || q) is a tiny negative number. We match
         // that form, so we only require it is close to zero.
-        assert!(kl.abs() < 1e-4, "KL of a distribution with itself should be ~0, got {kl}");
+        assert!(
+            kl.abs() < 1e-4,
+            "KL of a distribution with itself should be ~0, got {kl}"
+        );
     }
 
     #[test]
@@ -1499,7 +1656,8 @@ mod tests {
         let (k, block, t, d_per_t) = (3usize, 6usize, 4usize, 20usize);
         let (tokens, counts, times, rho, v) = planted_corpus(&mut rng, k, block, t, d_per_t);
         let m = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 32, 16, 2, 30, 64, 0.02, 1.2e-6, 0.0, None, &mut rng,
+            &tokens, &counts, &times, k, v, t, &rho, 0.005, 32, 16, 2, 30, 64, 0.02, 1.2e-6, 0.0,
+            None, &mut rng,
         );
         assert_eq!(m.num_topics, k);
         assert_eq!(m.num_times, t);
@@ -1533,11 +1691,13 @@ mod tests {
 
         let mut rng_a = ChaCha8Rng::seed_from_u64(123);
         let a = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 20, 64, 0.02, 1.2e-6, 0.0, None, &mut rng_a,
+            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 20, 64, 0.02, 1.2e-6, 0.0,
+            None, &mut rng_a,
         );
         let mut rng_b = ChaCha8Rng::seed_from_u64(123);
         let b = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 20, 64, 0.02, 1.2e-6, 0.0, None, &mut rng_b,
+            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 20, 64, 0.02, 1.2e-6, 0.0,
+            None, &mut rng_b,
         );
         for tt in 0..t {
             for kk in 0..k {
@@ -1554,8 +1714,8 @@ mod tests {
         let (k, block, t, d_per_t) = (3usize, 8usize, 5usize, 40usize);
         let (tokens, counts, times, rho, v) = planted_corpus(&mut rng, k, block, t, d_per_t);
         let m = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 32, 32, 2, 300, 1000, 0.02, 1.2e-6, 0.0,
-            None, &mut rng,
+            &tokens, &counts, &times, k, v, t, &rho, 0.005, 32, 32, 2, 300, 1000, 0.02, 1.2e-6,
+            0.0, None, &mut rng,
         );
         // The time-varying topic prior eta (the latent the random walk regularizes)
         // should move across the slices for at least one topic, recovering the
@@ -1567,8 +1727,13 @@ mod tests {
         let prior_at = |tt: usize| softmax(&m.eta[tt]);
         let p0 = prior_at(0);
         let plast = prior_at(t - 1);
-        let max_drift = (0..k).map(|kk| (plast[kk] - p0[kk]).abs()).fold(0.0f64, f64::max);
-        assert!(max_drift > 0.01, "eta prior did not drift across time (max {max_drift})");
+        let max_drift = (0..k)
+            .map(|kk| (plast[kk] - p0[kk]).abs())
+            .fold(0.0f64, f64::max);
+        assert!(
+            max_drift > 0.01,
+            "eta prior did not drift across time (max {max_drift})"
+        );
     }
 
     // ---- Finite-difference check on the LSTM q(eta) path --------------------
@@ -1612,7 +1777,8 @@ mod tests {
                 let dmm = fwd.mu[tt][c] - prior;
                 let inv_pv = 1.0 / (delta + 1e-6);
                 loss += 0.5
-                    * ((fwd.ls[tt][c].exp() + dmm * dmm) * inv_pv - 1.0 + log_delta - fwd.ls[tt][c]);
+                    * ((fwd.ls[tt][c].exp() + dmm * dmm) * inv_pv - 1.0 + log_delta
+                        - fwd.ls[tt][c]);
                 d_mu[tt][c] += inv_pv * dmm;
                 d_ls[tt][c] += 0.5 * (fwd.ls[tt][c].exp() * inv_pv - 1.0);
                 d_eta[tt - 1][c] += -inv_pv * dmm;
@@ -1628,16 +1794,27 @@ mod tests {
         let delta = 0.005;
         let net = EtaNet::new(v, k, eh, nl, &mut rng);
         // Fixed inputs / noise / downstream weights.
-        let rnn_input: Vec<Vec<f64>> =
-            (0..t).map(|_| (0..v).map(|_| rng.gen::<f64>()).collect()).collect();
-        let eps: Vec<Vec<f64>> =
-            (0..t).map(|_| (0..k).map(|_| randn(&mut rng)).collect()).collect();
-        let w: Vec<Vec<f64>> =
-            (0..t).map(|_| (0..k).map(|_| randn(&mut rng) * 0.3).collect()).collect();
+        let rnn_input: Vec<Vec<f64>> = (0..t)
+            .map(|_| (0..v).map(|_| rng.gen::<f64>()).collect())
+            .collect();
+        let eps: Vec<Vec<f64>> = (0..t)
+            .map(|_| (0..k).map(|_| randn(&mut rng)).collect())
+            .collect();
+        let w: Vec<Vec<f64>> = (0..t)
+            .map(|_| (0..k).map(|_| randn(&mut rng) * 0.3).collect())
+            .collect();
 
         // Analytic gradient via BPTT.
         let (_, d_eta, d_mu, d_ls) = eta_fd_loss(&net, &rnn_input, &eps, &w, delta);
-        let g = net.backward(&net.forward(&rnn_input, &eps, true), &d_eta, &d_mu, &d_ls, &eps, true, &rnn_input);
+        let g = net.backward(
+            &net.forward(&rnn_input, &eps, true),
+            &d_eta,
+            &d_mu,
+            &d_ls,
+            &eps,
+            true,
+            &rnn_input,
+        );
 
         let h = 1e-5;
         // Closure: perturb element `idx` of a chosen parameter block and recompute loss.
@@ -1691,7 +1868,8 @@ mod tests {
         let (k, block, t, d_per_t) = (3usize, 6usize, 4usize, 20usize);
         let (tokens, counts, times, rho, v) = planted_corpus(&mut rng, k, block, t, d_per_t);
         let m = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 25, 64, 0.02, 1.2e-6, 0.0, None, &mut rng,
+            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 25, 64, 0.02, 1.2e-6, 0.0,
+            None, &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/src/dmr.rs
+++ b/src/dmr.rs
@@ -265,11 +265,7 @@ mod tests {
     fn gradient_matches_finite_difference() {
         let num_topics = 3;
         let num_features = 2;
-        let lambda = vec![
-            vec![0.1, -0.2],
-            vec![-0.3, 0.4],
-            vec![0.05, 0.15],
-        ];
+        let lambda = vec![vec![0.1, -0.2], vec![-0.3, 0.4], vec![0.05, 0.15]];
         let features = vec![
             vec![1.0, 0.5],
             vec![1.0, -1.0],
@@ -285,7 +281,13 @@ mod tests {
         let sigma2 = 10.0;
 
         let (_, grad) = dmr_objective_and_gradient(
-            &lambda, &features, &counts, num_topics, num_features, sigma2, None,
+            &lambda,
+            &features,
+            &counts,
+            num_topics,
+            num_features,
+            sigma2,
+            None,
         );
 
         let eps = 1e-6;
@@ -295,15 +297,32 @@ mod tests {
                 let mut lm = lambda.clone();
                 lp[t][f] += eps;
                 lm[t][f] -= eps;
-                let (vp, _) =
-                    dmr_objective_and_gradient(&lp, &features, &counts, num_topics, num_features, sigma2, None);
-                let (vm, _) =
-                    dmr_objective_and_gradient(&lm, &features, &counts, num_topics, num_features, sigma2, None);
+                let (vp, _) = dmr_objective_and_gradient(
+                    &lp,
+                    &features,
+                    &counts,
+                    num_topics,
+                    num_features,
+                    sigma2,
+                    None,
+                );
+                let (vm, _) = dmr_objective_and_gradient(
+                    &lm,
+                    &features,
+                    &counts,
+                    num_topics,
+                    num_features,
+                    sigma2,
+                    None,
+                );
                 let numeric = (vp - vm) / (2.0 * eps);
                 assert!(
                     (numeric - grad[t][f]).abs() < 1e-4,
                     "grad[{}][{}]: analytic {} vs numeric {}",
-                    t, f, grad[t][f], numeric
+                    t,
+                    f,
+                    grad[t][f],
+                    numeric
                 );
             }
         }
@@ -329,7 +348,16 @@ mod tests {
             }
         }
         let mut lambda = vec![vec![0.0f64; num_features]; num_topics];
-        optimize_lambda(&mut lambda, &features, &counts, num_topics, num_features, 100.0, 100, None);
+        optimize_lambda(
+            &mut lambda,
+            &features,
+            &counts,
+            num_topics,
+            num_features,
+            100.0,
+            100,
+            None,
+        );
 
         // The covariate weight should push topic 1 up and topic 0 down.
         let effect_topic1 = lambda[1][1] - lambda[0][1];
@@ -340,4 +368,3 @@ mod tests {
         );
     }
 }
-

--- a/src/dtm.rs
+++ b/src/dtm.rs
@@ -18,8 +18,8 @@
 //! (`INIT_VARIANCE_CONST = 1000`, `OBS_NORM_CUTOFF = 2`, chain/obs variance
 //! defaults 0.005 / 0.5), so results track the reference implementation.
 
-use crate::variational::lbfgs_minimize;
 use crate::optimize::digamma;
+use crate::variational::lbfgs_minimize;
 use rand::Rng;
 use rayon::prelude::*;
 
@@ -95,14 +95,22 @@ impl Sslm {
         let fv = &mut self.fwd_variance[w];
         fv[0] = cv * INIT_VARIANCE_CONST;
         for i in 1..=t {
-            let c = if ov != 0.0 { ov / (fv[i - 1] + cv + ov) } else { 0.0 };
+            let c = if ov != 0.0 {
+                ov / (fv[i - 1] + cv + ov)
+            } else {
+                0.0
+            };
             fv[i] = c * (fv[i - 1] + cv);
         }
         let var = &mut self.variance[w];
         var[t] = self.fwd_variance[w][t];
         for i in (0..t).rev() {
             let fvt = self.fwd_variance[w][i];
-            let c = if fvt > 0.0 { (fvt / (fvt + cv)).powi(2) } else { 0.0 };
+            let c = if fvt > 0.0 {
+                (fvt / (fvt + cv)).powi(2)
+            } else {
+                0.0
+            };
             var[i] = c * (var[i + 1] - cv) + (1.0 - c) * fvt;
         }
     }
@@ -118,7 +126,11 @@ impl Sslm {
         }
         self.mean[w][t] = self.fwd_mean[w][t];
         for i in (0..t).rev() {
-            let c = if cv == 0.0 { 0.0 } else { cv / (self.fwd_variance[w][i] + cv) };
+            let c = if cv == 0.0 {
+                0.0
+            } else {
+                cv / (self.fwd_variance[w][i] + cv)
+            };
             self.mean[w][i] = c * self.fwd_mean[w][i] + (1.0 - c) * self.mean[w][i + 1];
         }
     }
@@ -149,7 +161,11 @@ impl Sslm {
         let var = &self.variance[w];
         let mut deriv = vec![0.0; t + 1];
         for i in 1..=t {
-            let coef = if ov > 0.0 { ov / (var[i - 1] + cv + ov) } else { 0.0 };
+            let coef = if ov > 0.0 {
+                ov / (var[i - 1] + cv + ov)
+            } else {
+                0.0
+            };
             let mut val = coef * deriv[i - 1];
             if time == i - 1 {
                 val += 1.0 - coef;
@@ -177,7 +193,11 @@ fn post_mean_from_obs(obs: &[f64], fwd_variance: &[f64], cv: f64, ov: f64) -> Ve
     let mut mean = vec![0.0; t + 1];
     mean[t] = fwd_mean[t];
     for i in (0..t).rev() {
-        let c = if cv == 0.0 { 0.0 } else { cv / (fwd_variance[i] + cv) };
+        let c = if cv == 0.0 {
+            0.0
+        } else {
+            cv / (fwd_variance[i] + cv)
+        };
         mean[i] = c * fwd_mean[i] + (1.0 - c) * mean[i + 1];
     }
     mean
@@ -185,15 +205,22 @@ fn post_mean_from_obs(obs: &[f64], fwd_variance: &[f64], cv: f64, ov: f64) -> Ve
 
 /// `f_obs` from gensim: the (negated) state-space bound as a function of the
 /// observations, evaluated through the resulting posterior `mean`.
-fn f_obs_val(mean: &[f64], variance: &[f64], wc: &[f64], totals: &[f64], zeta: &[f64], cv: f64) -> f64 {
+fn f_obs_val(
+    mean: &[f64],
+    variance: &[f64],
+    wc: &[f64],
+    totals: &[f64],
+    zeta: &[f64],
+    cv: f64,
+) -> f64 {
     let t = wc.len();
     let mut term1 = 0.0;
     let mut term2 = 0.0;
     for i in 1..=t {
         let d = mean[i] - mean[i - 1];
         term1 += d * d;
-        term2 += wc[i - 1] * mean[i]
-            - totals[i - 1] * (mean[i] + variance[i] / 2.0).exp() / zeta[i - 1];
+        term2 +=
+            wc[i - 1] * mean[i] - totals[i - 1] * (mean[i] + variance[i] / 2.0).exp() / zeta[i - 1];
     }
     if cv > 0.0 {
         term1 = -(term1 / (2.0 * cv)) - mean[0] * mean[0] / (2.0 * INIT_VARIANCE_CONST * cv);
@@ -215,7 +242,9 @@ fn obs_deriv(
     cv: f64,
 ) -> Vec<f64> {
     let t = wc.len();
-    let temp_vect: Vec<f64> = (0..t).map(|u| (mean[u + 1] + variance[u + 1] / 2.0).exp()).collect();
+    let temp_vect: Vec<f64> = (0..t)
+        .map(|u| (mean[u + 1] + variance[u + 1] / 2.0).exp())
+        .collect();
     let mut deriv = vec![0.0; t];
     for (slot, md) in deriv.iter_mut().zip(mean_deriv_mtx) {
         let mut term1 = 0.0;
@@ -268,7 +297,9 @@ impl Sslm {
             self.compute_post_mean(w);
         }
         self.update_zeta();
-        let mut val: f64 = (0..v).map(|w| self.variance[w][0] - self.variance[w][t]).sum();
+        let mut val: f64 = (0..v)
+            .map(|w| self.variance[w][0] - self.variance[w][t])
+            .sum();
         // (val / 2) * cv, matching gensim's sslm.compute_bound verbatim:
         //   val = sum(variance[w][0] - variance[w][t]) / 2 * chain_variance
         // (ldaseqmodel.py; `/ 2 * cv` is left-associative, i.e. a *multiply* by cv).
@@ -316,7 +347,15 @@ impl Sslm {
             let obj = |x: &[f64]| -> (f64, Vec<f64>) {
                 let mean = post_mean_from_obs(x, &fwd_variance_w, cv, ov);
                 let f = f_obs_val(&mean, &variance_w, &wc, &totals_v, &zeta, cv);
-                let mut d = obs_deriv(&mean, &variance_w, &mean_deriv_mtx, &zeta, &wc, &totals_v, cv);
+                let mut d = obs_deriv(
+                    &mean,
+                    &variance_w,
+                    &mean_deriv_mtx,
+                    &zeta,
+                    &wc,
+                    &totals_v,
+                    cv,
+                );
                 for di in d.iter_mut() {
                     *di = -*di; // gensim's df_obs returns the negated gradient
                 }
@@ -471,7 +510,9 @@ impl DtmModel {
 
     /// The full (num_topics × num_words) topic-word matrix at one slice.
     pub fn topic_word_matrix(&self, time: usize) -> Vec<Vec<f64>> {
-        (0..self.num_topics).map(|k| self.topic_word(k, time)).collect()
+        (0..self.num_topics)
+            .map(|k| self.topic_word(k, time))
+            .collect()
     }
 }
 
@@ -590,7 +631,8 @@ pub fn fit_dtm<R: Rng>(
     let bags: Vec<Vec<(usize, f64)>> = docs
         .iter()
         .map(|doc| {
-            let mut counts: std::collections::BTreeMap<usize, f64> = std::collections::BTreeMap::new();
+            let mut counts: std::collections::BTreeMap<usize, f64> =
+                std::collections::BTreeMap::new();
             for &w in doc {
                 *counts.entry(w as usize).or_insert(0.0) += 1.0;
             }
@@ -641,7 +683,14 @@ pub fn fit_dtm<R: Rng>(
         }
     }
 
-    DtmModel { num_topics: k, num_times: t, num_types: v, alpha, chains, bound }
+    DtmModel {
+        num_topics: k,
+        num_times: t,
+        num_types: v,
+        alpha,
+        chains,
+        bound,
+    }
 }
 
 use crate::estimator::{Estimator, ModelFamily};
@@ -699,7 +748,9 @@ mod tests {
                 docs.push(vec![aw[0], aw[1], aw[2], aw[0], aw[1], aw[2]]);
                 times.push(slice);
                 // topic-B document
-                docs.push(vec![b_words[0], b_words[1], b_words[2], b_words[0], b_words[1], b_words[2]]);
+                docs.push(vec![
+                    b_words[0], b_words[1], b_words[2], b_words[0], b_words[1], b_words[2],
+                ]);
                 times.push(slice);
             }
         }
@@ -712,7 +763,9 @@ mod tests {
         // slices; the other should be the stable {10,11,12} topic.
         let top_at = |k: usize, t: usize| -> usize {
             let d = model.topic_word(k, t);
-            (0..v).max_by(|&a, &b| d[a].partial_cmp(&d[b]).unwrap()).unwrap()
+            (0..v)
+                .max_by(|&a, &b| d[a].partial_cmp(&d[b]).unwrap())
+                .unwrap()
         };
         let drift_topic = (0..2)
             .find(|&k| top_at(k, 0) != top_at(k, 2))
@@ -727,8 +780,14 @@ mod tests {
         let d2 = model.topic_word(drift_topic, 2);
         let early_block = |d: &[f64]| -> f64 { [0usize, 1, 2].iter().map(|&w| d[w]).sum() };
         let late_block = |d: &[f64]| -> f64 { [4usize, 5, 6].iter().map(|&w| d[w]).sum() };
-        assert!(top_at(drift_topic, 0) <= 2, "t=0 top word not in early block");
-        assert!((4..=6).contains(&top_at(drift_topic, 2)), "t=2 top word not in late block");
+        assert!(
+            top_at(drift_topic, 0) <= 2,
+            "t=0 top word not in early block"
+        );
+        assert!(
+            (4..=6).contains(&top_at(drift_topic, 2)),
+            "t=2 top word not in late block"
+        );
         assert!(
             late_block(&d2) > late_block(&d0),
             "late-block mass should grow over time: t0={} t2={}",

--- a/src/ectm.rs
+++ b/src/ectm.rs
@@ -185,7 +185,21 @@ fn solve_and_blend_content(
     let kkg_old = kkg.to_vec();
     let kkgp_old = kkgp.to_vec();
     optimize_content(
-        m, kt, kkp, kkg, kkgp, &counts, k, g, p, v, sigma2, rw_kp, rw_kgp, shrink_kgp, inner_iters,
+        m,
+        kt,
+        kkp,
+        kkg,
+        kkgp,
+        &counts,
+        k,
+        g,
+        p,
+        v,
+        sigma2,
+        rw_kp,
+        rw_kgp,
+        shrink_kgp,
+        inner_iters,
     );
     blend_kappa(kt, &kt_old, rho);
     blend_kappa(kkp, &kkp_old, rho);
@@ -195,7 +209,12 @@ fn solve_and_blend_content(
     // content-model convergence signal: still-large at the end => not converged.
     let mut num = 0.0f64;
     let mut den = 0.0f64;
-    for (cur, old) in [(&*kt, &kt_old), (&*kkp, &kkp_old), (&*kkg, &kkg_old), (&*kkgp, &kkgp_old)] {
+    for (cur, old) in [
+        (&*kt, &kt_old),
+        (&*kkp, &kkp_old),
+        (&*kkg, &kkg_old),
+        (&*kkgp, &kkgp_old),
+    ] {
         for (cr, orow) in cur.iter().zip(old) {
             for (&c, &o) in cr.iter().zip(orow) {
                 num += (c - o) * (c - o);
@@ -265,8 +284,9 @@ fn optimize_content(
             let kt_i = |t: usize, w: usize| flat[t * v + w];
             let kkp_i = |t: usize, per: usize, w: usize| flat[off_kp + (t * p + per) * v + w];
             let kkg_i = |t: usize, grp: usize, w: usize| flat[off_kg + (t * g + grp) * v + w];
-            let kkgp_i =
-                |t: usize, grp: usize, per: usize, w: usize| flat[off_kgp + ((t * g + grp) * p + per) * v + w];
+            let kkgp_i = |t: usize, grp: usize, per: usize, w: usize| {
+                flat[off_kgp + ((t * g + grp) * p + per) * v + w]
+            };
 
             let mut value = 0.0f64;
             let mut grad = vec![0.0f64; flat.len()];
@@ -516,7 +536,9 @@ pub fn fit_ectm<R: Rng>(
         let mut sigma_ss = vec![0.0f64; km1 * km1];
         let mut lambda_sum = vec![0.0f64; km1];
 
-        let chunk = (128 * 1024 * 1024 / (km1 * km1 * 8).max(1)).max(256).min(d.max(1));
+        let chunk = (128 * 1024 * 1024 / (km1 * km1 * 8).max(1))
+            .max(256)
+            .min(d.max(1));
         let mut total_bound = 0.0f64;
         let mut base = 0usize;
         while base < d {
@@ -534,7 +556,9 @@ pub fn fit_ectm<R: Rng>(
                         7,
                         1e-5,
                     );
-                    let res = ctm_hpb(&opt, beta_doc, words, counts, &mu_d, &siginv, entropy, diagonal);
+                    let res = ctm_hpb(
+                        &opt, beta_doc, words, counts, &mu_d, &siginv, entropy, diagonal,
+                    );
                     (opt, res)
                 });
 
@@ -608,8 +632,21 @@ pub fn fit_ectm<R: Rng>(
 
         // Content M-step.
         content_beta = optimize_content(
-            &m_bg, &mut kt, &mut kkp, &mut kkg, &mut kkgp, &content_ss, k, g, p, num_types, sigma2,
-            rw_kp, rw_kgp, shrink_kgp, 20,
+            &m_bg,
+            &mut kt,
+            &mut kkp,
+            &mut kkg,
+            &mut kkgp,
+            &content_ss,
+            k,
+            g,
+            p,
+            num_types,
+            sigma2,
+            rw_kp,
+            rw_kgp,
+            shrink_kgp,
+            20,
         );
     }
 
@@ -834,7 +871,9 @@ pub fn fit_ectm_svi<R: Rng>(
                     7,
                     1e-5,
                 );
-                let res = ctm_hpb(&opt, beta_doc, words, counts, &mu_d, &siginv, entropy, diagonal);
+                let res = ctm_hpb(
+                    &opt, beta_doc, words, counts, &mu_d, &siginv, entropy, diagonal,
+                );
                 for (wi, &w) in words.iter().enumerate() {
                     for t in 0..k {
                         content_ss[t * num_cells + c][w] += res.phi[t][wi];
@@ -877,7 +916,10 @@ pub fn fit_ectm_svi<R: Rng>(
             }
 
             // Σ: blend toward the minibatch covariance estimate.
-            let mus: Vec<Vec<f64>> = chunk.iter().map(|&di| doc_mu(di, &gamma, &mu_shared)).collect();
+            let mus: Vec<Vec<f64>> = chunk
+                .iter()
+                .map(|&di| doc_mu(di, &gamma, &mu_shared))
+                .collect();
             for i in 0..km1 {
                 for j in 0..km1 {
                     let mut cross = 0.0;
@@ -901,11 +943,28 @@ pub fn fit_ectm_svi<R: Rng>(
                 n_ksolve += 1;
                 let rho_k = svi::rho(1.0, kappa, n_ksolve);
                 let shift = solve_and_blend_content(
-                    &m_bg, &mut kt, &mut kkp, &mut kkg, &mut kkgp, &content_ss, win_docs, d,
-                    k, g, p, num_types, sigma2, rw_kp, rw_kgp, shrink_kgp, rho_k, kiters,
+                    &m_bg,
+                    &mut kt,
+                    &mut kkp,
+                    &mut kkg,
+                    &mut kkgp,
+                    &content_ss,
+                    win_docs,
+                    d,
+                    k,
+                    g,
+                    p,
+                    num_types,
+                    sigma2,
+                    rw_kp,
+                    rw_kgp,
+                    shrink_kgp,
+                    rho_k,
+                    kiters,
                 );
                 content_shift_history.push(shift);
-                content_beta = build_content_beta(&m_bg, &kt, &kkp, &kkg, &kkgp, k, g, p, num_types);
+                content_beta =
+                    build_content_beta(&m_bg, &kt, &kkp, &kkg, &kkgp, k, g, p, num_types);
                 for row in content_ss.iter_mut() {
                     for c in row.iter_mut() {
                         *c = 0.0;
@@ -922,8 +981,24 @@ pub fn fit_ectm_svi<R: Rng>(
         n_ksolve += 1;
         let rho_k = svi::rho(1.0, kappa, n_ksolve);
         let shift = solve_and_blend_content(
-            &m_bg, &mut kt, &mut kkp, &mut kkg, &mut kkgp, &content_ss, win_docs, d, k, g, p,
-            num_types, sigma2, rw_kp, rw_kgp, shrink_kgp, rho_k, kiters,
+            &m_bg,
+            &mut kt,
+            &mut kkp,
+            &mut kkg,
+            &mut kkgp,
+            &content_ss,
+            win_docs,
+            d,
+            k,
+            g,
+            p,
+            num_types,
+            sigma2,
+            rw_kp,
+            rw_kgp,
+            shrink_kgp,
+            rho_k,
+            kiters,
         );
         content_shift_history.push(shift);
         content_beta = build_content_beta(&m_bg, &kt, &kkp, &kkg, &kkgp, k, g, p, num_types);
@@ -940,7 +1015,9 @@ pub fn fit_ectm_svi<R: Rng>(
         Some(l) => half_logdet(&l, km1),
         None => 0.0,
     };
-    let chunk = (128 * 1024 * 1024 / (km1 * km1 * 8).max(1)).max(256).min(d.max(1));
+    let chunk = (128 * 1024 * 1024 / (km1 * km1 * 8).max(1))
+        .max(256)
+        .min(d.max(1));
     let mut total_bound = 0.0f64;
     let mut base = 0usize;
     while base < d {
@@ -958,7 +1035,9 @@ pub fn fit_ectm_svi<R: Rng>(
                     7,
                     1e-5,
                 );
-                let res = ctm_hpb(&opt, beta_doc, words, counts, &mu_d, &siginv, entropy, diagonal);
+                let res = ctm_hpb(
+                    &opt, beta_doc, words, counts, &mu_d, &siginv, entropy, diagonal,
+                );
                 (opt, res)
             });
         for (local_di, (opt, res)) in &chunk_results {
@@ -1038,7 +1117,11 @@ impl Estimator for EctmModel {
     }
 
     fn fit_history(&self) -> Vec<(usize, f64)> {
-        self.bound_history.iter().enumerate().map(|(i, &b)| (i + 1, b)).collect()
+        self.bound_history
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| (i + 1, b))
+            .collect()
     }
 
     fn converged(&self) -> Option<bool> {
@@ -1098,8 +1181,25 @@ mod tests {
         let (docs, groups, periods) = growing_contrast_corpus();
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         fit_ectm(
-            &docs, 2, 4, &groups, 2, &periods, 3, 60, 0.0, 0.0, None, 1.0, 5.0, 5.0, 2.0, true, false,
-            init_spectral, &mut rng,
+            &docs,
+            2,
+            4,
+            &groups,
+            2,
+            &periods,
+            3,
+            60,
+            0.0,
+            0.0,
+            None,
+            1.0,
+            5.0,
+            5.0,
+            2.0,
+            true,
+            false,
+            init_spectral,
+            &mut rng,
         )
     }
 
@@ -1138,7 +1238,10 @@ mod tests {
             c2 > c0 + 0.2,
             "contrast should grow across periods: period0={c0:.3}, period2={c2:.3}"
         );
-        assert!(c2 > 0.3, "final-period contrast should be substantial: {c2:.3}");
+        assert!(
+            c2 > 0.3,
+            "final-period contrast should be substantial: {c2:.3}"
+        );
     }
 
     #[test]
@@ -1171,9 +1274,8 @@ mod tests {
             }
         }
         let cc = fit_small_init(8, false);
-        let any_diff = (0..a.content_beta.len()).any(|c| {
-            (0..a.num_topics).any(|k| a.content_beta[c][k] != cc.content_beta[c][k])
-        });
+        let any_diff = (0..a.content_beta.len())
+            .any(|c| (0..a.num_topics).any(|k| a.content_beta[c][k] != cc.content_beta[c][k]));
         assert!(any_diff, "different seeds should differ under random init");
     }
 

--- a/src/etm.rs
+++ b/src/etm.rs
@@ -29,8 +29,8 @@
 //! reference's scaling at some cost in per-document posterior accuracy.
 
 use crate::ctm::{ctm_grad, ctm_hpb, ctm_lhood, HpbResult};
-use crate::variational::{lbfgs_minimize, doc_sparse};
 use crate::linalg::{cholesky, half_logdet, make_diagonally_dominant, spd_inverse};
+use crate::variational::{doc_sparse, lbfgs_minimize};
 use rand::Rng;
 use rayon::prelude::*;
 
@@ -211,7 +211,11 @@ pub fn fit_etm<R: Rng>(
     }
     let mut alpha = vec![vec![0.0f64; e]; k];
     for (t, ak) in alpha.iter_mut().enumerate() {
-        let src = if num_types > 0 { &rho[idx[t % num_types]] } else { &vec![0.0; e] };
+        let src = if num_types > 0 {
+            &rho[idx[t % num_types]]
+        } else {
+            &vec![0.0; e]
+        };
         for (ae, &r) in ak.iter_mut().zip(src) {
             *ae = r + (rng.gen::<f64>() - 0.5) * 0.01;
         }
@@ -265,7 +269,9 @@ pub fn fit_etm<R: Rng>(
                     1e-5,
                 );
                 // ETM uses the full Laplace covariance (diagonal=false).
-                let res = ctm_hpb(&opt, &beta, words, counts, &mu_shared, &siginv, entropy, false);
+                let res = ctm_hpb(
+                    &opt, &beta, words, counts, &mu_shared, &siginv, entropy, false,
+                );
                 (di, opt, res)
             })
             .collect();
@@ -384,7 +390,13 @@ mod tests {
     fn kl(p: &[f64], q: &[f64]) -> f64 {
         p.iter()
             .zip(q)
-            .map(|(&pi, &qi)| if pi > 0.0 { pi * (pi / qi.max(1e-12)).ln() } else { 0.0 })
+            .map(|(&pi, &qi)| {
+                if pi > 0.0 {
+                    pi * (pi / qi.max(1e-12)).ln()
+                } else {
+                    0.0
+                }
+            })
             .sum()
     }
 
@@ -408,21 +420,28 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let (k, v, e) = (3, 30, 8);
         // Random word embeddings (fixed) and planted topic embeddings.
-        let rho: Vec<Vec<f64>> =
-            (0..v).map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect()).collect();
-        let alpha_true: Vec<Vec<f64>> =
-            (0..k).map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect()).collect();
+        let rho: Vec<Vec<f64>> = (0..v)
+            .map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect())
+            .collect();
+        let alpha_true: Vec<Vec<f64>> = (0..k)
+            .map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect())
+            .collect();
         let beta_true = softmax_beta(&rho, &alpha_true);
         // Expected counts: a large multiple of the planted beta, so the M-step
         // target is essentially beta_true.
-        let counts: Vec<Vec<f64>> =
-            beta_true.iter().map(|row| row.iter().map(|&p| p * 5000.0).collect()).collect();
+        let counts: Vec<Vec<f64>> = beta_true
+            .iter()
+            .map(|row| row.iter().map(|&p| p * 5000.0).collect())
+            .collect();
 
         let mut alpha = vec![vec![0.0f64; e]; k]; // start from zero
         let beta_hat = optimize_topic_embeddings(&rho, &mut alpha, &counts, 100.0, 200);
 
         for t in 0..k {
-            assert!(kl(&beta_true[t], &beta_hat[t]) < 1e-3, "topic {t} KL too large");
+            assert!(
+                kl(&beta_true[t], &beta_hat[t]) < 1e-3,
+                "topic {t} KL too large"
+            );
         }
     }
 
@@ -438,14 +457,18 @@ mod tests {
         let rho: Vec<Vec<f64>> = (0..v)
             .map(|w| {
                 let b = w / block;
-                (0..e).map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.2).collect()
+                (0..e)
+                    .map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.2)
+                    .collect()
             })
             .collect();
         // Documents: doc d draws 10 words from block d % k.
         let docs: Vec<Vec<u32>> = (0..90)
             .map(|d| {
                 let b = d % k;
-                (0..10).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..10)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
 
@@ -476,13 +499,17 @@ mod tests {
         let rho: Vec<Vec<f64>> = (0..v)
             .map(|w| {
                 let b = w / block;
-                (0..e).map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.2).collect()
+                (0..e)
+                    .map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.2)
+                    .collect()
             })
             .collect();
         let docs: Vec<Vec<u32>> = (0..90)
             .map(|d| {
                 let b = d % k;
-                (0..10).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..10)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
         let m = fit_etm(&docs, k, v, &rho, 50, 1e-5, 0.0, 1e6, 25, &mut rng);

--- a/src/etm_vae.rs
+++ b/src/etm_vae.rs
@@ -40,7 +40,9 @@ const ETM_DIR_ALPHA: f64 = 1.0;
 /// entries are uniform on `[-1/sqrt(fan_in), 1/sqrt(fan_in)]`.
 fn kaiming<R: Rng>(len: usize, fan_in: usize, rng: &mut R) -> Vec<f64> {
     let bound = 1.0 / (fan_in as f64).sqrt();
-    (0..len).map(|_| (rng.gen::<f64>() * 2.0 - 1.0) * bound).collect()
+    (0..len)
+        .map(|_| (rng.gen::<f64>() * 2.0 - 1.0) * bound)
+        .collect()
 }
 
 /// A standard-normal sample via Box-Muller.
@@ -132,7 +134,14 @@ impl Encoder {
             mu[c] = sm;
             logvar[c] = sl;
         }
-        Cache { pre1, h1, pre2, h2, mu, logvar }
+        Cache {
+            pre1,
+            h1,
+            pre2,
+            h2,
+            mu,
+            logvar,
+        }
     }
 
     /// Inference mean only: `theta = softmax(mu)` with no sampling.
@@ -219,17 +228,35 @@ fn reparam_theta(cache: &Cache, eps: &[f64], prior: Prior, noise_free: bool) -> 
                 }
                 softmax(&z)
             };
-            Reparam { theta, kw: vec![], lam: vec![], ln_l: vec![], g: vec![], s: 0.0, eta: vec![] }
+            Reparam {
+                theta,
+                kw: vec![],
+                lam: vec![],
+                ln_l: vec![],
+                g: vec![],
+                s: 0.0,
+                eta: vec![],
+            }
         }
         Prior::StickBreaking => {
             // Gaussian latent (same as laplace), simplex via stick-breaking.
             let z = if noise_free {
                 cache.mu.clone()
             } else {
-                (0..k).map(|t| cache.mu[t] + (0.5 * cache.logvar[t]).exp() * eps[t]).collect()
+                (0..k)
+                    .map(|t| cache.mu[t] + (0.5 * cache.logvar[t]).exp() * eps[t])
+                    .collect()
             };
             let (eta, theta) = stick_break(&z);
-            Reparam { theta, kw: vec![], lam: vec![], ln_l: vec![], g: vec![], s: 0.0, eta }
+            Reparam {
+                theta,
+                kw: vec![],
+                lam: vec![],
+                ln_l: vec![],
+                g: vec![],
+                s: 0.0,
+                eta,
+            }
         }
         Prior::Dirichlet => {
             let mut kw = vec![0.0; k];
@@ -252,7 +279,15 @@ fn reparam_theta(cache: &Cache, eps: &[f64], prior: Prior, noise_free: bool) -> 
                 s += gt;
             }
             let theta: Vec<f64> = (0..k).map(|t| g[t] / s).collect();
-            Reparam { theta, kw, lam, ln_l, g, s, eta: vec![] }
+            Reparam {
+                theta,
+                kw,
+                lam,
+                ln_l,
+                g,
+                s,
+                eta: vec![],
+            }
         }
     }
 }
@@ -320,7 +355,8 @@ fn backward_doc(
                 g_mu[t] += g_z[t];
                 g_logvar[t] += g_z[t] * eps[t] * 0.5 * s;
                 // KL = -0.5 (1 + logvar - mu^2 - exp logvar)
-                kl += -0.5 * (1.0 + cache.logvar[t] - cache.mu[t] * cache.mu[t] - cache.logvar[t].exp());
+                kl += -0.5
+                    * (1.0 + cache.logvar[t] - cache.mu[t] * cache.mu[t] - cache.logvar[t].exp());
                 g_mu[t] += cache.mu[t];
                 g_logvar[t] += 0.5 * (cache.logvar[t].exp() - 1.0);
             }
@@ -341,7 +377,8 @@ fn backward_doc(
                 let s = (0.5 * cache.logvar[t]).exp();
                 g_mu[t] += g_z[t];
                 g_logvar[t] += g_z[t] * eps[t] * 0.5 * s;
-                kl += -0.5 * (1.0 + cache.logvar[t] - cache.mu[t] * cache.mu[t] - cache.logvar[t].exp());
+                kl += -0.5
+                    * (1.0 + cache.logvar[t] - cache.mu[t] * cache.mu[t] - cache.logvar[t].exp());
                 g_mu[t] += cache.mu[t];
                 g_logvar[t] += 0.5 * (cache.logvar[t].exp() - 1.0);
             }
@@ -359,7 +396,11 @@ fn backward_doc(
             let dot: f64 = (0..k).map(|t| g_theta[t] * theta[t]).sum();
             for m in 0..k {
                 let dg = (g_theta[m] - dot) / rep.s;
-                let dg_dlam = if rep.lam[m] != 0.0 { rep.g[m] / rep.lam[m] } else { 0.0 };
+                let dg_dlam = if rep.lam[m] != 0.0 {
+                    rep.g[m] / rep.lam[m]
+                } else {
+                    0.0
+                };
                 let dg_dkw = rep.g[m] * (-rep.ln_l[m] / (rep.kw[m] * rep.kw[m]));
                 g_mu[m] += dg * dg_dkw * sigmoid(cache.mu[m]);
                 g_logvar[m] += dg * dg_dlam * sigmoid(cache.logvar[m]);
@@ -377,7 +418,11 @@ fn backward_doc(
                 let dot: f64 = (0..k).map(|t| dzp[t] * pos.theta[t]).sum();
                 for m in 0..k {
                     let dg = (dzp[m] - dot) / pos.s;
-                    let dg_dlam = if pos.lam[m] != 0.0 { pos.g[m] / pos.lam[m] } else { 0.0 };
+                    let dg_dlam = if pos.lam[m] != 0.0 {
+                        pos.g[m] / pos.lam[m]
+                    } else {
+                        0.0
+                    };
                     let dg_dkw = pos.g[m] * (-pos.ln_l[m] / (pos.kw[m] * pos.kw[m]));
                     g_mu[m] += dg * dg_dkw * sigmoid(cache.mu[m]);
                     g_logvar[m] += dg * dg_dlam * sigmoid(cache.logvar[m]);
@@ -448,7 +493,9 @@ impl EtmVaeModel {
     /// uses the normalized Weibull at the posterior median (`u = 0.5`), the
     /// deterministic counterpart of its training reparameterization.
     pub fn transform(&self, docs: &[Vec<u32>]) -> Vec<Vec<f64>> {
-        docs.iter().map(|d| self.infer_theta(&normalized_bow(d))).collect()
+        docs.iter()
+            .map(|d| self.infer_theta(&normalized_bow(d)))
+            .collect()
     }
 
     fn infer_theta(&self, xn: &[(usize, f64)]) -> Vec<f64> {
@@ -521,7 +568,13 @@ struct Adam {
 
 impl Adam {
     fn new(len: usize, lr: f64, wd: f64) -> Self {
-        Adam { m: vec![0.0; len], v: vec![0.0; len], t: 0, lr, wd }
+        Adam {
+            m: vec![0.0; len],
+            v: vec![0.0; len],
+            t: 0,
+            lr,
+            wd,
+        }
     }
     fn step(&mut self, p: &mut [f64], grad: &[f64]) {
         const B1: f64 = 0.9;
@@ -530,8 +583,9 @@ impl Adam {
         self.t += 1;
         let bc1 = 1.0 - B1.powi(self.t as i32);
         let bc2 = 1.0 - B2.powi(self.t as i32);
-        for (pi, (&g0, (mi, vi))) in
-            p.iter_mut().zip(grad.iter().zip(self.m.iter_mut().zip(self.v.iter_mut())))
+        for (pi, (&g0, (mi, vi))) in p
+            .iter_mut()
+            .zip(grad.iter().zip(self.m.iter_mut().zip(self.v.iter_mut())))
         {
             let g = g0 + self.wd * *pi;
             *mi = B1 * *mi + (1.0 - B1) * g;
@@ -626,8 +680,7 @@ pub fn fit_etm_vae<R: Rng>(
             // Contrastive InfoNCE gradients (anchor and positive views), scaled by
             // the contrastive weight. Empty when the flag is off or the batch is < 2.
             let (dz_c, dz_pos) = if opts.contrastive && bsz >= 2 {
-                let (mut dz, dzp) =
-                    info_nce_backward(&thetas, &thetas_pos, opts.contrastive_temp);
+                let (mut dz, dzp) = info_nce_backward(&thetas, &thetas_pos, opts.contrastive_temp);
                 for row in &mut dz {
                     for x in row.iter_mut() {
                         *x *= opts.contrastive_weight;
@@ -635,10 +688,14 @@ pub fn fit_etm_vae<R: Rng>(
                 }
                 let dzp: Vec<Vec<f64>> = dzp
                     .into_iter()
-                    .map(|row| row.into_iter().map(|x| x * opts.contrastive_weight).collect())
+                    .map(|row| {
+                        row.into_iter()
+                            .map(|x| x * opts.contrastive_weight)
+                            .collect()
+                    })
                     .collect();
-                batch_loss +=
-                    opts.contrastive_weight * info_nce_loss(&thetas, &thetas_pos, opts.contrastive_temp);
+                batch_loss += opts.contrastive_weight
+                    * info_nce_loss(&thetas, &thetas_pos, opts.contrastive_temp);
                 (Some(dz), Some(dzp))
             } else {
                 (None, None)
@@ -648,8 +705,18 @@ pub fn fit_etm_vae<R: Rng>(
                 let dx = dz_c.as_ref().map(|d| d[bi].as_slice());
                 let dxp = dz_pos.as_ref().map(|d| d[bi].as_slice());
                 let (recon, kl) = backward_doc(
-                    &enc, &xn[di], &bows[di], &caches[bi], &epss[bi], &reps[bi], opts.prior,
-                    dx, dxp, &beta, &mut g, &mut g_beta,
+                    &enc,
+                    &xn[di],
+                    &bows[di],
+                    &caches[bi],
+                    &epss[bi],
+                    &reps[bi],
+                    opts.prior,
+                    dx,
+                    dxp,
+                    &beta,
+                    &mut g,
+                    &mut g_beta,
                 );
                 batch_loss += recon + kl;
             }
@@ -705,7 +772,10 @@ pub fn fit_etm_vae<R: Rng>(
         prior: opts.prior,
     };
     let doc_topic: Vec<Vec<f64>> = xn.iter().map(|x| model_stub.infer_theta(x)).collect();
-    EtmVaeModel { doc_topic, ..model_stub }
+    EtmVaeModel {
+        doc_topic,
+        ..model_stub
+    }
 }
 
 fn scaled(v: &[f64], s: f64) -> Vec<f64> {
@@ -752,11 +822,17 @@ mod tests {
 
     fn clone_encoder(e: &Encoder) -> Encoder {
         Encoder {
-            v: e.v, hidden: e.hidden, k: e.k,
-            w1: e.w1.clone(), b1: e.b1.clone(),
-            w2: e.w2.clone(), b2: e.b2.clone(),
-            w_mu: e.w_mu.clone(), b_mu: e.b_mu.clone(),
-            w_ls: e.w_ls.clone(), b_ls: e.b_ls.clone(),
+            v: e.v,
+            hidden: e.hidden,
+            k: e.k,
+            w1: e.w1.clone(),
+            b1: e.b1.clone(),
+            w2: e.w2.clone(),
+            b2: e.b2.clone(),
+            w_mu: e.w_mu.clone(),
+            b_mu: e.b_mu.clone(),
+            w_ls: e.w_ls.clone(),
+            b_ls: e.b_ls.clone(),
         }
     }
 
@@ -767,16 +843,22 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let (v, hidden, k, e) = (6usize, 4usize, 3usize, 2usize);
         let enc0 = Encoder::new(v, hidden, k, &mut rng);
-        let rho: Vec<Vec<f64>> =
-            (0..v).map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect()).collect();
-        let alpha0: Vec<Vec<f64>> =
-            (0..k).map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect()).collect();
+        let rho: Vec<Vec<f64>> = (0..v)
+            .map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect())
+            .collect();
+        let alpha0: Vec<Vec<f64>> = (0..k)
+            .map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect())
+            .collect();
         let docs: Vec<Vec<u32>> = vec![vec![0, 0, 2, 3, 3, 5], vec![1, 4, 4, 5], vec![2, 2, 3, 0]];
         let xns: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| normalized_bow(d)).collect();
         let bows: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| raw_bow(d)).collect();
         let n = docs.len();
         let epss: Vec<Vec<f64>> = (0..n)
-            .map(|i| (0..k).map(|t| 0.2 * (i as f64 + 1.0) - 0.13 * t as f64).collect())
+            .map(|i| {
+                (0..k)
+                    .map(|t| 0.2 * (i as f64 + 1.0) - 0.13 * t as f64)
+                    .collect()
+            })
             .collect();
 
         // Whole-batch loss as a function of the encoder and alpha.
@@ -799,7 +881,9 @@ mod tests {
                         // Both keep the Gaussian latent, so the KL is N(q || N(0, I)).
                         for t in 0..k {
                             total += -0.5
-                                * (1.0 + cache.logvar[t] - cache.mu[t].powi(2) - cache.logvar[t].exp());
+                                * (1.0 + cache.logvar[t]
+                                    - cache.mu[t].powi(2)
+                                    - cache.logvar[t].exp());
                         }
                     }
                     Prior::Dirichlet => {
@@ -840,16 +924,36 @@ mod tests {
         }
         let (dz_c, dz_pos) = if opts.contrastive && n >= 2 {
             let (mut dz, dzp) = info_nce_backward(&thetas, &thetas_pos, opts.contrastive_temp);
-            for row in &mut dz { for x in row.iter_mut() { *x *= opts.contrastive_weight; } }
-            let dzp: Vec<Vec<f64>> = dzp.into_iter()
-                .map(|r| r.into_iter().map(|x| x * opts.contrastive_weight).collect()).collect();
+            for row in &mut dz {
+                for x in row.iter_mut() {
+                    *x *= opts.contrastive_weight;
+                }
+            }
+            let dzp: Vec<Vec<f64>> = dzp
+                .into_iter()
+                .map(|r| r.into_iter().map(|x| x * opts.contrastive_weight).collect())
+                .collect();
             (Some(dz), Some(dzp))
-        } else { (None, None) };
+        } else {
+            (None, None)
+        };
         for i in 0..n {
             let dx = dz_c.as_ref().map(|d| d[i].as_slice());
             let dxp = dz_pos.as_ref().map(|d| d[i].as_slice());
-            backward_doc(&enc0, &xns[i], &bows[i], &caches[i], &epss[i], &reps[i], opts.prior,
-                dx, dxp, &beta, &mut g, &mut g_beta);
+            backward_doc(
+                &enc0,
+                &xns[i],
+                &bows[i],
+                &caches[i],
+                &epss[i],
+                &reps[i],
+                opts.prior,
+                dx,
+                dxp,
+                &beta,
+                &mut g,
+                &mut g_beta,
+            );
         }
         let g_alpha = alpha_grad(&g_beta, &beta, &rho, e);
 
@@ -858,7 +962,9 @@ mod tests {
         let mut chk = |analytic: f64, num: f64| {
             let abs = (analytic - num).abs();
             let denom = analytic.abs().max(num.abs());
-            if denom > 1e-3 { max_rel = max_rel.max(abs / denom); }
+            if denom > 1e-3 {
+                max_rel = max_rel.max(abs / denom);
+            }
             assert!(abs < 1e-4, "analytic {analytic} vs numeric {num}");
         };
         macro_rules! check_block {
@@ -873,8 +979,14 @@ mod tests {
                 }
             };
         }
-        check_block!(w1); check_block!(b1); check_block!(w2); check_block!(b2);
-        check_block!(w_mu); check_block!(b_mu); check_block!(w_ls); check_block!(b_ls);
+        check_block!(w1);
+        check_block!(b1);
+        check_block!(w2);
+        check_block!(b2);
+        check_block!(w_mu);
+        check_block!(b_mu);
+        check_block!(w_ls);
+        check_block!(b_ls);
         for t in 0..k {
             for d in 0..e {
                 let mut ap = alpha0.clone();
@@ -897,16 +1009,24 @@ mod tests {
     #[test]
     fn etm_contrastive_gradients_match_fd() {
         let opts = AvitmOptions {
-            contrastive: true, contrastive_weight: 0.7, contrastive_temp: 0.4,
+            contrastive: true,
+            contrastive_weight: 0.7,
+            contrastive_temp: 0.4,
             ..AvitmOptions::default()
         };
         let max_rel = etm_fd_check(opts);
-        assert!(max_rel < 1e-4, "etm contrastive max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "etm contrastive max relative error {max_rel}"
+        );
     }
 
     #[test]
     fn etm_dirichlet_gradients_match_fd() {
-        let opts = AvitmOptions { prior: Prior::Dirichlet, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            prior: Prior::Dirichlet,
+            ..AvitmOptions::default()
+        };
         let max_rel = etm_fd_check(opts);
         assert!(max_rel < 1e-4, "etm dirichlet max relative error {max_rel}");
     }
@@ -914,28 +1034,44 @@ mod tests {
     #[test]
     fn etm_contrastive_and_dirichlet_compose_fd() {
         let opts = AvitmOptions {
-            prior: Prior::Dirichlet, contrastive: true,
-            contrastive_weight: 0.6, contrastive_temp: 0.5,
+            prior: Prior::Dirichlet,
+            contrastive: true,
+            contrastive_weight: 0.6,
+            contrastive_temp: 0.5,
         };
         let max_rel = etm_fd_check(opts);
-        assert!(max_rel < 1e-4, "etm contrastive+dirichlet max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "etm contrastive+dirichlet max relative error {max_rel}"
+        );
     }
 
     #[test]
     fn etm_stick_breaking_gradients_match_fd() {
-        let opts = AvitmOptions { prior: Prior::StickBreaking, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            prior: Prior::StickBreaking,
+            ..AvitmOptions::default()
+        };
         let max_rel = etm_fd_check(opts);
-        assert!(max_rel < 1e-4, "etm stick-breaking max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "etm stick-breaking max relative error {max_rel}"
+        );
     }
 
     #[test]
     fn etm_contrastive_and_stick_breaking_compose_fd() {
         let opts = AvitmOptions {
-            prior: Prior::StickBreaking, contrastive: true,
-            contrastive_weight: 0.6, contrastive_temp: 0.5,
+            prior: Prior::StickBreaking,
+            contrastive: true,
+            contrastive_weight: 0.6,
+            contrastive_temp: 0.5,
         };
         let max_rel = etm_fd_check(opts);
-        assert!(max_rel < 1e-4, "etm contrastive+stick-breaking max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "etm contrastive+stick-breaking max relative error {max_rel}"
+        );
     }
 
     // Planted blocks: K word-blocks, each document drawn from one block. The VAE
@@ -948,17 +1084,34 @@ mod tests {
         let rho: Vec<Vec<f64>> = (0..v)
             .map(|w| {
                 let b = w / block;
-                (0..e).map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.2).collect()
+                (0..e)
+                    .map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.2)
+                    .collect()
             })
             .collect();
         let docs: Vec<Vec<u32>> = (0..150)
             .map(|d| {
                 let b = d % k;
-                (0..12).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..12)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
 
-        let m = fit_etm_vae(&docs, k, v, &rho, 32, 200, 64, 0.01, 0.0, 0.0, AvitmOptions::default(), &mut rng);
+        let m = fit_etm_vae(
+            &docs,
+            k,
+            v,
+            &rho,
+            32,
+            200,
+            64,
+            0.01,
+            0.0,
+            0.0,
+            AvitmOptions::default(),
+            &mut rng,
+        );
         assert_eq!(m.beta.len(), k);
         for row in &m.doc_topic {
             assert!((row.iter().sum::<f64>() - 1.0).abs() < 1e-9);
@@ -967,7 +1120,8 @@ mod tests {
         for t in 0..k {
             let mut ord: Vec<usize> = (0..v).collect();
             ord.sort_by(|&a, &b| m.beta[t][b].total_cmp(&m.beta[t][a]));
-            let blocks: std::collections::HashSet<usize> = ord[..4].iter().map(|&w| w / block).collect();
+            let blocks: std::collections::HashSet<usize> =
+                ord[..4].iter().map(|&w| w / block).collect();
             assert_eq!(blocks.len(), 1, "topic {t} top words mix blocks");
             covered.insert(*blocks.iter().next().unwrap());
         }
@@ -982,18 +1136,34 @@ mod tests {
         let rho: Vec<Vec<f64>> = (0..v)
             .map(|w| {
                 let b = w / block;
-                (0..e).map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.2).collect()
+                (0..e)
+                    .map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.2)
+                    .collect()
             })
             .collect();
         let docs: Vec<Vec<u32>> = (0..150)
             .map(|d| {
                 let b = d % k;
-                (0..12).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..12)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
-        let m = fit_etm_vae(&docs, k, v, &rho, 32, 200, 64, 0.01, 0.0, 0.0, AvitmOptions::default(), &mut rng);
+        let m = fit_etm_vae(
+            &docs,
+            k,
+            v,
+            &rho,
+            32,
+            200,
+            64,
+            0.01,
+            0.0,
+            0.0,
+            AvitmOptions::default(),
+            &mut rng,
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }
 }
-

--- a/src/fastopic.rs
+++ b/src/fastopic.rs
@@ -56,7 +56,10 @@ pub fn softmax(v: &[f64]) -> Vec<f64> {
 /// For `p_k = softmax(z)_k`, `dL/dz_l = p_l (g_p_l - sum_k g_p_k p_k)`.
 fn softmax_backward(p: &[f64], g_p: &[f64]) -> Vec<f64> {
     let dot: f64 = p.iter().zip(g_p).map(|(&pk, &gk)| pk * gk).sum();
-    p.iter().zip(g_p).map(|(&pl, &gl)| pl * (gl - dot)).collect()
+    p.iter()
+        .zip(g_p)
+        .map(|(&pl, &gl)| pl * (gl - dot))
+        .collect()
 }
 
 /// Squared-Euclidean cost between every row of `x` (n rows) and every row of `y`
@@ -158,7 +161,15 @@ pub fn sinkhorn_forward(
         }
     }
 
-    Sinkhorn { plan, n, m, alpha, log_k, log_u_traj, log_v_traj }
+    Sinkhorn {
+        plan,
+        n,
+        m,
+        alpha,
+        log_k,
+        log_u_traj,
+        log_v_traj,
+    }
 }
 
 impl Sinkhorn {
@@ -317,7 +328,12 @@ struct Adam {
 
 impl Adam {
     fn new(len: usize, lr: f64) -> Self {
-        Adam { m: vec![0.0; len], v: vec![0.0; len], t: 0, lr }
+        Adam {
+            m: vec![0.0; len],
+            v: vec![0.0; len],
+            t: 0,
+            lr,
+        }
     }
     fn step(&mut self, params: &mut [f64], grad: &[f64]) {
         const B1: f64 = 0.9;
@@ -326,7 +342,11 @@ impl Adam {
         self.t += 1;
         let bc1 = 1.0 - B1.powi(self.t as i32);
         let bc2 = 1.0 - B2.powi(self.t as i32);
-        for ((p, &g), (mi, vi)) in params.iter_mut().zip(grad).zip(self.m.iter_mut().zip(self.v.iter_mut())) {
+        for ((p, &g), (mi, vi)) in params
+            .iter_mut()
+            .zip(grad)
+            .zip(self.m.iter_mut().zip(self.v.iter_mut()))
+        {
             *mi = B1 * *mi + (1.0 - B1) * g;
             *vi = B2 * *vi + (1.0 - B2) * g * g;
             let m_hat = *mi / bc1;
@@ -376,8 +396,26 @@ fn loss_and_grad(
     let log_a2: Vec<f64> = vec![-(k as f64).ln(); k];
     let log_b2: Vec<f64> = b2.iter().map(|&p| p.max(1e-30).ln()).collect();
 
-    let dt = sinkhorn_forward(&c1, n, k, &log_a1, &log_b1, dt_alpha, sinkhorn_iters, sinkhorn_tol);
-    let tw = sinkhorn_forward(&c2, k, v, &log_a2, &log_b2, tw_alpha, sinkhorn_iters, sinkhorn_tol);
+    let dt = sinkhorn_forward(
+        &c1,
+        n,
+        k,
+        &log_a1,
+        &log_b1,
+        dt_alpha,
+        sinkhorn_iters,
+        sinkhorn_tol,
+    );
+    let tw = sinkhorn_forward(
+        &c2,
+        k,
+        v,
+        &log_a2,
+        &log_b2,
+        tw_alpha,
+        sinkhorn_iters,
+        sinkhorn_tol,
+    );
     let theta: Vec<f64> = dt.plan.iter().map(|&p| p * n as f64).collect(); // N×K
     let beta: Vec<f64> = tw.plan.iter().map(|&p| p * k as f64).collect(); // K×V
 
@@ -430,8 +468,16 @@ fn loss_and_grad(
     }
 
     // log_b = log(softmax(logit)); chain log -> softmax -> logit.
-    let g_b1: Vec<f64> = g_log_b1.iter().zip(&b1).map(|(&g, &p)| g / p.max(1e-30)).collect();
-    let g_b2: Vec<f64> = g_log_b2.iter().zip(&b2).map(|(&g, &p)| g / p.max(1e-30)).collect();
+    let g_b1: Vec<f64> = g_log_b1
+        .iter()
+        .zip(&b1)
+        .map(|(&g, &p)| g / p.max(1e-30))
+        .collect();
+    let g_b2: Vec<f64> = g_log_b2
+        .iter()
+        .zip(&b2)
+        .map(|(&g, &p)| g / p.max(1e-30))
+        .collect();
     let g_topic_logit = softmax_backward(&b1, &g_b1);
     let g_word_logit = softmax_backward(&b2, &g_b2);
 
@@ -494,7 +540,11 @@ pub fn fit_fastopic<R: Rng>(
 ) -> FastopicModel {
     let k = num_topics;
     let v = num_types;
-    let h = if !doc_emb.is_empty() { doc_emb[0].len() } else { 0 };
+    let h = if !doc_emb.is_empty() {
+        doc_emb[0].len()
+    } else {
+        0
+    };
     let bow: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| doc_bow(d)).collect();
 
     let mut topic_emb = init_embeddings(k, h, rng);
@@ -514,8 +564,16 @@ pub fn fit_fastopic<R: Rng>(
     for epoch in 0..epochs {
         epochs_run = epoch + 1;
         let (loss, g_te, g_we, g_tl, g_wl) = loss_and_grad(
-            &bow, doc_emb, &topic_emb, &word_emb, &topic_logit, &word_logit, dt_alpha, tw_alpha,
-            sinkhorn_iters, sinkhorn_tol,
+            &bow,
+            doc_emb,
+            &topic_emb,
+            &word_emb,
+            &topic_logit,
+            &word_logit,
+            dt_alpha,
+            tw_alpha,
+            sinkhorn_iters,
+            sinkhorn_tol,
         );
         loss_history.push(loss);
 
@@ -550,7 +608,16 @@ pub fn fit_fastopic<R: Rng>(
     let b2 = softmax(&word_logit);
     let log_a2: Vec<f64> = vec![-(k as f64).ln(); k];
     let log_b2: Vec<f64> = b2.iter().map(|&p| p.max(1e-30).ln()).collect();
-    let tw = sinkhorn_forward(&c2, k, v, &log_a2, &log_b2, tw_alpha, sinkhorn_iters, sinkhorn_tol);
+    let tw = sinkhorn_forward(
+        &c2,
+        k,
+        v,
+        &log_a2,
+        &log_b2,
+        tw_alpha,
+        sinkhorn_iters,
+        sinkhorn_tol,
+    );
     let topic_word: Vec<Vec<f64>> = (0..k)
         .map(|t| (0..v).map(|j| tw.plan[t * v + j] * k as f64).collect())
         .collect();
@@ -624,11 +691,22 @@ mod tests {
         let z = [0.3, -1.2, 0.8, 0.1];
         let g_p = [0.5, -0.2, 1.0, 0.3];
         // L = sum_k g_p[k] * softmax(z)[k]
-        let loss = |z: &[f64]| softmax(z).iter().zip(&g_p).map(|(&p, &g)| p * g).sum::<f64>();
+        let loss = |z: &[f64]| {
+            softmax(z)
+                .iter()
+                .zip(&g_p)
+                .map(|(&p, &g)| p * g)
+                .sum::<f64>()
+        };
         let analytic = softmax_backward(&softmax(&z), &g_p);
         for i in 0..z.len() {
             let num = fd(loss, &z, i, 1e-6);
-            assert!((analytic[i] - num).abs() < 1e-7, "i={i}: {} vs {}", analytic[i], num);
+            assert!(
+                (analytic[i] - num).abs() < 1e-7,
+                "i={i}: {} vs {}",
+                analytic[i],
+                num
+            );
         }
     }
 
@@ -641,7 +719,9 @@ mod tests {
         let log_a = vec![-(n as f64).ln(); n];
         let b = softmax(&[0.4, -0.3, 0.1, 0.7]);
         let log_b: Vec<f64> = b.iter().map(|&p| p.ln()).collect();
-        let g_plan = [0.5, -0.2, 0.3, 0.1, 0.4, 0.0, -0.6, 0.2, 0.1, 0.3, -0.1, 0.5];
+        let g_plan = [
+            0.5, -0.2, 0.3, 0.1, 0.4, 0.0, -0.6, 0.2, 0.1, 0.3, -0.1, 0.5,
+        ];
         let alpha = 2.5;
         let iters = 40;
 
@@ -656,7 +736,12 @@ mod tests {
                 readout(&s.plan)
             };
             let num = fd(f, &cost, i, 1e-6);
-            assert!((g_cost[i] - num).abs() < 1e-5, "g_cost[{i}]: {} vs {}", g_cost[i], num);
+            assert!(
+                (g_cost[i] - num).abs() < 1e-5,
+                "g_cost[{i}]: {} vs {}",
+                g_cost[i],
+                num
+            );
         }
         // Column log-marginal gradient.
         for k in 0..m {
@@ -665,7 +750,12 @@ mod tests {
                 readout(&s.plan)
             };
             let num = fd(f, &log_b, k, 1e-6);
-            assert!((g_log_b[k] - num).abs() < 1e-5, "g_log_b[{k}]: {} vs {}", g_log_b[k], num);
+            assert!(
+                (g_log_b[k] - num).abs() < 1e-5,
+                "g_log_b[{k}]: {} vs {}",
+                g_log_b[k],
+                num
+            );
         }
     }
 
@@ -673,22 +763,34 @@ mod tests {
     fn loss_grad_matches_fd() {
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let (n, k, v, h) = (5usize, 3usize, 6usize, 4usize);
-        let doc_emb: Vec<Vec<f64>> =
-            (0..n).map(|_| (0..h).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect()).collect();
+        let doc_emb: Vec<Vec<f64>> = (0..n)
+            .map(|_| (0..h).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect())
+            .collect();
         let topic_emb = init_embeddings(k, h, &mut rng);
         let word_emb = init_embeddings(v, h, &mut rng);
         let topic_logit: Vec<f64> = (0..k).map(|_| rng.gen::<f64>() * 0.4 - 0.2).collect();
         let word_logit: Vec<f64> = (0..v).map(|_| rng.gen::<f64>() * 0.4 - 0.2).collect();
-        let docs: Vec<Vec<u32>> =
-            (0..n).map(|i| (0..6).map(|j| ((i + j) % v) as u32).collect()).collect();
+        let docs: Vec<Vec<u32>> = (0..n)
+            .map(|i| (0..6).map(|j| ((i + j) % v) as u32).collect())
+            .collect();
         let bow: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| doc_bow(d)).collect();
         let (dt_a, tw_a, it) = (3.0, 2.0, 30usize);
 
         let loss_of = |te: &[Vec<f64>], we: &[Vec<f64>], tl: &[f64], wl: &[f64]| {
             loss_and_grad(&bow, &doc_emb, te, we, tl, wl, dt_a, tw_a, it, 0.0).0
         };
-        let (_, g_te, g_we, g_tl, g_wl) =
-            loss_and_grad(&bow, &doc_emb, &topic_emb, &word_emb, &topic_logit, &word_logit, dt_a, tw_a, it, 0.0);
+        let (_, g_te, g_we, g_tl, g_wl) = loss_and_grad(
+            &bow,
+            &doc_emb,
+            &topic_emb,
+            &word_emb,
+            &topic_logit,
+            &word_logit,
+            dt_a,
+            tw_a,
+            it,
+            0.0,
+        );
 
         // Topic embeddings.
         for t in 0..k {
@@ -699,7 +801,12 @@ mod tests {
                     loss_of(&te, &word_emb, &topic_logit, &word_logit)
                 };
                 let num = (f(topic_emb[t][hh] + 1e-6) - f(topic_emb[t][hh] - 1e-6)) / 2e-6;
-                assert!((g_te[t][hh] - num).abs() < 1e-4, "g_te[{t}][{hh}]: {} vs {}", g_te[t][hh], num);
+                assert!(
+                    (g_te[t][hh] - num).abs() < 1e-4,
+                    "g_te[{t}][{hh}]: {} vs {}",
+                    g_te[t][hh],
+                    num
+                );
             }
         }
         // Word embeddings.
@@ -711,7 +818,12 @@ mod tests {
                     loss_of(&topic_emb, &we, &topic_logit, &word_logit)
                 };
                 let num = (f(word_emb[j][hh] + 1e-6) - f(word_emb[j][hh] - 1e-6)) / 2e-6;
-                assert!((g_we[j][hh] - num).abs() < 1e-4, "g_we[{j}][{hh}]: {} vs {}", g_we[j][hh], num);
+                assert!(
+                    (g_we[j][hh] - num).abs() < 1e-4,
+                    "g_we[{j}][{hh}]: {} vs {}",
+                    g_we[j][hh],
+                    num
+                );
             }
         }
         // Topic and word logits.
@@ -722,7 +834,12 @@ mod tests {
                 loss_of(&topic_emb, &word_emb, &tl, &word_logit)
             };
             let num = (f(topic_logit[t] + 1e-6) - f(topic_logit[t] - 1e-6)) / 2e-6;
-            assert!((g_tl[t] - num).abs() < 1e-4, "g_tl[{t}]: {} vs {}", g_tl[t], num);
+            assert!(
+                (g_tl[t] - num).abs() < 1e-4,
+                "g_tl[{t}]: {} vs {}",
+                g_tl[t],
+                num
+            );
         }
         for j in 0..v {
             let f = |val: f64| {
@@ -731,7 +848,12 @@ mod tests {
                 loss_of(&topic_emb, &word_emb, &topic_logit, &wl)
             };
             let num = (f(word_logit[j] + 1e-6) - f(word_logit[j] - 1e-6)) / 2e-6;
-            assert!((g_wl[j] - num).abs() < 1e-4, "g_wl[{j}]: {} vs {}", g_wl[j], num);
+            assert!(
+                (g_wl[j] - num).abs() < 1e-4,
+                "g_wl[{j}]: {} vs {}",
+                g_wl[j],
+                num
+            );
         }
     }
 
@@ -746,7 +868,9 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..120)
             .map(|d| {
                 let b = d % k;
-                (0..10).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..10)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
         // Document embedding: one-hot on its block axis plus noise.
@@ -754,11 +878,15 @@ mod tests {
             .iter()
             .map(|doc| {
                 let b = doc[0] as usize / block;
-                (0..h).map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.3).collect()
+                (0..h)
+                    .map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.3)
+                    .collect()
             })
             .collect();
 
-        let m = fit_fastopic(&docs, &doc_emb, k, v, 300, 0.05, 3.0, 2.0, 1.0, 1e-6, 50, 1e-4, &mut rng);
+        let m = fit_fastopic(
+            &docs, &doc_emb, k, v, 300, 0.05, 3.0, 2.0, 1.0, 1e-6, 50, 1e-4, &mut rng,
+        );
         assert_eq!(m.topic_word.len(), k);
         // Loss decreases overall.
         assert!(m.loss_history.last().unwrap() < &m.loss_history[0]);
@@ -771,7 +899,8 @@ mod tests {
         for t in 0..k {
             let mut order: Vec<usize> = (0..v).collect();
             order.sort_by(|&a, &b| m.topic_word[t][b].total_cmp(&m.topic_word[t][a]));
-            let blocks: std::collections::HashSet<usize> = order[..3].iter().map(|&w| w / block).collect();
+            let blocks: std::collections::HashSet<usize> =
+                order[..3].iter().map(|&w| w / block).collect();
             assert_eq!(blocks.len(), 1, "topic {t} top words mix blocks");
             covered.insert(*blocks.iter().next().unwrap());
         }
@@ -786,17 +915,23 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..120)
             .map(|d| {
                 let b = d % k;
-                (0..10).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..10)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
         let doc_emb: Vec<Vec<f64>> = docs
             .iter()
             .map(|doc| {
                 let b = doc[0] as usize / block;
-                (0..h).map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.3).collect()
+                (0..h)
+                    .map(|dim| if dim == b { 3.0 } else { 0.0 } + (rng.gen::<f64>() - 0.5) * 0.3)
+                    .collect()
             })
             .collect();
-        let m = fit_fastopic(&docs, &doc_emb, k, v, 300, 0.05, 3.0, 2.0, 1.0, 1e-6, 50, 1e-4, &mut rng);
+        let m = fit_fastopic(
+            &docs, &doc_emb, k, v, 300, 0.05, 3.0, 2.0, 1.0, 1e-6, 50, 1e-4, &mut rng,
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/gsdmm.rs
+++ b/src/gsdmm.rs
@@ -168,8 +168,7 @@ impl GsdmmModel {
 
                 // Stable softmax.
                 let max_lp = log_probs.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
-                let mut probs: Vec<f64> =
-                    log_probs.iter().map(|&lp| (lp - max_lp).exp()).collect();
+                let mut probs: Vec<f64> = log_probs.iter().map(|&lp| (lp - max_lp).exp()).collect();
                 let total: f64 = probs.iter().sum();
                 for p in &mut probs {
                     *p /= total;
@@ -201,12 +200,7 @@ fn sample_index<R: Rng>(probs: &[f64], rng: &mut R) -> usize {
 /// Process step).  The document is removed from its current cluster before
 /// computing the sampling probabilities and is added to the new cluster
 /// afterwards.
-fn resample_doc<R: Rng>(
-    model: &mut GsdmmModel,
-    d: usize,
-    doc: &[u32],
-    rng: &mut R,
-) {
+fn resample_doc<R: Rng>(model: &mut GsdmmModel, d: usize, doc: &[u32], rng: &mut R) {
     let k = model.k_max;
     let v = model.num_types;
     let vbeta = v as f64 * model.beta;
@@ -359,11 +353,14 @@ impl Estimator for GsdmmModel {
     }
 
     fn doc_topic(&self) -> Vec<Vec<f64>> {
-        self.z.iter().map(|&k| {
-            let mut v = vec![0.0f64; self.k_max];
-            v[k] = 1.0;
-            v
-        }).collect()
+        self.z
+            .iter()
+            .map(|&k| {
+                let mut v = vec![0.0f64; self.k_max];
+                v[k] = 1.0;
+                v
+            })
+            .collect()
     }
 
     fn fit_history(&self) -> Vec<(usize, f64)> {
@@ -435,12 +432,8 @@ mod tests {
             // Sum φ over each block and pick the best.
             (0..num_blocks)
                 .max_by(|&ba, &bb| {
-                    let sa: f64 = (0..block_size)
-                        .map(|i| phi[ba * block_size + i])
-                        .sum();
-                    let sb: f64 = (0..block_size)
-                        .map(|i| phi[bb * block_size + i])
-                        .sum();
+                    let sa: f64 = (0..block_size).map(|i| phi[ba * block_size + i]).sum();
+                    let sb: f64 = (0..block_size).map(|i| phi[bb * block_size + i]).sum();
                     sa.partial_cmp(&sb).unwrap()
                 })
                 .unwrap()
@@ -506,7 +499,11 @@ mod tests {
         // cluster_word(k) sums to 1 for every non-empty cluster.
         for &k in model.used_clusters().iter() {
             let phi = model.cluster_word(k);
-            assert_eq!(phi.len(), v, "cluster_word({k}) length should equal num_types");
+            assert_eq!(
+                phi.len(),
+                v,
+                "cluster_word({k}) length should equal num_types"
+            );
             let s: f64 = phi.iter().sum();
             assert!(
                 (s - 1.0).abs() < 1e-10,
@@ -518,7 +515,11 @@ mod tests {
         let dists = model.doc_cluster_dist(&docs);
         assert_eq!(dists.len(), docs.len());
         for (d, row) in dists.iter().enumerate() {
-            assert_eq!(row.len(), model.k_max, "doc_cluster_dist row {d} wrong length");
+            assert_eq!(
+                row.len(),
+                model.k_max,
+                "doc_cluster_dist row {d} wrong length"
+            );
             let s: f64 = row.iter().sum();
             assert!(
                 (s - 1.0).abs() < 1e-10,

--- a/src/hdp.rs
+++ b/src/hdp.rs
@@ -27,9 +27,9 @@ use rand::Rng;
 /// A fitted HDP topic model. `num_topics()` is the inferred K.
 pub struct HdpModel {
     pub num_types: usize,
-    pub eta: f64,   // topic-word Dirichlet (symmetric base measure)
-    pub alpha: f64, // α0, document-level DP concentration
-    pub gamma: f64, // γ, top-level DP concentration
+    pub eta: f64,           // topic-word Dirichlet (symmetric base measure)
+    pub alpha: f64,         // α0, document-level DP concentration
+    pub gamma: f64,         // γ, top-level DP concentration
     pub nkw: Vec<Vec<u32>>, // K × V topic-word counts
     pub nk: Vec<u32>,       // K topic totals
     pub beta: Vec<f64>,     // K top-level topic weights
@@ -214,7 +214,10 @@ impl HdpModel {
         for (new, &old) in keep.iter().enumerate() {
             remap[old] = new;
         }
-        self.nkw = keep.iter().map(|&t| std::mem::take(&mut self.nkw[t])).collect();
+        self.nkw = keep
+            .iter()
+            .map(|&t| std::mem::take(&mut self.nkw[t]))
+            .collect();
         self.nk = keep.iter().map(|&t| self.nk[t]).collect();
         self.beta = keep.iter().map(|&t| self.beta[t]).collect();
         for doc in &mut self.njk {
@@ -269,9 +272,12 @@ impl HdpModel {
         let (a, b) = (1.0, 1.0); // weak Gamma(shape, rate) prior
         let eta = sample_beta_dist(self.gamma + 1.0, m, rng).max(1e-12);
         let pi = (a + k - 1.0) / (a + k - 1.0 + m * (b - eta.ln()));
-        let shape = if rng.gen::<f64>() < pi { a + k } else { a + k - 1.0 };
-        self.gamma = (sample_gamma(shape, rng) / (b - eta.ln()))
-            .clamp(1e-3, CONCENTRATION_MAX);
+        let shape = if rng.gen::<f64>() < pi {
+            a + k
+        } else {
+            a + k - 1.0
+        };
+        self.gamma = (sample_gamma(shape, rng) / (b - eta.ln())).clamp(1e-3, CONCENTRATION_MAX);
     }
 
     /// Resample the document-level concentration α0 given per-document word
@@ -310,7 +316,14 @@ impl HdpModel {
     /// Draw a topic for token (j, i)=w from the current state (counts for this
     /// token must already be removed), instantiating a fresh topic if drawn, and
     /// add the token back under the chosen topic.
-    fn assign_token<R: Rng>(&mut self, j: usize, i: usize, w: usize, probs: &mut Vec<f64>, rng: &mut R) {
+    fn assign_token<R: Rng>(
+        &mut self,
+        j: usize,
+        i: usize,
+        w: usize,
+        probs: &mut Vec<f64>,
+        rng: &mut R,
+    ) {
         let v = self.num_types;
         let base = 1.0 / v as f64; // base-measure likelihood for a fresh topic
         let k = self.nk.len();
@@ -319,8 +332,7 @@ impl HdpModel {
         probs.clear();
         probs.resize(k + 1, 0.0);
         for t in 0..k {
-            let f =
-                (self.nkw[t][w] as f64 + self.eta) / (self.nk[t] as f64 + v as f64 * self.eta);
+            let f = (self.nkw[t][w] as f64 + self.eta) / (self.nk[t] as f64 + v as f64 * self.eta);
             probs[t] = (self.njk[j][t] as f64 + self.alpha * self.beta[t]) * f;
         }
         probs[k] = self.alpha * self.beta_u * base;
@@ -425,7 +437,7 @@ pub fn fit_hdp<R: Rng>(
     model
 }
 
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 
 impl Estimator for HdpModel {
     fn num_topics(&self) -> usize {
@@ -442,7 +454,10 @@ impl Estimator for HdpModel {
     }
 
     fn fit_history(&self) -> Vec<(usize, f64)> {
-        self.trace.iter().map(|&(it, _, ll, _, _)| (it, ll)).collect()
+        self.trace
+            .iter()
+            .map(|&(it, _, ll, _, _)| (it, ll))
+            .collect()
     }
 
     fn converged(&self) -> Option<bool> {
@@ -464,7 +479,10 @@ impl DirichletModel for HdpModel {
     }
 
     fn doc_lengths(&self) -> Vec<usize> {
-        self.njk.iter().map(|c| c.iter().map(|&x| x as usize).sum()).collect()
+        self.njk
+            .iter()
+            .map(|c| c.iter().map(|&x| x as usize).sum())
+            .collect()
     }
 }
 
@@ -492,7 +510,11 @@ mod tests {
         let k = model.num_topics();
         // Auto-K is approximate and HDP tends to slightly over-segment; the firm
         // requirement is that it recovers a sane count, not the exact 5.
-        assert!((4..=12).contains(&k), "inferred K={} not in a sane band for 5", k);
+        assert!(
+            (4..=12).contains(&k),
+            "inferred K={} not in a sane band for 5",
+            k
+        );
 
         // The substantive check: every planted block is the top of some topic.
         let tw = model.topic_word();
@@ -507,7 +529,12 @@ mod tests {
                 }
             }
         }
-        assert_eq!(covered.len(), 5, "recovered only {} of 5 planted blocks", covered.len());
+        assert_eq!(
+            covered.len(),
+            5,
+            "recovered only {} of 5 planted blocks",
+            covered.len()
+        );
     }
 
     #[test]
@@ -536,10 +563,14 @@ mod tests {
 
         let trace = &model.trace;
         // iters=120, interval=10 -> sweeps 10,20,...,120.
-        assert_eq!(trace.iter().map(|t| t.0).collect::<Vec<_>>(),
-                   (1..=12).map(|i| i * 10).collect::<Vec<_>>());
+        assert_eq!(
+            trace.iter().map(|t| t.0).collect::<Vec<_>>(),
+            (1..=12).map(|i| i * 10).collect::<Vec<_>>()
+        );
         // Topic count and log-likelihood are sane; the final K is recorded.
-        assert!(trace.iter().all(|t| t.1 >= 1 && t.2.is_finite() && t.2 < 0.0));
+        assert!(trace
+            .iter()
+            .all(|t| t.1 >= 1 && t.2.is_finite() && t.2 < 0.0));
         assert_eq!(trace.last().unwrap().1, model.num_topics());
         // The fit improves from the first recorded sweep to the last.
         assert!(trace.last().unwrap().2 > trace.first().unwrap().2);
@@ -571,8 +602,16 @@ mod tests {
             let (m_total, t_j) = model.resample_beta(&mut rng);
             model.resample_gamma(m_total, &mut rng);
             model.resample_alpha(&t_j, &mut rng);
-            assert!(model.gamma <= CONCENTRATION_MAX + 1e-9, "gamma {} > cap", model.gamma);
-            assert!(model.alpha <= CONCENTRATION_MAX + 1e-9, "alpha {} > cap", model.alpha);
+            assert!(
+                model.gamma <= CONCENTRATION_MAX + 1e-9,
+                "gamma {} > cap",
+                model.gamma
+            );
+            assert!(
+                model.alpha <= CONCENTRATION_MAX + 1e-9,
+                "alpha {} > cap",
+                model.alpha
+            );
         }
     }
 

--- a/src/hlda.rs
+++ b/src/hlda.rs
@@ -625,7 +625,9 @@ impl Estimator for HldaModel {
 
     fn topic_word(&self) -> Vec<Vec<f64>> {
         // Disambiguate: inherent topic_word(i) takes an index; the trait method takes none.
-        (0..self.num_nodes()).map(|i| HldaModel::topic_word(self, i)).collect()
+        (0..self.num_nodes())
+            .map(|i| HldaModel::topic_word(self, i))
+            .collect()
     }
 
     fn doc_topic(&self) -> Vec<Vec<f64>> {
@@ -711,10 +713,7 @@ mod tests {
         let root_top = top_words(&model.topic_word(root), shared.len());
         let shared_set: std::collections::HashSet<usize> =
             shared.iter().map(|&w| w as usize).collect();
-        let shared_in_root = root_top
-            .iter()
-            .filter(|w| shared_set.contains(w))
-            .count();
+        let shared_in_root = root_top.iter().filter(|w| shared_set.contains(w)).count();
         assert!(
             shared_in_root >= shared.len() - 1,
             "root top words not dominated by shared words: {:?}",

--- a/src/infoctm.rs
+++ b/src/infoctm.rs
@@ -135,7 +135,11 @@ fn mutual_info(
     let k = if va > 0 { fa.fea[0].len() } else { 0 };
     let mut loss = 0.0;
     // ds[i][j] accumulators (only needed for the backward).
-    let mut ds = if grads.is_some() { vec![vec![0.0f64; vb]; va] } else { Vec::new() };
+    let mut ds = if grads.is_some() {
+        vec![vec![0.0f64; vb]; va]
+    } else {
+        Vec::new()
+    };
 
     for i in 0..va {
         // s[i][.] and a per-row max for numerical stability.
@@ -234,10 +238,22 @@ fn tami(
     };
 
     let want = g_beta.is_some();
-    let loss_ab = mutual_info(&fa, &fb, &mab.pos, &mab.neg, temp,
-        if want { Some((&mut da, &mut db)) } else { None });
-    let loss_ba = mutual_info(&fb, &fa, &mba.pos, &mba.neg, temp,
-        if want { Some((&mut db, &mut da)) } else { None });
+    let loss_ab = mutual_info(
+        &fa,
+        &fb,
+        &mab.pos,
+        &mab.neg,
+        temp,
+        if want { Some((&mut da, &mut db)) } else { None },
+    );
+    let loss_ba = mutual_info(
+        &fb,
+        &fa,
+        &mba.pos,
+        &mba.neg,
+        temp,
+        if want { Some((&mut db, &mut da)) } else { None },
+    );
 
     if let Some((ga, gb)) = g_beta.as_mut() {
         for kk in 0..k {
@@ -271,10 +287,20 @@ struct LangState {
 }
 
 impl LangState {
-    fn new<R: Rng>(docs: &[Vec<u32>], v: usize, hidden: usize, k: usize, lr: f64, rng: &mut R) -> Self {
+    fn new<R: Rng>(
+        docs: &[Vec<u32>],
+        v: usize,
+        hidden: usize,
+        k: usize,
+        lr: f64,
+        rng: &mut R,
+    ) -> Self {
         let xn: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| normalized_bow(d)).collect();
         let bows: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| raw_bow(d)).collect();
-        let totals: Vec<f64> = bows.iter().map(|b| b.iter().map(|&(_, c)| c).sum()).collect();
+        let totals: Vec<f64> = bows
+            .iter()
+            .map(|b| b.iter().map(|&(_, c)| c).sum())
+            .collect();
         let w = Weights::new(v, 0, hidden, k, InputMode::BowOnly, rng);
         // Adam beta1 = 0.9 to match the InfoCTM reference's optimizer (default
         // torch Adam betas), NOT ProdLDA's high-momentum 0.99 anti-collapse value:
@@ -371,12 +397,24 @@ pub fn fit_infoctm<R: Rng>(
                 continue;
             }
             // Per-language ELBO forward/backward (reuses the ProdLDA core).
-            let (la, mut ga) = elbo_step(&mut a, ca, k, keep, &prior_mu, &prior_var, &alpha_vec, &opts, rng);
-            let (lb, mut gb) = elbo_step(&mut b, cb, k, keep, &prior_mu, &prior_var, &alpha_vec, &opts, rng);
+            let (la, mut ga) = elbo_step(
+                &mut a, ca, k, keep, &prior_mu, &prior_var, &alpha_vec, &opts, rng,
+            );
+            let (lb, mut gb) = elbo_step(
+                &mut b, cb, k, keep, &prior_mu, &prior_var, &alpha_vec, &opts, rng,
+            );
 
             // TAMI coupling on the two raw topic-word matrices, added to beta grads.
             let l_tami = tami(
-                &a.w.beta, &b.w.beta, k, va, vb, &mab, &mba, temperature, mi_weight,
+                &a.w.beta,
+                &b.w.beta,
+                k,
+                va,
+                vb,
+                &mab,
+                &mba,
+                temperature,
+                mi_weight,
                 Some((&mut ga.beta, &mut gb.beta)),
             );
 
@@ -397,9 +435,32 @@ pub fn fit_infoctm<R: Rng>(
         }
     }
 
-    let model_a = finish(a, k, bound_history.last().copied().unwrap_or(f64::NAN), &bound_history, converged, epochs_run, docs_a);
-    let model_b = finish(b, k, bound_history.last().copied().unwrap_or(f64::NAN), &bound_history, converged, epochs_run, docs_b);
-    InfoctmModel { num_topics: k, model_a, model_b, bound_history, converged, epochs_run }
+    let model_a = finish(
+        a,
+        k,
+        bound_history.last().copied().unwrap_or(f64::NAN),
+        &bound_history,
+        converged,
+        epochs_run,
+        docs_a,
+    );
+    let model_b = finish(
+        b,
+        k,
+        bound_history.last().copied().unwrap_or(f64::NAN),
+        &bound_history,
+        converged,
+        epochs_run,
+        docs_b,
+    );
+    InfoctmModel {
+        num_topics: k,
+        model_a,
+        model_b,
+        bound_history,
+        converged,
+        epochs_run,
+    }
 }
 
 /// One ELBO minibatch step for a language: forward+backward through the ProdLDA
@@ -419,12 +480,34 @@ fn elbo_step<R: Rng>(
 ) -> (f64, Grad) {
     let n = chunk.len();
     let hidden = s.w.hidden;
-    let eps: Vec<Vec<f64>> = (0..n).map(|_| (0..k).map(|_| randn(rng)).collect()).collect();
+    let eps: Vec<Vec<f64>> = (0..n)
+        .map(|_| (0..k).map(|_| randn(rng)).collect())
+        .collect();
     let masks2: Vec<Vec<f64>> = (0..n)
-        .map(|_| (0..hidden).map(|_| if rng.gen::<f64>() < keep { 1.0 / keep } else { 0.0 }).collect())
+        .map(|_| {
+            (0..hidden)
+                .map(|_| {
+                    if rng.gen::<f64>() < keep {
+                        1.0 / keep
+                    } else {
+                        0.0
+                    }
+                })
+                .collect()
+        })
         .collect();
     let masks_t: Vec<Vec<f64>> = (0..n)
-        .map(|_| (0..k).map(|_| if rng.gen::<f64>() < keep { 1.0 / keep } else { 0.0 }).collect())
+        .map(|_| {
+            (0..k)
+                .map(|_| {
+                    if rng.gen::<f64>() < keep {
+                        1.0 / keep
+                    } else {
+                        0.0
+                    }
+                })
+                .collect()
+        })
         .collect();
     let empty: Vec<f64> = Vec::new();
     let batch = Batch {
@@ -436,13 +519,16 @@ fn elbo_step<R: Rng>(
         masks2: &masks2,
         masks_t: &masks_t,
     };
-    let (loss, cache, stats) =
-        batch_forward(&s.w, &s.bn_mu, &s.bn_lv, &s.bn_dec, prior_mu, prior_var, alpha_vec, opts, &batch);
+    let (loss, cache, stats) = batch_forward(
+        &s.w, &s.bn_mu, &s.bn_lv, &s.bn_dec, prior_mu, prior_var, alpha_vec, opts, &batch,
+    );
     s.bn_mu.update_running(&stats[0].0, &stats[0].1);
     s.bn_lv.update_running(&stats[1].0, &stats[1].1);
     s.bn_dec.update_running(&stats[2].0, &stats[2].1);
     let mut g = Grad::zeros(&s.w);
-    batch_backward(&s.w, prior_mu, prior_var, alpha_vec, opts, &batch, &cache, &mut g);
+    batch_backward(
+        &s.w, prior_mu, prior_var, alpha_vec, opts, &batch, &cache, &mut g,
+    );
     g.scale(1.0 / n as f64);
     (loss / n as f64, g)
 }
@@ -517,7 +603,18 @@ mod tests {
         let (temp, weight) = (0.2, 5.0);
         let mut ga = vec![0.0; beta_a.len()];
         let mut gb = vec![0.0; beta_b.len()];
-        tami(&beta_a, &beta_b, k, va, vb, &mab, &mba, temp, weight, Some((&mut ga, &mut gb)));
+        tami(
+            &beta_a,
+            &beta_b,
+            k,
+            va,
+            vb,
+            &mab,
+            &mba,
+            temp,
+            weight,
+            Some((&mut ga, &mut gb)),
+        );
 
         let fd = 1e-6;
         let mut max_rel: f64 = 0.0;
@@ -525,7 +622,11 @@ mod tests {
         for (beta, g, vv) in [(beta_a.clone(), &ga, va), (beta_b.clone(), &gb, vb)] {
             for idx in 0..beta.len() {
                 let mut bp = beta.clone();
-                let (other, kk, ii) = if vv == va { (&beta_b, idx / va, idx % va) } else { (&beta_a, idx / vb, idx % vb) };
+                let (other, kk, ii) = if vv == va {
+                    (&beta_b, idx / va, idx % va)
+                } else {
+                    (&beta_a, idx / vb, idx % vb)
+                };
                 let _ = (kk, ii);
                 bp[idx] += fd;
                 let lp = if vv == va {
@@ -556,7 +657,9 @@ mod tests {
         (0..n)
             .map(|d| {
                 let b = d % k;
-                (0..15).map(|_| (b * per + (rng.gen::<f64>() * per as f64) as usize) as u32).collect()
+                (0..15)
+                    .map(|_| (b * per + (rng.gen::<f64>() * per as f64) as usize) as u32)
+                    .collect()
             })
             .collect()
     }
@@ -581,8 +684,8 @@ mod tests {
         let trans = block_dict(va, vb, k);
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         fit_infoctm(
-            &docs_a, &docs_b, va, vb, &trans, None, None, k, 32, 0.0, 60, 40, 0.01, 30.0, 0.2,
-            0.4, 0.0, &mut rng,
+            &docs_a, &docs_b, va, vb, &trans, None, None, k, 32, 0.0, 60, 40, 0.01, 30.0, 0.2, 0.4,
+            0.0, &mut rng,
         )
     }
 

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -52,8 +52,8 @@
 //!            × (γ₁ + nk1[k]) / (γ₁+γ₂ + nk0[k]+nk1[k])
 //! ```
 
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 use rand::Rng;
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
 
 // ---------------------------------------------------------------------------
 // Token weighting (keyATM's "weighted LDA")
@@ -495,27 +495,50 @@ impl KeyAtmModel {
 }
 
 impl Estimator for KeyAtmModel {
-    fn num_topics(&self) -> usize { self.num_topics }
-    fn topic_word(&self) -> Vec<Vec<f64>> { self.topic_word_all() }
-    fn doc_topic(&self) -> Vec<Vec<f64>> { self.doc_topic() }
-    fn fit_history(&self) -> Vec<(usize, f64)> {
-        self.log_likelihood_history.iter().map(|&(i, ll, _)| (i, ll)).collect()
+    fn num_topics(&self) -> usize {
+        self.num_topics
     }
-    fn converged(&self) -> Option<bool> { Some(self.converged) }
-    fn model_family(&self) -> ModelFamily { ModelFamily::Dirichlet }
+    fn topic_word(&self) -> Vec<Vec<f64>> {
+        self.topic_word_all()
+    }
+    fn doc_topic(&self) -> Vec<Vec<f64>> {
+        self.doc_topic()
+    }
+    fn fit_history(&self) -> Vec<(usize, f64)> {
+        self.log_likelihood_history
+            .iter()
+            .map(|&(i, ll, _)| (i, ll))
+            .collect()
+    }
+    fn converged(&self) -> Option<bool> {
+        Some(self.converged)
+    }
+    fn model_family(&self) -> ModelFamily {
+        ModelFamily::Dirichlet
+    }
 }
 
 impl DirichletModel for KeyAtmModel {
     fn alpha(&self) -> Vec<f64> {
-        self.alpha_vec.clone().unwrap_or_else(|| vec![self.alpha; self.num_topics])
+        self.alpha_vec
+            .clone()
+            .unwrap_or_else(|| vec![self.alpha; self.num_topics])
     }
     fn theta_draws(&self) -> Vec<Vec<Vec<f64>>> {
-        self.theta_draws.iter().map(|d| {
-            d.iter().map(|r| r.iter().map(|&x| x as f64).collect()).collect()
-        }).collect()
+        self.theta_draws
+            .iter()
+            .map(|d| {
+                d.iter()
+                    .map(|r| r.iter().map(|&x| x as f64).collect())
+                    .collect()
+            })
+            .collect()
     }
     fn doc_lengths(&self) -> Vec<usize> {
-        self.ndk.iter().map(|r| r.iter().sum::<f64>() as usize).collect()
+        self.ndk
+            .iter()
+            .map(|r| r.iter().sum::<f64>() as usize)
+            .collect()
     }
 }
 
@@ -645,7 +668,10 @@ impl KeywordIndex {
     /// cheaper than the hash map it replaces.
     #[inline]
     fn keyword_index(&self, k: usize, w: usize) -> Option<usize> {
-        self.by_word[w].iter().find(|&&(t, _)| t == k).map(|&(_, j)| j)
+        self.by_word[w]
+            .iter()
+            .find(|&&(t, _)| t == k)
+            .map(|&(_, j)| j)
     }
 }
 
@@ -709,7 +735,9 @@ fn resample_token_inner<R: Rng>(
         nkw_t_row[old_z] -= wt;
         nk0[old_z] -= wt;
     } else {
-        let j = ki.keyword_index(old_z, w).expect("old s=1 but w not a keyword");
+        let j = ki
+            .keyword_index(old_z, w)
+            .expect("old s=1 but w not a keyword");
         nkx[old_z][j] -= wt;
         nk1[old_z] -= wt;
     }
@@ -760,7 +788,9 @@ fn resample_token_inner<R: Rng>(
         nkw_t_row[new_k] += wt;
         nk0[new_k] += wt;
     } else {
-        let j = ki.keyword_index(new_k, w).expect("new s=1 but w not a keyword");
+        let j = ki
+            .keyword_index(new_k, w)
+            .expect("new s=1 but w not a keyword");
         nkx[new_k][j] += wt;
         nk1[new_k] += wt;
     }
@@ -817,9 +847,22 @@ fn sweep<R: Rng>(
             let wt = model.vocab_weights[w];
             let (old_z, old_s) = assignments[d][pos];
             let (new_z, new_s) = resample_token_inner(
-                &mut model.nkw, &mut nkw_t[w], &mut model.nk0, &mut model.nkx, &mut model.nk1,
-                &mut model.ndk[d], &model.l, ki, p, alpha_row, w, wt, old_z, old_s,
-                &mut scratch, rng,
+                &mut model.nkw,
+                &mut nkw_t[w],
+                &mut model.nk0,
+                &mut model.nkx,
+                &mut model.nk1,
+                &mut model.ndk[d],
+                &model.l,
+                ki,
+                p,
+                alpha_row,
+                w,
+                wt,
+                old_z,
+                old_s,
+                &mut scratch,
+                rng,
             );
             assignments[d][pos] = (new_z, new_s);
         }
@@ -857,8 +900,8 @@ fn parallel_sweep_keyatm(
     num_threads: usize,
     sweep_seed: u64,
 ) {
-    use rand_pcg::Pcg64Mcg;
     use rand::SeedableRng;
+    use rand_pcg::Pcg64Mcg;
     use rayon::prelude::*;
 
     let p = sample_params(model);
@@ -910,8 +953,22 @@ fn parallel_sweep_keyatm(
                     let wt = vocab_weights[w];
                     let (old_z, old_s) = asgn[li][pos];
                     let (new_z, new_s) = resample_token_inner(
-                        &mut nkw, &mut local_t[w], &mut nk0, &mut nkx, &mut nk1, &mut ndk[li],
-                        l, ki, p, alpha_row, w, wt, old_z, old_s, &mut scratch, &mut rng,
+                        &mut nkw,
+                        &mut local_t[w],
+                        &mut nk0,
+                        &mut nkx,
+                        &mut nk1,
+                        &mut ndk[li],
+                        l,
+                        ki,
+                        p,
+                        alpha_row,
+                        w,
+                        wt,
+                        old_z,
+                        old_s,
+                        &mut scratch,
+                        &mut rng,
                     );
                     asgn[li][pos] = (new_z, new_s);
                 }
@@ -920,7 +977,16 @@ fn parallel_sweep_keyatm(
             let mut touched: Vec<u32> = docs[start..end].iter().flatten().copied().collect();
             touched.sort_unstable();
             touched.dedup();
-            WorkerOut { nkw, nk0, nkx, nk1, start, ndk, asgn, touched }
+            WorkerOut {
+                nkw,
+                nk0,
+                nkx,
+                nk1,
+                start,
+                ndk,
+                asgn,
+                touched,
+            }
         })
         .collect();
 
@@ -1004,7 +1070,16 @@ fn run_sweep<R: Rng>(
         sweep(model, docs, assignments, nkw_t, ki, doc_alpha, rng);
     } else {
         let seed: u64 = rng.gen();
-        parallel_sweep_keyatm(model, docs, assignments, nkw_t, ki, doc_alpha, num_threads, seed);
+        parallel_sweep_keyatm(
+            model,
+            docs,
+            assignments,
+            nkw_t,
+            ki,
+            doc_alpha,
+            num_threads,
+            seed,
+        );
     }
 }
 
@@ -1083,11 +1158,32 @@ pub fn fit_keyatm<R: Rng>(
     let mut nkw_t = build_nkw_t(&model.nkw, num_types, num_topics);
 
     for it in 0..iters {
-        run_sweep(&mut model, docs, &mut assignments, &mut nkw_t, &ki, &doc_alpha, num_threads, rng);
+        run_sweep(
+            &mut model,
+            docs,
+            &mut assignments,
+            &mut nkw_t,
+            &ki,
+            &doc_alpha,
+            num_threads,
+            rng,
+        );
         if estimate_alpha {
             dyn_sample_alpha_state(
-                &mut alpha_vec, num_keyword_topics, 0, docs.len() - 1, &model.ndk, &doc_len,
-                1.0, 1.0, 2.0, 1.0, min_v, max_v, alpha_stride, rng,
+                &mut alpha_vec,
+                num_keyword_topics,
+                0,
+                docs.len() - 1,
+                &model.ndk,
+                &doc_len,
+                1.0,
+                1.0,
+                2.0,
+                1.0,
+                min_v,
+                max_v,
+                alpha_stride,
+                rng,
             );
             for row in doc_alpha.iter_mut() {
                 row.clone_from(&alpha_vec);
@@ -1173,7 +1269,8 @@ fn init_state<R: Rng>(
                     let (z, s): (usize, u8) = if cands.is_empty() {
                         ((rng.gen::<f64>() * k as f64) as usize % k, 0)
                     } else {
-                        let z = cands[(rng.gen::<f64>() * cands.len() as f64) as usize % cands.len()];
+                        let z =
+                            cands[(rng.gen::<f64>() * cands.len() as f64) as usize % cands.len()];
                         (z, 1)
                     };
                     ndk[d][z] += wt;
@@ -1251,7 +1348,11 @@ pub fn fit_keyatm_cvb0<R: Rng>(
     weights: WeightScheme,
     rng: &mut R,
 ) -> KeyAtmModel {
-    assert_eq!(keywords.len(), num_topics, "keywords length must equal num_topics");
+    assert_eq!(
+        keywords.len(),
+        num_topics,
+        "keywords length must equal num_topics"
+    );
     let (mut model, _assign, ki) = init_state(
         docs, num_types, num_topics, keywords, alpha, beta, beta_key, gamma1, gamma2, weights, rng,
     );
@@ -1278,8 +1379,14 @@ pub fn fit_keyatm_cvb0<R: Rng>(
     for row in model.ndk.iter_mut() {
         row.iter_mut().for_each(|x| *x = 0.0);
     }
-    model.nkw.iter_mut().for_each(|r| r.iter_mut().for_each(|x| *x = 0.0));
-    model.nkx.iter_mut().for_each(|r| r.iter_mut().for_each(|x| *x = 0.0));
+    model
+        .nkw
+        .iter_mut()
+        .for_each(|r| r.iter_mut().for_each(|x| *x = 0.0));
+    model
+        .nkx
+        .iter_mut()
+        .for_each(|r| r.iter_mut().for_each(|x| *x = 0.0));
     model.nk0.iter_mut().for_each(|x| *x = 0.0);
     model.nk1.iter_mut().for_each(|x| *x = 0.0);
 
@@ -1360,8 +1467,8 @@ pub fn fit_keyatm_cvb0<R: Rng>(
                     let ndk_val = model.ndk[d][t] + alpha;
                     let lk = model.l[t] as f64;
                     let key = (model.nkx[t][j] + beta_key) / (lk * beta_key + model.nk1[t]);
-                    let sw1 = (gamma1 + model.nk1[t])
-                        / (gamma1 + gamma2 + model.nk0[t] + model.nk1[t]);
+                    let sw1 =
+                        (gamma1 + model.nk1[t]) / (gamma1 + gamma2 + model.nk0[t] + model.nk1[t]);
                     let val = ndk_val * key * sw1;
                     let val = if val > 0.0 { val } else { 0.0 };
                     g1[d][ci][idx] = val;
@@ -1429,7 +1536,11 @@ impl ThetaDrawOpts {
     /// snapshots over the run so the ring-buffered `cap` land in the back half.
     pub fn new(keep: bool, num_draws: usize, iters: usize) -> Self {
         let cap = if keep { num_draws } else { 0 };
-        let thin = if cap == 0 { 0 } else { (iters / (2 * cap)).max(1) };
+        let thin = if cap == 0 {
+            0
+        } else {
+            (iters / (2 * cap)).max(1)
+        };
         ThetaDrawOpts { cap, thin }
     }
 
@@ -1495,10 +1606,22 @@ pub fn fit_keyatm_cov<R: Rng>(
     convergence_tol: f64,
     rng: &mut R,
 ) -> KeyAtmModel {
-    assert_eq!(keywords.len(), num_topics, "keywords length must equal num_topics");
-    assert_eq!(features.len(), docs.len(), "features rows must equal number of documents");
+    assert_eq!(
+        keywords.len(),
+        num_topics,
+        "keywords length must equal num_topics"
+    );
+    assert_eq!(
+        features.len(),
+        docs.len(),
+        "features rows must equal number of documents"
+    );
     if let Some(off) = offset {
-        assert_eq!(off.len(), docs.len(), "offset rows must equal number of documents");
+        assert_eq!(
+            off.len(),
+            docs.len(),
+            "offset rows must equal number of documents"
+        );
         assert!(
             off.iter().all(|r| r.len() == num_topics),
             "offset columns must equal num_topics"
@@ -1522,7 +1645,16 @@ pub fn fit_keyatm_cov<R: Rng>(
     let mut nkw_t = build_nkw_t(&model.nkw, num_types, num_topics);
 
     for it in 0..iters {
-        run_sweep(&mut model, docs, &mut assignments, &mut nkw_t, &ki, &doc_alpha, num_threads, rng);
+        run_sweep(
+            &mut model,
+            docs,
+            &mut assignments,
+            &mut nkw_t,
+            &ki,
+            &doc_alpha,
+            num_threads,
+            rng,
+        );
         if opt_interval > 0 && it + 1 > burn_in && (it + 1 - burn_in) % opt_interval == 0 {
             crate::dmr::optimize_lambda(
                 &mut lambda,
@@ -1603,7 +1735,16 @@ fn dyn_alpha_loglik_sub(
     stride: usize,
 ) -> f64 {
     if stride <= 1 {
-        return dyn_alpha_loglik(alpha, k, doc_start, doc_end, ndk, doc_len, prior_shape, prior_scale);
+        return dyn_alpha_loglik(
+            alpha,
+            k,
+            doc_start,
+            doc_end,
+            ndk,
+            doc_len,
+            prior_shape,
+            prior_scale,
+        );
     }
     let alpha_sum: f64 = alpha.iter().sum();
     let fixed = lgamma(alpha_sum) - lgamma(alpha[k]);
@@ -1681,19 +1822,22 @@ fn dyn_sample_alpha_state<R: Rng>(
         };
 
         let keep = alpha[k];
-        let store_loglik =
-            dyn_alpha_loglik_sub(alpha, k, doc_start, doc_end, ndk, doc_len, shape, scale, stride);
+        let store_loglik = dyn_alpha_loglik_sub(
+            alpha, k, doc_start, doc_end, ndk, doc_len, shape, scale, stride,
+        );
 
         let mut start = min_v;
         let mut end = max_v;
         let previous_p = shrinkp(alpha[k]);
-        let slice_ = store_loglik - 2.0 * (1.0 - previous_p).ln() + rng.gen::<f64>().max(1e-300).ln();
+        let slice_ =
+            store_loglik - 2.0 * (1.0 - previous_p).ln() + rng.gen::<f64>().max(1e-300).ln();
 
         for _ in 0..MAX_SHRINK_TIME {
             let new_p = start + (end - start) * rng.gen::<f64>();
             alpha[k] = new_p / (1.0 - new_p); // expandp
-            let new_loglik =
-                dyn_alpha_loglik_sub(alpha, k, doc_start, doc_end, ndk, doc_len, shape, scale, stride);
+            let new_loglik = dyn_alpha_loglik_sub(
+                alpha, k, doc_start, doc_end, ndk, doc_len, shape, scale, stride,
+            );
             let new_likelihood = new_loglik - 2.0 * (1.0 - new_p).ln();
 
             if slice_ < new_likelihood {
@@ -1756,16 +1900,30 @@ pub fn fit_keyatm_dynamic<R: Rng>(
     convergence_tol: f64,
     rng: &mut R,
 ) -> KeyAtmModel {
-    assert_eq!(keywords.len(), num_topics, "keywords length must equal num_topics");
-    assert_eq!(time_index.len(), docs.len(), "time_index length must equal number of documents");
+    assert_eq!(
+        keywords.len(),
+        num_topics,
+        "keywords length must equal num_topics"
+    );
+    assert_eq!(
+        time_index.len(),
+        docs.len(),
+        "time_index length must equal number of documents"
+    );
     assert!(num_states >= 1, "num_states must be at least 1");
 
     // Time segments must be contiguous and non-decreasing (docs sorted by time).
     for w in time_index.windows(2) {
-        assert!(w[1] >= w[0], "documents must be sorted by time_index (non-decreasing)");
+        assert!(
+            w[1] >= w[0],
+            "documents must be sorted by time_index (non-decreasing)"
+        );
     }
     let num_time = time_index.iter().copied().max().map(|m| m + 1).unwrap_or(0);
-    assert!(num_time >= num_states, "num_time ({num_time}) must be >= num_states ({num_states})");
+    assert!(
+        num_time >= num_states,
+        "num_time ({num_time}) must be >= num_states ({num_states})"
+    );
 
     // Document index ranges for each time segment.
     let mut time_doc_start = vec![0usize; num_time];
@@ -1844,7 +2002,16 @@ pub fn fit_keyatm_dynamic<R: Rng>(
             .iter()
             .map(|&t| alphas[r_est[t]].clone())
             .collect();
-        run_sweep(&mut model, docs, &mut assignments, &mut nkw_t, &ki, &doc_alpha, num_threads, rng);
+        run_sweep(
+            &mut model,
+            docs,
+            &mut assignments,
+            &mut nkw_t,
+            &ki,
+            &doc_alpha,
+            num_threads,
+            rng,
+        );
         // Snapshot under the (ndk, doc_alpha) pair this sweep just used — coherent
         // smoothing even though r_est/alphas are resampled below.
         draws.maybe_collect(&mut theta_draw_buf, it + 1, &model.ndk, &doc_alpha);
@@ -1865,8 +2032,8 @@ pub fn fit_keyatm_dynamic<R: Rng>(
                 .collect()
         };
         if num_threads > 1 {
-            use rand_pcg::Pcg64Mcg;
             use rand::SeedableRng;
+            use rand_pcg::Pcg64Mcg;
             use rayon::prelude::*;
             let base: u64 = rng.gen();
             let ndk = &model.ndk;
@@ -1879,15 +2046,39 @@ pub fn fit_keyatm_dynamic<R: Rng>(
                         base ^ (r as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
                     );
                     dyn_sample_alpha_state(
-                        alpha, num_keyword_topics, d_start, d_end, ndk, &doc_len,
-                        eta1, eta2, eta1_reg, eta2_reg, min_v, max_v, 1, &mut srng,
+                        alpha,
+                        num_keyword_topics,
+                        d_start,
+                        d_end,
+                        ndk,
+                        &doc_len,
+                        eta1,
+                        eta2,
+                        eta1_reg,
+                        eta2_reg,
+                        min_v,
+                        max_v,
+                        1,
+                        &mut srng,
                     );
                 });
         } else {
             for (r, &(d_start, d_end)) in ranges.iter().enumerate() {
                 dyn_sample_alpha_state(
-                    &mut alphas[r], num_keyword_topics, d_start, d_end, &model.ndk, &doc_len,
-                    eta1, eta2, eta1_reg, eta2_reg, min_v, max_v, 1, rng,
+                    &mut alphas[r],
+                    num_keyword_topics,
+                    d_start,
+                    d_end,
+                    &model.ndk,
+                    &doc_len,
+                    eta1,
+                    eta2,
+                    eta1_reg,
+                    eta2_reg,
+                    min_v,
+                    max_v,
+                    1,
+                    rng,
                 );
             }
         }
@@ -1902,7 +2093,15 @@ pub fn fit_keyatm_dynamic<R: Rng>(
                 .into_par_iter()
                 .map(|t| {
                     (0..num_states)
-                        .map(|r| dyn_polyapdfln(&alphas[r], time_doc_start[t], time_doc_end[t], ndk, &doc_len))
+                        .map(|r| {
+                            dyn_polyapdfln(
+                                &alphas[r],
+                                time_doc_start[t],
+                                time_doc_end[t],
+                                ndk,
+                                &doc_len,
+                            )
+                        })
                         .collect()
                 })
                 .collect()
@@ -1910,7 +2109,15 @@ pub fn fit_keyatm_dynamic<R: Rng>(
             (1..num_time)
                 .map(|t| {
                     (0..num_states)
-                        .map(|r| dyn_polyapdfln(&alphas[r], time_doc_start[t], time_doc_end[t], &model.ndk, &doc_len))
+                        .map(|r| {
+                            dyn_polyapdfln(
+                                &alphas[r],
+                                time_doc_start[t],
+                                time_doc_end[t],
+                                &model.ndk,
+                                &doc_len,
+                            )
+                        })
                         .collect()
                 })
                 .collect()
@@ -1952,7 +2159,9 @@ pub fn fit_keyatm_dynamic<R: Rng>(
         r_count[num_states - 1] += 1;
         for t in (0..num_time - 1).rev() {
             let next = r_est[t + 1];
-            let probs: Vec<f64> = (0..num_states).map(|r| prk[t][r] * p_est[r][next]).collect();
+            let probs: Vec<f64> = (0..num_states)
+                .map(|r| prk[t][r] * p_est[r][next])
+                .collect();
             let s = sample_index(&probs, rng);
             r_est[t] = s;
             r_count[s] += 1;
@@ -2055,7 +2264,24 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 200, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
+            &docs,
+            v,
+            3,
+            &keywords,
+            0.1,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            200,
+            0,
+            true,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            1,
+            &mut rng,
         );
 
         // Helper: block with max probability mass in topic_word(k).
@@ -2094,8 +2320,9 @@ mod tests {
         for b in 0..num_blocks {
             let offset = b * block_size;
             for d in 0..100usize {
-                let mut doc: Vec<u32> =
-                    (0..5).map(|i| (offset + (i + d) % block_size) as u32).collect();
+                let mut doc: Vec<u32> = (0..5)
+                    .map(|i| (offset + (i + d) % block_size) as u32)
+                    .collect();
                 doc.push(((b + 1) % num_blocks * block_size + d % block_size) as u32);
                 docs.push(doc);
             }
@@ -2103,7 +2330,18 @@ mod tests {
         let keywords: Vec<Vec<usize>> = vec![vec![0, 1], vec![10, 11], vec![]];
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let model = fit_keyatm_cvb0(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 100, WeightScheme::None, &mut rng,
+            &docs,
+            v,
+            3,
+            &keywords,
+            0.1,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            100,
+            WeightScheme::None,
+            &mut rng,
         );
         let dominant_block = |k: usize| -> usize {
             let phi = model.topic_word(k);
@@ -2127,8 +2365,21 @@ mod tests {
         let keywords: Vec<Vec<usize>> = vec![vec![0], vec![6], vec![]];
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(7);
-            fit_keyatm_cvb0(&docs, 12, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, WeightScheme::None, &mut rng)
-                .doc_topic()
+            fit_keyatm_cvb0(
+                &docs,
+                12,
+                3,
+                &keywords,
+                0.1,
+                0.1,
+                0.5,
+                1.0,
+                1.0,
+                40,
+                WeightScheme::None,
+                &mut rng,
+            )
+            .doc_topic()
         };
         let (a, b) = (run(), run());
         for (ra, rb) in a.iter().zip(b.iter()) {
@@ -2148,15 +2399,32 @@ mod tests {
             .collect();
 
         let keywords: Vec<Vec<usize>> = vec![
-            vec![0, 1, 2],  // keyword topic
-            vec![10, 11],   // keyword topic
-            vec![],         // regular
-            vec![],         // regular
+            vec![0, 1, 2], // keyword topic
+            vec![10, 11],  // keyword topic
+            vec![],        // regular
+            vec![],        // regular
         ];
 
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let model = fit_keyatm(
-            &docs, v, 4, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 50, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
+            &docs,
+            v,
+            4,
+            &keywords,
+            0.1,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            50,
+            0,
+            true,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            1,
+            &mut rng,
         );
 
         let rates = model.keyword_rate();
@@ -2172,7 +2440,10 @@ mod tests {
         }
         // Regular topics must be exactly 0.
         for k in 2..4 {
-            assert_eq!(rates[k], 0.0, "keyword_rate[{k}] should be 0 for regular topic");
+            assert_eq!(
+                rates[k], 0.0,
+                "keyword_rate[{k}] should be 0 for regular topic"
+            );
         }
     }
 
@@ -2192,7 +2463,24 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(123);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.5, 0.1, 0.5, 1.0, 1.0, 30, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
+            &docs,
+            v,
+            3,
+            &keywords,
+            0.5,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            30,
+            0,
+            true,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            1,
+            &mut rng,
         );
 
         let d = docs.len();
@@ -2238,9 +2526,7 @@ mod tests {
             let b_heavy = t >= 5;
             for d in 0..30usize {
                 let (heavy_off, light_off) = if b_heavy { (6, 0) } else { (0, 6) };
-                let mut doc: Vec<u32> = (0..6)
-                    .map(|i| (heavy_off + (i + d) % 6) as u32)
-                    .collect();
+                let mut doc: Vec<u32> = (0..6).map(|i| (heavy_off + (i + d) % 6) as u32).collect();
                 doc.push((light_off + d % 6) as u32);
                 docs.push(doc);
                 time_index.push(t);
@@ -2249,8 +2535,27 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let model = fit_keyatm_dynamic(
-            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0,
-            2.0, 1.0, 300, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut rng,
+            &docs,
+            12,
+            2,
+            &keywords,
+            &time_index,
+            2,
+            0.01,
+            0.1,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            2.0,
+            1.0,
+            300,
+            0,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            &mut rng,
         );
 
         let dyn_ = model.dynamic.as_ref().expect("dynamic state present");
@@ -2265,7 +2570,10 @@ mod tests {
         let tp = model.time_prevalence().unwrap();
         let early = tp[0][1];
         let late = tp[num_time - 1][1];
-        assert!(late - early > 0.3, "social prevalence should rise: {early} -> {late}");
+        assert!(
+            late - early > 0.3,
+            "social prevalence should rise: {early} -> {late}"
+        );
     }
 
     /// Dynamic fits with the same seed must be identical.
@@ -2284,10 +2592,50 @@ mod tests {
         let mut r1 = ChaCha8Rng::seed_from_u64(9);
         let mut r2 = ChaCha8Rng::seed_from_u64(9);
         let m1 = fit_keyatm_dynamic(
-            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut r1,
+            &docs,
+            12,
+            2,
+            &keywords,
+            &time_index,
+            2,
+            0.01,
+            0.1,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            2.0,
+            1.0,
+            100,
+            0,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            &mut r1,
         );
         let m2 = fit_keyatm_dynamic(
-            &docs, 12, 2, &keywords, &time_index, 2, 0.01, 0.1, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 100, 0, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, &mut r2,
+            &docs,
+            12,
+            2,
+            &keywords,
+            &time_index,
+            2,
+            0.01,
+            0.1,
+            1.0,
+            1.0,
+            1.0,
+            1.0,
+            2.0,
+            1.0,
+            100,
+            0,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            &mut r2,
         );
         assert_eq!(
             m1.dynamic.as_ref().unwrap().r_est,
@@ -2313,8 +2661,46 @@ mod tests {
         let mut r1 = ChaCha8Rng::seed_from_u64(77);
         let mut r2 = ChaCha8Rng::seed_from_u64(77);
 
-        let m1 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut r1);
-        let m2 = fit_keyatm(&docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 40, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut r2);
+        let m1 = fit_keyatm(
+            &docs,
+            v,
+            3,
+            &keywords,
+            0.1,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            40,
+            0,
+            true,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            1,
+            &mut r1,
+        );
+        let m2 = fit_keyatm(
+            &docs,
+            v,
+            3,
+            &keywords,
+            0.1,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            40,
+            0,
+            true,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            1,
+            &mut r2,
+        );
 
         assert_eq!(
             m1.topic_word_all(),
@@ -2344,13 +2730,35 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(3);
         let model = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 10, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
+            &docs,
+            v,
+            3,
+            &keywords,
+            0.1,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            60,
+            10,
+            true,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            1,
+            &mut rng,
         );
         let h = &model.log_likelihood_history;
         // iters=60, interval=10 -> sweeps 10,20,30,40,50,60.
-        assert_eq!(h.iter().map(|&(i, _, _)| i).collect::<Vec<_>>(), vec![10, 20, 30, 40, 50, 60]);
+        assert_eq!(
+            h.iter().map(|&(i, _, _)| i).collect::<Vec<_>>(),
+            vec![10, 20, 30, 40, 50, 60]
+        );
         // (iter, collapsed log-likelihood < 0, perplexity > 1).
-        assert!(h.iter().all(|&(_, ll, ppl)| ll.is_finite() && ll < 0.0 && ppl > 1.0));
+        assert!(h
+            .iter()
+            .all(|&(_, ll, ppl)| ll.is_finite() && ll < 0.0 && ppl > 1.0));
         // The collapsed log-likelihood rises (toward 0) as Gibbs converges.
         assert!(
             h.last().unwrap().1 >= h.first().unwrap().1 - 1e-6,
@@ -2360,7 +2768,24 @@ mod tests {
         // interval 0 disables tracing.
         let mut rng2 = ChaCha8Rng::seed_from_u64(3);
         let none = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true, WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng2,
+            &docs,
+            v,
+            3,
+            &keywords,
+            0.1,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            20,
+            0,
+            true,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            1,
+            &mut rng2,
         );
         assert!(none.log_likelihood_history.is_empty());
     }
@@ -2374,8 +2799,24 @@ mod tests {
         let keywords: Vec<Vec<usize>> = vec![vec![0, 1], vec![10, 11], vec![]];
         let mut rng = ChaCha8Rng::seed_from_u64(77);
         let m = fit_keyatm(
-            &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 20, 0, true,
-            WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, 1, &mut rng,
+            &docs,
+            v,
+            3,
+            &keywords,
+            0.1,
+            0.1,
+            0.5,
+            1.0,
+            1.0,
+            20,
+            0,
+            true,
+            WeightScheme::None,
+            1,
+            ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            1,
+            &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
@@ -2396,8 +2837,24 @@ mod tests {
         let f = |stride: usize, seed: u64| {
             let mut r = ChaCha8Rng::seed_from_u64(seed);
             fit_keyatm(
-                &docs, v, 3, &keywords, 0.1, 0.1, 0.5, 1.0, 1.0, 60, 0, true,
-                WeightScheme::None, 1, ThetaDrawOpts::new(false, 0, 0), 0.0, stride, &mut r,
+                &docs,
+                v,
+                3,
+                &keywords,
+                0.1,
+                0.1,
+                0.5,
+                1.0,
+                1.0,
+                60,
+                0,
+                true,
+                WeightScheme::None,
+                1,
+                ThetaDrawOpts::new(false, 0, 0),
+                0.0,
+                stride,
+                &mut r,
             )
         };
         // stride = 1 is the exact path: identical to a no-stride fit.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,16 +6,14 @@ pub use topica_core::{corpus, ctm, cvb0, estimator, linalg, spectral, variationa
 // because `TopicModel` stays in `topica`).
 pub mod cvb0_ext;
 
-pub mod saveformat;
 pub mod coherence;
 pub mod conformance;
-pub mod dmr;
-pub mod ectm;
-pub mod sts;
 pub mod detm;
+pub mod dmr;
+pub mod dtm;
+pub mod ectm;
 pub mod etm;
 pub mod etm_vae;
-pub mod dtm;
 pub mod gsdmm;
 pub mod hdp;
 pub mod hlda;
@@ -34,24 +32,26 @@ pub mod prodlda;
 pub mod pt;
 pub mod sage;
 pub mod sampler;
+pub mod saveformat;
 pub mod seeded;
 pub mod slda;
+pub mod sts;
 pub mod warplda;
 
 // Embedding-native model branch (Top2Vec/BERTopic/...): clustering pipeline over
 // user-supplied embeddings. Behind the `embeddings` feature (implied by `python`).
 // reduce -> cluster -> represent are the three pipeline stages.
 #[cfg(feature = "embeddings")]
+pub mod bertopic;
+#[cfg(feature = "embeddings")]
 pub mod cluster;
+pub mod fastopic;
 #[cfg(feature = "embeddings")]
 pub mod reduce;
 #[cfg(feature = "embeddings")]
 pub mod represent;
 #[cfg(feature = "embeddings")]
 pub mod top2vec;
-#[cfg(feature = "embeddings")]
-pub mod bertopic;
-pub mod fastopic;
 
 #[cfg(feature = "python")]
 mod python;

--- a/src/lightlda.rs
+++ b/src/lightlda.rs
@@ -223,8 +223,7 @@ impl LightLda {
                 if word_tables[w].is_none() {
                     let mut qw = vec![0.0f64; k];
                     for t in 0..k {
-                        qw[t] = (self.n_wk[w][t] as f64 + beta)
-                            / (self.n_k[t] as f64 + beta_sum);
+                        qw[t] = (self.n_wk[w][t] as f64 + beta) / (self.n_k[t] as f64 + beta_sum);
                     }
                     let table = Alias::build(&qw);
                     word_tables[w] = Some((table, qw));
@@ -265,10 +264,9 @@ impl LightLda {
                     let n_s_di = self.n_k[s] as f64;
 
                     // True conditional masses p(t), p(s) (shared numerator forms).
-                    let p_t = (n_td_excl + self.alpha[t_prop]) * (n_tw_di + beta)
-                        / (n_t_di + beta_sum);
-                    let p_s = (n_sd_excl + self.alpha[s]) * (n_sw_di + beta)
-                        / (n_s_di + beta_sum);
+                    let p_t =
+                        (n_td_excl + self.alpha[t_prop]) * (n_tw_di + beta) / (n_t_di + beta_sum);
+                    let p_s = (n_sd_excl + self.alpha[s]) * (n_sw_di + beta) / (n_s_di + beta_sum);
 
                     let pi = if word_prop {
                         // π_w = (p(t)/p(s)) · (p_w(s)/p_w(t)), Eq. 8.
@@ -329,8 +327,7 @@ impl LightLda {
     /// (optimisation, save/load, log-likelihood, held-out inference) can be
     /// reused without knowing the sampler ran on dense tables.
     pub fn to_topic_model(&self) -> TopicModel {
-        let mut model =
-            TopicModel::new(self.num_topics, self.alpha_sum, self.beta, self.num_types);
+        let mut model = TopicModel::new(self.num_topics, self.alpha_sum, self.beta, self.num_types);
         model.alpha.copy_from_slice(&self.alpha);
         model.alpha_sum = self.alpha_sum;
         model.beta = self.beta;

--- a/src/lsa.rs
+++ b/src/lsa.rs
@@ -106,8 +106,9 @@ pub fn fit_lsa(
     let mut u_rows: Vec<Vec<f64>> = (0..d)
         .map(|i| (0..kk).map(|c| u.at(i, c)).collect())
         .collect();
-    let mut vt_rows: Vec<Vec<f64>> =
-        (0..kk).map(|c| (0..v).map(|j| vt.at(c, j)).collect()).collect();
+    let mut vt_rows: Vec<Vec<f64>> = (0..kk)
+        .map(|c| (0..v).map(|j| vt.at(c, j)).collect())
+        .collect();
 
     svd_flip(&mut u_rows, &mut vt_rows, kk, v);
 
@@ -210,7 +211,11 @@ mod tests {
         let mut covered = std::collections::HashSet::new();
         for t in 0..k {
             let mut ord: Vec<usize> = (0..v).collect();
-            ord.sort_by(|&a, &b| m.topic_word[t][b].abs().total_cmp(&m.topic_word[t][a].abs()));
+            ord.sort_by(|&a, &b| {
+                m.topic_word[t][b]
+                    .abs()
+                    .total_cmp(&m.topic_word[t][a].abs())
+            });
             let blocks: std::collections::HashSet<usize> =
                 ord[..4].iter().map(|&w| w / block).collect();
             assert_eq!(blocks.len(), 1, "component {t} top loadings mix blocks");
@@ -249,8 +254,14 @@ mod tests {
                 .build()
                 .unwrap()
                 .install(|| fit_lsa(&docs, k, v, tfidf, 77));
-            assert_eq!(one.topic_word, many.topic_word, "topic_word differs by thread count");
-            assert_eq!(one.doc_topic, many.doc_topic, "doc_topic differs by thread count");
+            assert_eq!(
+                one.topic_word, many.topic_word,
+                "topic_word differs by thread count"
+            );
+            assert_eq!(
+                one.doc_topic, many.doc_topic,
+                "doc_topic differs by thread count"
+            );
             assert_eq!(one.singular_values, many.singular_values);
         }
     }
@@ -297,7 +308,11 @@ mod tests {
             .collect();
         let docs: Vec<Vec<u32>> = (0..nd).map(|_| doc.clone()).collect();
         let m = fit_lsa(&docs, 2, v, false, 42);
-        let bnorm: f64 = b.iter().map(|&x| (x as f64) * (x as f64)).sum::<f64>().sqrt();
+        let bnorm: f64 = b
+            .iter()
+            .map(|&x| (x as f64) * (x as f64))
+            .sum::<f64>()
+            .sqrt();
         let want = (nd as f64).sqrt() * bnorm;
         assert!(
             (m.singular_values[0] - want).abs() / want < 1e-6,

--- a/src/model.rs
+++ b/src/model.rs
@@ -1,6 +1,6 @@
-use rand::Rng;
 use crate::corpus::Corpus;
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
+use rand::Rng;
 
 #[derive(Clone, serde::Serialize, serde::Deserialize)]
 pub struct TopicModel {
@@ -91,7 +91,9 @@ impl TopicModel {
             .iter()
             .zip(self.doc_topics.iter())
             .flat_map(|(doc, topics)| {
-                doc.iter().map(|&w| w as usize).zip(topics.iter().map(|&t| t as usize))
+                doc.iter()
+                    .map(|&w| w as usize)
+                    .zip(topics.iter().map(|&t| t as usize))
             })
             .collect();
 
@@ -123,7 +125,9 @@ impl TopicModel {
             .iter()
             .zip(self.doc_topics.iter())
             .flat_map(|(doc, topics)| {
-                doc.iter().map(|&w| w as usize).zip(topics.iter().map(|&t| t as usize))
+                doc.iter()
+                    .map(|&w| w as usize)
+                    .zip(topics.iter().map(|&t| t as usize))
             })
             .collect();
         for (word_id, topic) in assignments {
@@ -143,12 +147,7 @@ impl TopicModel {
     /// Deterministic given `rng`. Equivalent in every other respect to
     /// [`Self::initialize`] (same count-table sizing and accumulation); only
     /// the initial topic draw differs.
-    pub fn initialize_spectral<R: Rng>(
-        &mut self,
-        corpus: &Corpus,
-        beta: &[Vec<f64>],
-        rng: &mut R,
-    ) {
+    pub fn initialize_spectral<R: Rng>(&mut self, corpus: &Corpus, beta: &[Vec<f64>], rng: &mut R) {
         let k = self.num_topics;
 
         let mut type_totals = vec![0usize; self.num_types];
@@ -204,7 +203,9 @@ impl TopicModel {
             .iter()
             .zip(self.doc_topics.iter())
             .flat_map(|(doc, topics)| {
-                doc.iter().map(|&w| w as usize).zip(topics.iter().map(|&t| t as usize))
+                doc.iter()
+                    .map(|&w| w as usize)
+                    .zip(topics.iter().map(|&t| t as usize))
             })
             .collect();
         for (word_id, topic) in assignments {
@@ -242,8 +243,6 @@ impl TopicModel {
             index -= 1;
         }
     }
-
-
 
     /// Decrement the count for (word_id, topic) in type_topic_counts,
     /// maintaining descending sort (mirror of `increment_type_topic`, used by
@@ -302,11 +301,12 @@ impl TopicModel {
             .map(|t| self.beta_sum + self.tokens_per_topic[t] as f64)
             .collect();
         // start every cell at the no-count value β/denom
-        let mut phi: Vec<Vec<f64>> =
-            (0..k).map(|t| vec![self.beta / denom[t]; v]).collect();
+        let mut phi: Vec<Vec<f64>> = (0..k).map(|t| vec![self.beta / denom[t]; v]).collect();
         for w in 0..v {
             for &entry in &self.type_topic_counts[w] {
-                if entry == 0 { break; }
+                if entry == 0 {
+                    break;
+                }
                 let t = (entry & self.topic_mask) as usize;
                 let count = (entry >> self.topic_bits) as f64;
                 phi[t][w] = (self.beta + count) / denom[t];
@@ -323,7 +323,9 @@ impl TopicModel {
             .iter()
             .map(|topics| {
                 let mut cnt = vec![0.0f64; k];
-                for &t in topics { cnt[t as usize] += 1.0; }
+                for &t in topics {
+                    cnt[t as usize] += 1.0;
+                }
                 let denom = topics.len() as f64 + self.alpha_sum;
                 (0..k).map(|t| (cnt[t] + self.alpha[t]) / denom).collect()
             })
@@ -332,18 +334,36 @@ impl TopicModel {
 }
 
 impl Estimator for TopicModel {
-    fn num_topics(&self) -> usize { self.num_topics }
-    fn topic_word(&self) -> Vec<Vec<f64>> { TopicModel::topic_word(self) }
-    fn doc_topic(&self) -> Vec<Vec<f64>> { TopicModel::doc_topic(self) }
-    fn fit_history(&self) -> Vec<(usize, f64)> { Vec::new() }
-    fn converged(&self) -> Option<bool> { None }
-    fn model_family(&self) -> ModelFamily { ModelFamily::Dirichlet }
+    fn num_topics(&self) -> usize {
+        self.num_topics
+    }
+    fn topic_word(&self) -> Vec<Vec<f64>> {
+        TopicModel::topic_word(self)
+    }
+    fn doc_topic(&self) -> Vec<Vec<f64>> {
+        TopicModel::doc_topic(self)
+    }
+    fn fit_history(&self) -> Vec<(usize, f64)> {
+        Vec::new()
+    }
+    fn converged(&self) -> Option<bool> {
+        None
+    }
+    fn model_family(&self) -> ModelFamily {
+        ModelFamily::Dirichlet
+    }
 }
 
 impl DirichletModel for TopicModel {
-    fn alpha(&self) -> Vec<f64> { self.alpha.clone() }
-    fn theta_draws(&self) -> Vec<Vec<Vec<f64>>> { Vec::new() }
-    fn doc_lengths(&self) -> Vec<usize> { self.doc_topics.iter().map(|d| d.len()).collect() }
+    fn alpha(&self) -> Vec<f64> {
+        self.alpha.clone()
+    }
+    fn theta_draws(&self) -> Vec<Vec<Vec<f64>>> {
+        Vec::new()
+    }
+    fn doc_lengths(&self) -> Vec<usize> {
+        self.doc_topics.iter().map(|d| d.len()).collect()
+    }
 }
 
 #[cfg(test)]

--- a/src/nmf.rs
+++ b/src/nmf.rs
@@ -69,7 +69,11 @@ pub(crate) struct Mat {
 
 impl Mat {
     pub(crate) fn zeros(rows: usize, cols: usize) -> Self {
-        Mat { rows, cols, data: vec![0.0; rows * cols] }
+        Mat {
+            rows,
+            cols,
+            data: vec![0.0; rows * cols],
+        }
     }
     #[inline]
     pub(crate) fn at(&self, r: usize, c: usize) -> f64 {
@@ -250,17 +254,20 @@ fn sp_x_bt(x: &SpMat, b: &Mat) -> Mat {
     let n = b.rows;
     let k = b.cols;
     let mut out = Mat::zeros(x.rows, n);
-    out.data.par_chunks_mut(n).enumerate().for_each(|(i, orow)| {
-        let (cols, vals) = x.row(i);
-        for (j, ocell) in orow.iter_mut().enumerate() {
-            let brow = &b.data[j * k..(j + 1) * k];
-            let mut s = 0.0;
-            for (&c, &xv) in cols.iter().zip(vals.iter()) {
-                s += xv * brow[c];
+    out.data
+        .par_chunks_mut(n)
+        .enumerate()
+        .for_each(|(i, orow)| {
+            let (cols, vals) = x.row(i);
+            for (j, ocell) in orow.iter_mut().enumerate() {
+                let brow = &b.data[j * k..(j + 1) * k];
+                let mut s = 0.0;
+                for (&c, &xv) in cols.iter().zip(vals.iter()) {
+                    s += xv * brow[c];
+                }
+                *ocell = s;
             }
-            *ocell = s;
-        }
-    });
+        });
     out
 }
 
@@ -271,15 +278,18 @@ fn sp_x_b(x: &SpMat, b: &Mat) -> Mat {
     debug_assert_eq!(x.cols, b.rows);
     let n = b.cols;
     let mut out = Mat::zeros(x.rows, n);
-    out.data.par_chunks_mut(n).enumerate().for_each(|(i, orow)| {
-        let (cols, vals) = x.row(i);
-        for (&c, &xv) in cols.iter().zip(vals.iter()) {
-            let brow = &b.data[c * n..(c + 1) * n];
-            for j in 0..n {
-                orow[j] += xv * brow[j];
+    out.data
+        .par_chunks_mut(n)
+        .enumerate()
+        .for_each(|(i, orow)| {
+            let (cols, vals) = x.row(i);
+            for (&c, &xv) in cols.iter().zip(vals.iter()) {
+                let brow = &b.data[c * n..(c + 1) * n];
+                for j in 0..n {
+                    orow[j] += xv * brow[j];
+                }
             }
-        }
-    });
+        });
     out
 }
 
@@ -645,18 +655,15 @@ fn frobenius_error(x: &SpMat, w: &Mat, h: &Mat) -> f64 {
     // collect per-row partials into an indexed Vec and sum sequentially, so the
     // total is independent of thread completion order (deterministic).
     let mut partials = vec![0.0; x.rows];
-    partials
-        .par_iter_mut()
-        .enumerate()
-        .for_each(|(i, slot)| {
-            let wrow = &w.data[i * k..(i + 1) * k];
-            let (cols, vals) = x.row(i);
-            let mut s = 0.0;
-            for (&j, &xv) in cols.iter().zip(vals.iter()) {
-                s += xv * wh_cell(wrow, h, j, k);
-            }
-            *slot = s;
-        });
+    partials.par_iter_mut().enumerate().for_each(|(i, slot)| {
+        let wrow = &w.data[i * k..(i + 1) * k];
+        let (cols, vals) = x.row(i);
+        let mut s = 0.0;
+        for (&j, &xv) in cols.iter().zip(vals.iter()) {
+            s += xv * wh_cell(wrow, h, j, k);
+        }
+        *slot = s;
+    });
     let cross: f64 = partials.iter().sum();
     // tr((W^T W)(H H^T)) = sum_{a,b} (W^T W)_ab (H H^T)_ab.
     let wtw = matmul_at(w, w); // k x k
@@ -679,21 +686,18 @@ fn kl_error(x: &SpMat, w: &Mat, h: &Mat) -> f64 {
     // sum over nnz of X ln(X/WH), parallel over independent rows. Per-row
     // partials are summed sequentially so the total is thread-count-independent.
     let mut partials = vec![0.0; x.rows];
-    partials
-        .par_iter_mut()
-        .enumerate()
-        .for_each(|(i, slot)| {
-            let wrow = &w.data[i * k..(i + 1) * k];
-            let (cols, vals) = x.row(i);
-            let mut s = 0.0;
-            for (&j, &xv) in cols.iter().zip(vals.iter()) {
-                if xv > 0.0 {
-                    let whij = wh_cell(wrow, h, j, k).max(EPS);
-                    s += xv * (xv / whij).ln();
-                }
+    partials.par_iter_mut().enumerate().for_each(|(i, slot)| {
+        let wrow = &w.data[i * k..(i + 1) * k];
+        let (cols, vals) = x.row(i);
+        let mut s = 0.0;
+        for (&j, &xv) in cols.iter().zip(vals.iter()) {
+            if xv > 0.0 {
+                let whij = wh_cell(wrow, h, j, k).max(EPS);
+                s += xv * (xv / whij).ln();
             }
-            *slot = s;
-        });
+        }
+        *slot = s;
+    });
     let nnz_term: f64 = partials.iter().sum();
     // sum WH = sum_k (sum_i W_ik) (sum_j H_kj).
     let mut sum_wh = 0.0;
@@ -886,7 +890,13 @@ pub(crate) fn count_matrix(docs: &[Vec<u32>], num_types: usize) -> SpMat {
         touched.clear();
         indptr.push(col_idx.len());
     }
-    SpMat { rows: d, cols: num_types, indptr, col_idx, vals }
+    SpMat {
+        rows: d,
+        cols: num_types,
+        indptr,
+        col_idx,
+        vals,
+    }
 }
 
 /// Build the sparse TF-IDF document-term matrix (CSR): `tf * (ln((1+D)/(1+df))
@@ -1042,7 +1052,13 @@ mod tests {
 
     /// A planted-block corpus: K well-separated word blocks, each document drawn
     /// from a single block.
-    fn planted(k: usize, block: usize, ndocs: usize, dlen: usize, seed: u64) -> (Vec<Vec<u32>>, usize) {
+    fn planted(
+        k: usize,
+        block: usize,
+        ndocs: usize,
+        dlen: usize,
+        seed: u64,
+    ) -> (Vec<Vec<u32>>, usize) {
         let v = k * block;
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         let docs: Vec<Vec<u32>> = (0..ndocs)
@@ -1060,7 +1076,17 @@ mod tests {
     fn fit_recovers_planted_blocks() {
         let (k, block) = (3usize, 8usize);
         let (docs, v) = planted(k, block, 180, 15, 1);
-        let m = fit_nmf(&docs, k, v, BetaLoss::Frobenius, Init::Nndsvd, false, 200, 1e-4, 42);
+        let m = fit_nmf(
+            &docs,
+            k,
+            v,
+            BetaLoss::Frobenius,
+            Init::Nndsvd,
+            false,
+            200,
+            1e-4,
+            42,
+        );
         assert_eq!(m.num_topics, k);
         let tw = &m.topic_word;
         let mut covered = std::collections::HashSet::new();
@@ -1080,13 +1106,53 @@ mod tests {
         let (k, block) = (3usize, 6usize);
         let (docs, v) = planted(k, block, 90, 12, 7);
         // NNDSVD path (seed-independent init).
-        let a = fit_nmf(&docs, k, v, BetaLoss::Frobenius, Init::Nndsvd, false, 60, 0.0, 42);
-        let b = fit_nmf(&docs, k, v, BetaLoss::Frobenius, Init::Nndsvd, false, 60, 0.0, 42);
+        let a = fit_nmf(
+            &docs,
+            k,
+            v,
+            BetaLoss::Frobenius,
+            Init::Nndsvd,
+            false,
+            60,
+            0.0,
+            42,
+        );
+        let b = fit_nmf(
+            &docs,
+            k,
+            v,
+            BetaLoss::Frobenius,
+            Init::Nndsvd,
+            false,
+            60,
+            0.0,
+            42,
+        );
         assert_eq!(a.topic_word, b.topic_word);
         assert_eq!(a.doc_topic, b.doc_topic);
         // Random path (seeded by user seed).
-        let c = fit_nmf(&docs, k, v, BetaLoss::Frobenius, Init::Random, false, 60, 0.0, 99);
-        let d = fit_nmf(&docs, k, v, BetaLoss::Frobenius, Init::Random, false, 60, 0.0, 99);
+        let c = fit_nmf(
+            &docs,
+            k,
+            v,
+            BetaLoss::Frobenius,
+            Init::Random,
+            false,
+            60,
+            0.0,
+            99,
+        );
+        let d = fit_nmf(
+            &docs,
+            k,
+            v,
+            BetaLoss::Frobenius,
+            Init::Random,
+            false,
+            60,
+            0.0,
+            99,
+        );
         assert_eq!(c.topic_word, d.topic_word);
         assert_eq!(c.doc_topic, d.doc_topic);
     }
@@ -1124,10 +1190,21 @@ mod tests {
             }
             indptr.push(col_idx.len());
         }
-        let x = SpMat { rows: d, cols: v, indptr, col_idx, vals };
+        let x = SpMat {
+            rows: d,
+            cols: v,
+            indptr,
+            col_idx,
+            vals,
+        };
         let (_, s, _) = randomized_svd(&x, 2);
         let want = norm(&a) * norm(&b);
-        assert!((s[0] - want).abs() / want < 1e-6, "sigma0 {} vs {}", s[0], want);
+        assert!(
+            (s[0] - want).abs() / want < 1e-6,
+            "sigma0 {} vs {}",
+            s[0],
+            want
+        );
         // The second singular value of a rank-1 matrix is ~0.
         assert!(s[1] < 1e-6, "sigma1 {} should be near zero", s[1]);
     }
@@ -1138,9 +1215,7 @@ mod tests {
         // proving the parallel matmuls do not depend on thread completion order.
         let (k, block) = (4usize, 7usize);
         let (docs, v) = planted(k, block, 200, 18, 11);
-        let fit = |loss, init| {
-            fit_nmf(&docs, k, v, loss, init, false, 120, 0.0, 77)
-        };
+        let fit = |loss, init| fit_nmf(&docs, k, v, loss, init, false, 120, 0.0, 77);
         for &loss in &[BetaLoss::Frobenius, BetaLoss::KullbackLeibler] {
             for &init in &[Init::Nndsvd, Init::Random] {
                 let one = rayon::ThreadPoolBuilder::new()
@@ -1153,10 +1228,14 @@ mod tests {
                     .build()
                     .unwrap()
                     .install(|| fit(loss, init));
-                assert_eq!(one.topic_word, many.topic_word,
-                    "topic_word differs by thread count (loss={loss:?}, init={init:?})");
-                assert_eq!(one.doc_topic, many.doc_topic,
-                    "doc_topic differs by thread count (loss={loss:?}, init={init:?})");
+                assert_eq!(
+                    one.topic_word, many.topic_word,
+                    "topic_word differs by thread count (loss={loss:?}, init={init:?})"
+                );
+                assert_eq!(
+                    one.doc_topic, many.doc_topic,
+                    "doc_topic differs by thread count (loss={loss:?}, init={init:?})"
+                );
             }
         }
     }
@@ -1165,7 +1244,17 @@ mod tests {
     fn nmf_conforms() {
         let (k, block) = (3usize, 8usize);
         let (docs, v) = planted(k, block, 180, 15, 1);
-        let m = fit_nmf(&docs, k, v, BetaLoss::Frobenius, Init::Nndsvd, false, 150, 1e-4, 42);
+        let m = fit_nmf(
+            &docs,
+            k,
+            v,
+            BetaLoss::Frobenius,
+            Init::Nndsvd,
+            false,
+            150,
+            1e-4,
+            42,
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -13,8 +13,7 @@ pub fn digamma(mut x: f64) -> f64 {
     // Asymptotic: ln x - 1/(2x) - 1/(12x²) + 1/(120x⁴) - 1/(252x⁶)
     let inv = 1.0 / x;
     let inv2 = inv * inv;
-    result + x.ln() - 0.5 * inv
-        - inv2 * (1.0 / 12.0 - inv2 * (1.0 / 120.0 - inv2 / 252.0))
+    result + x.ln() - 0.5 * inv - inv2 * (1.0 / 12.0 - inv2 * (1.0 / 120.0 - inv2 / 252.0))
 }
 
 /// One Minka fixed-point step for a symmetric Dirichlet concentration parameter.
@@ -38,7 +37,7 @@ fn update_symmetric_concentration(
 ) -> f64 {
     let per_dim = concentration / num_dims as f64;
     let dg_per_dim = digamma(per_dim);
-    let dg_conc   = digamma(concentration);
+    let dg_conc = digamma(concentration);
 
     let numerator: f64 = count_hist
         .iter()
@@ -74,7 +73,7 @@ pub fn optimize_alpha(model: &mut TopicModel, corpus: &Corpus) {
     let max_len = corpus.docs.iter().map(|d| d.len()).max().unwrap_or(0);
 
     let mut doc_length_hist = vec![0u32; max_len + 1];
-    let mut topic_doc_hist  = vec![vec![0u32; max_len + 1]; model.num_topics];
+    let mut topic_doc_hist = vec![vec![0u32; max_len + 1]; model.num_topics];
 
     for doc_idx in 0..corpus.num_docs() {
         let doc_len = corpus.docs[doc_idx].len();
@@ -148,7 +147,10 @@ pub fn optimize_alpha_symmetric(model: &mut TopicModel, corpus: &Corpus) {
     }
 
     let new_sum = update_symmetric_concentration(
-        &count_hist, &doc_length_hist, model.num_topics, model.alpha_sum,
+        &count_hist,
+        &doc_length_hist,
+        model.num_topics,
+        model.alpha_sum,
     );
     model.alpha_sum = new_sum;
     let per_topic = new_sum / model.num_topics as f64;
@@ -196,6 +198,6 @@ pub fn optimize_beta(model: &mut TopicModel) {
         model.beta_sum,
     );
 
-    model.beta     = new_beta_sum / model.num_types as f64;
+    model.beta = new_beta_sum / model.num_types as f64;
     model.beta_sum = new_beta_sum;
 }

--- a/src/output.rs
+++ b/src/output.rs
@@ -14,10 +14,7 @@ fn log_gamma(mut z: f64) -> f64 {
         z += 1.0;
         shift += 1;
     }
-    let mut result = HALF_LOG_TWO_PI
-        + (z - 0.5) * z.ln()
-        - z
-        + 1.0 / (12.0 * z)
+    let mut result = HALF_LOG_TWO_PI + (z - 0.5) * z.ln() - z + 1.0 / (12.0 * z)
         - 1.0 / (360.0 * z * z * z)
         + 1.0 / (1260.0 * z * z * z * z * z);
     while shift > 0 {
@@ -49,8 +46,7 @@ pub fn model_log_likelihood(model: &TopicModel, corpus: &Corpus) -> f64 {
         let doc_len = corpus.docs[doc_idx].len();
         for t in 0..model.num_topics {
             if topic_counts[t] > 0 {
-                ll += log_gamma(model.alpha[t] + topic_counts[t] as f64)
-                    - topic_log_gammas[t];
+                ll += log_gamma(model.alpha[t] + topic_counts[t] as f64) - topic_log_gammas[t];
             }
         }
         ll -= log_gamma(model.alpha_sum + doc_len as f64);
@@ -86,14 +82,20 @@ pub fn display_top_words(model: &TopicModel, corpus: &Corpus, n: usize) -> Strin
         let mut word_scores: Vec<(u32, usize)> = (0..model.num_types)
             .filter_map(|word_id| {
                 let count = model.get_type_topic_count(word_id, topic);
-                if count > 0 { Some((count, word_id)) } else { None }
+                if count > 0 {
+                    Some((count, word_id))
+                } else {
+                    None
+                }
             })
             .collect();
         word_scores.sort_by(|a, b| b.0.cmp(&a.0));
 
         out.push_str(&format!("{}\t{:.5}\t", topic, model.alpha[topic]));
         for (i, (_, id)) in word_scores.iter().take(n).enumerate() {
-            if i > 0 { out.push(' '); }
+            if i > 0 {
+                out.push(' ');
+            }
             out.push_str(&corpus.id_to_word[*id]);
         }
         out.push('\n');
@@ -138,7 +140,9 @@ pub fn write_doc_topic(model: &TopicModel, corpus: &Corpus, path: &Path) -> io::
 
     // Header
     write!(writer, "doc")?;
-    if has_labels { write!(writer, "\tlabel")?; }
+    if has_labels {
+        write!(writer, "\tlabel")?;
+    }
     for t in 0..model.num_topics {
         write!(writer, "\ttopic_{}", t)?;
     }
@@ -155,7 +159,9 @@ pub fn write_doc_topic(model: &TopicModel, corpus: &Corpus, path: &Path) -> io::
         }
 
         write!(writer, "{}", corpus.doc_names[doc_idx])?;
-        if has_labels { write!(writer, "\t{}", corpus.doc_labels[doc_idx])?; }
+        if has_labels {
+            write!(writer, "\t{}", corpus.doc_labels[doc_idx])?;
+        }
         for t in 0..model.num_topics {
             let prob = (topic_counts[t] as f64 + model.alpha[t]) / denominator;
             write!(writer, "\t{:.8}", prob)?;
@@ -168,11 +174,7 @@ pub fn write_doc_topic(model: &TopicModel, corpus: &Corpus, path: &Path) -> io::
 
 /// Write topic-word probabilities from a pre-averaged matrix.
 /// `phi[word_id][topic]` = averaged probability estimate.
-pub fn write_topic_word_matrix(
-    phi: &[Vec<f64>],
-    corpus: &Corpus,
-    path: &Path,
-) -> io::Result<()> {
+pub fn write_topic_word_matrix(phi: &[Vec<f64>], corpus: &Corpus, path: &Path) -> io::Result<()> {
     let file = fs::File::create(path)?;
     let mut writer = BufWriter::new(file);
 
@@ -193,11 +195,7 @@ pub fn write_topic_word_matrix(
 
 /// Write document-topic probabilities from a pre-averaged matrix.
 /// `theta[doc_idx][topic]` = averaged probability estimate.
-pub fn write_doc_topic_matrix(
-    theta: &[Vec<f64>],
-    corpus: &Corpus,
-    path: &Path,
-) -> io::Result<()> {
+pub fn write_doc_topic_matrix(theta: &[Vec<f64>], corpus: &Corpus, path: &Path) -> io::Result<()> {
     let file = fs::File::create(path)?;
     let mut writer = BufWriter::new(file);
 
@@ -205,7 +203,9 @@ pub fn write_doc_topic_matrix(
     let has_labels = corpus.has_labels();
 
     write!(writer, "doc")?;
-    if has_labels { write!(writer, "\tlabel")?; }
+    if has_labels {
+        write!(writer, "\tlabel")?;
+    }
     for t in 0..num_topics {
         write!(writer, "\ttopic_{}", t)?;
     }
@@ -213,7 +213,9 @@ pub fn write_doc_topic_matrix(
 
     for doc_idx in 0..corpus.num_docs() {
         write!(writer, "{}", corpus.doc_names[doc_idx])?;
-        if has_labels { write!(writer, "\t{}", corpus.doc_labels[doc_idx])?; }
+        if has_labels {
+            write!(writer, "\t{}", corpus.doc_labels[doc_idx])?;
+        }
         for t in 0..num_topics {
             write!(writer, "\t{:.8}", theta[doc_idx][t])?;
         }
@@ -221,4 +223,3 @@ pub fn write_doc_topic_matrix(
     }
     Ok(())
 }
-

--- a/src/pa.rs
+++ b/src/pa.rs
@@ -49,23 +49,23 @@
 //! prior informative and stable. The sampler is self-contained and deterministic
 //! for a fixed `rng`.
 
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 use rand::Rng;
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
 
 /// A fitted Pachinko Allocation model (four-level, two-tier).
 pub struct PamModel {
-    pub num_types: usize, // V, vocabulary size
-    pub num_super: usize, // S, number of super-topics
-    pub num_sub: usize,   // K, number of sub-topics
-    pub alpha: f64,       // symmetric Dirichlet prior on the doc→super multinomial
-    pub beta: f64,        // symmetric Dirichlet prior on the sub-topic→word multinomials
+    pub num_types: usize,         // V, vocabulary size
+    pub num_super: usize,         // S, number of super-topics
+    pub num_sub: usize,           // K, number of sub-topics
+    pub alpha: f64,               // symmetric Dirichlet prior on the doc→super multinomial
+    pub beta: f64,                // symmetric Dirichlet prior on the sub-topic→word multinomials
     pub alpha_sk: Vec<Vec<f64>>,  // S × K  estimated super→sub Dirichlet parameters
     pub nkw: Vec<Vec<u32>>,       // K × V  sub-topic ↦ word counts
     pub nk: Vec<u32>,             // K      sub-topic totals
     pub nds: Vec<Vec<u32>>,       // D × S  doc ↦ super-topic counts
     pub ndsk: Vec<Vec<Vec<u32>>>, // D × S × K  doc ↦ (super, sub) counts
-    pub zs: Vec<Vec<usize>>, // per-document token super-topic assignments
-    pub zk: Vec<Vec<usize>>, // per-document token sub-topic assignments
+    pub zs: Vec<Vec<usize>>,      // per-document token super-topic assignments
+    pub zk: Vec<Vec<usize>>,      // per-document token sub-topic assignments
     /// Thinned θ draws (num_draws, D, K): sub-topic proportions marginalized
     /// over super-topics at each snapshot. Empty when draw_cap=0.
     pub theta_draws: Vec<Vec<Vec<f32>>>,
@@ -89,7 +89,9 @@ impl PamModel {
             .zip(&self.nk)
             .map(|(row, &nk)| {
                 let denom = nk as f64 + v as f64 * self.beta;
-                row.iter().map(|&c| (c as f64 + self.beta) / denom).collect()
+                row.iter()
+                    .map(|&c| (c as f64 + self.beta) / denom)
+                    .collect()
             })
             .collect()
     }
@@ -149,20 +151,39 @@ impl PamModel {
 }
 
 impl Estimator for PamModel {
-    fn num_topics(&self) -> usize { self.num_sub }
-    fn topic_word(&self) -> Vec<Vec<f64>> { PamModel::topic_word(self) }
-    fn doc_topic(&self) -> Vec<Vec<f64>> { PamModel::doc_topic(self) }
-    fn fit_history(&self) -> Vec<(usize, f64)> { Vec::new() }
-    fn converged(&self) -> Option<bool> { None }
-    fn model_family(&self) -> ModelFamily { ModelFamily::Dirichlet }
+    fn num_topics(&self) -> usize {
+        self.num_sub
+    }
+    fn topic_word(&self) -> Vec<Vec<f64>> {
+        PamModel::topic_word(self)
+    }
+    fn doc_topic(&self) -> Vec<Vec<f64>> {
+        PamModel::doc_topic(self)
+    }
+    fn fit_history(&self) -> Vec<(usize, f64)> {
+        Vec::new()
+    }
+    fn converged(&self) -> Option<bool> {
+        None
+    }
+    fn model_family(&self) -> ModelFamily {
+        ModelFamily::Dirichlet
+    }
 }
 
 impl DirichletModel for PamModel {
-    fn alpha(&self) -> Vec<f64> { vec![self.alpha; self.num_sub] }
+    fn alpha(&self) -> Vec<f64> {
+        vec![self.alpha; self.num_sub]
+    }
     fn theta_draws(&self) -> Vec<Vec<Vec<f64>>> {
-        self.theta_draws.iter().map(|d| {
-            d.iter().map(|r| r.iter().map(|&x| x as f64).collect()).collect()
-        }).collect()
+        self.theta_draws
+            .iter()
+            .map(|d| {
+                d.iter()
+                    .map(|r| r.iter().map(|&x| x as f64).collect())
+                    .collect()
+            })
+            .collect()
     }
     fn doc_lengths(&self) -> Vec<usize> {
         self.zk.iter().map(|d| d.len()).collect()
@@ -185,7 +206,14 @@ impl PamModel {
     /// Draw a `(super, sub)` pair for token (d, i)=w from the current state (the
     /// token's counts must already be removed) and add the token back under the
     /// chosen pair.
-    fn assign_token<R: Rng>(&mut self, d: usize, i: usize, w: usize, probs: &mut [f64], rng: &mut R) {
+    fn assign_token<R: Rng>(
+        &mut self,
+        d: usize,
+        i: usize,
+        w: usize,
+        probs: &mut [f64],
+        rng: &mut R,
+    ) {
         let v = self.num_types;
         let s_count = self.num_super;
         let k = self.num_sub;
@@ -327,9 +355,16 @@ pub fn fit_pam<R: Rng>(
     // Plain fit is the draw-collecting fit with collection disabled, so the
     // sampler lives in exactly one place (see `fit_pam_with_draws`).
     let (model, _, _) = fit_pam_with_draws(
-        docs, num_types, num_super, num_sub, alpha, beta, iters,
+        docs,
+        num_types,
+        num_super,
+        num_sub,
+        alpha,
+        beta,
+        iters,
         crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
-        0.0, 0,
+        0.0,
+        0,
         rng,
     );
     model
@@ -368,7 +403,11 @@ pub fn fit_pam_with_draws<R: Rng>(
             (0..num_sub)
                 .map(|kk| {
                     let owner = (kk * num_super) / num_sub;
-                    if owner == s { alpha * 5.0 } else { alpha }
+                    if owner == s {
+                        alpha * 5.0
+                    } else {
+                        alpha
+                    }
                 })
                 .collect()
         })
@@ -414,15 +453,21 @@ pub fn fit_pam_with_draws<R: Rng>(
         }
         let iter = it + 1;
         if opts.thin > 0 && iter % opts.thin == 0 {
-            let snap: Vec<Vec<f32>> = model.ndsk.iter().map(|doc| {
-                let mut row = vec![0.0f64; k];
-                for sub in 0..k {
-                    let total: u32 = (0..model.num_super).map(|s| doc[s][sub]).sum();
-                    row[sub] = total as f64 + model.alpha;
-                }
-                let s: f64 = row.iter().sum();
-                row.iter().map(|&x| (if s > 0.0 { x / s } else { 1.0 / k as f64 }) as f32).collect()
-            }).collect();
+            let snap: Vec<Vec<f32>> = model
+                .ndsk
+                .iter()
+                .map(|doc| {
+                    let mut row = vec![0.0f64; k];
+                    for sub in 0..k {
+                        let total: u32 = (0..model.num_super).map(|s| doc[s][sub]).sum();
+                        row[sub] = total as f64 + model.alpha;
+                    }
+                    let s: f64 = row.iter().sum();
+                    row.iter()
+                        .map(|&x| (if s > 0.0 { x / s } else { 1.0 / k as f64 }) as f32)
+                        .collect()
+                })
+                .collect();
             if model.theta_draws.len() < opts.cap {
                 model.theta_draws.push(snap);
             } else {
@@ -506,14 +551,20 @@ mod tests {
                 }
             }
             assert_ne!(
-                sub_to_block[k], usize::MAX,
+                sub_to_block[k],
+                usize::MAX,
                 "sub-topic {} top words do not fill a single planted block",
                 k
             );
         }
         // All four blocks should be covered, one per sub-topic (a bijection).
         let covered: std::collections::HashSet<usize> = sub_to_block.iter().copied().collect();
-        assert_eq!(covered.len(), 4, "sub-topics did not recover all 4 blocks: {:?}", sub_to_block);
+        assert_eq!(
+            covered.len(),
+            4,
+            "sub-topics did not recover all 4 blocks: {:?}",
+            sub_to_block
+        );
 
         // (2) The super_sub() matrix groups the co-occurring sub-topics. For each
         // super-topic take its top-2 sub-topics, translate to the blocks they
@@ -527,10 +578,8 @@ mod tests {
             idx[..2].iter().map(|&k| sub_to_block[k]).collect()
         };
         let recovered: Vec<std::collections::HashSet<usize>> = (0..2).map(top2_blocks).collect();
-        let planted: Vec<std::collections::HashSet<usize>> = groups
-            .iter()
-            .map(|g| g.iter().copied().collect())
-            .collect();
+        let planted: Vec<std::collections::HashSet<usize>> =
+            groups.iter().map(|g| g.iter().copied().collect()).collect();
 
         // Match super-topics to planted groups up to permutation.
         let matches = |perm: [usize; 2]| -> bool {

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -36,7 +36,9 @@ use rand::Rng;
 /// entries uniform on `[-1/sqrt(fan_in), 1/sqrt(fan_in)]`.
 fn kaiming<R: Rng>(len: usize, fan_in: usize, rng: &mut R) -> Vec<f64> {
     let bound = 1.0 / (fan_in.max(1) as f64).sqrt();
-    (0..len).map(|_| (rng.gen::<f64>() * 2.0 - 1.0) * bound).collect()
+    (0..len)
+        .map(|_| (rng.gen::<f64>() * 2.0 - 1.0) * bound)
+        .collect()
 }
 
 /// A standard-normal sample via Box-Muller.
@@ -87,7 +89,11 @@ struct BnCache {
 
 impl BatchNorm {
     pub(crate) fn new(f: usize) -> Self {
-        BatchNorm { running_mean: vec![0.0; f], running_var: vec![1.0; f], momentum: 0.1 }
+        BatchNorm {
+            running_mean: vec![0.0; f],
+            running_var: vec![1.0; f],
+            momentum: 0.1,
+        }
     }
 
     /// Forward over a minibatch `x` (N x F) using batch statistics. Returns the
@@ -199,10 +205,10 @@ pub struct Weights {
     pub hidden: usize,
     pub k: usize,
     pub mode: InputMode,
-    pub w1: Vec<f64>, // hidden x (V + E)
-    pub b1: Vec<f64>, // hidden
-    pub w2: Vec<f64>, // hidden x hidden
-    pub b2: Vec<f64>, // hidden
+    pub w1: Vec<f64>,   // hidden x (V + E)
+    pub b1: Vec<f64>,   // hidden
+    pub w2: Vec<f64>,   // hidden x hidden
+    pub b2: Vec<f64>,   // hidden
     pub w_mu: Vec<f64>, // K x hidden
     pub b_mu: Vec<f64>, // K
     pub w_ls: Vec<f64>, // K x hidden
@@ -299,7 +305,14 @@ impl Weights {
             mu_raw[c] = sm;
             lv_raw[c] = sl;
         }
-        DocCache { pre1, h1, pre2, hd, mu_raw, lv_raw }
+        DocCache {
+            pre1,
+            h1,
+            pre2,
+            hd,
+            mu_raw,
+            lv_raw,
+        }
     }
 }
 
@@ -344,8 +357,15 @@ impl Grad {
     }
     pub(crate) fn scale(&mut self, s: f64) {
         for blk in [
-            &mut self.w1, &mut self.b1, &mut self.w2, &mut self.b2, &mut self.w_mu,
-            &mut self.b_mu, &mut self.w_ls, &mut self.b_ls, &mut self.beta,
+            &mut self.w1,
+            &mut self.b1,
+            &mut self.w2,
+            &mut self.b2,
+            &mut self.w_mu,
+            &mut self.b_mu,
+            &mut self.w_ls,
+            &mut self.b_ls,
+            &mut self.beta,
         ] {
             for x in blk.iter_mut() {
                 *x *= s;
@@ -362,8 +382,10 @@ pub(crate) fn laplace_prior(alpha: &[f64]) -> (Vec<f64>, Vec<f64>) {
     let mean_log: f64 = alpha.iter().map(|&a| a.ln()).sum::<f64>() / kf;
     let sum_inv: f64 = alpha.iter().map(|&a| 1.0 / a).sum();
     let mu1: Vec<f64> = alpha.iter().map(|&a| a.ln() - mean_log).collect();
-    let var1: Vec<f64> =
-        alpha.iter().map(|&a| (1.0 / a) * (1.0 - 2.0 / kf) + sum_inv / (kf * kf)).collect();
+    let var1: Vec<f64> = alpha
+        .iter()
+        .map(|&a| (1.0 / a) * (1.0 - 2.0 / kf) + sum_inv / (kf * kf))
+        .collect();
     (mu1, var1)
 }
 
@@ -550,11 +572,11 @@ pub(crate) struct BatchCache {
     bn_mu: BnCache,
     bn_lv: BnCache,
     bn_dec: BnCache,
-    mu: Vec<Vec<f64>>,      // N x K (post-BN)
-    lv: Vec<Vec<f64>>,      // N x K (post-BN)
-    theta: Vec<Vec<f64>>,   // N x K
+    mu: Vec<Vec<f64>>,       // N x K (post-BN)
+    lv: Vec<Vec<f64>>,       // N x K (post-BN)
+    theta: Vec<Vec<f64>>,    // N x K
     theta_do: Vec<Vec<f64>>, // N x K (post-dropout)
-    recon: Vec<Vec<f64>>,   // N x V
+    recon: Vec<Vec<f64>>,    // N x V
     // Dirichlet (Weibull) reparameterization scratch, empty on the laplace path.
     // For each (doc, topic): Weibull shape `kw`, scale `lam`, the constant
     // `L = -ln(1-u)` from the noise, and the unnormalized weight `g = lam * L^(1/kw)`.
@@ -576,11 +598,11 @@ struct SbCache {
 
 /// Per-(doc, topic) Weibull reparameterization quantities for the Dirichlet prior.
 struct DirCache {
-    kw: Vec<Vec<f64>>,  // N x K Weibull shape  = softplus(mu) + floor
-    lam: Vec<Vec<f64>>, // N x K Weibull scale  = softplus(lv) + floor
+    kw: Vec<Vec<f64>>,   // N x K Weibull shape  = softplus(mu) + floor
+    lam: Vec<Vec<f64>>,  // N x K Weibull scale  = softplus(lv) + floor
     ln_l: Vec<Vec<f64>>, // N x K  ln L, L = -ln(1-u), u = Phi(eps) (constant in params)
-    g: Vec<Vec<f64>>,   // N x K unnormalized weight g = lam * L^(1/kw)
-    s: Vec<f64>,        // N      normalizer sum_t g
+    g: Vec<Vec<f64>>,    // N x K unnormalized weight g = lam * L^(1/kw)
+    s: Vec<f64>,         // N      normalizer sum_t g
 }
 
 /// The contrastive positive view: a second deterministic topic vector per document.
@@ -621,8 +643,7 @@ pub(crate) fn weibull_weight(a: f64, b: f64, ln_l: f64) -> (f64, f64, f64) {
 /// into independent `Gamma(alpha, 1)` priors on the unnormalized weights, so the KL
 /// sums these per-topic terms.
 pub(crate) fn weibull_gamma_kl(kw: f64, lam: f64, alpha: f64) -> f64 {
-    EULER_GAMMA * alpha / kw - alpha * lam.ln() + kw.ln()
-        + lam * lgamma(1.0 + 1.0 / kw).exp()
+    EULER_GAMMA * alpha / kw - alpha * lam.ln() + kw.ln() + lam * lgamma(1.0 + 1.0 / kw).exp()
         - EULER_GAMMA
         - 1.0
         + lgamma(alpha)
@@ -652,8 +673,7 @@ fn digamma(mut x: f64) -> f64 {
     }
     let inv = 1.0 / x;
     let inv2 = inv * inv;
-    result + x.ln() - 0.5 * inv
-        - inv2 * (1.0 / 12.0 - inv2 * (1.0 / 120.0 - inv2 / 252.0))
+    result + x.ln() - 0.5 * inv - inv2 * (1.0 / 12.0 - inv2 * (1.0 / 120.0 - inv2 / 252.0))
 }
 
 /// InfoNCE contrastive loss (CLNTM, Nguyen & Luu 2021) over a minibatch of topic
@@ -728,7 +748,11 @@ fn cosine_grad_a(a: &[f64], b: &[f64]) -> Vec<f64> {
 /// InfoNCE loss w.r.t. the anchor vectors `z` and the positive-view vectors `z_pos`.
 /// Each anchor `z_i` appears both as its own anchor and as a negative for every
 /// other document, so its gradient accumulates both contributions.
-pub(crate) fn info_nce_backward(z: &[Vec<f64>], z_pos: &[Vec<f64>], temp: f64) -> (Vec<Vec<f64>>, Vec<Vec<f64>>) {
+pub(crate) fn info_nce_backward(
+    z: &[Vec<f64>],
+    z_pos: &[Vec<f64>],
+    temp: f64,
+) -> (Vec<Vec<f64>>, Vec<Vec<f64>>) {
     let n = z.len();
     let k = if n > 0 { z[0].len() } else { 0 };
     let mut dz = vec![vec![0.0; k]; n];
@@ -790,8 +814,9 @@ pub(crate) fn batch_forward(
     let n = batch.xns.len();
 
     // Encoder up to the pre-BN heads.
-    let doc: Vec<DocCache> =
-        (0..n).map(|i| w.encode_raw(batch.xns[i], batch.embs[i], &batch.masks2[i])).collect();
+    let doc: Vec<DocCache> = (0..n)
+        .map(|i| w.encode_raw(batch.xns[i], batch.embs[i], &batch.masks2[i]))
+        .collect();
     let mu_raw: Vec<Vec<f64>> = doc.iter().map(|d| d.mu_raw.clone()).collect();
     let lv_raw: Vec<Vec<f64>> = doc.iter().map(|d| d.lv_raw.clone()).collect();
 
@@ -916,7 +941,8 @@ pub(crate) fn batch_forward(
             for t in 0..k {
                 let s0 = lv[i][t].exp();
                 let dm = prior_mu[t] - mu[i][t];
-                kl += s0 / prior_var[t] + dm * dm / prior_var[t] - 1.0 + prior_var[t].ln() - lv[i][t];
+                kl +=
+                    s0 / prior_var[t] + dm * dm / prior_var[t] - 1.0 + prior_var[t].ln() - lv[i][t];
             }
             loss += 0.5 * kl;
         }
@@ -939,13 +965,27 @@ pub(crate) fn batch_forward(
         theta_do,
         recon,
         dir: if dirichlet {
-            Some(DirCache { kw: d_kw, lam: d_lam, ln_l: d_ln_l, g: d_g, s: d_s })
+            Some(DirCache {
+                kw: d_kw,
+                lam: d_lam,
+                ln_l: d_ln_l,
+                g: d_g,
+                s: d_s,
+            })
         } else {
             None
         },
-        sb: if stick { Some(SbCache { eta: sb_eta }) } else { None },
+        sb: if stick {
+            Some(SbCache { eta: sb_eta })
+        } else {
+            None
+        },
         contrast: if contrastive {
-            Some(ContrastCache { theta_pos, g_pos, s_pos })
+            Some(ContrastCache {
+                theta_pos,
+                g_pos,
+                s_pos,
+            })
         } else {
             None
         },
@@ -1045,7 +1085,11 @@ pub(crate) fn batch_backward(
         }
         let dzp: Vec<Vec<f64>> = dzp
             .into_iter()
-            .map(|row| row.into_iter().map(|x| x * opts.contrastive_weight).collect())
+            .map(|row| {
+                row.into_iter()
+                    .map(|x| x * opts.contrastive_weight)
+                    .collect()
+            })
             .collect();
         (Some(dz), Some(dzp))
     } else {
@@ -1069,8 +1113,16 @@ pub(crate) fn batch_backward(
         if dirichlet {
             let dir = c.dir.as_ref().unwrap();
             weibull_reparam_backward(
-                &dtheta, &dir.g[i], dir.s[i], &dir.kw[i], &dir.lam[i], &dir.ln_l[i],
-                &c.mu[i], &c.lv[i], &mut dmu[i], &mut dlv[i],
+                &dtheta,
+                &dir.g[i],
+                dir.s[i],
+                &dir.kw[i],
+                &dir.lam[i],
+                &dir.ln_l[i],
+                &c.mu[i],
+                &c.lv[i],
+                &mut dmu[i],
+                &mut dlv[i],
             );
             // KL( Weibull || Gamma ) gradients, through softplus on each head.
             for t in 0..k {
@@ -1107,11 +1159,23 @@ pub(crate) fn batch_backward(
                 // theta_pos via Weibull at u = 0.5 (L = ln 2), depends on mu and lv.
                 let ln2 = std::f64::consts::LN_2;
                 let ln_l_pos = vec![ln2.ln(); k]; // ln L, L = -ln(1-0.5) = ln 2
-                let kw_pos: Vec<f64> = (0..k).map(|t| softplus(c.mu[i][t]) + WEIBULL_SHAPE_FLOOR).collect();
-                let lam_pos: Vec<f64> = (0..k).map(|t| softplus(c.lv[i][t]) + WEIBULL_FLOOR).collect();
+                let kw_pos: Vec<f64> = (0..k)
+                    .map(|t| softplus(c.mu[i][t]) + WEIBULL_SHAPE_FLOOR)
+                    .collect();
+                let lam_pos: Vec<f64> = (0..k)
+                    .map(|t| softplus(c.lv[i][t]) + WEIBULL_FLOOR)
+                    .collect();
                 weibull_reparam_backward(
-                    &dzp[i], &cc.g_pos[i], cc.s_pos[i], &kw_pos, &lam_pos, &ln_l_pos,
-                    &c.mu[i], &c.lv[i], &mut dmu[i], &mut dlv[i],
+                    &dzp[i],
+                    &cc.g_pos[i],
+                    cc.s_pos[i],
+                    &kw_pos,
+                    &lam_pos,
+                    &ln_l_pos,
+                    &c.mu[i],
+                    &c.lv[i],
+                    &mut dmu[i],
+                    &mut dlv[i],
                 );
             } else if stick {
                 // theta_pos via no-noise stick-breaking on z = mu; grad into mu only.
@@ -1210,7 +1274,14 @@ struct Adam {
 
 impl Adam {
     fn new(len: usize, lr: f64, b1: f64, wd: f64) -> Self {
-        Adam { m: vec![0.0; len], v: vec![0.0; len], t: 0, lr, b1, wd }
+        Adam {
+            m: vec![0.0; len],
+            v: vec![0.0; len],
+            t: 0,
+            lr,
+            b1,
+            wd,
+        }
     }
     fn step(&mut self, p: &mut [f64], grad: &[f64]) {
         const B2: f64 = 0.999;
@@ -1218,8 +1289,9 @@ impl Adam {
         self.t += 1;
         let bc1 = 1.0 - self.b1.powi(self.t as i32);
         let bc2 = 1.0 - B2.powi(self.t as i32);
-        for (pi, (&g0, (mi, vi))) in
-            p.iter_mut().zip(grad.iter().zip(self.m.iter_mut().zip(self.v.iter_mut())))
+        for (pi, (&g0, (mi, vi))) in p
+            .iter_mut()
+            .zip(grad.iter().zip(self.m.iter_mut().zip(self.v.iter_mut())))
         {
             let g = g0 + self.wd * *pi;
             *mi = self.b1 * *mi + (1.0 - self.b1) * g;
@@ -1294,7 +1366,9 @@ impl ProdldaModel {
     /// topic display.
     pub fn topic_word(&self) -> Vec<Vec<f64>> {
         let (k, v) = (self.num_topics, self.num_types);
-        (0..k).map(|t| softmax(&self.weights.beta[t * v..(t + 1) * v])).collect()
+        (0..k)
+            .map(|t| softmax(&self.weights.beta[t * v..(t + 1) * v]))
+            .collect()
     }
 
     /// Topic proportions for new documents: one encoder forward pass each,
@@ -1375,8 +1449,21 @@ pub fn fit_prodlda<R: Rng>(
 ) -> ProdldaModel {
     let empty: Vec<Vec<f64>> = vec![Vec::new(); docs.len()];
     fit_avitm(
-        docs, &empty, InputMode::BowOnly, num_topics, num_types, 0, hidden, alpha,
-        dropout, epochs, batch_size, lr, em_tol, AvitmOptions::default(), rng,
+        docs,
+        &empty,
+        InputMode::BowOnly,
+        num_topics,
+        num_types,
+        0,
+        hidden,
+        alpha,
+        dropout,
+        epochs,
+        batch_size,
+        lr,
+        em_tol,
+        AvitmOptions::default(),
+        rng,
     )
 }
 
@@ -1408,7 +1495,10 @@ pub fn fit_avitm<R: Rng>(
     let d = docs.len();
     let xn: Vec<Vec<(usize, f64)>> = docs.iter().map(|doc| normalized_bow(doc)).collect();
     let bows: Vec<Vec<(usize, f64)>> = docs.iter().map(|doc| raw_bow(doc)).collect();
-    let totals: Vec<f64> = bows.iter().map(|b| b.iter().map(|&(_, c)| c).sum()).collect();
+    let totals: Vec<f64> = bows
+        .iter()
+        .map(|b| b.iter().map(|&(_, c)| c).sum())
+        .collect();
 
     let alpha_vec = vec![alpha; k];
     let (prior_mu, prior_var) = laplace_prior(&alpha_vec);
@@ -1441,18 +1531,33 @@ pub fn fit_avitm<R: Rng>(
                 continue; // batchnorm needs at least two documents
             }
             // Per-document reparameterization noise and dropout masks.
-            let eps: Vec<Vec<f64>> =
-                (0..n).map(|_| (0..k).map(|_| randn(rng)).collect()).collect();
+            let eps: Vec<Vec<f64>> = (0..n)
+                .map(|_| (0..k).map(|_| randn(rng)).collect())
+                .collect();
             let masks2: Vec<Vec<f64>> = (0..n)
                 .map(|_| {
                     (0..hidden)
-                        .map(|_| if rng.gen::<f64>() < keep { 1.0 / keep } else { 0.0 })
+                        .map(|_| {
+                            if rng.gen::<f64>() < keep {
+                                1.0 / keep
+                            } else {
+                                0.0
+                            }
+                        })
                         .collect()
                 })
                 .collect();
             let masks_t: Vec<Vec<f64>> = (0..n)
                 .map(|_| {
-                    (0..k).map(|_| if rng.gen::<f64>() < keep { 1.0 / keep } else { 0.0 }).collect()
+                    (0..k)
+                        .map(|_| {
+                            if rng.gen::<f64>() < keep {
+                                1.0 / keep
+                            } else {
+                                0.0
+                            }
+                        })
+                        .collect()
                 })
                 .collect();
             let batch = Batch {
@@ -1473,7 +1578,9 @@ pub fn fit_avitm<R: Rng>(
             bn_dec.update_running(&stats[2].0, &stats[2].1);
 
             let mut g = Grad::zeros(&w);
-            batch_backward(&w, &prior_mu, &prior_var, &alpha_vec, &opts, &batch, &cache, &mut g);
+            batch_backward(
+                &w, &prior_mu, &prior_var, &alpha_vec, &opts, &batch, &cache, &mut g,
+            );
             g.scale(1.0 / n as f64);
             opt.step(&mut w, &g);
 
@@ -1561,7 +1668,10 @@ mod tests {
         let bn_mu = BatchNorm::new(w.k);
         let bn_lv = BatchNorm::new(w.k);
         let bn_dec = BatchNorm::new(w.v);
-        batch_forward(w, &bn_mu, &bn_lv, &bn_dec, prior_mu, prior_var, alpha, opts, batch).0
+        batch_forward(
+            w, &bn_mu, &bn_lv, &bn_dec, prior_mu, prior_var, alpha, opts, batch,
+        )
+        .0
     }
 
     // FD gradient check for a given encoder input mode and option set. Every weight
@@ -1576,18 +1686,33 @@ mod tests {
         let (prior_mu, prior_var) = laplace_prior(&alpha);
 
         // A small batch (>=2 docs so batchnorm statistics are well-defined).
-        let docs: Vec<Vec<u32>> =
-            vec![vec![0, 0, 2, 3, 6], vec![1, 4, 4, 5], vec![2, 2, 3, 5, 6, 0]];
+        let docs: Vec<Vec<u32>> = vec![
+            vec![0, 0, 2, 3, 6],
+            vec![1, 4, 4, 5],
+            vec![2, 2, 3, 5, 6, 0],
+        ];
         let xns: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| normalized_bow(d)).collect();
         let bows: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| raw_bow(d)).collect();
-        let totals: Vec<f64> = bows.iter().map(|b| b.iter().map(|&(_, c)| c).sum()).collect();
+        let totals: Vec<f64> = bows
+            .iter()
+            .map(|b| b.iter().map(|&(_, c)| c).sum())
+            .collect();
         let n = docs.len();
         // Distinct, nonzero embeddings so the embedding columns get a real signal.
         let embs: Vec<Vec<f64>> = (0..n)
-            .map(|i| (0..emb_dim).map(|j| 0.3 * (i as f64 + 1.0) - 0.17 * j as f64 + 0.05).collect())
+            .map(|i| {
+                (0..emb_dim)
+                    .map(|j| 0.3 * (i as f64 + 1.0) - 0.17 * j as f64 + 0.05)
+                    .collect()
+            })
             .collect();
-        let eps: Vec<Vec<f64>> =
-            (0..n).map(|i| (0..k).map(|t| 0.1 * (i as f64 + 1.0) - 0.05 * t as f64).collect()).collect();
+        let eps: Vec<Vec<f64>> = (0..n)
+            .map(|i| {
+                (0..k)
+                    .map(|t| 0.1 * (i as f64 + 1.0) - 0.05 * t as f64)
+                    .collect()
+            })
+            .collect();
         let masks2 = vec![vec![1.0; hidden]; n]; // dropout disabled for the check
         let masks_t = vec![vec![1.0; k]; n];
         let batch = Batch {
@@ -1604,10 +1729,13 @@ mod tests {
         let bn_mu = BatchNorm::new(k);
         let bn_lv = BatchNorm::new(k);
         let bn_dec = BatchNorm::new(v);
-        let (_, cache, _) =
-            batch_forward(&w0, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha, &opts, &batch);
+        let (_, cache, _) = batch_forward(
+            &w0, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha, &opts, &batch,
+        );
         let mut g = Grad::zeros(&w0);
-        batch_backward(&w0, &prior_mu, &prior_var, &alpha, &opts, &batch, &cache, &mut g);
+        batch_backward(
+            &w0, &prior_mu, &prior_var, &alpha, &opts, &batch, &cache, &mut g,
+        );
 
         let fd = 1e-6;
         let mut max_rel = 0.0f64;
@@ -1636,7 +1764,11 @@ mod tests {
                     assert!(
                         abs_err < 1e-4,
                         "{:?} {} [{}]: analytic {} vs numeric {}",
-                        mode, $label, idx, analytic, num
+                        mode,
+                        $label,
+                        idx,
+                        analytic,
+                        num
                     );
                 }
             };
@@ -1683,7 +1815,10 @@ mod tests {
             ..AvitmOptions::default()
         };
         let max_rel = fd_check_mode_opts(InputMode::BowOnly, 0, opts);
-        assert!(max_rel < 1e-4, "contrastive bow-only max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "contrastive bow-only max relative error {max_rel}"
+        );
     }
 
     #[test]
@@ -1695,36 +1830,63 @@ mod tests {
             ..AvitmOptions::default()
         };
         let max_rel = fd_check_mode_opts(InputMode::BowEmb, 6, opts);
-        assert!(max_rel < 1e-4, "contrastive bow+emb max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "contrastive bow+emb max relative error {max_rel}"
+        );
     }
 
     // --- #176 Dirichlet (Weibull) prior FD checks (BowOnly + an embedding mode) --
     #[test]
     fn dirichlet_gradients_match_fd_bow_only() {
-        let opts = AvitmOptions { prior: Prior::Dirichlet, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            prior: Prior::Dirichlet,
+            ..AvitmOptions::default()
+        };
         let max_rel = fd_check_mode_opts(InputMode::BowOnly, 0, opts);
-        assert!(max_rel < 1e-4, "dirichlet bow-only max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "dirichlet bow-only max relative error {max_rel}"
+        );
     }
 
     #[test]
     fn dirichlet_gradients_match_fd_emb_only() {
-        let opts = AvitmOptions { prior: Prior::Dirichlet, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            prior: Prior::Dirichlet,
+            ..AvitmOptions::default()
+        };
         let max_rel = fd_check_mode_opts(InputMode::EmbOnly, 6, opts);
-        assert!(max_rel < 1e-4, "dirichlet emb-only max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "dirichlet emb-only max relative error {max_rel}"
+        );
     }
 
     #[test]
     fn stick_breaking_gradients_match_fd_bow_only() {
-        let opts = AvitmOptions { prior: Prior::StickBreaking, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            prior: Prior::StickBreaking,
+            ..AvitmOptions::default()
+        };
         let max_rel = fd_check_mode_opts(InputMode::BowOnly, 0, opts);
-        assert!(max_rel < 1e-4, "stick-breaking bow-only max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "stick-breaking bow-only max relative error {max_rel}"
+        );
     }
 
     #[test]
     fn stick_breaking_gradients_match_fd_emb_only() {
-        let opts = AvitmOptions { prior: Prior::StickBreaking, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            prior: Prior::StickBreaking,
+            ..AvitmOptions::default()
+        };
         let max_rel = fd_check_mode_opts(InputMode::EmbOnly, 6, opts);
-        assert!(max_rel < 1e-4, "stick-breaking emb-only max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "stick-breaking emb-only max relative error {max_rel}"
+        );
     }
 
     // --- composition: both flags on at once must still FD-check ------------------
@@ -1737,7 +1899,10 @@ mod tests {
             contrastive_temp: 0.5,
         };
         let max_rel = fd_check_mode_opts(InputMode::BowEmb, 6, opts);
-        assert!(max_rel < 1e-4, "contrastive+dirichlet max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "contrastive+dirichlet max relative error {max_rel}"
+        );
     }
 
     #[test]
@@ -1749,7 +1914,10 @@ mod tests {
             contrastive_temp: 0.5,
         };
         let max_rel = fd_check_mode_opts(InputMode::BowEmb, 6, opts);
-        assert!(max_rel < 1e-4, "contrastive+stick-breaking max relative error {max_rel}");
+        assert!(
+            max_rel < 1e-4,
+            "contrastive+stick-breaking max relative error {max_rel}"
+        );
     }
 
     // The Weibull-to-Gamma KL gradient checked directly against finite differences.
@@ -1758,8 +1926,10 @@ mod tests {
         let fd = 1e-7;
         for &(kw, lam, a) in &[(0.7, 1.3, 1.0), (2.0, 0.5, 0.8), (1.1, 2.2, 1.5)] {
             let (dkw, dlam) = weibull_gamma_kl_grad(kw, lam, a);
-            let num_kw = (weibull_gamma_kl(kw + fd, lam, a) - weibull_gamma_kl(kw - fd, lam, a)) / (2.0 * fd);
-            let num_lam = (weibull_gamma_kl(kw, lam + fd, a) - weibull_gamma_kl(kw, lam - fd, a)) / (2.0 * fd);
+            let num_kw = (weibull_gamma_kl(kw + fd, lam, a) - weibull_gamma_kl(kw - fd, lam, a))
+                / (2.0 * fd);
+            let num_lam = (weibull_gamma_kl(kw, lam + fd, a) - weibull_gamma_kl(kw, lam - fd, a))
+                / (2.0 * fd);
             assert!((dkw - num_kw).abs() < 1e-5, "dkw {dkw} vs {num_kw}");
             assert!((dlam - num_lam).abs() < 1e-5, "dlam {dlam} vs {num_lam}");
         }
@@ -1788,7 +1958,9 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..180)
             .map(|d| {
                 let b = d % k;
-                (0..15).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..15)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
 
@@ -1822,7 +1994,9 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..180)
             .map(|d| {
                 let b = d % k;
-                (0..15).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..15)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
         let m = fit_prodlda(&docs, k, v, 32, 1.0, 0.0, 250, 60, 0.01, 0.0, &mut rng);
@@ -1876,8 +2050,21 @@ mod tests {
         let (docs, embs, k, block, v) = planted_emb_corpus(180, 1);
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let m = fit_avitm(
-            &docs, &embs, InputMode::BowEmb, k, v, k, 32, 1.0, 0.0, 250, 60, 0.01, 0.0,
-            AvitmOptions::default(), &mut rng,
+            &docs,
+            &embs,
+            InputMode::BowEmb,
+            k,
+            v,
+            k,
+            32,
+            1.0,
+            0.0,
+            250,
+            60,
+            0.01,
+            0.0,
+            AvitmOptions::default(),
+            &mut rng,
         );
         let tw = m.topic_word();
         for row in &tw {
@@ -1886,7 +2073,11 @@ mod tests {
         for row in &m.doc_topic {
             assert!((row.iter().sum::<f64>() - 1.0).abs() < 1e-9);
         }
-        assert_eq!(top_blocks(&tw, k, v, block), k, "topics did not cover all blocks");
+        assert_eq!(
+            top_blocks(&tw, k, v, block),
+            k,
+            "topics did not cover all blocks"
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }
@@ -1896,15 +2087,32 @@ mod tests {
         let (docs, embs, k, block, v) = planted_emb_corpus(180, 1);
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let m = fit_avitm(
-            &docs, &embs, InputMode::EmbOnly, k, v, k, 32, 1.0, 0.0, 250, 60, 0.01, 0.0,
-            AvitmOptions::default(), &mut rng,
+            &docs,
+            &embs,
+            InputMode::EmbOnly,
+            k,
+            v,
+            k,
+            32,
+            1.0,
+            0.0,
+            250,
+            60,
+            0.01,
+            0.0,
+            AvitmOptions::default(),
+            &mut rng,
         );
         let tw = m.topic_word();
         for row in &tw {
             assert!((row.iter().sum::<f64>() - 1.0).abs() < 1e-9);
         }
         // The encoder never saw the BoW; topics are recovered from embeddings alone.
-        assert_eq!(top_blocks(&tw, k, v, block), k, "topics did not cover all blocks");
+        assert_eq!(
+            top_blocks(&tw, k, v, block),
+            k,
+            "topics did not cover all blocks"
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }
@@ -1915,10 +2123,49 @@ mod tests {
         for mode in [InputMode::BowEmb, InputMode::EmbOnly] {
             let mut r1 = ChaCha8Rng::seed_from_u64(11);
             let mut r2 = ChaCha8Rng::seed_from_u64(11);
-            let a = fit_avitm(&docs, &embs, mode, k, v, k, 16, 1.0, 0.0, 30, 30, 0.01, 0.0, AvitmOptions::default(), &mut r1);
-            let b = fit_avitm(&docs, &embs, mode, k, v, k, 16, 1.0, 0.0, 30, 30, 0.01, 0.0, AvitmOptions::default(), &mut r2);
-            assert_eq!(a.topic_word(), b.topic_word(), "{mode:?} topic_word not bit-identical");
-            assert_eq!(a.doc_topic, b.doc_topic, "{mode:?} doc_topic not bit-identical");
+            let a = fit_avitm(
+                &docs,
+                &embs,
+                mode,
+                k,
+                v,
+                k,
+                16,
+                1.0,
+                0.0,
+                30,
+                30,
+                0.01,
+                0.0,
+                AvitmOptions::default(),
+                &mut r1,
+            );
+            let b = fit_avitm(
+                &docs,
+                &embs,
+                mode,
+                k,
+                v,
+                k,
+                16,
+                1.0,
+                0.0,
+                30,
+                30,
+                0.01,
+                0.0,
+                AvitmOptions::default(),
+                &mut r2,
+            );
+            assert_eq!(
+                a.topic_word(),
+                b.topic_word(),
+                "{mode:?} topic_word not bit-identical"
+            );
+            assert_eq!(
+                a.doc_topic, b.doc_topic,
+                "{mode:?} doc_topic not bit-identical"
+            );
         }
     }
 
@@ -1931,16 +2178,38 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..180)
             .map(|d| {
                 let b = d % k;
-                (0..15).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..15)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
-        let opts = AvitmOptions { contrastive: true, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            contrastive: true,
+            ..AvitmOptions::default()
+        };
         let m = fit_avitm(
-            &docs, &vec![Vec::new(); docs.len()], InputMode::BowOnly, k, v, 0, 32, 1.0, 0.0,
-            250, 60, 0.01, 0.0, opts, &mut rng,
+            &docs,
+            &vec![Vec::new(); docs.len()],
+            InputMode::BowOnly,
+            k,
+            v,
+            0,
+            32,
+            1.0,
+            0.0,
+            250,
+            60,
+            0.01,
+            0.0,
+            opts,
+            &mut rng,
         );
         let tw = m.topic_word();
-        assert_eq!(top_blocks(&tw, k, v, block), k, "contrastive: topics did not cover all blocks");
+        assert_eq!(
+            top_blocks(&tw, k, v, block),
+            k,
+            "contrastive: topics did not cover all blocks"
+        );
     }
 
     #[test]
@@ -1951,13 +2220,31 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..180)
             .map(|d| {
                 let b = d % k;
-                (0..15).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..15)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
-        let opts = AvitmOptions { prior: Prior::Dirichlet, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            prior: Prior::Dirichlet,
+            ..AvitmOptions::default()
+        };
         let m = fit_avitm(
-            &docs, &vec![Vec::new(); docs.len()], InputMode::BowOnly, k, v, 0, 32, 0.5, 0.0,
-            400, 60, 0.005, 0.0, opts, &mut rng,
+            &docs,
+            &vec![Vec::new(); docs.len()],
+            InputMode::BowOnly,
+            k,
+            v,
+            0,
+            32,
+            0.5,
+            0.0,
+            400,
+            60,
+            0.005,
+            0.0,
+            opts,
+            &mut rng,
         );
         let tw = m.topic_word();
         for row in &tw {
@@ -1979,10 +2266,17 @@ mod tests {
                 counts[w / block] += 1;
             }
             let (dom, &cnt) = counts.iter().enumerate().max_by_key(|(_, &c)| c).unwrap();
-            assert!(cnt >= 2, "dirichlet topic top words do not concentrate in a block");
+            assert!(
+                cnt >= 2,
+                "dirichlet topic top words do not concentrate in a block"
+            );
             covered.insert(dom);
         }
-        assert_eq!(covered.len(), k, "dirichlet: topics did not cover all blocks");
+        assert_eq!(
+            covered.len(),
+            k,
+            "dirichlet: topics did not cover all blocks"
+        );
     }
 
     #[test]
@@ -1993,13 +2287,31 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..180)
             .map(|d| {
                 let b = d % k;
-                (0..15).map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32).collect()
+                (0..15)
+                    .map(|_| (b * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
             })
             .collect();
-        let opts = AvitmOptions { prior: Prior::StickBreaking, ..AvitmOptions::default() };
+        let opts = AvitmOptions {
+            prior: Prior::StickBreaking,
+            ..AvitmOptions::default()
+        };
         let m = fit_avitm(
-            &docs, &vec![Vec::new(); docs.len()], InputMode::BowOnly, k, v, 0, 32, 0.5, 0.0,
-            400, 60, 0.005, 0.0, opts, &mut rng,
+            &docs,
+            &vec![Vec::new(); docs.len()],
+            InputMode::BowOnly,
+            k,
+            v,
+            0,
+            32,
+            0.5,
+            0.0,
+            400,
+            60,
+            0.005,
+            0.0,
+            opts,
+            &mut rng,
         );
         let tw = m.topic_word();
         for row in &tw {
@@ -2021,12 +2333,16 @@ mod tests {
                 counts[w / block] += 1;
             }
             let (dom, &cnt) = counts.iter().enumerate().max_by_key(|(_, &c)| c).unwrap();
-            assert!(cnt >= 2, "stick-breaking topic top words do not concentrate in a block");
+            assert!(
+                cnt >= 2,
+                "stick-breaking topic top words do not concentrate in a block"
+            );
             covered.insert(dom);
         }
-        assert_eq!(covered.len(), k, "stick-breaking: topics did not cover all blocks");
+        assert_eq!(
+            covered.len(),
+            k,
+            "stick-breaking: topics did not cover all blocks"
+        );
     }
 }
-
-
-

--- a/src/pt.rs
+++ b/src/pt.rs
@@ -18,8 +18,8 @@
 //!   - `doc_topic()[d][k]`   = (n_{l_d,k} + α) / (n_{l_d} + K·α)   (D × K)
 //!     i.e. the real doc inherits its pseudo-doc's topic distribution.
 
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 use rand::Rng;
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
 
 // ---------------------------------------------------------------------------
 // Log-Gamma helper (Stirling series shifted to z ≥ 10, matching dmr.rs)
@@ -80,7 +80,9 @@ impl PtmModel {
             .zip(&self.nk)
             .map(|(row, &nk)| {
                 let denom = nk as f64 + v as f64 * self.beta;
-                row.iter().map(|&c| (c as f64 + self.beta) / denom).collect()
+                row.iter()
+                    .map(|&c| (c as f64 + self.beta) / denom)
+                    .collect()
             })
             .collect()
     }
@@ -103,22 +105,43 @@ impl PtmModel {
 }
 
 impl Estimator for PtmModel {
-    fn num_topics(&self) -> usize { self.num_topics }
-    fn topic_word(&self) -> Vec<Vec<f64>> { PtmModel::topic_word(self) }
-    fn doc_topic(&self) -> Vec<Vec<f64>> { PtmModel::doc_topic(self) }
-    fn fit_history(&self) -> Vec<(usize, f64)> { Vec::new() }
-    fn converged(&self) -> Option<bool> { None }
-    fn model_family(&self) -> ModelFamily { ModelFamily::Dirichlet }
+    fn num_topics(&self) -> usize {
+        self.num_topics
+    }
+    fn topic_word(&self) -> Vec<Vec<f64>> {
+        PtmModel::topic_word(self)
+    }
+    fn doc_topic(&self) -> Vec<Vec<f64>> {
+        PtmModel::doc_topic(self)
+    }
+    fn fit_history(&self) -> Vec<(usize, f64)> {
+        Vec::new()
+    }
+    fn converged(&self) -> Option<bool> {
+        None
+    }
+    fn model_family(&self) -> ModelFamily {
+        ModelFamily::Dirichlet
+    }
 }
 
 impl DirichletModel for PtmModel {
-    fn alpha(&self) -> Vec<f64> { vec![self.alpha; self.num_topics] }
-    fn theta_draws(&self) -> Vec<Vec<Vec<f64>>> {
-        self.theta_draws.iter().map(|d| {
-            d.iter().map(|r| r.iter().map(|&x| x as f64).collect()).collect()
-        }).collect()
+    fn alpha(&self) -> Vec<f64> {
+        vec![self.alpha; self.num_topics]
     }
-    fn doc_lengths(&self) -> Vec<usize> { self.z.iter().map(|d| d.len()).collect() }
+    fn theta_draws(&self) -> Vec<Vec<Vec<f64>>> {
+        self.theta_draws
+            .iter()
+            .map(|d| {
+                d.iter()
+                    .map(|r| r.iter().map(|&x| x as f64).collect())
+                    .collect()
+            })
+            .collect()
+    }
+    fn doc_lengths(&self) -> Vec<usize> {
+        self.z.iter().map(|d| d.len()).collect()
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -141,7 +164,14 @@ fn sample_index<R: Rng>(probs: &[f64], rng: &mut R) -> usize {
 impl PtmModel {
     /// Sample a new topic for token (d, i) with word w, given pseudo-doc p.
     /// Removes the token from counts before sampling, then re-adds.
-    fn resample_token<R: Rng>(&mut self, d: usize, i: usize, w: usize, probs: &mut [f64], rng: &mut R) {
+    fn resample_token<R: Rng>(
+        &mut self,
+        d: usize,
+        i: usize,
+        w: usize,
+        probs: &mut [f64],
+        rng: &mut R,
+    ) {
         let p = self.l[d];
         let k_old = self.z[d][i];
         // Remove token from counts.
@@ -179,12 +209,7 @@ impl PtmModel {
     ///
     /// This is the PTM pseudo-document posterior (uniform prior over pseudo-docs,
     /// matching the simplest PTM variant — no pseudo-doc count prior term).
-    fn resample_pseudo<R: Rng>(
-        &mut self,
-        d: usize,
-        doc: &[u32],
-        rng: &mut R,
-    ) {
+    fn resample_pseudo<R: Rng>(&mut self, d: usize, doc: &[u32], rng: &mut R) {
         let k = self.num_topics;
         let p_old = self.l[d];
 
@@ -321,9 +346,16 @@ pub fn fit_ptm<R: Rng>(
     // Plain fit is the draw-collecting fit with collection disabled, so the
     // sampler lives in exactly one place (see `fit_ptm_with_draws`).
     let (model, _, _) = fit_ptm_with_draws(
-        docs, num_types, num_topics, num_pseudo, alpha, beta, iters,
+        docs,
+        num_types,
+        num_topics,
+        num_pseudo,
+        alpha,
+        beta,
+        iters,
         crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
-        0.0, 0,
+        0.0,
+        0,
         rng,
     );
     model
@@ -352,7 +384,9 @@ pub fn fit_ptm_with_draws<R: Rng>(
     let p = num_pseudo;
     let v = num_types;
 
-    let l: Vec<usize> = (0..d_count).map(|_| (rng.gen::<f64>() * p as f64) as usize % p).collect();
+    let l: Vec<usize> = (0..d_count)
+        .map(|_| (rng.gen::<f64>() * p as f64) as usize % p)
+        .collect();
     let z: Vec<Vec<usize>> = docs
         .iter()
         .map(|doc| {
@@ -399,10 +433,16 @@ pub fn fit_ptm_with_draws<R: Rng>(
     for iter in 1..=iters {
         model.sweep(docs, rng);
         if opts.thin > 0 && iter % opts.thin == 0 {
-            let snap: Vec<Vec<f32>> = model.l.iter().map(|&pd| {
-                let denom = model.np[pd] as f64 + k as f64 * model.alpha;
-                (0..k).map(|kk| ((model.npk[pd][kk] as f64 + model.alpha) / denom) as f32).collect()
-            }).collect();
+            let snap: Vec<Vec<f32>> = model
+                .l
+                .iter()
+                .map(|&pd| {
+                    let denom = model.np[pd] as f64 + k as f64 * model.alpha;
+                    (0..k)
+                        .map(|kk| ((model.npk[pd][kk] as f64 + model.alpha) / denom) as f32)
+                        .collect()
+                })
+                .collect();
             if model.theta_draws.len() < opts.cap {
                 model.theta_draws.push(snap);
             } else {
@@ -487,10 +527,18 @@ mod tests {
             .fold(0.0f64, f64::max);
         // Which block is best for each topic?
         let argmax_0 = (0..num_topics)
-            .max_by(|&a, &b| block_score(&tw[0], a).partial_cmp(&block_score(&tw[0], b)).unwrap())
+            .max_by(|&a, &b| {
+                block_score(&tw[0], a)
+                    .partial_cmp(&block_score(&tw[0], b))
+                    .unwrap()
+            })
             .unwrap();
         let argmax_1 = (0..num_topics)
-            .max_by(|&a, &b| block_score(&tw[1], a).partial_cmp(&block_score(&tw[1], b)).unwrap())
+            .max_by(|&a, &b| {
+                block_score(&tw[1], a)
+                    .partial_cmp(&block_score(&tw[1], b))
+                    .unwrap()
+            })
             .unwrap();
 
         // Short docs (3 tokens each) produce noisy per-document statistics; PTM
@@ -501,17 +549,22 @@ mod tests {
             "topic 0 should concentrate on one block but max block mass is {:.3}.\n\
              Block masses: {:?}",
             best_0,
-            (0..num_topics).map(|bi| block_score(&tw[0], bi)).collect::<Vec<_>>()
+            (0..num_topics)
+                .map(|bi| block_score(&tw[0], bi))
+                .collect::<Vec<_>>()
         );
         assert!(
             best_1 > 0.65,
             "topic 1 should concentrate on one block but max block mass is {:.3}.\n\
              Block masses: {:?}",
             best_1,
-            (0..num_topics).map(|bi| block_score(&tw[1], bi)).collect::<Vec<_>>()
+            (0..num_topics)
+                .map(|bi| block_score(&tw[1], bi))
+                .collect::<Vec<_>>()
         );
         assert_ne!(
-            argmax_0, argmax_1,
+            argmax_0,
+            argmax_1,
             "both topics concentrated on the same block ({argmax_0}); \
              no block coverage for block {}",
             1 - argmax_0

--- a/src/python.rs
+++ b/src/python.rs
@@ -22,29 +22,29 @@ use pyo3::types::{PyDict, PyList, PyTuple};
 use numpy::ndarray::{Array1, Array2, Array3};
 use numpy::{PyArray1, PyArray2, PyArray3, PyReadonlyArray2, ToPyArray};
 
-use crate::cvb0_ext::Cvb0ToModel;  // re-adds Cvb0::to_topic_model (TopicModel lives in topica)
+use crate::bertopic;
+use crate::cvb0_ext::Cvb0ToModel; // re-adds Cvb0::to_topic_model (TopicModel lives in topica)
 use crate::detm;
 use crate::dmr;
 use crate::dtm;
+use crate::etm;
+use crate::etm_vae;
+use crate::fastopic;
 use crate::gsdmm;
 use crate::hdp;
+use crate::hlda;
 use crate::infoctm;
 use crate::keyatm;
-use crate::seeded;
-use crate::hlda;
+use crate::labeled;
 use crate::lsa;
 use crate::nmf;
 use crate::pa;
 use crate::prodlda;
 use crate::pt;
+use crate::sage;
+use crate::seeded;
 use crate::slda;
 use crate::top2vec;
-use crate::bertopic;
-use crate::etm;
-use crate::etm_vae;
-use crate::fastopic;
-use crate::labeled;
-use crate::sage;
 use crate::variational::LogisticNormalModel;
 
 use rand::{Rng, SeedableRng};
@@ -55,7 +55,9 @@ use regex::Regex;
 
 use crate::corpus::{self, InputFormat, LoadOptions};
 use crate::model::TopicModel;
-use crate::{coherence as coh, ctm, cvb0, lightlda, optimize, output, sampler, spectral, sts, warplda};
+use crate::{
+    coherence as coh, ctm, cvb0, lightlda, optimize, output, sampler, spectral, sts, warplda,
+};
 
 // ---------------------------------------------------------------------------
 // Error helpers
@@ -175,7 +177,11 @@ struct Arr3f32 {
 }
 
 fn arr2_opt(a: &Option<Array2<f64>>) -> Option<Arr2> {
-    a.as_ref().map(|m| Arr2 { rows: m.nrows(), cols: m.ncols(), data: m.iter().copied().collect() })
+    a.as_ref().map(|m| Arr2 {
+        rows: m.nrows(),
+        cols: m.ncols(),
+        data: m.iter().copied().collect(),
+    })
 }
 fn arr2_back(s: Option<Arr2>) -> Option<Array2<f64>> {
     s.map(|a| Array2::from_shape_vec((a.rows, a.cols), a.data).unwrap())
@@ -183,7 +189,12 @@ fn arr2_back(s: Option<Arr2>) -> Option<Array2<f64>> {
 fn arr3_opt(a: &Option<Array3<f64>>) -> Option<Arr3> {
     a.as_ref().map(|m| {
         let d = m.dim();
-        Arr3 { d0: d.0, d1: d.1, d2: d.2, data: m.iter().copied().collect() }
+        Arr3 {
+            d0: d.0,
+            d1: d.1,
+            d2: d.2,
+            data: m.iter().copied().collect(),
+        }
     })
 }
 fn arr3_back(s: Option<Arr3>) -> Option<Array3<f64>> {
@@ -206,7 +217,12 @@ fn run_with_threads<T: Send, F: FnOnce() -> T + Send>(num_threads: Option<usize>
 fn arr3f32_opt(a: &Option<Array3<f32>>) -> Option<Arr3f32> {
     a.as_ref().map(|m| {
         let d = m.dim();
-        Arr3f32 { d0: d.0, d1: d.1, d2: d.2, data: m.iter().copied().collect() }
+        Arr3f32 {
+            d0: d.0,
+            d1: d.1,
+            d2: d.2,
+            data: m.iter().copied().collect(),
+        }
     })
 }
 fn arr3f32_back(s: Option<Arr3f32>) -> Option<Array3<f32>> {
@@ -235,70 +251,69 @@ fn arr1_back(s: Option<Vec<f64>>) -> Option<Array1<f64>> {
 // ---------------------------------------------------------------------------
 
 // One tag per concrete model type that calls write_state / read_state.
-const MODEL_TAG_LDA:       u8 = 1;
-const MODEL_TAG_DMR:       u8 = 2;
-const MODEL_TAG_LABELED:   u8 = 3;
-const MODEL_TAG_SAGE:      u8 = 4;
-const MODEL_TAG_CTM:       u8 = 5;
-const MODEL_TAG_STM:       u8 = 6;
-const MODEL_TAG_STS:       u8 = 7;
-const MODEL_TAG_HDP:       u8 = 8;
-const MODEL_TAG_DTM:       u8 = 9;
-const MODEL_TAG_SLDA:      u8 = 10;
-const MODEL_TAG_PT:        u8 = 11;
-const MODEL_TAG_GSDMM:     u8 = 12;
-const MODEL_TAG_SEEDED:    u8 = 13;
-const MODEL_TAG_TOP2VEC:   u8 = 14;
-const MODEL_TAG_BERTOPIC:  u8 = 15;
-const MODEL_TAG_ETM:       u8 = 16;
-const MODEL_TAG_PRODLDA:   u8 = 17;
-const MODEL_TAG_FASTOPIC:  u8 = 18;
-const MODEL_TAG_KEYATM:    u8 = 19;
-const MODEL_TAG_PA:        u8 = 20;
-const MODEL_TAG_HLDA:      u8 = 21;
-const MODEL_TAG_NMF:       u8 = 22;
-const MODEL_TAG_LSA:       u8 = 23;
+const MODEL_TAG_LDA: u8 = 1;
+const MODEL_TAG_DMR: u8 = 2;
+const MODEL_TAG_LABELED: u8 = 3;
+const MODEL_TAG_SAGE: u8 = 4;
+const MODEL_TAG_CTM: u8 = 5;
+const MODEL_TAG_STM: u8 = 6;
+const MODEL_TAG_STS: u8 = 7;
+const MODEL_TAG_HDP: u8 = 8;
+const MODEL_TAG_DTM: u8 = 9;
+const MODEL_TAG_SLDA: u8 = 10;
+const MODEL_TAG_PT: u8 = 11;
+const MODEL_TAG_GSDMM: u8 = 12;
+const MODEL_TAG_SEEDED: u8 = 13;
+const MODEL_TAG_TOP2VEC: u8 = 14;
+const MODEL_TAG_BERTOPIC: u8 = 15;
+const MODEL_TAG_ETM: u8 = 16;
+const MODEL_TAG_PRODLDA: u8 = 17;
+const MODEL_TAG_FASTOPIC: u8 = 18;
+const MODEL_TAG_KEYATM: u8 = 19;
+const MODEL_TAG_PA: u8 = 20;
+const MODEL_TAG_HLDA: u8 = 21;
+const MODEL_TAG_NMF: u8 = 22;
+const MODEL_TAG_LSA: u8 = 23;
 const MODEL_TAG_COMBINEDTM: u8 = 24;
 const MODEL_TAG_ZEROSHOTTM: u8 = 25;
-const MODEL_TAG_DETM:      u8 = 26;
-const MODEL_TAG_ECTM:      u8 = 27;
+const MODEL_TAG_DETM: u8 = 26;
+const MODEL_TAG_ECTM: u8 = 27;
 
 fn model_tag_name(tag: u8) -> &'static str {
     match tag {
-        MODEL_TAG_LDA      => "LDA",
-        MODEL_TAG_DMR      => "DMR",
-        MODEL_TAG_LABELED  => "LabeledLDA",
-        MODEL_TAG_SAGE     => "SAGE",
-        MODEL_TAG_CTM      => "CTM",
-        MODEL_TAG_STM      => "STM",
-        MODEL_TAG_STS      => "STS",
-        MODEL_TAG_HDP      => "HDP",
-        MODEL_TAG_DTM      => "DTM",
-        MODEL_TAG_SLDA     => "SupervisedLDA",
-        MODEL_TAG_PT       => "PT",
-        MODEL_TAG_GSDMM    => "GSDMM",
-        MODEL_TAG_SEEDED   => "SeededLDA",
-        MODEL_TAG_TOP2VEC  => "Top2Vec",
+        MODEL_TAG_LDA => "LDA",
+        MODEL_TAG_DMR => "DMR",
+        MODEL_TAG_LABELED => "LabeledLDA",
+        MODEL_TAG_SAGE => "SAGE",
+        MODEL_TAG_CTM => "CTM",
+        MODEL_TAG_STM => "STM",
+        MODEL_TAG_STS => "STS",
+        MODEL_TAG_HDP => "HDP",
+        MODEL_TAG_DTM => "DTM",
+        MODEL_TAG_SLDA => "SupervisedLDA",
+        MODEL_TAG_PT => "PT",
+        MODEL_TAG_GSDMM => "GSDMM",
+        MODEL_TAG_SEEDED => "SeededLDA",
+        MODEL_TAG_TOP2VEC => "Top2Vec",
         MODEL_TAG_BERTOPIC => "BERTopic",
-        MODEL_TAG_ETM      => "ETM",
-        MODEL_TAG_PRODLDA  => "ProdLDA",
+        MODEL_TAG_ETM => "ETM",
+        MODEL_TAG_PRODLDA => "ProdLDA",
         MODEL_TAG_FASTOPIC => "FASTopic",
-        MODEL_TAG_KEYATM   => "KeyATM",
-        MODEL_TAG_PA       => "PA",
-        MODEL_TAG_HLDA     => "HLDA",
-        MODEL_TAG_NMF      => "NMF",
-        MODEL_TAG_LSA      => "LSA",
+        MODEL_TAG_KEYATM => "KeyATM",
+        MODEL_TAG_PA => "PA",
+        MODEL_TAG_HLDA => "HLDA",
+        MODEL_TAG_NMF => "NMF",
+        MODEL_TAG_LSA => "LSA",
         MODEL_TAG_COMBINEDTM => "CombinedTM",
         MODEL_TAG_ZEROSHOTTM => "ZeroShotTM",
-        MODEL_TAG_DETM     => "DETM",
-        MODEL_TAG_ECTM     => "ECTM",
-        _                  => "unknown",
+        MODEL_TAG_DETM => "DETM",
+        MODEL_TAG_ECTM => "ECTM",
+        _ => "unknown",
     }
 }
 
 fn write_state<S: serde::Serialize>(path: &str, model_tag: u8, state: &S) -> PyResult<()> {
-    let buf = crate::saveformat::encode_state(model_tag, state)
-        .map_err(PyValueError::new_err)?;
+    let buf = crate::saveformat::encode_state(model_tag, state).map_err(PyValueError::new_err)?;
     std::fs::write(path, buf).map_err(io_err)
 }
 fn read_state<S: serde::de::DeserializeOwned>(path: &str, expected_tag: u8) -> PyResult<S> {
@@ -310,56 +325,109 @@ fn read_state<S: serde::de::DeserializeOwned>(path: &str, expected_tag: u8) -> P
 // Per-model serializable snapshots (ndarray fields stored as Arr2/Arr3/Vec).
 #[derive(serde::Serialize, serde::Deserialize)]
 struct LdaState {
-    num_topics: usize, alpha_sum: Option<f64>, beta: f64, optimize_interval: usize,
-    burn_in: usize, seed: u64, num_threads: usize, fitted: bool,
-    phi: Option<Arr2>, theta: Option<Arr2>, model: Option<TopicModel>,
+    num_topics: usize,
+    alpha_sum: Option<f64>,
+    beta: f64,
+    optimize_interval: usize,
+    burn_in: usize,
+    seed: u64,
+    num_threads: usize,
+    fitted: bool,
+    phi: Option<Arr2>,
+    theta: Option<Arr2>,
+    model: Option<TopicModel>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default)] use_symmetric_alpha: bool,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
-    #[serde(default)] converged: bool,
-    #[serde(default)] init_spectral: bool,
+    #[serde(default)]
+    use_symmetric_alpha: bool,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64)>,
+    #[serde(default)]
+    converged: bool,
+    #[serde(default)]
+    init_spectral: bool,
     // Sampler backend flags (persisted so a reloaded model is behaviorally identical).
-    #[serde(default)] light: bool,
-    #[serde(default)] warp: bool,
-    #[serde(default)] cvb0: bool,
+    #[serde(default)]
+    light: bool,
+    #[serde(default)]
+    warp: bool,
+    #[serde(default)]
+    cvb0: bool,
     // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
-    #[serde(default)] theta_draws: Option<Arr3f32>,
+    #[serde(default)]
+    theta_draws: Option<Arr3f32>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct DmrState {
-    num_topics: usize, beta: f64, optimize_interval: usize, burn_in: usize, seed: u64,
-    prior_variance: f64, lbfgs_iters: usize, fitted: bool,
-    phi: Option<Arr2>, theta: Option<Arr2>, feature_effects: Option<Arr2>,
-    feature_names: Vec<String>, corpus: Option<corpus::Corpus>,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
-    #[serde(default)] converged: bool,
+    num_topics: usize,
+    beta: f64,
+    optimize_interval: usize,
+    burn_in: usize,
+    seed: u64,
+    prior_variance: f64,
+    lbfgs_iters: usize,
+    fitted: bool,
+    phi: Option<Arr2>,
+    theta: Option<Arr2>,
+    feature_effects: Option<Arr2>,
+    feature_names: Vec<String>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64)>,
+    #[serde(default)]
+    converged: bool,
     // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
-    #[serde(default)] theta_draws: Option<Arr3f32>,
+    #[serde(default)]
+    theta_draws: Option<Arr3f32>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct LabeledState {
-    alpha: f64, beta: f64, seed: u64, fitted: bool, num_topics: usize,
-    phi: Option<Arr2>, theta: Option<Arr2>, label_vocab: Vec<String>,
+    alpha: f64,
+    beta: f64,
+    seed: u64,
+    fitted: bool,
+    num_topics: usize,
+    phi: Option<Arr2>,
+    theta: Option<Arr2>,
+    label_vocab: Vec<String>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
-    #[serde(default)] converged: bool,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64)>,
+    #[serde(default)]
+    converged: bool,
     // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
-    #[serde(default)] theta_draws: Option<Arr3f32>,
+    #[serde(default)]
+    theta_draws: Option<Arr3f32>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SageState {
-    num_topics: usize, alpha: f64, prior_variance: f64, optimize_interval: usize,
-    burn_in: usize, seed: u64, lbfgs_iters: usize, fitted: bool, num_groups: usize,
-    beta: Vec<Vec<f64>>, theta: Option<Arr2>, group_names: Vec<String>,
+    num_topics: usize,
+    alpha: f64,
+    prior_variance: f64,
+    optimize_interval: usize,
+    burn_in: usize,
+    seed: u64,
+    lbfgs_iters: usize,
+    fitted: bool,
+    num_groups: usize,
+    beta: Vec<Vec<f64>>,
+    theta: Option<Arr2>,
+    group_names: Vec<String>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
-    #[serde(default)] converged: bool,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64)>,
+    #[serde(default)]
+    converged: bool,
     // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
-    #[serde(default)] theta_draws: Option<Arr3f32>,
+    #[serde(default)]
+    theta_draws: Option<Arr3f32>,
 }
 /// serde default for the bound of a model saved before convergence tracking
 /// existed: NaN signals "unknown", distinct from a real bound of 0.
@@ -379,154 +447,323 @@ fn default_false() -> bool {
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct CtmState {
-    num_topics: usize, sigma_shrink: f64, seed: u64, init_spectral: bool, fitted: bool,
-    beta: Option<Arr2>, theta: Option<Arr2>, corr: Option<Arr2>,
-    eta_mean: Option<Arr2>, eta_cov: Option<Arr3>,
-    #[serde(default)] mu: Vec<f64>, #[serde(default)] sigma: Vec<f64>,
+    num_topics: usize,
+    sigma_shrink: f64,
+    seed: u64,
+    init_spectral: bool,
+    fitted: bool,
+    beta: Option<Arr2>,
+    theta: Option<Arr2>,
+    corr: Option<Arr2>,
+    eta_mean: Option<Arr2>,
+    eta_cov: Option<Arr3>,
+    #[serde(default)]
+    mu: Vec<f64>,
+    #[serde(default)]
+    sigma: Vec<f64>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default = "nan")] bound: f64,
-    #[serde(default)] bound_history: Vec<f64>,
-    #[serde(default)] converged: bool,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default = "default_variational")] variational: String,
+    #[serde(default = "nan")]
+    bound: f64,
+    #[serde(default)]
+    bound_history: Vec<f64>,
+    #[serde(default)]
+    converged: bool,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default = "default_variational")]
+    variational: String,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct StmState {
-    num_topics: usize, sigma_shrink: f64, seed: u64, init_spectral: bool, fitted: bool,
-    beta: Option<Arr2>, theta: Option<Arr2>, corr: Option<Arr2>,
-    eta_mean: Option<Arr2>, eta_cov: Option<Arr3>, gamma: Option<Arr2>,
-    feature_names: Vec<String>, content_beta: Option<Vec<Vec<Vec<f64>>>>,
-    #[serde(default)] mu: Vec<f64>, #[serde(default)] sigma: Vec<f64>,
-    group_names: Vec<String>, corpus: Option<corpus::Corpus>,
-    #[serde(default = "nan")] bound: f64,
-    #[serde(default)] bound_history: Vec<f64>,
-    #[serde(default)] converged: bool,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default = "default_variational")] variational: String,
-    #[serde(default)] content_kappa: Option<ctm::ContentKappa>,
+    num_topics: usize,
+    sigma_shrink: f64,
+    seed: u64,
+    init_spectral: bool,
+    fitted: bool,
+    beta: Option<Arr2>,
+    theta: Option<Arr2>,
+    corr: Option<Arr2>,
+    eta_mean: Option<Arr2>,
+    eta_cov: Option<Arr3>,
+    gamma: Option<Arr2>,
+    feature_names: Vec<String>,
+    content_beta: Option<Vec<Vec<Vec<f64>>>>,
+    #[serde(default)]
+    mu: Vec<f64>,
+    #[serde(default)]
+    sigma: Vec<f64>,
+    group_names: Vec<String>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default = "nan")]
+    bound: f64,
+    #[serde(default)]
+    bound_history: Vec<f64>,
+    #[serde(default)]
+    converged: bool,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default = "default_variational")]
+    variational: String,
+    #[serde(default)]
+    content_kappa: Option<ctm::ContentKappa>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct EctmState {
-    num_topics: usize, sigma_shrink: f64, seed: u64, fitted: bool,
-    beta: Option<Arr2>, theta: Option<Arr2>,
-    eta_mean: Option<Arr2>, eta_cov: Option<Arr3>, gamma: Option<Arr2>,
+    num_topics: usize,
+    sigma_shrink: f64,
+    seed: u64,
+    fitted: bool,
+    beta: Option<Arr2>,
+    theta: Option<Arr2>,
+    eta_mean: Option<Arr2>,
+    eta_cov: Option<Arr3>,
+    gamma: Option<Arr2>,
     feature_names: Vec<String>,
     content_beta: Vec<Vec<Vec<f64>>>,
-    num_groups: usize, num_periods: usize,
-    group_names: Vec<String>, period_names: Vec<String>,
-    #[serde(default)] mu: Vec<f64>, #[serde(default)] sigma: Vec<f64>,
+    num_groups: usize,
+    num_periods: usize,
+    group_names: Vec<String>,
+    period_names: Vec<String>,
+    #[serde(default)]
+    mu: Vec<f64>,
+    #[serde(default)]
+    sigma: Vec<f64>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default = "nan")] bound: f64,
-    #[serde(default)] bound_history: Vec<f64>,
-    #[serde(default)] converged: bool,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default = "default_variational")] variational: String,
-    #[serde(default = "default_false")] init_spectral: bool,
-    #[serde(default)] content_shift_history: Vec<f64>,
+    #[serde(default = "nan")]
+    bound: f64,
+    #[serde(default)]
+    bound_history: Vec<f64>,
+    #[serde(default)]
+    converged: bool,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default = "default_variational")]
+    variational: String,
+    #[serde(default = "default_false")]
+    init_spectral: bool,
+    #[serde(default)]
+    content_shift_history: Vec<f64>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct StsState {
-    num_topics: usize, seed: u64, init_spectral: bool, fitted: bool,
-    beta: Option<Arr2>, theta: Option<Arr2>, sentiment: Option<Arr2>,
-    gamma: Option<Arr2>, eta_mean: Option<Arr2>, eta_cov: Option<Arr3>,
+    num_topics: usize,
+    seed: u64,
+    init_spectral: bool,
+    fitted: bool,
+    beta: Option<Arr2>,
+    theta: Option<Arr2>,
+    sentiment: Option<Arr2>,
+    gamma: Option<Arr2>,
+    eta_mean: Option<Arr2>,
+    eta_cov: Option<Arr3>,
     feature_names: Vec<String>,
-    kappa_t: Vec<Vec<f64>>, kappa_s: Vec<Vec<f64>>, mv: Vec<f64>, sigma: Vec<f64>,
+    kappa_t: Vec<Vec<f64>>,
+    kappa_s: Vec<Vec<f64>>,
+    mv: Vec<f64>,
+    sigma: Vec<f64>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default = "nan")] bound: f64,
-    #[serde(default)] bound_history: Vec<f64>,
-    #[serde(default)] converged: bool,
-    #[serde(default)] topic_names: Vec<String>,
+    #[serde(default = "nan")]
+    bound: f64,
+    #[serde(default)]
+    bound_history: Vec<f64>,
+    #[serde(default)]
+    converged: bool,
+    #[serde(default)]
+    topic_names: Vec<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct HdpState {
-    alpha: f64, gamma: f64, eta: f64, seed: u64, resample_conc: bool, fitted: bool,
-    num_topics: usize, learned_alpha: f64, learned_gamma: f64,
-    beta: Option<Arr2>, theta: Option<Arr2>, corpus: Option<corpus::Corpus>,
-    #[serde(default)] trace: Vec<(usize, usize, f64, f64, f64)>,
-    #[serde(default)] topic_names: Vec<String>,
+    alpha: f64,
+    gamma: f64,
+    eta: f64,
+    seed: u64,
+    resample_conc: bool,
+    fitted: bool,
+    num_topics: usize,
+    learned_alpha: f64,
+    learned_gamma: f64,
+    beta: Option<Arr2>,
+    theta: Option<Arr2>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default)]
+    trace: Vec<(usize, usize, f64, f64, f64)>,
+    #[serde(default)]
+    topic_names: Vec<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct DtmState {
-    num_topics: usize, alpha: f64, chain_variance: f64, obs_variance: f64, seed: u64,
-    fitted: bool, num_times: usize, bound: f64,
-    topic_words: Option<Vec<Vec<Vec<f64>>>>, corpus: Option<corpus::Corpus>,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default = "default_false")] init_spectral: bool,
+    num_topics: usize,
+    alpha: f64,
+    chain_variance: f64,
+    obs_variance: f64,
+    seed: u64,
+    fitted: bool,
+    num_times: usize,
+    bound: f64,
+    topic_words: Option<Vec<Vec<Vec<f64>>>>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default = "default_false")]
+    init_spectral: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SldaState {
-    num_topics: usize, alpha: f64, seed: u64, fitted: bool, sigma2: f64,
-    eta: Option<Vec<f64>>, beta: Option<Arr2>, theta: Option<Arr2>,
-    log_beta: Option<Vec<Vec<f64>>>, corpus: Option<corpus::Corpus>,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
-    #[serde(default)] converged: bool,
+    num_topics: usize,
+    alpha: f64,
+    seed: u64,
+    fitted: bool,
+    sigma2: f64,
+    eta: Option<Vec<f64>>,
+    beta: Option<Arr2>,
+    theta: Option<Arr2>,
+    log_beta: Option<Vec<Vec<f64>>>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64)>,
+    #[serde(default)]
+    converged: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct PtState {
-    num_topics: usize, num_pseudo: usize, alpha: f64, beta: f64, seed: u64, fitted: bool,
-    phi: Option<Arr2>, theta: Option<Arr2>, corpus: Option<corpus::Corpus>,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
-    #[serde(default)] converged: bool,
+    num_topics: usize,
+    num_pseudo: usize,
+    alpha: f64,
+    beta: f64,
+    seed: u64,
+    fitted: bool,
+    phi: Option<Arr2>,
+    theta: Option<Arr2>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64)>,
+    #[serde(default)]
+    converged: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct GsdmmState {
-    k_max: usize, alpha: f64, beta: f64, seed: u64, fitted: bool, num_used: usize,
-    phi: Option<Arr2>, theta: Option<Arr2>, doc_cluster: Vec<usize>,
+    k_max: usize,
+    alpha: f64,
+    beta: f64,
+    seed: u64,
+    fitted: bool,
+    num_used: usize,
+    phi: Option<Arr2>,
+    theta: Option<Arr2>,
+    doc_cluster: Vec<usize>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default)] trace: Vec<(usize, usize, f64)>,
-    #[serde(default)] topic_names: Vec<String>,
+    #[serde(default)]
+    trace: Vec<(usize, usize, f64)>,
+    #[serde(default)]
+    topic_names: Vec<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SeededState {
-    num_topics: usize, alpha: f64, beta: f64, weight: f64, seed: u64, fitted: bool,
-    topic_names: Vec<String>, phi: Option<Arr2>, theta: Option<Arr2>,
+    num_topics: usize,
+    alpha: f64,
+    beta: f64,
+    weight: f64,
+    seed: u64,
+    fitted: bool,
+    topic_names: Vec<String>,
+    phi: Option<Arr2>,
+    theta: Option<Arr2>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
-    #[serde(default)] converged: bool,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64)>,
+    #[serde(default)]
+    converged: bool,
     // Seed metadata: persisted so load() restores the model faithfully.
     // seed_names / seed_words allow re-fit without re-supplying the keyword dict;
     // residual is the count of unseeded fallback topics.
-    #[serde(default)] seed_names: Vec<String>,
-    #[serde(default)] seed_words: Vec<Vec<String>>,
-    #[serde(default)] residual: usize,
+    #[serde(default)]
+    seed_names: Vec<String>,
+    #[serde(default)]
+    seed_words: Vec<Vec<String>>,
+    #[serde(default)]
+    residual: usize,
     // Sampler backend flags.
-    #[serde(default)] warp: bool,
-    #[serde(default)] cvb0: bool,
+    #[serde(default)]
+    warp: bool,
+    #[serde(default)]
+    cvb0: bool,
     // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
-    #[serde(default)] theta_draws: Option<Arr3f32>,
+    #[serde(default)]
+    theta_draws: Option<Arr3f32>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct KeyAtmState {
-    num_topics: usize, alpha: f64, beta: f64, beta_keyword: f64, gamma1: f64, gamma2: f64,
-    seed: u64, fitted: bool, topic_names: Vec<String>, keyword_rate: Vec<f64>,
-    phi: Option<Arr2>, theta: Option<Arr2>, corpus: Option<corpus::Corpus>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64, f64)>,
-    #[serde(default)] converged: bool,
-    #[serde(default)] alpha_history: Vec<(usize, Vec<f64>)>,
-    #[serde(default)] pi_history: Vec<(usize, Vec<f64>)>,
-    #[serde(default)] alpha_vec: Option<Vec<f64>>,
-    #[serde(default = "default_num_threads")] num_threads: usize,
+    num_topics: usize,
+    alpha: f64,
+    beta: f64,
+    beta_keyword: f64,
+    gamma1: f64,
+    gamma2: f64,
+    seed: u64,
+    fitted: bool,
+    topic_names: Vec<String>,
+    keyword_rate: Vec<f64>,
+    phi: Option<Arr2>,
+    theta: Option<Arr2>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64, f64)>,
+    #[serde(default)]
+    converged: bool,
+    #[serde(default)]
+    alpha_history: Vec<(usize, Vec<f64>)>,
+    #[serde(default)]
+    pi_history: Vec<(usize, Vec<f64>)>,
+    #[serde(default)]
+    alpha_vec: Option<Vec<f64>>,
+    #[serde(default = "default_num_threads")]
+    num_threads: usize,
     // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
-    #[serde(default)] theta_draws: Option<Arr3f32>,
+    #[serde(default)]
+    theta_draws: Option<Arr3f32>,
 }
-fn default_num_threads() -> usize { 1 }
+fn default_num_threads() -> usize {
+    1
+}
 #[derive(serde::Serialize, serde::Deserialize)]
 struct PaState {
-    num_super: usize, num_sub: usize, alpha: f64, beta: f64, seed: u64, fitted: bool,
-    phi: Option<Arr2>, theta: Option<Arr2>, super_sub: Option<Arr2>,
+    num_super: usize,
+    num_sub: usize,
+    alpha: f64,
+    beta: f64,
+    seed: u64,
+    fitted: bool,
+    phi: Option<Arr2>,
+    theta: Option<Arr2>,
+    super_sub: Option<Arr2>,
     corpus: Option<corpus::Corpus>,
-    #[serde(default)] topic_names: Vec<String>,
-    #[serde(default)] log_likelihood_history: Vec<(usize, f64)>,
-    #[serde(default)] converged: bool,
+    #[serde(default)]
+    topic_names: Vec<String>,
+    #[serde(default)]
+    log_likelihood_history: Vec<(usize, f64)>,
+    #[serde(default)]
+    converged: bool,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct HldaState {
-    depth: usize, gamma: f64, eta: f64, alpha: f64, seed: u64, fitted: bool,
-    num_nodes: usize, node_topic_word: Option<Arr2>, node_levels: Vec<usize>,
-    node_parents: Vec<i64>, doc_paths: Vec<Vec<usize>>, corpus: Option<corpus::Corpus>,
-    #[serde(default)] topic_names: Vec<String>,
+    depth: usize,
+    gamma: f64,
+    eta: f64,
+    alpha: f64,
+    seed: u64,
+    fitted: bool,
+    num_nodes: usize,
+    node_topic_word: Option<Arr2>,
+    node_levels: Vec<usize>,
+    node_parents: Vec<i64>,
+    doc_paths: Vec<Vec<usize>>,
+    corpus: Option<corpus::Corpus>,
+    #[serde(default)]
+    topic_names: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -607,8 +844,8 @@ fn build_corpus_from_docs(
         per_doc_type_sets.push(seen);
     }
 
-    let doc_names: Vec<String> = doc_names_in
-        .unwrap_or_else(|| (0..n).map(|i| format!("doc_{}", i)).collect());
+    let doc_names: Vec<String> =
+        doc_names_in.unwrap_or_else(|| (0..n).map(|i| format!("doc_{}", i)).collect());
     let doc_labels: Vec<String> = doc_labels_in.unwrap_or_else(|| vec![String::new(); n]);
 
     let num_types = id_to_word.len();
@@ -797,7 +1034,11 @@ impl Corpus {
             min_cf,
             rm_top,
         )?;
-        Ok(Corpus { inner, kept_indices, metadata: None })
+        Ok(Corpus {
+            inner,
+            kept_indices,
+            metadata: None,
+        })
     }
 
     /// Load and tokenise a raw text file (MALLET-style), matching the
@@ -849,7 +1090,11 @@ impl Corpus {
         };
         let inner = corpus::load_text_file(Path::new(path), &opts).map_err(io_err)?;
         let kept_indices = (0..inner.num_docs()).collect();
-        Ok(Corpus { inner, kept_indices, metadata: None })
+        Ok(Corpus {
+            inner,
+            kept_indices,
+            metadata: None,
+        })
     }
 
     /// Load a binary corpus file written by the ``preprocess`` CLI or
@@ -858,7 +1103,11 @@ impl Corpus {
     fn load(path: &str) -> PyResult<Self> {
         let inner = corpus::load_corpus(Path::new(path)).map_err(io_err)?;
         let kept_indices = (0..inner.num_docs()).collect();
-        Ok(Corpus { inner, kept_indices, metadata: None })
+        Ok(Corpus {
+            inner,
+            kept_indices,
+            metadata: None,
+        })
     }
 
     /// Write this corpus to a binary file (the ``preprocess`` format), so it
@@ -906,7 +1155,11 @@ impl Corpus {
         self.inner
             .docs
             .iter()
-            .map(|d| d.iter().map(|&w| self.inner.id_to_word[w as usize].clone()).collect())
+            .map(|d| {
+                d.iter()
+                    .map(|&w| self.inner.id_to_word[w as usize].clone())
+                    .collect()
+            })
             .collect()
     }
 
@@ -998,7 +1251,7 @@ pub struct LDA {
     corpus: Option<corpus::Corpus>,
     // Convergence tracking (issue #46 uniform interface).
     log_likelihood_history: Vec<(usize, f64)>, // (iteration, log_likelihood)
-    converged: bool,   // true only when convergence_tol criterion was met
+    converged: bool,                           // true only when convergence_tol criterion was met
 }
 
 impl LDA {
@@ -1044,7 +1297,9 @@ impl LDA {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 
@@ -1065,10 +1320,7 @@ impl LDA {
     /// Map held-out documents (a `Corpus` or `list[list[str]]`) to trained
     /// vocabulary ids, dropping out-of-vocabulary tokens. Returns
     /// `(docs_as_ids, num_tokens_scored, num_oov_dropped)`.
-    fn map_heldout(
-        &self,
-        data: &Bound<'_, PyAny>,
-    ) -> PyResult<(Vec<Vec<usize>>, usize, usize)> {
+    fn map_heldout(&self, data: &Bound<'_, PyAny>) -> PyResult<(Vec<Vec<usize>>, usize, usize)> {
         let trained = self.corpus.as_ref().unwrap();
         let index: HashMap<&str, usize> = trained
             .id_to_word
@@ -1089,7 +1341,9 @@ impl LDA {
                 .collect()
         } else {
             data.extract::<Vec<Vec<String>>>().map_err(|_| {
-                PyValueError::new_err("expected a Corpus or a list of token lists (list[list[str]])")
+                PyValueError::new_err(
+                    "expected a Corpus or a list of token lists (list[list[str]])",
+                )
             })?
         };
 
@@ -1165,7 +1419,9 @@ impl LDA {
             }
         };
         if light && mh_steps == 0 {
-            return Err(PyValueError::new_err("mh_steps must be >= 1 for the lightlda sampler"));
+            return Err(PyValueError::new_err(
+                "mh_steps must be >= 1 for the lightlda sampler",
+            ));
         }
         let init_spectral = match init {
             "spectral" => true,
@@ -1365,8 +1621,10 @@ impl LDA {
                     (acc_phi, acc_theta, ll_history, converged, model, corpus)
                 });
             self.theta_draws = None;
-            self.finalize_fit(num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus,
-                ll_history, converged);
+            self.finalize_fit(
+                num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus, ll_history,
+                converged,
+            );
             return Ok(());
         }
 
@@ -1378,30 +1636,66 @@ impl LDA {
         // trace, converged=false). The SparseLDA path stays separate to keep its
         // convergence trace, parallel sweep, and CLI byte-parity untouched.
         if warp || light {
-            let (acc_phi, acc_theta, theta_draw_buf, model, corpus) =
-                py.allow_threads(move || {
-                    let alpha0 = vec![alpha_sum / num_topics as f64; num_topics];
-                    if warp {
-                        let ws = warplda::WarpLda::new(&corpus, num_topics, &alpha0, beta, &mut rng);
-                        run_mh_training(
-                            ws, corpus, num_topics, num_types, num_docs, iters, num_samples,
-                            sample_interval, burn_in, optimize_interval, use_symmetric_alpha,
-                            draw_thin, draw_cap, total_tokens, &mut rng, &progress, progress_interval,
-                        )
-                    } else {
-                        let mut ls =
-                            lightlda::LightLda::new(&corpus, num_topics, &alpha0, beta, &mut rng);
-                        ls.mh_steps = mh_steps;
-                        run_mh_training(
-                            ls, corpus, num_topics, num_types, num_docs, iters, num_samples,
-                            sample_interval, burn_in, optimize_interval, use_symmetric_alpha,
-                            draw_thin, draw_cap, total_tokens, &mut rng, &progress, progress_interval,
-                        )
-                    }
-                });
+            let (acc_phi, acc_theta, theta_draw_buf, model, corpus) = py.allow_threads(move || {
+                let alpha0 = vec![alpha_sum / num_topics as f64; num_topics];
+                if warp {
+                    let ws = warplda::WarpLda::new(&corpus, num_topics, &alpha0, beta, &mut rng);
+                    run_mh_training(
+                        ws,
+                        corpus,
+                        num_topics,
+                        num_types,
+                        num_docs,
+                        iters,
+                        num_samples,
+                        sample_interval,
+                        burn_in,
+                        optimize_interval,
+                        use_symmetric_alpha,
+                        draw_thin,
+                        draw_cap,
+                        total_tokens,
+                        &mut rng,
+                        &progress,
+                        progress_interval,
+                    )
+                } else {
+                    let mut ls =
+                        lightlda::LightLda::new(&corpus, num_topics, &alpha0, beta, &mut rng);
+                    ls.mh_steps = mh_steps;
+                    run_mh_training(
+                        ls,
+                        corpus,
+                        num_topics,
+                        num_types,
+                        num_docs,
+                        iters,
+                        num_samples,
+                        sample_interval,
+                        burn_in,
+                        optimize_interval,
+                        use_symmetric_alpha,
+                        draw_thin,
+                        draw_cap,
+                        total_tokens,
+                        &mut rng,
+                        &progress,
+                        progress_interval,
+                    )
+                }
+            });
             self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
-            self.finalize_fit(num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus,
-                Vec::new(), false);
+            self.finalize_fit(
+                num_topics,
+                num_types,
+                num_docs,
+                acc_phi,
+                acc_theta,
+                model,
+                corpus,
+                Vec::new(),
+                false,
+            );
             return Ok(());
         }
 
@@ -1409,139 +1703,146 @@ impl LDA {
         // re-acquires it. allow_threads returns the owned model + accumulators.
         let (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, model) =
             py.allow_threads(move || {
-            // One logical Gibbs sweep: exact sequential path when
-            // single-threaded, approximate parallel sampling otherwise. `sweep`
-            // seeds the per-worker RNGs so parallel runs are deterministic.
-            //
-            // In turbo mode (merge_every > 1, parallel only) sampling proceeds in
-            // batches: each `do_sweep` call runs `merge_every` worker sweeps and
-            // reconciles once, returning a globally consistent model. The caller
-            // therefore steps the iteration counter by `merge_every` per call and
-            // runs the per-iteration bookkeeping (θ-draws, α/β optimization,
-            // convergence checks) at those batch boundaries, where the model is
-            // consistent. With merge_every == 1 this is the exact per-sweep path.
-            let mut sweep: u64 = 0;
-            // logical iterations advanced by one do_sweep call.
-            let step = if num_threads <= 1 { 1 } else { merge_every };
-            // `batch` is the number of worker sweeps to run before reconciling;
-            // it is `step` for full windows and the remainder for a short tail
-            // window so the run never samples more than `iters` total sweeps.
-            let mut do_sweep =
-                |model: &mut TopicModel, rng: &mut Pcg64Mcg, batch: usize| {
+                // One logical Gibbs sweep: exact sequential path when
+                // single-threaded, approximate parallel sampling otherwise. `sweep`
+                // seeds the per-worker RNGs so parallel runs are deterministic.
+                //
+                // In turbo mode (merge_every > 1, parallel only) sampling proceeds in
+                // batches: each `do_sweep` call runs `merge_every` worker sweeps and
+                // reconciles once, returning a globally consistent model. The caller
+                // therefore steps the iteration counter by `merge_every` per call and
+                // runs the per-iteration bookkeeping (θ-draws, α/β optimization,
+                // convergence checks) at those batch boundaries, where the model is
+                // consistent. With merge_every == 1 this is the exact per-sweep path.
+                let mut sweep: u64 = 0;
+                // logical iterations advanced by one do_sweep call.
+                let step = if num_threads <= 1 { 1 } else { merge_every };
+                // `batch` is the number of worker sweeps to run before reconciling;
+                // it is `step` for full windows and the remainder for a short tail
+                // window so the run never samples more than `iters` total sweeps.
+                let mut do_sweep = |model: &mut TopicModel, rng: &mut Pcg64Mcg, batch: usize| {
                     if num_threads <= 1 {
                         sweep += 1;
                         sampler::run_iteration(model, &corpus, rng);
                     } else {
                         sweep += 1;
-                        let s = seed_base
-                            .wrapping_add(sweep.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+                        let s = seed_base.wrapping_add(sweep.wrapping_mul(0x9E37_79B9_7F4A_7C15));
                         parallel_sweep_batched(model, &corpus.docs, num_threads, s, batch.max(1));
                     }
                 };
-            let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
-            let mut ll_history: Vec<(usize, f64)> = Vec::new();
-            let mut converged = false;
+                let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+                let mut ll_history: Vec<(usize, f64)> = Vec::new();
+                let mut converged = false;
 
-            // ---- main training loop (ports src/bin/train.rs) ----
-            // `step` is 1 except in turbo mode, where each do_sweep advances
-            // `step` logical iterations. We sample at the start of each window
-            // and run the per-iteration bookkeeping at its end (where the model
-            // is freshly reconciled), so θ-draws/optimization/convergence always
-            // observe a consistent global state.
-            let mut iter = 0usize;
-            while iter < iters {
-                let batch = (iters - iter).min(step);
-                do_sweep(&mut model, &mut rng, batch);
-                iter += batch;
+                // ---- main training loop (ports src/bin/train.rs) ----
+                // `step` is 1 except in turbo mode, where each do_sweep advances
+                // `step` logical iterations. We sample at the start of each window
+                // and run the per-iteration bookkeeping at its end (where the model
+                // is freshly reconciled), so θ-draws/optimization/convergence always
+                // observe a consistent global state.
+                let mut iter = 0usize;
+                while iter < iters {
+                    let batch = (iters - iter).min(step);
+                    do_sweep(&mut model, &mut rng, batch);
+                    iter += batch;
 
-                if draw_thin > 0 && iter % draw_thin == 0 {
-                    push_capped(
-                        &mut theta_draw_buf,
-                        theta_snapshot_f32(&model, &corpus),
-                        draw_cap,
-                    );
-                }
-
-                if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
-                    if use_symmetric_alpha {
-                        optimize::optimize_alpha_symmetric(&mut model, &corpus);
-                    } else {
-                        optimize::optimize_alpha(&mut model, &corpus);
+                    if draw_thin > 0 && iter % draw_thin == 0 {
+                        push_capped(
+                            &mut theta_draw_buf,
+                            theta_snapshot_f32(&model, &corpus),
+                            draw_cap,
+                        );
                     }
-                    optimize::optimize_beta(&mut model);
-                }
 
-                // Trace recording and optional convergence check (never alters RNG).
-                if convergence_tol > 0.0 && check_every > 0 && iter % check_every == 0 {
-                    let ll = output::model_log_likelihood(&model, &corpus);
-                    ll_history.push((iter, ll));
-                    // Relative change criterion: compare the current ll to the
-                    // one recorded one window back (window = check_every sweeps).
-                    if ll_history.len() >= 2 {
-                        let prev = ll_history[ll_history.len() - 2].1;
-                        let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
-                        if rel < convergence_tol {
-                            converged = true;
-                            break;
+                    if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
+                        if use_symmetric_alpha {
+                            optimize::optimize_alpha_symmetric(&mut model, &corpus);
+                        } else {
+                            optimize::optimize_alpha(&mut model, &corpus);
+                        }
+                        optimize::optimize_beta(&mut model);
+                    }
+
+                    // Trace recording and optional convergence check (never alters RNG).
+                    if convergence_tol > 0.0 && check_every > 0 && iter % check_every == 0 {
+                        let ll = output::model_log_likelihood(&model, &corpus);
+                        ll_history.push((iter, ll));
+                        // Relative change criterion: compare the current ll to the
+                        // one recorded one window back (window = check_every sweeps).
+                        if ll_history.len() >= 2 {
+                            let prev = ll_history[ll_history.len() - 2].1;
+                            let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
+                            if rel < convergence_tol {
+                                converged = true;
+                                break;
+                            }
+                        }
+                    } else if convergence_tol == 0.0 && check_every > 0 && iter % check_every == 0 {
+                        // When tol is disabled, still record the trace so fit_history
+                        // is non-empty, but never break early.
+                        let ll = output::model_log_likelihood(&model, &corpus);
+                        ll_history.push((iter, ll));
+                    }
+
+                    if let Some(cb) = &progress {
+                        if progress_interval > 0 && iter % progress_interval == 0 {
+                            let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
+                            Python::with_gil(|py| {
+                                let _ = cb.call1(py, (iter, ll));
+                            });
                         }
                     }
-                } else if convergence_tol == 0.0 && check_every > 0 && iter % check_every == 0 {
-                    // When tol is disabled, still record the trace so fit_history
-                    // is non-empty, but never break early.
-                    let ll = output::model_log_likelihood(&model, &corpus);
-                    ll_history.push((iter, ll));
                 }
 
-                if let Some(cb) = &progress {
-                    if progress_interval > 0 && iter % progress_interval == 0 {
-                        let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
-                        Python::with_gil(|py| {
-                            let _ = cb.call1(py, (iter, ll));
-                        });
+                // Under early stop, draw_thin was computed against the nominal `iters`
+                // but the loop ended at `actual_iters` sweeps; remaining draws are
+                // whatever was already collected (ring-buffered), which is correct.
+
+                // ---- sampling phase: average num_samples smoothed snapshots ----
+                let mut acc_phi = vec![vec![0.0f64; num_topics]; num_types];
+                let mut acc_theta = vec![vec![0.0f64; num_topics]; num_docs];
+
+                for _ in 0..num_samples {
+                    // Step through `sample_interval` sweeps; in turbo mode each
+                    // do_sweep covers a batch of `step`, reconciling once per batch.
+                    let mut done = 0usize;
+                    while done < sample_interval {
+                        let batch = (sample_interval - done).min(step);
+                        do_sweep(&mut model, &mut rng, batch);
+                        done += batch;
+                    }
+                    accumulate_phi(&model, &mut acc_phi);
+                    accumulate_theta(&model, &corpus, &mut acc_theta);
+                }
+
+                let n = (num_samples.max(1)) as f64;
+                for row in acc_phi.iter_mut() {
+                    for v in row.iter_mut() {
+                        *v /= n;
                     }
                 }
-            }
-
-            // Under early stop, draw_thin was computed against the nominal `iters`
-            // but the loop ended at `actual_iters` sweeps; remaining draws are
-            // whatever was already collected (ring-buffered), which is correct.
-
-            // ---- sampling phase: average num_samples smoothed snapshots ----
-            let mut acc_phi = vec![vec![0.0f64; num_topics]; num_types];
-            let mut acc_theta = vec![vec![0.0f64; num_topics]; num_docs];
-
-            for _ in 0..num_samples {
-                // Step through `sample_interval` sweeps; in turbo mode each
-                // do_sweep covers a batch of `step`, reconciling once per batch.
-                let mut done = 0usize;
-                while done < sample_interval {
-                    let batch = (sample_interval - done).min(step);
-                    do_sweep(&mut model, &mut rng, batch);
-                    done += batch;
+                for row in acc_theta.iter_mut() {
+                    for v in row.iter_mut() {
+                        *v /= n;
+                    }
                 }
-                accumulate_phi(&model, &mut acc_phi);
-                accumulate_theta(&model, &corpus, &mut acc_theta);
-            }
 
-            let n = (num_samples.max(1)) as f64;
-            for row in acc_phi.iter_mut() {
-                for v in row.iter_mut() {
-                    *v /= n;
-                }
-            }
-            for row in acc_theta.iter_mut() {
-                for v in row.iter_mut() {
-                    *v /= n;
-                }
-            }
-
-            // Return the corpus too (move it back out for storage).
-            (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, (model, corpus))
-        });
+                // Return the corpus too (move it back out for storage).
+                (
+                    acc_phi,
+                    acc_theta,
+                    theta_draw_buf,
+                    ll_history,
+                    converged,
+                    (model, corpus),
+                )
+            });
         let (model, corpus) = model;
         self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
-        self.finalize_fit(num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus,
-            ll_history, converged);
+        self.finalize_fit(
+            num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus, ll_history,
+            converged,
+        );
         Ok(())
     }
 
@@ -1664,7 +1965,9 @@ impl LDA {
             let items: Vec<Bound<'py, PyTuple>> = idx
                 .iter()
                 .take(n)
-                .map(|&w| PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), phi[[t, w]].into_py(py)]))
+                .map(|&w| {
+                    PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), phi[[t, w]].into_py(py)])
+                })
                 .collect();
             Ok(PyList::new_bound(py, items))
         };
@@ -1672,8 +1975,9 @@ impl LDA {
         match topic {
             Some(t) => Ok(one_topic(t)?.into_any()),
             None => {
-                let all: Vec<Bound<'py, PyList>> =
-                    (0..self.num_topics).map(one_topic).collect::<PyResult<_>>()?;
+                let all: Vec<Bound<'py, PyList>> = (0..self.num_topics)
+                    .map(one_topic)
+                    .collect::<PyResult<_>>()?;
                 Ok(PyList::new_bound(py, all).into_any())
             }
         }
@@ -1758,7 +2062,12 @@ impl LDA {
         buf.push_str("#doc source pos typeindex type topic\n");
         buf.push_str("#alpha : ");
         buf.push_str(
-            &model.alpha.iter().map(|a| a.to_string()).collect::<Vec<_>>().join(" "),
+            &model
+                .alpha
+                .iter()
+                .map(|a| a.to_string())
+                .collect::<Vec<_>>()
+                .join(" "),
         );
         buf.push('\n');
         buf.push_str(&format!("#beta : {}\n", model.beta));
@@ -1771,7 +2080,10 @@ impl LDA {
             let z = &model.doc_topics[d];
             for (pos, &w) in doc.iter().enumerate() {
                 let word = &corpus.id_to_word[w as usize];
-                buf.push_str(&format!("{} {} {} {} {} {}\n", d, source, pos, w, word, z[pos]));
+                buf.push_str(&format!(
+                    "{} {} {} {} {} {}\n",
+                    d, source, pos, w, word, z[pos]
+                ));
             }
         }
 
@@ -1798,7 +2110,9 @@ impl LDA {
         // Detect gzip by magic bytes; fall back to plain text otherwise.
         let text = if raw.starts_with(&[0x1f, 0x8b]) {
             let mut s = String::new();
-            GzDecoder::new(&raw[..]).read_to_string(&mut s).map_err(io_err)?;
+            GzDecoder::new(&raw[..])
+                .read_to_string(&mut s)
+                .map_err(io_err)?;
             s
         } else {
             String::from_utf8(raw).map_err(|e| PyValueError::new_err(e.to_string()))?
@@ -1816,7 +2130,10 @@ impl LDA {
 
         for line in text.lines() {
             if let Some(rest) = line.strip_prefix("#alpha") {
-                alpha = rest.split_whitespace().filter_map(|s| s.parse().ok()).collect();
+                alpha = rest
+                    .split_whitespace()
+                    .filter_map(|s| s.parse().ok())
+                    .collect();
                 continue;
             }
             if let Some(rest) = line.strip_prefix("#beta") {
@@ -1831,7 +2148,9 @@ impl LDA {
             // doc source pos typeindex type topic
             let p: Vec<&str> = line.split_whitespace().collect();
             if p.len() < 6 {
-                return Err(PyValueError::new_err(format!("malformed state row: {line:?}")));
+                return Err(PyValueError::new_err(format!(
+                    "malformed state row: {line:?}"
+                )));
             }
             let parse_err = || PyValueError::new_err(format!("malformed state row: {line:?}"));
             let doc: usize = p[0].parse().map_err(|_| parse_err())?;
@@ -1843,14 +2162,21 @@ impl LDA {
             }
             id_to_word[typeindex] = p[4].to_string();
             max_topic = max_topic.max(topic);
-            docs_tokens.entry(doc).or_default().push((pos, typeindex as u32, topic));
+            docs_tokens
+                .entry(doc)
+                .or_default()
+                .push((pos, typeindex as u32, topic));
             doc_source.entry(doc).or_insert_with(|| p[1].to_string());
         }
 
         if docs_tokens.is_empty() {
             return Err(PyValueError::new_err("state file contains no token rows"));
         }
-        let num_topics = if alpha.is_empty() { max_topic as usize + 1 } else { alpha.len() };
+        let num_topics = if alpha.is_empty() {
+            max_topic as usize + 1
+        } else {
+            alpha.len()
+        };
         let num_types = id_to_word.len();
 
         let mut docs_v: Vec<Vec<u32>> = Vec::new();
@@ -1861,7 +2187,11 @@ impl LDA {
             docs_v.push(toks.iter().map(|&(_, w, _)| w).collect());
             doc_topics.push(toks.iter().map(|&(_, _, t)| t).collect());
             let src = doc_source.remove(&doc_id).unwrap_or_default();
-            doc_names.push(if src.is_empty() || src == "NA" { format!("doc_{doc_id}") } else { src });
+            doc_names.push(if src.is_empty() || src == "NA" {
+                format!("doc_{doc_id}")
+            } else {
+                src
+            });
         }
         let num_docs = docs_v.len();
 
@@ -2087,7 +2417,12 @@ impl LDA {
         }
 
         // Corpus word distribution (for the corpus-distance diagnostic).
-        let total_tokens: f64 = corpus.total_freqs.iter().map(|&c| c as f64).sum::<f64>().max(1.0);
+        let total_tokens: f64 = corpus
+            .total_freqs
+            .iter()
+            .map(|&c| c as f64)
+            .sum::<f64>()
+            .max(1.0);
 
         let list = PyList::empty_bound(py);
         for t in 0..self.num_topics {
@@ -2125,7 +2460,11 @@ impl LDA {
             let effective_words = h.exp();
 
             let tt = model.tokens_per_topic[t] as f64;
-            let document_entropy = if tt > 0.0 { tt.ln() - doc_ent_s[t] / tt } else { 0.0 };
+            let document_entropy = if tt > 0.0 {
+                tt.ln() - doc_ent_s[t] / tt
+            } else {
+                0.0
+            };
 
             let words: Vec<String> = topn.iter().map(|&w| vocab[w].clone()).collect();
 
@@ -2175,7 +2514,15 @@ impl LDA {
         let thetas: Vec<Vec<f64>> = py.allow_threads(move || {
             docs.iter()
                 .map(|d| {
-                    infer_doc(model, d, iterations, burn_in, num_samples, sample_interval, &mut rng)
+                    infer_doc(
+                        model,
+                        d,
+                        iterations,
+                        burn_in,
+                        num_samples,
+                        sample_interval,
+                        &mut rng,
+                    )
                 })
                 .collect()
         });
@@ -2298,20 +2645,33 @@ impl LDA {
     /// Save the fitted model to `path` (compact binary). Reload with `LDA.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_LDA, &LdaState {
-            num_topics: self.num_topics, alpha_sum: self.alpha_sum, beta: self.beta,
-            optimize_interval: self.optimize_interval, burn_in: self.burn_in, seed: self.seed,
-            num_threads: self.num_threads, fitted: self.fitted,
-            phi: arr2_opt(&self.phi), theta: arr2_opt(&self.theta),
-            model: self.model.clone(), corpus: self.corpus.clone(),
-            use_symmetric_alpha: self.use_symmetric_alpha,
-            topic_names: self.topic_names.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-            init_spectral: self.init_spectral,
-            light: self.light, warp: self.warp, cvb0: self.cvb0,
-            theta_draws: arr3f32_opt(&self.theta_draws),
-        })
+        write_state(
+            path,
+            MODEL_TAG_LDA,
+            &LdaState {
+                num_topics: self.num_topics,
+                alpha_sum: self.alpha_sum,
+                beta: self.beta,
+                optimize_interval: self.optimize_interval,
+                burn_in: self.burn_in,
+                seed: self.seed,
+                num_threads: self.num_threads,
+                fitted: self.fitted,
+                phi: arr2_opt(&self.phi),
+                theta: arr2_opt(&self.theta),
+                model: self.model.clone(),
+                corpus: self.corpus.clone(),
+                use_symmetric_alpha: self.use_symmetric_alpha,
+                topic_names: self.topic_names.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+                init_spectral: self.init_spectral,
+                light: self.light,
+                warp: self.warp,
+                cvb0: self.cvb0,
+                theta_draws: arr3f32_opt(&self.theta_draws),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -2324,16 +2684,26 @@ impl LDA {
             s.topic_names
         };
         Ok(LDA {
-            num_topics: s.num_topics, alpha_sum: s.alpha_sum, beta: s.beta,
-            optimize_interval: s.optimize_interval, burn_in: s.burn_in, seed: s.seed,
-            num_threads: s.num_threads, light: s.light, warp: s.warp, cvb0: s.cvb0,
-            mh_steps: 2, fitted: s.fitted,
+            num_topics: s.num_topics,
+            alpha_sum: s.alpha_sum,
+            beta: s.beta,
+            optimize_interval: s.optimize_interval,
+            burn_in: s.burn_in,
+            seed: s.seed,
+            num_threads: s.num_threads,
+            light: s.light,
+            warp: s.warp,
+            cvb0: s.cvb0,
+            mh_steps: 2,
+            fitted: s.fitted,
             use_symmetric_alpha: s.use_symmetric_alpha,
             init_spectral: s.init_spectral,
             topic_names,
-            phi: arr2_back(s.phi), theta: arr2_back(s.theta),
+            phi: arr2_back(s.phi),
+            theta: arr2_back(s.theta),
             theta_draws: arr3f32_back(s.theta_draws),
-            model: s.model, corpus: s.corpus,
+            model: s.model,
+            corpus: s.corpus,
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
         })
@@ -2512,10 +2882,14 @@ fn run_mh_training<S: crate::mh::MhSampler>(
     }
     let n = (num_samples.max(1)) as f64;
     for row in acc_phi.iter_mut() {
-        for v in row.iter_mut() { *v /= n; }
+        for v in row.iter_mut() {
+            *v /= n;
+        }
     }
     for row in acc_theta.iter_mut() {
-        for v in row.iter_mut() { *v /= n; }
+        for v in row.iter_mut() {
+            *v /= n;
+        }
     }
     let model = sampler.to_topic_model();
     (acc_phi, acc_theta, theta_draw_buf, model, corpus)
@@ -2675,7 +3049,12 @@ fn parallel_sweep_batched(
                     &mut rng,
                 );
             }
-            WorkerOut { ttc, tpt, start, dt }
+            WorkerOut {
+                ttc,
+                tpt,
+                start,
+                dt,
+            }
         })
         .collect();
 
@@ -3002,7 +3381,10 @@ fn infer_theta_gibbs<R: Rng>(
     }
 
     // Per-token phi column (probability of this word under each topic).
-    let cols: Vec<Vec<f64>> = doc.iter().map(|&w| (0..k).map(|t| phi[t][w]).collect()).collect();
+    let cols: Vec<Vec<f64>> = doc
+        .iter()
+        .map(|&w| (0..k).map(|t| phi[t][w]).collect())
+        .collect();
 
     let mut local = vec![0u32; k];
     let mut z = vec![0usize; n];
@@ -3100,8 +3482,10 @@ fn transform_gibbs<'py>(
     base_seed: u64,
 ) -> PyResult<Bound<'py, PyArray2<f64>>> {
     let docs = docs_to_ids(data, id_to_word)?;
-    let docs_usize: Vec<Vec<usize>> =
-        docs.iter().map(|d| d.iter().map(|&w| w as usize).collect()).collect();
+    let docs_usize: Vec<Vec<usize>> = docs
+        .iter()
+        .map(|d| d.iter().map(|&w| w as usize).collect())
+        .collect();
     let phi_rows: Vec<Vec<f64>> = phi.outer_iter().map(|r| r.to_vec()).collect();
     let alpha_v = alpha.to_vec();
     let k = phi_rows.len();
@@ -3113,7 +3497,13 @@ fn transform_gibbs<'py>(
             .map(|(i, d)| {
                 let mut rng = ChaCha8Rng::seed_from_u64(base_seed.wrapping_add(i as u64));
                 infer_theta_gibbs(
-                    &phi_rows, &alpha_v, d, iterations, burn_in, num_samples, sample_interval,
+                    &phi_rows,
+                    &alpha_v,
+                    d,
+                    iterations,
+                    burn_in,
+                    num_samples,
+                    sample_interval,
                     &mut rng,
                 )
             })
@@ -3192,7 +3582,12 @@ fn topic_words_helper<'py>(
         }
         let items: Vec<Bound<'py, PyTuple>> = tops[t]
             .iter()
-            .map(|&w| PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)]))
+            .map(|&w| {
+                PyTuple::new_bound(
+                    py,
+                    &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)],
+                )
+            })
             .collect();
         Ok(PyList::new_bound(py, items))
     };
@@ -3347,8 +3742,8 @@ pub struct DMR {
 
     fitted: bool,
     topic_names: Vec<String>,
-    phi: Option<Array2<f64>>,            // (num_topics, num_words)
-    theta: Option<Array2<f64>>,          // (num_docs, num_topics)
+    phi: Option<Array2<f64>>,   // (num_topics, num_words)
+    theta: Option<Array2<f64>>, // (num_docs, num_topics)
     // Thinned MCMC θ snapshots (num_draws, num_docs, num_topics), f32; None when
     // keep_theta_draws=False. Feeds composition_theta's cross-sweep uncertainty.
     theta_draws: Option<Array3<f32>>,
@@ -3364,7 +3759,9 @@ impl DMR {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -3478,7 +3875,17 @@ impl DMR {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -3495,7 +3902,9 @@ impl DMR {
         check_all_finite_2d("features", &raw)?;
         let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
         if raw.iter().any(|r| r.len() != f_in) {
-            return Err(PyValueError::new_err("all feature rows must have the same length"));
+            return Err(PyValueError::new_err(
+                "all feature rows must have the same length",
+            ));
         }
         if let Some(names) = &feature_names {
             if names.len() != f_in {
@@ -3545,8 +3954,16 @@ impl DMR {
         let beta = self.beta;
         let warp = self.warp;
         let cvb0_flag = self.cvb0;
-        let (acc_phi, acc_theta, theta_draw_buf, feat_eff, ll_history, converged_flag, model, corpus) =
-          if cvb0_flag {
+        let (
+            acc_phi,
+            acc_theta,
+            theta_draw_buf,
+            feat_eff,
+            ll_history,
+            converged_flag,
+            model,
+            corpus,
+        ) = if cvb0_flag {
             // CVB0 DMR: deterministic; per-document α is fed to the CVB0 sweep,
             // and the soft expected counts E[n_dk] feed the λ optimizer directly.
             // No MCMC, so no θ-draws and no convergence trace.
@@ -3559,8 +3976,14 @@ impl DMR {
                     cv.sweep();
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                         dmr::optimize_lambda(
-                            &mut lambda, &feats, cv.doc_topic_expected(), k, nf,
-                            prior_variance, lbfgs_iters, None,
+                            &mut lambda,
+                            &feats,
+                            cv.doc_topic_expected(),
+                            k,
+                            nf,
+                            prior_variance,
+                            lbfgs_iters,
+                            None,
                         );
                     }
                 }
@@ -3569,9 +3992,18 @@ impl DMR {
                 cv.phi_into(&mut acc_phi);
                 cv.theta_into(&mut acc_theta);
                 let model = cv.to_topic_model(&corpus);
-                (acc_phi, acc_theta, Vec::new(), lambda, Vec::new(), false, model, corpus)
+                (
+                    acc_phi,
+                    acc_theta,
+                    Vec::new(),
+                    lambda,
+                    Vec::new(),
+                    false,
+                    model,
+                    corpus,
+                )
             })
-          } else if warp {
+        } else if warp {
             // WarpLDA DMR path: same λ-optimization loop, but the per-document
             // prior α is fed to the WarpLDA per-doc doc phase each sweep. Like the
             // LDA WarpLDA path it computes no inline log_likelihood, so the
@@ -3588,20 +4020,33 @@ impl DMR {
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                         let dtc = doc_topic_counts(ws.doc_topics(), k);
                         dmr::optimize_lambda(
-                            &mut lambda, &feats, &dtc, k, nf, prior_variance, lbfgs_iters, None,
+                            &mut lambda,
+                            &feats,
+                            &dtc,
+                            k,
+                            nf,
+                            prior_variance,
+                            lbfgs_iters,
+                            None,
                         );
                     }
 
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
                         let doc_alpha_snap = dmr::compute_doc_alpha(&lambda, &feats, None);
-                        let snap: Vec<Vec<f32>> = ws.doc_topics().iter()
+                        let snap: Vec<Vec<f32>> = ws
+                            .doc_topics()
+                            .iter()
                             .enumerate()
                             .map(|(d, topics)| {
                                 let mut c = vec![0.0f64; k];
-                                for &t in topics { c[t as usize] += 1.0; }
+                                for &t in topics {
+                                    c[t as usize] += 1.0;
+                                }
                                 let asum: f64 = doc_alpha_snap[d].iter().sum();
                                 let denom = c.iter().sum::<f64>() + asum;
-                                (0..k).map(|t| ((c[t] + doc_alpha_snap[d][t]) / denom) as f32).collect()
+                                (0..k)
+                                    .map(|t| ((c[t] + doc_alpha_snap[d][t]) / denom) as f32)
+                                    .collect()
                             })
                             .collect();
                         push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
@@ -3611,7 +4056,13 @@ impl DMR {
                         if progress_interval > 0 && iter % progress_interval == 0 {
                             let dtc = doc_topic_counts(ws.doc_topics(), k);
                             let (ll, _) = dmr::dmr_objective_and_gradient(
-                                &lambda, &feats, &dtc, k, nf, prior_variance, None,
+                                &lambda,
+                                &feats,
+                                &dtc,
+                                k,
+                                nf,
+                                prior_variance,
+                                None,
                             );
                             let llpt = ll / total_tokens;
                             Python::with_gil(|py| {
@@ -3642,95 +4093,36 @@ impl DMR {
                 }
                 let n = num_samples.max(1) as f64;
                 for row in acc_phi.iter_mut() {
-                    for v in row.iter_mut() { *v /= n; }
+                    for v in row.iter_mut() {
+                        *v /= n;
+                    }
                 }
                 for row in acc_theta.iter_mut() {
-                    for v in row.iter_mut() { *v /= n; }
+                    for v in row.iter_mut() {
+                        *v /= n;
+                    }
                 }
                 let model = ws.to_topic_model();
-                (acc_phi, acc_theta, theta_draw_buf, lambda, Vec::new(), false, model, corpus)
+                (
+                    acc_phi,
+                    acc_theta,
+                    theta_draw_buf,
+                    lambda,
+                    Vec::new(),
+                    false,
+                    model,
+                    corpus,
+                )
             })
-          } else {
+        } else {
             model.initialize(&corpus, &mut rng);
             py.allow_threads(move || {
-            let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
-            let mut ll_history: Vec<(usize, f64)> = Vec::new();
-            let mut converged_flag = false;
+                let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+                let mut ll_history: Vec<(usize, f64)> = Vec::new();
+                let mut converged_flag = false;
 
-            'outer: for iter in 1..=iters {
-                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
-                dmr::run_sweep_dmr(
-                    &mut model.type_topic_counts,
-                    &mut model.tokens_per_topic,
-                    &mut model.doc_topics,
-                    &corpus.docs,
-                    &doc_alpha,
-                    model.beta,
-                    model.beta_sum,
-                    model.topic_mask,
-                    model.topic_bits,
-                    k,
-                    &mut rng,
-                );
-
-                if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
-                    let dtc = doc_topic_counts(&model.doc_topics, k);
-                    dmr::optimize_lambda(
-                        &mut lambda, &feats, &dtc, k, nf, prior_variance, lbfgs_iters, None,
-                    );
-                }
-
-                // Snapshot θ = (n_dk + α_dk) / (N_d + Σα_d) every thin sweeps.
-                if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
-                    let doc_alpha_snap = dmr::compute_doc_alpha(&lambda, &feats, None);
-                    let snap: Vec<Vec<f32>> = model.doc_topics.iter()
-                        .enumerate()
-                        .map(|(d, topics)| {
-                            let mut c = vec![0.0f64; k];
-                            for &t in topics { c[t as usize] += 1.0; }
-                            let asum: f64 = doc_alpha_snap[d].iter().sum();
-                            let denom = c.iter().sum::<f64>() + asum;
-                            (0..k).map(|t| ((c[t] + doc_alpha_snap[d][t]) / denom) as f32).collect()
-                        })
-                        .collect();
-                    push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
-                }
-
-                if let Some(cb) = &progress {
-                    if progress_interval > 0 && iter % progress_interval == 0 {
-                        let dtc = doc_topic_counts(&model.doc_topics, k);
-                        let (ll, _) = dmr::dmr_objective_and_gradient(
-                            &lambda, &feats, &dtc, k, nf, prior_variance, None,
-                        );
-                        let llpt = ll / total_tokens;
-                        Python::with_gil(|py| {
-                            let _ = cb.call1(py, (iter, llpt));
-                        });
-                    }
-                }
-
-                // Trace recording and optional convergence check (never alters RNG).
-                if check_every > 0 && iter % check_every == 0 {
-                    let ll = output::model_log_likelihood(&model, &corpus);
-                    ll_history.push((iter, ll));
-                    if convergence_tol > 0.0 && ll_history.len() >= 2 {
-                        let prev = ll_history[ll_history.len() - 2].1;
-                        let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
-                        if rel < convergence_tol {
-                            converged_flag = true;
-                            break 'outer;
-                        }
-                    }
-                }
-            }
-
-            // Sampling phase: λ is now fixed, so α per doc is fixed too.
-            let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
-            let mut acc_phi = vec![vec![0.0f64; k]; num_types];
-            let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
-
-            for _ in 0..num_samples {
-                for _ in 0..sample_interval {
+                'outer: for iter in 1..=iters {
+                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
                     dmr::run_sweep_dmr(
                         &mut model.type_topic_counts,
                         &mut model.tokens_per_topic,
@@ -3744,34 +4136,134 @@ impl DMR {
                         k,
                         &mut rng,
                     );
-                }
-                accumulate_phi(&model, &mut acc_phi);
-                // DMR θ uses the per-document prior.
-                let counts = doc_topic_counts(&model.doc_topics, k);
-                for d in 0..num_docs {
-                    let asum: f64 = doc_alpha[d].iter().sum();
-                    let denom = corpus.docs[d].len() as f64 + asum;
-                    for t in 0..k {
-                        acc_theta[d][t] += (counts[d][t] as f64 + doc_alpha[d][t]) / denom;
+
+                    if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
+                        let dtc = doc_topic_counts(&model.doc_topics, k);
+                        dmr::optimize_lambda(
+                            &mut lambda,
+                            &feats,
+                            &dtc,
+                            k,
+                            nf,
+                            prior_variance,
+                            lbfgs_iters,
+                            None,
+                        );
+                    }
+
+                    // Snapshot θ = (n_dk + α_dk) / (N_d + Σα_d) every thin sweeps.
+                    if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                        let doc_alpha_snap = dmr::compute_doc_alpha(&lambda, &feats, None);
+                        let snap: Vec<Vec<f32>> = model
+                            .doc_topics
+                            .iter()
+                            .enumerate()
+                            .map(|(d, topics)| {
+                                let mut c = vec![0.0f64; k];
+                                for &t in topics {
+                                    c[t as usize] += 1.0;
+                                }
+                                let asum: f64 = doc_alpha_snap[d].iter().sum();
+                                let denom = c.iter().sum::<f64>() + asum;
+                                (0..k)
+                                    .map(|t| ((c[t] + doc_alpha_snap[d][t]) / denom) as f32)
+                                    .collect()
+                            })
+                            .collect();
+                        push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
+                    }
+
+                    if let Some(cb) = &progress {
+                        if progress_interval > 0 && iter % progress_interval == 0 {
+                            let dtc = doc_topic_counts(&model.doc_topics, k);
+                            let (ll, _) = dmr::dmr_objective_and_gradient(
+                                &lambda,
+                                &feats,
+                                &dtc,
+                                k,
+                                nf,
+                                prior_variance,
+                                None,
+                            );
+                            let llpt = ll / total_tokens;
+                            Python::with_gil(|py| {
+                                let _ = cb.call1(py, (iter, llpt));
+                            });
+                        }
+                    }
+
+                    // Trace recording and optional convergence check (never alters RNG).
+                    if check_every > 0 && iter % check_every == 0 {
+                        let ll = output::model_log_likelihood(&model, &corpus);
+                        ll_history.push((iter, ll));
+                        if convergence_tol > 0.0 && ll_history.len() >= 2 {
+                            let prev = ll_history[ll_history.len() - 2].1;
+                            let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
+                            if rel < convergence_tol {
+                                converged_flag = true;
+                                break 'outer;
+                            }
+                        }
                     }
                 }
-            }
 
-            let n = num_samples.max(1) as f64;
-            for row in acc_phi.iter_mut() {
-                for v in row.iter_mut() {
-                    *v /= n;
-                }
-            }
-            for row in acc_theta.iter_mut() {
-                for v in row.iter_mut() {
-                    *v /= n;
-                }
-            }
+                // Sampling phase: λ is now fixed, so α per doc is fixed too.
+                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                let mut acc_phi = vec![vec![0.0f64; k]; num_types];
+                let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
 
-            (acc_phi, acc_theta, theta_draw_buf, lambda, ll_history, converged_flag, model, corpus)
+                for _ in 0..num_samples {
+                    for _ in 0..sample_interval {
+                        dmr::run_sweep_dmr(
+                            &mut model.type_topic_counts,
+                            &mut model.tokens_per_topic,
+                            &mut model.doc_topics,
+                            &corpus.docs,
+                            &doc_alpha,
+                            model.beta,
+                            model.beta_sum,
+                            model.topic_mask,
+                            model.topic_bits,
+                            k,
+                            &mut rng,
+                        );
+                    }
+                    accumulate_phi(&model, &mut acc_phi);
+                    // DMR θ uses the per-document prior.
+                    let counts = doc_topic_counts(&model.doc_topics, k);
+                    for d in 0..num_docs {
+                        let asum: f64 = doc_alpha[d].iter().sum();
+                        let denom = corpus.docs[d].len() as f64 + asum;
+                        for t in 0..k {
+                            acc_theta[d][t] += (counts[d][t] as f64 + doc_alpha[d][t]) / denom;
+                        }
+                    }
+                }
+
+                let n = num_samples.max(1) as f64;
+                for row in acc_phi.iter_mut() {
+                    for v in row.iter_mut() {
+                        *v /= n;
+                    }
+                }
+                for row in acc_theta.iter_mut() {
+                    for v in row.iter_mut() {
+                        *v /= n;
+                    }
+                }
+
+                (
+                    acc_phi,
+                    acc_theta,
+                    theta_draw_buf,
+                    lambda,
+                    ll_history,
+                    converged_flag,
+                    model,
+                    corpus,
+                )
             })
-          };
+        };
         let _ = model;
 
         let mut phi = Array2::<f64>::zeros((k, num_types));
@@ -4001,10 +4493,17 @@ impl DMR {
         let nf = eff.shape()[1];
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let docs = docs_to_ids(data, id_to_word)?;
-        let docs_usize: Vec<Vec<usize>> =
-            docs.iter().map(|d| d.iter().map(|&w| w as usize).collect()).collect();
-        let phi_rows: Vec<Vec<f64>> =
-            self.phi.as_ref().unwrap().outer_iter().map(|r| r.to_vec()).collect();
+        let docs_usize: Vec<Vec<usize>> = docs
+            .iter()
+            .map(|d| d.iter().map(|&w| w as usize).collect())
+            .collect();
+        let phi_rows: Vec<Vec<f64>> = self
+            .phi
+            .as_ref()
+            .unwrap()
+            .outer_iter()
+            .map(|r| r.to_vec())
+            .collect();
 
         // Per-document Dirichlet prior α_d = exp(Xγ); intercept is column 0.
         let alphas: Vec<Vec<f64>> = match &features {
@@ -4052,7 +4551,13 @@ impl DMR {
                 .map(|(i, (d, alpha))| {
                     let mut rng = Pcg64Mcg::seed_from_u64(base_seed.wrapping_add(i as u64));
                     infer_theta_gibbs(
-                        &phi_rows, alpha, d, iterations, burn_in, num_samples, sample_interval,
+                        &phi_rows,
+                        alpha,
+                        d,
+                        iterations,
+                        burn_in,
+                        num_samples,
+                        sample_interval,
                         &mut rng,
                     )
                 })
@@ -4070,18 +4575,29 @@ impl DMR {
     /// Save the fitted model to `path` (compact binary). Reload with `DMR.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_DMR, &DmrState {
-            num_topics: self.num_topics, beta: self.beta,
-            optimize_interval: self.optimize_interval, burn_in: self.burn_in, seed: self.seed,
-            prior_variance: self.prior_variance, lbfgs_iters: self.lbfgs_iters, fitted: self.fitted,
-            phi: arr2_opt(&self.phi), theta: arr2_opt(&self.theta),
-            feature_effects: arr2_opt(&self.feature_effects),
-            feature_names: self.feature_names.clone(), corpus: self.corpus.clone(),
-            topic_names: self.topic_names.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-            theta_draws: arr3f32_opt(&self.theta_draws),
-        })
+        write_state(
+            path,
+            MODEL_TAG_DMR,
+            &DmrState {
+                num_topics: self.num_topics,
+                beta: self.beta,
+                optimize_interval: self.optimize_interval,
+                burn_in: self.burn_in,
+                seed: self.seed,
+                prior_variance: self.prior_variance,
+                lbfgs_iters: self.lbfgs_iters,
+                fitted: self.fitted,
+                phi: arr2_opt(&self.phi),
+                theta: arr2_opt(&self.theta),
+                feature_effects: arr2_opt(&self.feature_effects),
+                feature_names: self.feature_names.clone(),
+                corpus: self.corpus.clone(),
+                topic_names: self.topic_names.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+                theta_draws: arr3f32_opt(&self.theta_draws),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -4094,13 +4610,22 @@ impl DMR {
             s.topic_names
         };
         Ok(DMR {
-            num_topics: s.num_topics, beta: s.beta, optimize_interval: s.optimize_interval,
-            burn_in: s.burn_in, seed: s.seed, prior_variance: s.prior_variance,
-            lbfgs_iters: s.lbfgs_iters, warp: false, cvb0: false, fitted: s.fitted,
+            num_topics: s.num_topics,
+            beta: s.beta,
+            optimize_interval: s.optimize_interval,
+            burn_in: s.burn_in,
+            seed: s.seed,
+            prior_variance: s.prior_variance,
+            lbfgs_iters: s.lbfgs_iters,
+            warp: false,
+            cvb0: false,
+            fitted: s.fitted,
             topic_names,
-            phi: arr2_back(s.phi), theta: arr2_back(s.theta),
+            phi: arr2_back(s.phi),
+            theta: arr2_back(s.theta),
             feature_effects: arr2_back(s.feature_effects),
-            feature_names: s.feature_names, corpus: s.corpus,
+            feature_names: s.feature_names,
+            corpus: s.corpus,
             theta_draws: arr3f32_back(s.theta_draws),
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
@@ -4108,7 +4633,10 @@ impl DMR {
     }
 
     fn __repr__(&self) -> String {
-        format!("DMR(num_topics={}, fitted={})", self.num_topics, self.fitted)
+        format!(
+            "DMR(num_topics={}, fitted={})",
+            self.num_topics, self.fitted
+        )
     }
 }
 
@@ -4149,7 +4677,9 @@ impl LabeledLDA {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -4228,7 +4758,17 @@ impl LabeledLDA {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         let num_docs = corpus.num_docs();
         if num_docs == 0 {
@@ -4258,7 +4798,9 @@ impl LabeledLDA {
             }
         };
         if label_vocab.is_empty() {
-            return Err(PyValueError::new_err("no labels found; provide labels or label_names"));
+            return Err(PyValueError::new_err(
+                "no labels found; provide labels or label_names",
+            ));
         }
         let k = label_vocab.len();
         let index: HashMap<&str, usize> = label_vocab
@@ -4270,8 +4812,10 @@ impl LabeledLDA {
         let allowed: Vec<Vec<usize>> = labels
             .iter()
             .map(|ls| {
-                let mut v: Vec<usize> =
-                    ls.iter().filter_map(|l| index.get(l.as_str()).copied()).collect();
+                let mut v: Vec<usize> = ls
+                    .iter()
+                    .filter_map(|l| index.get(l.as_str()).copied())
+                    .collect();
                 v.sort_unstable();
                 v.dedup();
                 v
@@ -4285,7 +4829,13 @@ impl LabeledLDA {
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
         labeled::initialize_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
 
-        let check_every_labeled = if check_every == 0 { 0 } else if convergence_tol > 0.0 { check_every.max(1) } else { check_every };
+        let check_every_labeled = if check_every == 0 {
+            0
+        } else if convergence_tol > 0.0 {
+            check_every.max(1)
+        } else {
+            check_every
+        };
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
@@ -4330,86 +4880,102 @@ impl LabeledLDA {
             return Ok(());
         }
 
-        let (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, model, corpus) = py.allow_threads(move || {
-            let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
-            let all_topics: Vec<usize> = (0..k).collect();
-            let mut ll_history: Vec<(usize, f64)> = Vec::new();
-            let mut converged = false;
+        let (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, model, corpus) = py
+            .allow_threads(move || {
+                let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+                let all_topics: Vec<usize> = (0..k).collect();
+                let mut ll_history: Vec<(usize, f64)> = Vec::new();
+                let mut converged = false;
 
-            'outer: for iter in 1..=iters {
-                labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
-                if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                'outer: for iter in 1..=iters {
+                    labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
+                    if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                        let counts = doc_topic_counts(&model.doc_topics, k);
+                        let snap: Vec<Vec<f32>> = (0..num_docs)
+                            .map(|d| {
+                                let allow: &[usize] = if allowed[d].is_empty() {
+                                    &all_topics
+                                } else {
+                                    &allowed[d]
+                                };
+                                let asum: f64 = allow.iter().map(|&t| model.alpha[t]).sum();
+                                let denom = corpus.docs[d].len() as f64 + asum;
+                                let mut row = vec![0.0f32; k];
+                                for &t in allow {
+                                    row[t] =
+                                        ((counts[d][t] as f64 + model.alpha[t]) / denom) as f32;
+                                }
+                                row
+                            })
+                            .collect();
+                        push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
+                    }
+                    if let Some(cb) = &progress {
+                        if progress_interval > 0 && iter % progress_interval == 0 {
+                            let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
+                            Python::with_gil(|py| {
+                                let _ = cb.call1(py, (iter, ll));
+                            });
+                        }
+                    }
+                    // Trace recording and optional convergence check (never alters RNG).
+                    if check_every_labeled > 0 && iter % check_every_labeled == 0 {
+                        let ll = output::model_log_likelihood(&model, &corpus);
+                        ll_history.push((iter, ll));
+                        if convergence_tol > 0.0 && ll_history.len() >= 2 {
+                            let prev = ll_history[ll_history.len() - 2].1;
+                            let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
+                            if rel < convergence_tol {
+                                converged = true;
+                                break 'outer;
+                            }
+                        }
+                    }
+                }
+
+                let mut acc_phi = vec![vec![0.0f64; k]; num_types];
+                let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
+                for _ in 0..num_samples {
+                    for _ in 0..sample_interval {
+                        labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
+                    }
+                    accumulate_phi(&model, &mut acc_phi);
                     let counts = doc_topic_counts(&model.doc_topics, k);
-                    let snap: Vec<Vec<f32>> = (0..num_docs).map(|d| {
-                        let allow: &[usize] = if allowed[d].is_empty() { &all_topics } else { &allowed[d] };
+                    for d in 0..num_docs {
+                        let allow: &[usize] = if allowed[d].is_empty() {
+                            &all_topics
+                        } else {
+                            &allowed[d]
+                        };
                         let asum: f64 = allow.iter().map(|&t| model.alpha[t]).sum();
                         let denom = corpus.docs[d].len() as f64 + asum;
-                        let mut row = vec![0.0f32; k];
                         for &t in allow {
-                            row[t] = ((counts[d][t] as f64 + model.alpha[t]) / denom) as f32;
-                        }
-                        row
-                    }).collect();
-                    push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
-                }
-                if let Some(cb) = &progress {
-                    if progress_interval > 0 && iter % progress_interval == 0 {
-                        let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
-                        Python::with_gil(|py| {
-                            let _ = cb.call1(py, (iter, ll));
-                        });
-                    }
-                }
-                // Trace recording and optional convergence check (never alters RNG).
-                if check_every_labeled > 0 && iter % check_every_labeled == 0 {
-                    let ll = output::model_log_likelihood(&model, &corpus);
-                    ll_history.push((iter, ll));
-                    if convergence_tol > 0.0 && ll_history.len() >= 2 {
-                        let prev = ll_history[ll_history.len() - 2].1;
-                        let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
-                        if rel < convergence_tol {
-                            converged = true;
-                            break 'outer;
+                            acc_theta[d][t] += (counts[d][t] as f64 + model.alpha[t]) / denom;
                         }
                     }
                 }
-            }
 
-            let mut acc_phi = vec![vec![0.0f64; k]; num_types];
-            let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
-            for _ in 0..num_samples {
-                for _ in 0..sample_interval {
-                    labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
-                }
-                accumulate_phi(&model, &mut acc_phi);
-                let counts = doc_topic_counts(&model.doc_topics, k);
-                for d in 0..num_docs {
-                    let allow: &[usize] = if allowed[d].is_empty() {
-                        &all_topics
-                    } else {
-                        &allowed[d]
-                    };
-                    let asum: f64 = allow.iter().map(|&t| model.alpha[t]).sum();
-                    let denom = corpus.docs[d].len() as f64 + asum;
-                    for &t in allow {
-                        acc_theta[d][t] += (counts[d][t] as f64 + model.alpha[t]) / denom;
+                let n = num_samples.max(1) as f64;
+                for row in acc_phi.iter_mut() {
+                    for v in row.iter_mut() {
+                        *v /= n;
                     }
                 }
-            }
-
-            let n = num_samples.max(1) as f64;
-            for row in acc_phi.iter_mut() {
-                for v in row.iter_mut() {
-                    *v /= n;
+                for row in acc_theta.iter_mut() {
+                    for v in row.iter_mut() {
+                        *v /= n;
+                    }
                 }
-            }
-            for row in acc_theta.iter_mut() {
-                for v in row.iter_mut() {
-                    *v /= n;
-                }
-            }
-            (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, model, corpus)
-        });
+                (
+                    acc_phi,
+                    acc_theta,
+                    theta_draw_buf,
+                    ll_history,
+                    converged,
+                    model,
+                    corpus,
+                )
+            });
         let _ = model;
 
         let mut phi = Array2::<f64>::zeros((k, num_types));
@@ -4475,7 +5041,11 @@ impl LabeledLDA {
     #[getter]
     fn doc_lengths(&self) -> PyResult<Vec<usize>> {
         self.require_fitted()?;
-        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
     }
 
     /// The label name for each topic, in topic (column) order.
@@ -4608,8 +5178,15 @@ impl LabeledLDA {
         self.require_fitted()?;
         let alpha = vec![self.alpha; self.num_topics];
         transform_gibbs(
-            py, data, &self.corpus.as_ref().unwrap().id_to_word, self.phi.as_ref().unwrap(),
-            &alpha, iters, burn_in, num_samples, sample_interval,
+            py,
+            data,
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.phi.as_ref().unwrap(),
+            &alpha,
+            iters,
+            burn_in,
+            num_samples,
+            sample_interval,
             seed.unwrap_or(self.seed),
         )
     }
@@ -4617,15 +5194,25 @@ impl LabeledLDA {
     /// Save the fitted model to `path`. Reload with `LabeledLDA.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_LABELED, &LabeledState {
-            alpha: self.alpha, beta: self.beta, seed: self.seed, fitted: self.fitted,
-            num_topics: self.num_topics, phi: arr2_opt(&self.phi), theta: arr2_opt(&self.theta),
-            label_vocab: self.label_vocab.clone(), corpus: self.corpus.clone(),
-            topic_names: self.topic_names.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-            theta_draws: arr3f32_opt(&self.theta_draws),
-        })
+        write_state(
+            path,
+            MODEL_TAG_LABELED,
+            &LabeledState {
+                alpha: self.alpha,
+                beta: self.beta,
+                seed: self.seed,
+                fitted: self.fitted,
+                num_topics: self.num_topics,
+                phi: arr2_opt(&self.phi),
+                theta: arr2_opt(&self.theta),
+                label_vocab: self.label_vocab.clone(),
+                corpus: self.corpus.clone(),
+                topic_names: self.topic_names.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+                theta_draws: arr3f32_opt(&self.theta_draws),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -4638,10 +5225,17 @@ impl LabeledLDA {
             s.topic_names
         };
         Ok(LabeledLDA {
-            alpha: s.alpha, beta: s.beta, seed: s.seed, cvb0: false, fitted: s.fitted,
-            num_topics: s.num_topics, topic_names,
-            phi: arr2_back(s.phi), theta: arr2_back(s.theta),
-            label_vocab: s.label_vocab, corpus: s.corpus,
+            alpha: s.alpha,
+            beta: s.beta,
+            seed: s.seed,
+            cvb0: false,
+            fitted: s.fitted,
+            num_topics: s.num_topics,
+            topic_names,
+            phi: arr2_back(s.phi),
+            theta: arr2_back(s.theta),
+            label_vocab: s.label_vocab,
+            corpus: s.corpus,
             theta_draws: arr3f32_back(s.theta_draws),
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
@@ -4668,7 +5262,9 @@ fn parse_groups(obj: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
     if let Ok(v) = obj.extract::<Vec<i64>>() {
         return Ok(v.iter().map(|x| x.to_string()).collect());
     }
-    Err(PyValueError::new_err("groups must be a list of strings or ints"))
+    Err(PyValueError::new_err(
+        "groups must be a list of strings or ints",
+    ))
 }
 
 /// Content-covariate topic model (SAGE / the STM content model).
@@ -4706,7 +5302,9 @@ impl SAGE {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 
@@ -4801,7 +5399,17 @@ impl SAGE {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         let num_docs = corpus.num_docs();
         if num_docs == 0 {
@@ -4834,10 +5442,9 @@ impl SAGE {
         let groups_idx: Vec<usize> = groups_str
             .iter()
             .map(|g| {
-                gindex
-                    .get(g.as_str())
-                    .copied()
-                    .ok_or_else(|| PyValueError::new_err(format!("group {:?} not in group_names", g)))
+                gindex.get(g.as_str()).copied().ok_or_else(|| {
+                    PyValueError::new_err(format!("group {:?} not in group_names", g))
+                })
             })
             .collect::<PyResult<_>>()?;
 
@@ -4860,83 +5467,95 @@ impl SAGE {
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        let (beta, acc_theta, theta_draw_buf, ll_history, converged_flag, corpus) = py.allow_threads(move || {
-            let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
-            let mut ll_history: Vec<(usize, f64)> = Vec::new();
-            let mut converged_flag = false;
+        let (beta, acc_theta, theta_draw_buf, ll_history, converged_flag, corpus) = py
+            .allow_threads(move || {
+                let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
+                let mut ll_history: Vec<(usize, f64)> = Vec::new();
+                let mut converged_flag = false;
 
-            // Inline LL for SAGE: sum_c sum_v n_cv * ln(beta_cv).
-            let compute_ll = |model: &sage::SageModel| -> f64 {
-                let mut ll = 0.0f64;
-                for c in 0..(k * group_n) {
-                    for v in 0..num_types {
-                        let n = model.counts[c][v] as f64;
-                        if n > 0.0 {
-                            ll += n * model.beta[c][v].max(1e-300).ln();
+                // Inline LL for SAGE: sum_c sum_v n_cv * ln(beta_cv).
+                let compute_ll = |model: &sage::SageModel| -> f64 {
+                    let mut ll = 0.0f64;
+                    for c in 0..(k * group_n) {
+                        for v in 0..num_types {
+                            let n = model.counts[c][v] as f64;
+                            if n > 0.0 {
+                                ll += n * model.beta[c][v].max(1e-300).ln();
+                            }
                         }
                     }
-                }
-                ll
-            };
+                    ll
+                };
 
-            'outer: for iter in 1..=iters {
-                sage::run_sweep_sage(&mut model, &corpus.docs, &groups_idx, &mut rng);
-                if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
-                    sage::optimize_kappa(&mut model, lbfgs_iters);
-                }
-                if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
-                    let counts = doc_topic_counts(&model.doc_topics, k);
-                    let snap: Vec<Vec<f32>> = (0..num_docs).map(|d| {
-                        let denom = corpus.docs[d].len() as f64 + alpha_sum;
-                        (0..k).map(|t| ((counts[d][t] as f64 + alpha) / denom) as f32).collect()
-                    }).collect();
-                    push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
-                }
-                if let Some(cb) = &progress {
-                    if progress_interval > 0 && iter % progress_interval == 0 {
-                        let llpt = compute_ll(&model) / total_tokens;
-                        Python::with_gil(|py| {
-                            let _ = cb.call1(py, (iter, llpt));
-                        });
-                    }
-                }
-                // Trace recording and optional convergence check (never alters RNG).
-                if check_every > 0 && iter % check_every == 0 {
-                    let ll = compute_ll(&model);
-                    ll_history.push((iter, ll));
-                    if convergence_tol > 0.0 && ll_history.len() >= 2 {
-                        let prev = ll_history[ll_history.len() - 2].1;
-                        let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
-                        if rel < convergence_tol {
-                            converged_flag = true;
-                            break 'outer;
-                        }
-                    }
-                }
-            }
-            sage::optimize_kappa(&mut model, lbfgs_iters); // final β refresh
-
-            let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
-            for _ in 0..num_samples {
-                for _ in 0..sample_interval {
+                'outer: for iter in 1..=iters {
                     sage::run_sweep_sage(&mut model, &corpus.docs, &groups_idx, &mut rng);
-                }
-                let counts = doc_topic_counts(&model.doc_topics, k);
-                for d in 0..num_docs {
-                    let denom = corpus.docs[d].len() as f64 + alpha_sum;
-                    for t in 0..k {
-                        acc_theta[d][t] += (counts[d][t] as f64 + alpha) / denom;
+                    if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
+                        sage::optimize_kappa(&mut model, lbfgs_iters);
+                    }
+                    if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
+                        let counts = doc_topic_counts(&model.doc_topics, k);
+                        let snap: Vec<Vec<f32>> = (0..num_docs)
+                            .map(|d| {
+                                let denom = corpus.docs[d].len() as f64 + alpha_sum;
+                                (0..k)
+                                    .map(|t| ((counts[d][t] as f64 + alpha) / denom) as f32)
+                                    .collect()
+                            })
+                            .collect();
+                        push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
+                    }
+                    if let Some(cb) = &progress {
+                        if progress_interval > 0 && iter % progress_interval == 0 {
+                            let llpt = compute_ll(&model) / total_tokens;
+                            Python::with_gil(|py| {
+                                let _ = cb.call1(py, (iter, llpt));
+                            });
+                        }
+                    }
+                    // Trace recording and optional convergence check (never alters RNG).
+                    if check_every > 0 && iter % check_every == 0 {
+                        let ll = compute_ll(&model);
+                        ll_history.push((iter, ll));
+                        if convergence_tol > 0.0 && ll_history.len() >= 2 {
+                            let prev = ll_history[ll_history.len() - 2].1;
+                            let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
+                            if rel < convergence_tol {
+                                converged_flag = true;
+                                break 'outer;
+                            }
+                        }
                     }
                 }
-            }
-            let n = num_samples.max(1) as f64;
-            for row in acc_theta.iter_mut() {
-                for v in row.iter_mut() {
-                    *v /= n;
+                sage::optimize_kappa(&mut model, lbfgs_iters); // final β refresh
+
+                let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
+                for _ in 0..num_samples {
+                    for _ in 0..sample_interval {
+                        sage::run_sweep_sage(&mut model, &corpus.docs, &groups_idx, &mut rng);
+                    }
+                    let counts = doc_topic_counts(&model.doc_topics, k);
+                    for d in 0..num_docs {
+                        let denom = corpus.docs[d].len() as f64 + alpha_sum;
+                        for t in 0..k {
+                            acc_theta[d][t] += (counts[d][t] as f64 + alpha) / denom;
+                        }
+                    }
                 }
-            }
-            (model.beta.clone(), acc_theta, theta_draw_buf, ll_history, converged_flag, corpus)
-        });
+                let n = num_samples.max(1) as f64;
+                for row in acc_theta.iter_mut() {
+                    for v in row.iter_mut() {
+                        *v /= n;
+                    }
+                }
+                (
+                    model.beta.clone(),
+                    acc_theta,
+                    theta_draw_buf,
+                    ll_history,
+                    converged_flag,
+                    corpus,
+                )
+            });
 
         let mut theta = Array2::<f64>::zeros((num_docs, k));
         for (d, row) in acc_theta.iter().enumerate() {
@@ -5014,7 +5633,11 @@ impl SAGE {
     #[getter]
     fn doc_lengths(&self) -> PyResult<Vec<usize>> {
         self.require_fitted()?;
-        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
     }
 
     /// Group names, in the index order used by :attr:`topic_word`'s second axis.
@@ -5185,17 +5808,29 @@ impl SAGE {
     /// Save the fitted model to `path`. Reload with `SAGE.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_SAGE, &SageState {
-            num_topics: self.num_topics, alpha: self.alpha, prior_variance: self.prior_variance,
-            optimize_interval: self.optimize_interval, burn_in: self.burn_in, seed: self.seed,
-            lbfgs_iters: self.lbfgs_iters, fitted: self.fitted, num_groups: self.num_groups,
-            beta: self.beta.clone(), theta: arr2_opt(&self.theta),
-            group_names: self.group_names.clone(), corpus: self.corpus.clone(),
-            topic_names: self.topic_names.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-            theta_draws: arr3f32_opt(&self.theta_draws),
-        })
+        write_state(
+            path,
+            MODEL_TAG_SAGE,
+            &SageState {
+                num_topics: self.num_topics,
+                alpha: self.alpha,
+                prior_variance: self.prior_variance,
+                optimize_interval: self.optimize_interval,
+                burn_in: self.burn_in,
+                seed: self.seed,
+                lbfgs_iters: self.lbfgs_iters,
+                fitted: self.fitted,
+                num_groups: self.num_groups,
+                beta: self.beta.clone(),
+                theta: arr2_opt(&self.theta),
+                group_names: self.group_names.clone(),
+                corpus: self.corpus.clone(),
+                topic_names: self.topic_names.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+                theta_draws: arr3f32_opt(&self.theta_draws),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -5208,11 +5843,20 @@ impl SAGE {
             s.topic_names
         };
         Ok(SAGE {
-            num_topics: s.num_topics, alpha: s.alpha, prior_variance: s.prior_variance,
-            optimize_interval: s.optimize_interval, burn_in: s.burn_in, seed: s.seed,
-            lbfgs_iters: s.lbfgs_iters, fitted: s.fitted, num_groups: s.num_groups,
+            num_topics: s.num_topics,
+            alpha: s.alpha,
+            prior_variance: s.prior_variance,
+            optimize_interval: s.optimize_interval,
+            burn_in: s.burn_in,
+            seed: s.seed,
+            lbfgs_iters: s.lbfgs_iters,
+            fitted: s.fitted,
+            num_groups: s.num_groups,
             topic_names,
-            beta: s.beta, theta: arr2_back(s.theta), group_names: s.group_names, corpus: s.corpus,
+            beta: s.beta,
+            theta: arr2_back(s.theta),
+            group_names: s.group_names,
+            corpus: s.corpus,
             theta_draws: arr3f32_back(s.theta_draws),
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
@@ -5248,8 +5892,18 @@ impl SAGE {
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let phi = self.topic_marginal();
         let alpha = vec![self.alpha; self.num_topics];
-        transform_gibbs(py, data, id_to_word, &phi, &alpha, iters, burn_in,
-                        num_samples, sample_interval, seed.unwrap_or(self.seed))
+        transform_gibbs(
+            py,
+            data,
+            id_to_word,
+            &phi,
+            &alpha,
+            iters,
+            burn_in,
+            num_samples,
+            sample_interval,
+            seed.unwrap_or(self.seed),
+        )
     }
 
     fn __repr__(&self) -> String {
@@ -5279,7 +5933,9 @@ impl SAGE {
                 .position(|g| g == &s)
                 .ok_or_else(|| PyValueError::new_err(format!("unknown group {:?}", s)));
         }
-        Err(PyValueError::new_err("group must be a name (str) or index (int)"))
+        Err(PyValueError::new_err(
+            "group must be a name (str) or index (int)",
+        ))
     }
 }
 
@@ -5294,10 +5950,7 @@ impl SAGE {
 /// Map new documents (a `Corpus` or `list[list[str]]`) onto the training
 /// vocabulary, dropping out-of-vocabulary tokens. Tokens are lowercased to
 /// match the corpus loader. Returns one `Vec<u32>` of word-ids per document.
-fn docs_to_ids(
-    data: &Bound<'_, PyAny>,
-    id_to_word: &[String],
-) -> PyResult<Vec<Vec<u32>>> {
+fn docs_to_ids(data: &Bound<'_, PyAny>, id_to_word: &[String]) -> PyResult<Vec<Vec<u32>>> {
     let word_to_id: HashMap<&str, u32> = id_to_word
         .iter()
         .enumerate()
@@ -5307,7 +5960,11 @@ fn docs_to_ids(
         c.inner
             .docs
             .iter()
-            .map(|d| d.iter().map(|&w| c.inner.id_to_word[w as usize].clone()).collect())
+            .map(|d| {
+                d.iter()
+                    .map(|&w| c.inner.id_to_word[w as usize].clone())
+                    .collect()
+            })
             .collect()
     } else {
         data.extract().map_err(|_| {
@@ -5401,7 +6058,6 @@ fn infer_theta_batch_per_doc(
     out
 }
 
-
 /// Correlated Topic Model (Blei & Lafferty; the STM core). Topics are drawn
 /// from a logistic-normal prior with a full covariance, so they can correlate —
 /// unlike LDA's Dirichlet. Fit by variational EM (STM's Laplace E-step).
@@ -5425,13 +6081,13 @@ pub struct CTM {
 
     fitted: bool,
     topic_names: Vec<String>,
-    beta: Option<Array2<f64>>,  // (num_topics, num_words)
-    theta: Option<Array2<f64>>, // (num_docs, num_topics)
-    corr: Option<Array2<f64>>,  // (num_topics, num_topics)
+    beta: Option<Array2<f64>>,     // (num_topics, num_words)
+    theta: Option<Array2<f64>>,    // (num_docs, num_topics)
+    corr: Option<Array2<f64>>,     // (num_topics, num_topics)
     eta_mean: Option<Array2<f64>>, // (num_docs, num_topics-1) variational means λ
-    eta_cov: Option<Array3<f32>>,  // (num_docs, K-1, K-1) variational covariances ν — stored as f32 to halve memory
-    mu: Vec<f64>,                  // K-1 logistic-normal prior mean (for inference)
-    sigma: Vec<f64>,               // (K-1)² logistic-normal prior covariance
+    eta_cov: Option<Array3<f32>>, // (num_docs, K-1, K-1) variational covariances ν — stored as f32 to halve memory
+    mu: Vec<f64>,                 // K-1 logistic-normal prior mean (for inference)
+    sigma: Vec<f64>,              // (K-1)² logistic-normal prior covariance
     /// Sigma from the last E-step (may differ from sigma when the final M-step
     /// updated sigma after the last E-step). Used by `_recompute_eta_cov`.
     sigma_estep: Vec<f64>,
@@ -5439,9 +6095,9 @@ pub struct CTM {
     /// M-step updated `beta`). Used by `_recompute_eta_cov` to reproduce ν.
     beta_estep: Option<Array2<f64>>,
     corpus: Option<corpus::Corpus>,
-    bound: f64,                    // final variational bound (ELBO)
-    bound_history: Vec<f64>,       // bound after each EM iteration
-    converged: bool,               // hit em_tol (true) or em_iters cap (false)
+    bound: f64,              // final variational bound (ELBO)
+    bound_history: Vec<f64>, // bound after each EM iteration
+    converged: bool,         // hit em_tol (true) or em_iters cap (false)
 }
 
 impl CTM {
@@ -5449,7 +6105,9 @@ impl CTM {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -5467,7 +6125,13 @@ impl CTM {
     /// off-diagonal posterior covariance — topic-correlation/SE precision is lower).
     #[new]
     #[pyo3(signature = (num_topics, *, sigma_shrink=0.0, seed=42, init="spectral", variational="laplace"))]
-    fn new(#[pyo3(from_py_with = "py_num_topics")] num_topics: usize, sigma_shrink: f64, seed: u64, init: &str, variational: &str) -> PyResult<Self> {
+    fn new(
+        #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
+        sigma_shrink: f64,
+        seed: u64,
+        init: &str,
+        variational: &str,
+    ) -> PyResult<Self> {
         if num_topics < 2 {
             return Err(PyValueError::new_err("num_topics must be >= 2"));
         }
@@ -5480,7 +6144,9 @@ impl CTM {
             _ => return Err(PyValueError::new_err("init must be 'spectral' or 'random'")),
         };
         if variational != "laplace" && variational != "diagonal" {
-            return Err(PyValueError::new_err("variational must be 'laplace' or 'diagonal'"));
+            return Err(PyValueError::new_err(
+                "variational must be 'laplace' or 'diagonal'",
+            ));
         }
         Ok(CTM {
             num_topics,
@@ -5545,13 +6211,20 @@ impl CTM {
     ) -> PyResult<()> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "CTM.fit(em_tol=) is deprecated; use convergence_tol= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
+            warnings.call_method1(
+                "warn",
+                (
+                    "CTM.fit(em_tol=) is deprecated; use convergence_tol= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
             // convergence_tol wins if explicitly set (not the default 1e-5); else deprecated.
-            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON {
+                convergence_tol
+            } else {
+                old_val
+            }
         } else {
             convergence_tol
         };
@@ -5561,7 +6234,17 @@ impl CTM {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -5589,14 +6272,35 @@ impl CTM {
             let m = run_with_threads(num_threads, || {
                 if svi {
                     ctm::fit_ctm_svi(
-                        &corpus.docs, k, num_types, iters, batch_size, tau, kappa, shrink, spectral,
-                        keep_eta_cov, diagonal, &mut rng,
+                        &corpus.docs,
+                        k,
+                        num_types,
+                        iters,
+                        batch_size,
+                        tau,
+                        kappa,
+                        shrink,
+                        spectral,
+                        keep_eta_cov,
+                        diagonal,
+                        &mut rng,
                     )
                 } else {
                     ctm::fit_ctm(
-                        &corpus.docs, k, num_types, iters, convergence_tol, shrink, None, None,
-                        spectral, init_beta.as_deref(), ctm::GammaPrior::Pooled, keep_eta_cov,
-                        diagonal, &mut rng,
+                        &corpus.docs,
+                        k,
+                        num_types,
+                        iters,
+                        convergence_tol,
+                        shrink,
+                        None,
+                        None,
+                        spectral,
+                        init_beta.as_deref(),
+                        ctm::GammaPrior::Pooled,
+                        keep_eta_cov,
+                        diagonal,
+                        &mut rng,
                     )
                 }
             });
@@ -5730,7 +6434,8 @@ impl CTM {
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         self.require_fitted()?;
-        Ok(self.bound_history
+        Ok(self
+            .bound_history
             .iter()
             .enumerate()
             .map(|(i, &b)| (i + 1, b))
@@ -5771,12 +6476,15 @@ impl CTM {
     #[getter]
     fn eta_cov<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
         self.require_fitted()?;
-        self.eta_cov.as_ref()
+        self.eta_cov
+            .as_ref()
             .map(|c| c.to_pyarray_bound(py))
-            .ok_or_else(|| PyRuntimeError::new_err(
-                "model was fit with keep_eta_cov=False; refit with keep_eta_cov=True, \
-                 or use posterior_theta_samples/_recompute_eta_cov which recompute it on demand"
-            ))
+            .ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "model was fit with keep_eta_cov=False; refit with keep_eta_cov=True, \
+                 or use posterior_theta_samples/_recompute_eta_cov which recompute it on demand",
+                )
+            })
     }
 
     /// Recompute the per-document variational covariance ν on demand.
@@ -5789,18 +6497,27 @@ impl CTM {
         })?;
         let k = self.num_topics;
         let km1 = k - 1;
-        let sparse: Vec<(Vec<usize>, Vec<f64>)> = corpus.docs.iter()
+        let sparse: Vec<(Vec<usize>, Vec<f64>)> = corpus
+            .docs
+            .iter()
             .map(|doc| crate::variational::doc_sparse(doc))
             .collect();
         // Build a minimal CtmModel stub using only the fields recompute_nu needs.
         // Use beta_estep (the topic-word matrix from the last E-step, before the
         // final M-step updated beta) so the Hessian computation is bit-identical
         // to what was used when nu was originally stored.
-        let beta_src = self.beta_estep.as_ref().unwrap_or_else(|| self.beta.as_ref().unwrap());
-        let beta_v: Vec<Vec<f64>> = beta_src
-            .outer_iter().map(|r| r.to_vec()).collect();
-        let lambda_v: Vec<Vec<f64>> = self.eta_mean.as_ref().unwrap()
-            .outer_iter().map(|r| r.to_vec()).collect();
+        let beta_src = self
+            .beta_estep
+            .as_ref()
+            .unwrap_or_else(|| self.beta.as_ref().unwrap());
+        let beta_v: Vec<Vec<f64>> = beta_src.outer_iter().map(|r| r.to_vec()).collect();
+        let lambda_v: Vec<Vec<f64>> = self
+            .eta_mean
+            .as_ref()
+            .unwrap()
+            .outer_iter()
+            .map(|r| r.to_vec())
+            .collect();
         let d = lambda_v.len();
         // ν is independent of the prior mean μ, so recompute_nu uses self.mu for
         // every document. Fall back to self.sigma for loaded models (sigma_estep
@@ -5897,7 +6614,10 @@ impl CTM {
             let items: Vec<Bound<'py, PyTuple>> = tops[t]
                 .iter()
                 .map(|&w| {
-                    PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)])
+                    PyTuple::new_bound(
+                        py,
+                        &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)],
+                    )
                 })
                 .collect();
             Ok(PyList::new_bound(py, items))
@@ -5965,18 +6685,30 @@ impl CTM {
         // eta_cov is stored as f32 in memory; upcast to f64 for the on-disk format
         // so existing saved models remain compatible.
         let eta_cov_f64 = self.eta_cov.as_ref().map(|c| c.mapv(|x| x as f64));
-        write_state(path, MODEL_TAG_CTM, &CtmState {
-            num_topics: self.num_topics, sigma_shrink: self.sigma_shrink, seed: self.seed,
-            init_spectral: self.init_spectral, fitted: self.fitted,
-            beta: arr2_opt(&self.beta), theta: arr2_opt(&self.theta), corr: arr2_opt(&self.corr),
-            eta_mean: arr2_opt(&self.eta_mean), eta_cov: arr3_opt(&eta_cov_f64),
-            mu: self.mu.clone(), sigma: self.sigma.clone(),
-            corpus: self.corpus.clone(),
-            bound: self.bound, bound_history: self.bound_history.clone(),
-            converged: self.converged,
-            topic_names: self.topic_names.clone(),
-            variational: self.variational.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_CTM,
+            &CtmState {
+                num_topics: self.num_topics,
+                sigma_shrink: self.sigma_shrink,
+                seed: self.seed,
+                init_spectral: self.init_spectral,
+                fitted: self.fitted,
+                beta: arr2_opt(&self.beta),
+                theta: arr2_opt(&self.theta),
+                corr: arr2_opt(&self.corr),
+                eta_mean: arr2_opt(&self.eta_mean),
+                eta_cov: arr3_opt(&eta_cov_f64),
+                mu: self.mu.clone(),
+                sigma: self.sigma.clone(),
+                corpus: self.corpus.clone(),
+                bound: self.bound,
+                bound_history: self.bound_history.clone(),
+                converged: self.converged,
+                topic_names: self.topic_names.clone(),
+                variational: self.variational.clone(),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -5991,21 +6723,34 @@ impl CTM {
         // eta_cov is saved as f64 for format compatibility; downcast to f32 in memory.
         let eta_cov = arr3_back(s.eta_cov).map(|c| c.mapv(|x| x as f32));
         Ok(CTM {
-            num_topics: s.num_topics, sigma_shrink: s.sigma_shrink, seed: s.seed,
-            init_spectral: s.init_spectral, variational: s.variational, fitted: s.fitted,
+            num_topics: s.num_topics,
+            sigma_shrink: s.sigma_shrink,
+            seed: s.seed,
+            init_spectral: s.init_spectral,
+            variational: s.variational,
+            fitted: s.fitted,
             topic_names,
-            beta: arr2_back(s.beta), theta: arr2_back(s.theta), corr: arr2_back(s.corr),
-            eta_mean: arr2_back(s.eta_mean), eta_cov,
-            mu: s.mu, sigma: s.sigma,
-            sigma_estep: Vec::new(),  // not persisted; falls back to sigma in _recompute_eta_cov
-            beta_estep: None,         // not persisted; falls back to self.beta
+            beta: arr2_back(s.beta),
+            theta: arr2_back(s.theta),
+            corr: arr2_back(s.corr),
+            eta_mean: arr2_back(s.eta_mean),
+            eta_cov,
+            mu: s.mu,
+            sigma: s.sigma,
+            sigma_estep: Vec::new(), // not persisted; falls back to sigma in _recompute_eta_cov
+            beta_estep: None,        // not persisted; falls back to self.beta
             corpus: s.corpus,
-            bound: s.bound, bound_history: s.bound_history, converged: s.converged,
+            bound: s.bound,
+            bound_history: s.bound_history,
+            converged: s.converged,
         })
     }
 
     fn __repr__(&self) -> String {
-        format!("CTM(num_topics={}, variational={:?}, fitted={})", self.num_topics, self.variational, self.fitted)
+        format!(
+            "CTM(num_topics={}, variational={:?}, fitted={})",
+            self.num_topics, self.variational, self.fitted
+        )
     }
 }
 
@@ -6040,8 +6785,8 @@ pub struct STM {
     theta: Option<Array2<f64>>,
     corr: Option<Array2<f64>>,
     eta_mean: Option<Array2<f64>>, // (num_docs, num_topics-1) variational means λ
-    eta_cov: Option<Array3<f32>>,  // (num_docs, K-1, K-1) variational covariances ν — stored as f32 to halve memory
-    gamma: Option<Array2<f64>>, // (num_features, num_topics-1); None if no prevalence
+    eta_cov: Option<Array3<f32>>, // (num_docs, K-1, K-1) variational covariances ν — stored as f32 to halve memory
+    gamma: Option<Array2<f64>>,   // (num_features, num_topics-1); None if no prevalence
     feature_names: Vec<String>,
     content_beta: Option<Vec<Vec<Vec<f64>>>>, // G×K×V; None if no content
     content_kappa: Option<ctm::ContentKappa>, // SAGE κ decomposition; None if no content
@@ -6055,9 +6800,9 @@ pub struct STM {
     /// M-step updated `beta`). Used by `_recompute_eta_cov` to reproduce ν.
     beta_estep: Option<Array2<f64>>,
     corpus: Option<corpus::Corpus>,
-    bound: f64,                // final variational bound (ELBO)
-    bound_history: Vec<f64>,   // bound after each EM iteration
-    converged: bool,           // hit em_tol (true) or em_iters cap (false)
+    bound: f64,              // final variational bound (ELBO)
+    bound_history: Vec<f64>, // bound after each EM iteration
+    converged: bool,         // hit em_tol (true) or em_iters cap (false)
 }
 
 impl STM {
@@ -6065,7 +6810,9 @@ impl STM {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 
@@ -6083,7 +6830,9 @@ impl STM {
                 .position(|g| g == &s)
                 .ok_or_else(|| PyValueError::new_err(format!("unknown group {:?}", s)));
         }
-        Err(PyValueError::new_err("group must be a name (str) or index (int)"))
+        Err(PyValueError::new_err(
+            "group must be a name (str) or index (int)",
+        ))
     }
 }
 
@@ -6101,7 +6850,13 @@ impl STM {
     /// off-diagonal posterior covariance — topic-correlation/SE precision is lower).
     #[new]
     #[pyo3(signature = (num_topics, *, sigma_shrink=0.0, seed=42, init="spectral", variational="laplace"))]
-    fn new(#[pyo3(from_py_with = "py_num_topics")] num_topics: usize, sigma_shrink: f64, seed: u64, init: &str, variational: &str) -> PyResult<Self> {
+    fn new(
+        #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
+        sigma_shrink: f64,
+        seed: u64,
+        init: &str,
+        variational: &str,
+    ) -> PyResult<Self> {
         if num_topics < 2 {
             return Err(PyValueError::new_err("num_topics must be >= 2"));
         }
@@ -6114,7 +6869,9 @@ impl STM {
             _ => return Err(PyValueError::new_err("init must be 'spectral' or 'random'")),
         };
         if variational != "laplace" && variational != "diagonal" {
-            return Err(PyValueError::new_err("variational must be 'laplace' or 'diagonal'"));
+            return Err(PyValueError::new_err(
+                "variational must be 'laplace' or 'diagonal'",
+            ));
         }
         Ok(STM {
             num_topics,
@@ -6199,12 +6956,19 @@ impl STM {
     ) -> PyResult<()> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "STM.fit(em_tol=) is deprecated; use convergence_tol= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
-            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+            warnings.call_method1(
+                "warn",
+                (
+                    "STM.fit(em_tol=) is deprecated; use convergence_tol= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
+            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON {
+                convergence_tol
+            } else {
+                old_val
+            }
         } else {
             convergence_tol
         };
@@ -6225,7 +6989,17 @@ impl STM {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         let num_docs = corpus.num_docs();
         if num_docs == 0 {
@@ -6252,7 +7026,9 @@ impl STM {
             check_all_finite_2d("prevalence", &raw)?;
             let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
             if raw.iter().any(|r| r.len() != f_in) {
-                return Err(PyValueError::new_err("all prevalence rows must have the same length"));
+                return Err(PyValueError::new_err(
+                    "all prevalence rows must have the same length",
+                ));
             }
             if let Some(names) = &prevalence_names {
                 if names.len() != f_in {
@@ -6324,9 +7100,12 @@ impl STM {
                 }
                 ctm::GammaPrior::L1 { alpha: gamma_enet }
             }
-            other => return Err(PyValueError::new_err(format!(
-                "gamma_prior must be \"pooled\" or \"l1\", got {:?}", other
-            ))),
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "gamma_prior must be \"pooled\" or \"l1\", got {:?}",
+                    other
+                )))
+            }
         };
 
         let k = self.num_topics;
@@ -6343,8 +7122,20 @@ impl STM {
             let cont_ref = content_groups.as_ref().map(|(g, n)| (g.as_slice(), *n));
             let m = run_with_threads(num_threads, || {
                 ctm::fit_ctm(
-                    &corpus.docs, k, num_types, iters, convergence_tol, shrink, prev_ref, cont_ref,
-                    spectral, init_beta.as_deref(), gprior, keep_eta_cov, diagonal, &mut rng,
+                    &corpus.docs,
+                    k,
+                    num_types,
+                    iters,
+                    convergence_tol,
+                    shrink,
+                    prev_ref,
+                    cont_ref,
+                    spectral,
+                    init_beta.as_deref(),
+                    gprior,
+                    keep_eta_cov,
+                    diagonal,
+                    &mut rng,
                 )
             });
             (m, corpus)
@@ -6492,7 +7283,8 @@ impl STM {
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         self.require_fitted()?;
-        Ok(self.bound_history
+        Ok(self
+            .bound_history
             .iter()
             .enumerate()
             .map(|(i, &b)| (i + 1, b))
@@ -6532,12 +7324,15 @@ impl STM {
     #[getter]
     fn eta_cov<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
         self.require_fitted()?;
-        self.eta_cov.as_ref()
+        self.eta_cov
+            .as_ref()
             .map(|c| c.to_pyarray_bound(py))
-            .ok_or_else(|| PyRuntimeError::new_err(
-                "model was fit with keep_eta_cov=False; refit with keep_eta_cov=True, \
-                 or use posterior_theta_samples/_recompute_eta_cov which recompute it on demand"
-            ))
+            .ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "model was fit with keep_eta_cov=False; refit with keep_eta_cov=True, \
+                 or use posterior_theta_samples/_recompute_eta_cov which recompute it on demand",
+                )
+            })
     }
 
     /// Recompute the per-document variational covariance ν on demand.
@@ -6550,17 +7345,26 @@ impl STM {
         })?;
         let k = self.num_topics;
         let km1 = k - 1;
-        let sparse: Vec<(Vec<usize>, Vec<f64>)> = corpus.docs.iter()
+        let sparse: Vec<(Vec<usize>, Vec<f64>)> = corpus
+            .docs
+            .iter()
             .map(|doc| crate::variational::doc_sparse(doc))
             .collect();
         // Use beta_estep (the topic-word matrix from the last E-step, before the
         // final M-step updated beta) so the Hessian computation is bit-identical
         // to what was used when nu was originally stored.
-        let beta_src = self.beta_estep.as_ref().unwrap_or_else(|| self.beta.as_ref().unwrap());
-        let beta_v: Vec<Vec<f64>> = beta_src
-            .outer_iter().map(|r| r.to_vec()).collect();
-        let lambda_v: Vec<Vec<f64>> = self.eta_mean.as_ref().unwrap()
-            .outer_iter().map(|r| r.to_vec()).collect();
+        let beta_src = self
+            .beta_estep
+            .as_ref()
+            .unwrap_or_else(|| self.beta.as_ref().unwrap());
+        let beta_v: Vec<Vec<f64>> = beta_src.outer_iter().map(|r| r.to_vec()).collect();
+        let lambda_v: Vec<Vec<f64>> = self
+            .eta_mean
+            .as_ref()
+            .unwrap()
+            .outer_iter()
+            .map(|r| r.to_vec())
+            .collect();
         let d = lambda_v.len();
         // ν is independent of the prior mean μ, so recompute_nu uses self.mu for
         // every document.
@@ -6627,10 +7431,9 @@ impl STM {
     #[getter]
     fn prevalence_effects<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
-        let g = self
-            .gamma
-            .as_ref()
-            .ok_or_else(|| PyRuntimeError::new_err("model was fit without prevalence covariates"))?;
+        let g = self.gamma.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("model was fit without prevalence covariates")
+        })?;
         Ok(g.to_pyarray_bound(py))
     }
 
@@ -6639,9 +7442,10 @@ impl STM {
     #[getter]
     fn topic_word_by_group<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f64>>> {
         self.require_fitted()?;
-        let cb = self.content_beta.as_ref().ok_or_else(|| {
-            PyRuntimeError::new_err("model was fit without content covariates")
-        })?;
+        let cb = self
+            .content_beta
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("model was fit without content covariates"))?;
         let g = cb.len();
         let k = self.num_topics;
         let v = self.corpus.as_ref().unwrap().num_types();
@@ -6668,9 +7472,10 @@ impl STM {
     #[getter]
     fn content_kappa<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         self.require_fitted()?;
-        let ck = self.content_kappa.as_ref().ok_or_else(|| {
-            PyRuntimeError::new_err("model was fit without content covariates")
-        })?;
+        let ck = self
+            .content_kappa
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("model was fit without content covariates"))?;
         let k = self.num_topics;
         let g = self.group_names.len();
         let v = ck.m.len();
@@ -6709,7 +7514,9 @@ impl STM {
     fn groups(&self) -> PyResult<Vec<String>> {
         self.require_fitted()?;
         if self.group_names.is_empty() {
-            return Err(PyRuntimeError::new_err("model was fit without content covariates"));
+            return Err(PyRuntimeError::new_err(
+                "model was fit without content covariates",
+            ));
         }
         Ok(self.group_names.clone())
     }
@@ -6727,9 +7534,10 @@ impl STM {
         n: usize,
     ) -> PyResult<Bound<'py, PyList>> {
         self.require_fitted()?;
-        let cb = self.content_beta.as_ref().ok_or_else(|| {
-            PyRuntimeError::new_err("model was fit without content covariates")
-        })?;
+        let cb = self
+            .content_beta
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("model was fit without content covariates"))?;
         if topic >= self.num_topics {
             return Err(PyValueError::new_err("topic out of range"));
         }
@@ -6795,7 +7603,10 @@ impl STM {
             let items: Vec<Bound<'py, PyTuple>> = tops[t]
                 .iter()
                 .map(|&w| {
-                    PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)])
+                    PyTuple::new_bound(
+                        py,
+                        &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)],
+                    )
                 })
                 .collect();
             Ok(PyList::new_bound(py, items))
@@ -6889,22 +7700,35 @@ impl STM {
         // eta_cov is stored as f32 in memory; upcast to f64 for the on-disk format
         // so existing saved models remain compatible.
         let eta_cov_f64 = self.eta_cov.as_ref().map(|c| c.mapv(|x| x as f64));
-        write_state(path, MODEL_TAG_STM, &StmState {
-            num_topics: self.num_topics, sigma_shrink: self.sigma_shrink, seed: self.seed,
-            init_spectral: self.init_spectral, fitted: self.fitted,
-            beta: arr2_opt(&self.beta), theta: arr2_opt(&self.theta), corr: arr2_opt(&self.corr),
-            eta_mean: arr2_opt(&self.eta_mean), eta_cov: arr3_opt(&eta_cov_f64),
-            gamma: arr2_opt(&self.gamma), feature_names: self.feature_names.clone(),
-            content_beta: self.content_beta.clone(),
-            mu: self.mu.clone(), sigma: self.sigma.clone(),
-            group_names: self.group_names.clone(),
-            corpus: self.corpus.clone(),
-            bound: self.bound, bound_history: self.bound_history.clone(),
-            converged: self.converged,
-            topic_names: self.topic_names.clone(),
-            variational: self.variational.clone(),
-            content_kappa: self.content_kappa.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_STM,
+            &StmState {
+                num_topics: self.num_topics,
+                sigma_shrink: self.sigma_shrink,
+                seed: self.seed,
+                init_spectral: self.init_spectral,
+                fitted: self.fitted,
+                beta: arr2_opt(&self.beta),
+                theta: arr2_opt(&self.theta),
+                corr: arr2_opt(&self.corr),
+                eta_mean: arr2_opt(&self.eta_mean),
+                eta_cov: arr3_opt(&eta_cov_f64),
+                gamma: arr2_opt(&self.gamma),
+                feature_names: self.feature_names.clone(),
+                content_beta: self.content_beta.clone(),
+                mu: self.mu.clone(),
+                sigma: self.sigma.clone(),
+                group_names: self.group_names.clone(),
+                corpus: self.corpus.clone(),
+                bound: self.bound,
+                bound_history: self.bound_history.clone(),
+                converged: self.converged,
+                topic_names: self.topic_names.clone(),
+                variational: self.variational.clone(),
+                content_kappa: self.content_kappa.clone(),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -6919,24 +7743,39 @@ impl STM {
         // eta_cov is saved as f64 for format compatibility; downcast to f32 in memory.
         let eta_cov = arr3_back(s.eta_cov).map(|c| c.mapv(|x| x as f32));
         Ok(STM {
-            num_topics: s.num_topics, sigma_shrink: s.sigma_shrink, seed: s.seed,
-            init_spectral: s.init_spectral, variational: s.variational, fitted: s.fitted,
+            num_topics: s.num_topics,
+            sigma_shrink: s.sigma_shrink,
+            seed: s.seed,
+            init_spectral: s.init_spectral,
+            variational: s.variational,
+            fitted: s.fitted,
             topic_names,
-            beta: arr2_back(s.beta), theta: arr2_back(s.theta), corr: arr2_back(s.corr),
-            eta_mean: arr2_back(s.eta_mean), eta_cov,
-            gamma: arr2_back(s.gamma), feature_names: s.feature_names,
+            beta: arr2_back(s.beta),
+            theta: arr2_back(s.theta),
+            corr: arr2_back(s.corr),
+            eta_mean: arr2_back(s.eta_mean),
+            eta_cov,
+            gamma: arr2_back(s.gamma),
+            feature_names: s.feature_names,
             content_beta: s.content_beta,
             content_kappa: s.content_kappa,
-            mu: s.mu, sigma: s.sigma,
-            sigma_estep: Vec::new(),  // not persisted; falls back to sigma in _recompute_eta_cov
-            beta_estep: None,         // not persisted; falls back to self.beta
-            group_names: s.group_names, corpus: s.corpus,
-            bound: s.bound, bound_history: s.bound_history, converged: s.converged,
+            mu: s.mu,
+            sigma: s.sigma,
+            sigma_estep: Vec::new(), // not persisted; falls back to sigma in _recompute_eta_cov
+            beta_estep: None,        // not persisted; falls back to self.beta
+            group_names: s.group_names,
+            corpus: s.corpus,
+            bound: s.bound,
+            bound_history: s.bound_history,
+            converged: s.converged,
         })
     }
 
     fn __repr__(&self) -> String {
-        format!("STM(num_topics={}, variational={:?}, fitted={})", self.num_topics, self.variational, self.fitted)
+        format!(
+            "STM(num_topics={}, variational={:?}, fitted={})",
+            self.num_topics, self.variational, self.fitted
+        )
     }
 }
 
@@ -6998,7 +7837,9 @@ impl ECTM {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 
@@ -7016,7 +7857,9 @@ impl ECTM {
                 .position(|g| g == &s)
                 .ok_or_else(|| PyValueError::new_err(format!("unknown group {:?}", s)));
         }
-        Err(PyValueError::new_err("group must be a name (str) or index (int)"))
+        Err(PyValueError::new_err(
+            "group must be a name (str) or index (int)",
+        ))
     }
 
     fn resolve_period(&self, obj: &Bound<'_, PyAny>) -> PyResult<usize> {
@@ -7033,7 +7876,9 @@ impl ECTM {
                 .position(|p| p == &s)
                 .ok_or_else(|| PyValueError::new_err(format!("unknown period {:?}", s)));
         }
-        Err(PyValueError::new_err("period must be a label (str) or index (int)"))
+        Err(PyValueError::new_err(
+            "period must be a label (str) or index (int)",
+        ))
     }
 }
 
@@ -7064,7 +7909,9 @@ impl ECTM {
             return Err(PyValueError::new_err("sigma_shrink must be in [0, 1]"));
         }
         if variational != "laplace" && variational != "diagonal" {
-            return Err(PyValueError::new_err("variational must be 'laplace' or 'diagonal'"));
+            return Err(PyValueError::new_err(
+                "variational must be 'laplace' or 'diagonal'",
+            ));
         }
         let init_spectral = match init {
             "spectral" => true,
@@ -7168,7 +8015,17 @@ impl ECTM {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         let num_docs = corpus.num_docs();
         if num_docs == 0 {
@@ -7207,8 +8064,11 @@ impl ECTM {
                 v
             }
         };
-        let gindex: HashMap<&str, usize> =
-            group_vocab.iter().enumerate().map(|(i, g)| (g.as_str(), i)).collect();
+        let gindex: HashMap<&str, usize> = group_vocab
+            .iter()
+            .enumerate()
+            .map(|(i, g)| (g.as_str(), i))
+            .collect();
         let group_idx: Vec<usize> = groups_str
             .iter()
             .map(|g| {
@@ -7234,7 +8094,9 @@ impl ECTM {
             check_all_finite_2d("prevalence", &raw)?;
             let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
             if raw.iter().any(|r| r.len() != f_in) {
-                return Err(PyValueError::new_err("all prevalence rows must have the same length"));
+                return Err(PyValueError::new_err(
+                    "all prevalence rows must have the same length",
+                ));
             }
             if let Some(names) = &prevalence_names {
                 if names.len() != f_in {
@@ -7256,7 +8118,8 @@ impl ECTM {
             );
             feat_names.push("intercept".to_string());
             feat_names.extend(
-                prevalence_names.unwrap_or_else(|| (0..f_in).map(|i| format!("feature_{}", i)).collect()),
+                prevalence_names
+                    .unwrap_or_else(|| (0..f_in).map(|i| format!("feature_{}", i)).collect()),
             );
         }
 
@@ -7272,16 +8135,49 @@ impl ECTM {
             let m = run_with_threads(num_threads, || {
                 if svi {
                     crate::ectm::fit_ectm_svi(
-                        &corpus.docs, k, num_types, &group_idx, num_groups, &period_idx, num_periods,
-                        iters, batch_size, tau, kappa, content_every, shrink, prev_ref,
-                        content_prior_var, period_smooth, period_smooth, interaction_shrink,
-                        keep_eta_cov, diagonal, init_spectral, &mut rng,
+                        &corpus.docs,
+                        k,
+                        num_types,
+                        &group_idx,
+                        num_groups,
+                        &period_idx,
+                        num_periods,
+                        iters,
+                        batch_size,
+                        tau,
+                        kappa,
+                        content_every,
+                        shrink,
+                        prev_ref,
+                        content_prior_var,
+                        period_smooth,
+                        period_smooth,
+                        interaction_shrink,
+                        keep_eta_cov,
+                        diagonal,
+                        init_spectral,
+                        &mut rng,
                     )
                 } else {
                     crate::ectm::fit_ectm(
-                        &corpus.docs, k, num_types, &group_idx, num_groups, &period_idx, num_periods,
-                        iters, convergence_tol, shrink, prev_ref, content_prior_var, period_smooth,
-                        period_smooth, interaction_shrink, keep_eta_cov, diagonal, init_spectral,
+                        &corpus.docs,
+                        k,
+                        num_types,
+                        &group_idx,
+                        num_groups,
+                        &period_idx,
+                        num_periods,
+                        iters,
+                        convergence_tol,
+                        shrink,
+                        prev_ref,
+                        content_prior_var,
+                        period_smooth,
+                        period_smooth,
+                        interaction_shrink,
+                        keep_eta_cov,
+                        diagonal,
+                        init_spectral,
                         &mut rng,
                     )
                 }
@@ -7483,9 +8379,14 @@ impl ECTM {
     #[getter]
     fn eta_cov<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
         self.require_fitted()?;
-        self.eta_cov.as_ref().map(|c| c.to_pyarray_bound(py)).ok_or_else(|| {
-            PyRuntimeError::new_err("model was fit with keep_eta_cov=False; refit with keep_eta_cov=True")
-        })
+        self.eta_cov
+            .as_ref()
+            .map(|c| c.to_pyarray_bound(py))
+            .ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "model was fit with keep_eta_cov=False; refit with keep_eta_cov=True",
+                )
+            })
     }
 
     /// Final variational bound (approximate ELBO) at convergence.
@@ -7537,7 +8438,12 @@ impl ECTM {
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         self.require_fitted()?;
-        Ok(self.bound_history.iter().enumerate().map(|(i, &b)| (i + 1, b)).collect())
+        Ok(self
+            .bound_history
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| (i + 1, b))
+            .collect())
     }
 
     /// Variational-covariance mode (``"laplace"`` or ``"diagonal"``).
@@ -7549,7 +8455,12 @@ impl ECTM {
     /// Top `n` words per topic (or one topic) as ``(word, probability)`` pairs,
     /// from the cell-averaged β.
     #[pyo3(signature = (n=10, *, topic=None))]
-    fn top_words<'py>(&self, py: Python<'py>, n: usize, topic: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
+    fn top_words<'py>(
+        &self,
+        py: Python<'py>,
+        n: usize,
+        topic: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
         let beta = self.beta.as_ref().unwrap();
         let vocab = &self.corpus.as_ref().unwrap().id_to_word;
@@ -7560,14 +8471,20 @@ impl ECTM {
             }
             let items: Vec<Bound<'py, PyTuple>> = tops[t]
                 .iter()
-                .map(|&w| PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)]))
+                .map(|&w| {
+                    PyTuple::new_bound(
+                        py,
+                        &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)],
+                    )
+                })
                 .collect();
             Ok(PyList::new_bound(py, items))
         };
         match topic {
             Some(t) => Ok(one(t)?.into_any()),
             None => {
-                let all: Vec<Bound<'py, PyList>> = (0..self.num_topics).map(one).collect::<PyResult<_>>()?;
+                let all: Vec<Bound<'py, PyList>> =
+                    (0..self.num_topics).map(one).collect::<PyResult<_>>()?;
                 Ok(PyList::new_bound(py, all).into_any())
             }
         }
@@ -7606,24 +8523,37 @@ impl ECTM {
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
         let eta_cov_f64 = self.eta_cov.as_ref().map(|c| c.mapv(|x| x as f64));
-        write_state(path, MODEL_TAG_ECTM, &EctmState {
-            num_topics: self.num_topics, sigma_shrink: self.sigma_shrink, seed: self.seed,
-            fitted: self.fitted,
-            beta: arr2_opt(&self.beta), theta: arr2_opt(&self.theta),
-            eta_mean: arr2_opt(&self.eta_mean), eta_cov: arr3_opt(&eta_cov_f64),
-            gamma: arr2_opt(&self.gamma), feature_names: self.feature_names.clone(),
-            content_beta: self.content_beta.clone(),
-            num_groups: self.num_groups, num_periods: self.num_periods,
-            group_names: self.group_names.clone(), period_names: self.period_names.clone(),
-            mu: self.mu.clone(), sigma: self.sigma.clone(),
-            corpus: self.corpus.clone(),
-            bound: self.bound, bound_history: self.bound_history.clone(),
-            converged: self.converged,
-            topic_names: self.topic_names.clone(),
-            variational: self.variational.clone(),
-            init_spectral: self.init_spectral,
-            content_shift_history: self.content_shift_history.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_ECTM,
+            &EctmState {
+                num_topics: self.num_topics,
+                sigma_shrink: self.sigma_shrink,
+                seed: self.seed,
+                fitted: self.fitted,
+                beta: arr2_opt(&self.beta),
+                theta: arr2_opt(&self.theta),
+                eta_mean: arr2_opt(&self.eta_mean),
+                eta_cov: arr3_opt(&eta_cov_f64),
+                gamma: arr2_opt(&self.gamma),
+                feature_names: self.feature_names.clone(),
+                content_beta: self.content_beta.clone(),
+                num_groups: self.num_groups,
+                num_periods: self.num_periods,
+                group_names: self.group_names.clone(),
+                period_names: self.period_names.clone(),
+                mu: self.mu.clone(),
+                sigma: self.sigma.clone(),
+                corpus: self.corpus.clone(),
+                bound: self.bound,
+                bound_history: self.bound_history.clone(),
+                converged: self.converged,
+                topic_names: self.topic_names.clone(),
+                variational: self.variational.clone(),
+                init_spectral: self.init_spectral,
+                content_shift_history: self.content_shift_history.clone(),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -7638,16 +8568,30 @@ impl ECTM {
         };
         let eta_cov = arr3_back(s.eta_cov).map(|c| c.mapv(|x| x as f32));
         Ok(ECTM {
-            num_topics: s.num_topics, sigma_shrink: s.sigma_shrink, seed: s.seed,
-            variational: s.variational, init_spectral: s.init_spectral, fitted: s.fitted, topic_names,
-            beta: arr2_back(s.beta), theta: arr2_back(s.theta),
+            num_topics: s.num_topics,
+            sigma_shrink: s.sigma_shrink,
+            seed: s.seed,
+            variational: s.variational,
+            init_spectral: s.init_spectral,
+            fitted: s.fitted,
+            topic_names,
+            beta: arr2_back(s.beta),
+            theta: arr2_back(s.theta),
             content_beta: s.content_beta,
-            num_groups: s.num_groups, num_periods: s.num_periods,
-            group_names: s.group_names, period_names: s.period_names,
-            eta_mean: arr2_back(s.eta_mean), eta_cov,
-            gamma: arr2_back(s.gamma), feature_names: s.feature_names,
-            mu: s.mu, sigma: s.sigma, corpus: s.corpus,
-            bound: s.bound, bound_history: s.bound_history, converged: s.converged,
+            num_groups: s.num_groups,
+            num_periods: s.num_periods,
+            group_names: s.group_names,
+            period_names: s.period_names,
+            eta_mean: arr2_back(s.eta_mean),
+            eta_cov,
+            gamma: arr2_back(s.gamma),
+            feature_names: s.feature_names,
+            mu: s.mu,
+            sigma: s.sigma,
+            corpus: s.corpus,
+            bound: s.bound,
+            bound_history: s.bound_history,
+            converged: s.converged,
             content_shift_history: s.content_shift_history,
         })
     }
@@ -7747,7 +8691,16 @@ fn project<'py>(
     let n = rows.len();
     let method = method.to_string(); // own it so the GIL can be released
     let out = py.allow_threads(move || {
-        crate::reduce::project(&rows, n_components, &method, n_neighbors, perplexity, 0.5, 1000, seed)
+        crate::reduce::project(
+            &rows,
+            n_components,
+            &method,
+            n_neighbors,
+            perplexity,
+            0.5,
+            1000,
+            seed,
+        )
     });
     let mut arr = Array2::<f64>::zeros((n, n_components));
     for (i, r) in out.iter().enumerate() {
@@ -7860,12 +8813,12 @@ pub struct STS {
     sentiment: Option<Array2<f64>>, // D×K topic sentiment-discourse α^(s)
     gamma: Option<Array2<f64>>,     // F×(2K-1) prevalence+sentiment regression
     feature_names: Vec<String>,
-    kappa_t: Vec<Vec<f64>>, // K×V (final, after last κ M-step)
-    kappa_s: Vec<Vec<f64>>, // K×V (final, after last κ M-step)
-    mv: Vec<f64>,           // V
-    sigma: Vec<f64>,        // (2K-1)²
-    eta_mean: Option<Array2<f64>>,  // D×(2K-1)
-    eta_cov: Option<Array3<f32>>,   // D×(2K-1)×(2K-1) — stored as f32 to halve memory; None when fit with keep_eta_cov=False
+    kappa_t: Vec<Vec<f64>>,        // K×V (final, after last κ M-step)
+    kappa_s: Vec<Vec<f64>>,        // K×V (final, after last κ M-step)
+    mv: Vec<f64>,                  // V
+    sigma: Vec<f64>,               // (2K-1)²
+    eta_mean: Option<Array2<f64>>, // D×(2K-1)
+    eta_cov: Option<Array3<f32>>, // D×(2K-1)×(2K-1) — stored as f32 to halve memory; None when fit with keep_eta_cov=False
     /// Sigma from the last E-step (before the final Σ M-step). Used by
     /// `_recompute_eta_cov` to reproduce ν exactly. Empty when not needed (loaded
     /// models) — falls back to `sigma` in that case.
@@ -7886,7 +8839,9 @@ impl STS {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -7975,12 +8930,19 @@ impl STS {
     ) -> PyResult<()> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "STS.fit(em_tol=) is deprecated; use convergence_tol= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
-            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+            warnings.call_method1(
+                "warn",
+                (
+                    "STS.fit(em_tol=) is deprecated; use convergence_tol= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
+            if (convergence_tol - 1e-5_f64).abs() > f64::EPSILON {
+                convergence_tol
+            } else {
+                old_val
+            }
         } else {
             convergence_tol
         };
@@ -7996,11 +8958,15 @@ impl STS {
             (None, None) => None,
         };
         let kappa_est = match kappa_estimation {
-            "lasso" => sts::KappaEst::Lasso { nlambda: 100, lambda_min_ratio: 0.001 },
+            "lasso" => sts::KappaEst::Lasso {
+                nlambda: 100,
+                lambda_min_ratio: 0.001,
+            },
             "ridge" => sts::KappaEst::Ridge(kappa_ridge),
             other => {
                 return Err(PyValueError::new_err(format!(
-                    "kappa_estimation must be \"lasso\" or \"ridge\", got {:?}", other
+                    "kappa_estimation must be \"lasso\" or \"ridge\", got {:?}",
+                    other
                 )))
             }
         };
@@ -8010,7 +8976,17 @@ impl STS {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         let num_docs = corpus.num_docs();
         if num_docs == 0 {
@@ -8039,7 +9015,9 @@ impl STS {
             check_all_finite_2d("prevalence", &raw)?;
             let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
             if raw.iter().any(|r| r.len() != f_in) {
-                return Err(PyValueError::new_err("all prevalence rows must have the same length"));
+                return Err(PyValueError::new_err(
+                    "all prevalence rows must have the same length",
+                ));
             }
             if let Some(names) = &prevalence_names {
                 if names.len() != f_in {
@@ -8073,8 +9051,17 @@ impl STS {
         let (model, corpus) = py.allow_threads(move || {
             let prev_ref = prevalence_x.as_deref();
             let m = sts::fit_sts(
-                &corpus.docs, k, num_types, iters, convergence_tol, prev_ref, Some(&sentiment_seed),
-                kappa_est, spectral, keep_eta_cov, &mut rng,
+                &corpus.docs,
+                k,
+                num_types,
+                iters,
+                convergence_tol,
+                prev_ref,
+                Some(&sentiment_seed),
+                kappa_est,
+                spectral,
+                keep_eta_cov,
+                &mut rng,
             );
             (m, corpus)
         });
@@ -8170,10 +9157,22 @@ impl STS {
     /// every topic), shape ``(num_topics, num_words)``. Inspect the wording at
     /// positive vs. negative sentiment by passing percentiles of :attr:`sentiment`.
     #[pyo3(signature = (level))]
-    fn topic_word_at<'py>(&self, py: Python<'py>, level: f64) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    fn topic_word_at<'py>(
+        &self,
+        py: Python<'py>,
+        level: f64,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         let v = self.mv.len();
-        Ok(sts_beta_at(&self.kappa_t, &self.kappa_s, &self.mv, self.num_topics, v, level).to_pyarray_bound(py))
+        Ok(sts_beta_at(
+            &self.kappa_t,
+            &self.kappa_s,
+            &self.mv,
+            self.num_topics,
+            v,
+            level,
+        )
+        .to_pyarray_bound(py))
     }
 
     /// Document-topic prevalence matrix θ, shape ``(num_docs, num_topics)``.
@@ -8254,12 +9253,15 @@ impl STS {
     #[getter]
     fn eta_cov<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
         self.require_fitted()?;
-        self.eta_cov.as_ref()
+        self.eta_cov
+            .as_ref()
             .map(|c| c.to_pyarray_bound(py))
-            .ok_or_else(|| PyRuntimeError::new_err(
-                "model was fit with keep_eta_cov=False; refit with keep_eta_cov=True, \
-                 or use _recompute_eta_cov which recomputes it on demand"
-            ))
+            .ok_or_else(|| {
+                PyRuntimeError::new_err(
+                    "model was fit with keep_eta_cov=False; refit with keep_eta_cov=True, \
+                 or use _recompute_eta_cov which recomputes it on demand",
+                )
+            })
     }
 
     /// Recompute the per-document variational covariance ν on demand.
@@ -8268,14 +9270,22 @@ impl STS {
     /// array as :attr:`eta_cov`.
     fn _recompute_eta_cov<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f32>>> {
         self.require_fitted()?;
-        let corpus = self.corpus.as_ref()
-            .ok_or_else(|| PyRuntimeError::new_err("no corpus retained; cannot recompute eta_cov"))?;
-        let sparse: Vec<(Vec<usize>, Vec<f64>)> =
-            corpus.docs.iter().map(|d| crate::variational::doc_sparse(d)).collect();
+        let corpus = self.corpus.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err("no corpus retained; cannot recompute eta_cov")
+        })?;
+        let sparse: Vec<(Vec<usize>, Vec<f64>)> = corpus
+            .docs
+            .iter()
+            .map(|d| crate::variational::doc_sparse(d))
+            .collect();
 
         // Build a minimal StsModel stub with only the fields recompute_nu_sts needs.
-        let alpha = self.eta_mean.as_ref().unwrap()
-            .rows().into_iter()
+        let alpha = self
+            .eta_mean
+            .as_ref()
+            .unwrap()
+            .rows()
+            .into_iter()
             .map(|r| r.to_vec())
             .collect::<Vec<_>>();
         // ν is independent of the prior mean μ — use sigma_estep (the sigma that was
@@ -8359,7 +9369,12 @@ impl STS {
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         self.require_fitted()?;
-        Ok(self.bound_history.iter().enumerate().map(|(i, &b)| (i + 1, b)).collect())
+        Ok(self
+            .bound_history
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| (i + 1, b))
+            .collect())
     }
 
     #[getter]
@@ -8400,7 +9415,14 @@ impl STS {
         self.require_fitted()?;
         let docs = docs_to_ids(data, &self.corpus.as_ref().unwrap().id_to_word)?;
         let theta = py.allow_threads(|| {
-            sts::sts_infer(&docs, &self.kappa_t, &self.kappa_s, &self.mv, &self.sigma, self.num_topics)
+            sts::sts_infer(
+                &docs,
+                &self.kappa_t,
+                &self.kappa_s,
+                &self.mv,
+                &self.sigma,
+                self.num_topics,
+            )
         });
         Ok(vecs_to_arr2(&theta).to_pyarray_bound(py))
     }
@@ -8411,19 +9433,32 @@ impl STS {
         // eta_cov is stored as f32 in memory; upcast to f64 for the on-disk format
         // so existing saved models remain compatible.
         let eta_cov_f64 = self.eta_cov.as_ref().map(|c| c.mapv(|x| x as f64));
-        write_state(path, MODEL_TAG_STS, &StsState {
-            num_topics: self.num_topics, seed: self.seed, init_spectral: self.init_spectral,
-            fitted: self.fitted,
-            beta: arr2_opt(&self.beta), theta: arr2_opt(&self.theta),
-            sentiment: arr2_opt(&self.sentiment), gamma: arr2_opt(&self.gamma),
-            eta_mean: arr2_opt(&self.eta_mean), eta_cov: arr3_opt(&eta_cov_f64),
-            feature_names: self.feature_names.clone(),
-            kappa_t: self.kappa_t.clone(), kappa_s: self.kappa_s.clone(),
-            mv: self.mv.clone(), sigma: self.sigma.clone(),
-            corpus: self.corpus.clone(),
-            bound: self.bound, bound_history: self.bound_history.clone(),
-            converged: self.converged, topic_names: self.topic_names.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_STS,
+            &StsState {
+                num_topics: self.num_topics,
+                seed: self.seed,
+                init_spectral: self.init_spectral,
+                fitted: self.fitted,
+                beta: arr2_opt(&self.beta),
+                theta: arr2_opt(&self.theta),
+                sentiment: arr2_opt(&self.sentiment),
+                gamma: arr2_opt(&self.gamma),
+                eta_mean: arr2_opt(&self.eta_mean),
+                eta_cov: arr3_opt(&eta_cov_f64),
+                feature_names: self.feature_names.clone(),
+                kappa_t: self.kappa_t.clone(),
+                kappa_s: self.kappa_s.clone(),
+                mv: self.mv.clone(),
+                sigma: self.sigma.clone(),
+                corpus: self.corpus.clone(),
+                bound: self.bound,
+                bound_history: self.bound_history.clone(),
+                converged: self.converged,
+                topic_names: self.topic_names.clone(),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -8438,17 +9473,28 @@ impl STS {
         // eta_cov is saved as f64 for format compatibility; downcast to f32 in memory.
         let eta_cov = arr3_back(s.eta_cov).map(|c| c.mapv(|x| x as f32));
         Ok(STS {
-            num_topics: s.num_topics, seed: s.seed, init_spectral: s.init_spectral,
-            fitted: s.fitted, topic_names,
-            beta: arr2_back(s.beta), theta: arr2_back(s.theta),
-            sentiment: arr2_back(s.sentiment), gamma: arr2_back(s.gamma),
-            eta_mean: arr2_back(s.eta_mean), eta_cov,
+            num_topics: s.num_topics,
+            seed: s.seed,
+            init_spectral: s.init_spectral,
+            fitted: s.fitted,
+            topic_names,
+            beta: arr2_back(s.beta),
+            theta: arr2_back(s.theta),
+            sentiment: arr2_back(s.sentiment),
+            gamma: arr2_back(s.gamma),
+            eta_mean: arr2_back(s.eta_mean),
+            eta_cov,
             feature_names: s.feature_names,
-            kappa_t: s.kappa_t, kappa_s: s.kappa_s, mv: s.mv, sigma: s.sigma,
-            sigma_estep: Vec::new(),         // not persisted; falls back to sigma in _recompute_eta_cov
-            kappa_t_estep: Vec::new(),       // not persisted; falls back to kappa_t/kappa_s
+            kappa_t: s.kappa_t,
+            kappa_s: s.kappa_s,
+            mv: s.mv,
+            sigma: s.sigma,
+            sigma_estep: Vec::new(), // not persisted; falls back to sigma in _recompute_eta_cov
+            kappa_t_estep: Vec::new(), // not persisted; falls back to kappa_t/kappa_s
             kappa_s_estep: Vec::new(),
-            corpus: s.corpus, bound: s.bound, bound_history: s.bound_history,
+            corpus: s.corpus,
+            bound: s.bound,
+            bound_history: s.bound_history,
             converged: s.converged,
         })
     }
@@ -8456,7 +9502,12 @@ impl STS {
     /// Top `n` words per topic (or one topic) at neutral sentiment, as
     /// ``(word, probability)`` pairs.
     #[pyo3(signature = (n=10, *, topic=None))]
-    fn top_words<'py>(&self, py: Python<'py>, n: usize, topic: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
+    fn top_words<'py>(
+        &self,
+        py: Python<'py>,
+        n: usize,
+        topic: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
         let beta = self.beta.as_ref().unwrap();
         let vocab = &self.corpus.as_ref().unwrap().id_to_word;
@@ -8467,14 +9518,20 @@ impl STS {
             }
             let items: Vec<Bound<'py, PyTuple>> = tops[t]
                 .iter()
-                .map(|&w| PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)]))
+                .map(|&w| {
+                    PyTuple::new_bound(
+                        py,
+                        &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)],
+                    )
+                })
                 .collect();
             Ok(PyList::new_bound(py, items))
         };
         match topic {
             Some(t) => Ok(one(t)?.into_any()),
             None => {
-                let all: Vec<Bound<'py, PyList>> = (0..self.num_topics).map(one).collect::<PyResult<_>>()?;
+                let all: Vec<Bound<'py, PyList>> =
+                    (0..self.num_topics).map(one).collect::<PyResult<_>>()?;
                 Ok(PyList::new_bound(py, all).into_any())
             }
         }
@@ -8554,7 +9611,9 @@ impl HDP {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -8578,15 +9637,30 @@ impl HDP {
     /// `gamma` to choose the granularity directly.
     #[new]
     #[pyo3(signature = (*, alpha=0.1, gamma=0.1, beta=0.01, seed=42, resample_conc=false, eta=None))]
-    fn new(py: Python<'_>, alpha: f64, gamma: f64, beta: f64, seed: u64, resample_conc: bool, eta: Option<f64>) -> PyResult<Self> {
+    fn new(
+        py: Python<'_>,
+        alpha: f64,
+        gamma: f64,
+        beta: f64,
+        seed: u64,
+        resample_conc: bool,
+        eta: Option<f64>,
+    ) -> PyResult<Self> {
         let beta = if let Some(old_val) = eta {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "HDP(eta=) is deprecated; use beta= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
-            if (beta - 0.01_f64).abs() > f64::EPSILON { beta } else { old_val }
+            warnings.call_method1(
+                "warn",
+                (
+                    "HDP(eta=) is deprecated; use beta= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
+            if (beta - 0.01_f64).abs() > f64::EPSILON {
+                beta
+            } else {
+                old_val
+            }
         } else {
             beta
         };
@@ -8631,13 +9705,20 @@ impl HDP {
     ) -> PyResult<()> {
         let progress_interval = if let Some(old_val) = report_interval {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "HDP.fit(report_interval=) is deprecated; use progress_interval= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
+            warnings.call_method1(
+                "warn",
+                (
+                    "HDP.fit(report_interval=) is deprecated; use progress_interval= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
             // progress_interval wins if explicitly set (non-zero); else deprecated value.
-            if progress_interval != 0 { progress_interval } else { old_val }
+            if progress_interval != 0 {
+                progress_interval
+            } else {
+                old_val
+            }
         } else {
             progress_interval
         };
@@ -8647,7 +9728,17 @@ impl HDP {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -8658,7 +9749,11 @@ impl HDP {
         let (alpha, gamma, eta, conc) = (self.alpha, self.gamma, self.eta, self.resample_conc);
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
         // 0 = auto: ~50 evenly spaced trace points across the run.
-        let ll_interval = if progress_interval == 0 { (iters / 50).max(1) } else { progress_interval };
+        let ll_interval = if progress_interval == 0 {
+            (iters / 50).max(1)
+        } else {
+            progress_interval
+        };
 
         // HDP's K varies during training, so theta_draws are sampled from the final
         // Dirichlet posterior Dirichlet(njk[d]+alpha*beta[k]) after the chain ends.
@@ -8666,7 +9761,15 @@ impl HDP {
 
         let (model, corpus) = py.allow_threads(move || {
             let m = hdp::fit_hdp(
-                &corpus.docs, num_types, alpha, gamma, eta, iters, conc, ll_interval, &mut rng,
+                &corpus.docs,
+                num_types,
+                alpha,
+                gamma,
+                eta,
+                iters,
+                conc,
+                ll_interval,
+                &mut rng,
             );
             (m, corpus)
         });
@@ -8694,19 +9797,25 @@ impl HDP {
         if draw_cap > 0 {
             let mut draw_rng = Pcg64Mcg::seed_from_u64(self.seed.wrapping_add(1));
             for _ in 0..draw_cap {
-                let snap: Vec<Vec<f32>> = model.njk.iter().map(|counts| {
-                    let mut gammas: Vec<f64> = (0..k)
-                        .map(|t| {
-                            let shape = counts[t] as f64 + model.alpha * model.beta[t];
-                            hdp::sample_gamma(shape.max(1e-12), &mut draw_rng)
-                        })
-                        .collect();
-                    let s: f64 = gammas.iter().sum();
-                    if s > 0.0 {
-                        for g in gammas.iter_mut() { *g /= s; }
-                    }
-                    gammas.iter().map(|&g| g as f32).collect()
-                }).collect();
+                let snap: Vec<Vec<f32>> = model
+                    .njk
+                    .iter()
+                    .map(|counts| {
+                        let mut gammas: Vec<f64> = (0..k)
+                            .map(|t| {
+                                let shape = counts[t] as f64 + model.alpha * model.beta[t];
+                                hdp::sample_gamma(shape.max(1e-12), &mut draw_rng)
+                            })
+                            .collect();
+                        let s: f64 = gammas.iter().sum();
+                        if s > 0.0 {
+                            for g in gammas.iter_mut() {
+                                *g /= s;
+                            }
+                        }
+                        gammas.iter().map(|&g| g as f32).collect()
+                    })
+                    .collect();
                 theta_draw_buf.push(snap);
             }
         }
@@ -8760,7 +9869,11 @@ impl HDP {
     #[getter]
     fn log_likelihood_history(&self) -> PyResult<Vec<(usize, f64)>> {
         self.require_fitted()?;
-        Ok(self.trace.iter().map(|&(it, _, ll, _, _)| (it, ll)).collect())
+        Ok(self
+            .trace
+            .iter()
+            .map(|&(it, _, ll, _, _)| (it, ll))
+            .collect())
     }
 
     /// Uniform convergence trace: ``(iteration, log_likelihood)`` pairs (same as
@@ -8768,7 +9881,11 @@ impl HDP {
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         self.require_fitted()?;
-        Ok(self.trace.iter().map(|&(it, _, ll, _, _)| (it, ll)).collect())
+        Ok(self
+            .trace
+            .iter()
+            .map(|&(it, _, ll, _, _)| (it, ll))
+            .collect())
     }
 
     /// HDP does not implement an early-stop criterion; always ``False``.
@@ -8784,7 +9901,11 @@ impl HDP {
     #[getter]
     fn concentration_history(&self) -> PyResult<Vec<(usize, f64, f64)>> {
         self.require_fitted()?;
-        Ok(self.trace.iter().map(|&(it, _, _, a, g)| (it, a, g)).collect())
+        Ok(self
+            .trace
+            .iter()
+            .map(|&(it, _, _, a, g)| (it, a, g))
+            .collect())
     }
 
     /// The fitted document-level concentration α0 (resampled if enabled).
@@ -8812,7 +9933,11 @@ impl HDP {
     #[getter]
     fn doc_lengths(&self) -> PyResult<Vec<usize>> {
         self.require_fitted()?;
-        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
     }
 
     #[getter]
@@ -8846,7 +9971,10 @@ impl HDP {
             let items: Vec<Bound<'py, PyTuple>> = tops[t]
                 .iter()
                 .map(|&w| {
-                    PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)])
+                    PyTuple::new_bound(
+                        py,
+                        &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)],
+                    )
                 })
                 .collect();
             Ok(PyList::new_bound(py, items))
@@ -8893,8 +10021,15 @@ impl HDP {
         let k = self.num_topics;
         let alpha = vec![self.learned_alpha / k as f64; k];
         transform_gibbs(
-            py, data, &self.corpus.as_ref().unwrap().id_to_word, self.beta.as_ref().unwrap(),
-            &alpha, iters, burn_in, num_samples, sample_interval,
+            py,
+            data,
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.beta.as_ref().unwrap(),
+            &alpha,
+            iters,
+            burn_in,
+            num_samples,
+            sample_interval,
             seed.unwrap_or(self.seed),
         )
     }
@@ -8923,14 +10058,26 @@ impl HDP {
     /// Save the fitted model to `path`. Reload with `HDP.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_HDP, &HdpState {
-            alpha: self.alpha, gamma: self.gamma, eta: self.eta, seed: self.seed,
-            resample_conc: self.resample_conc, fitted: self.fitted, num_topics: self.num_topics,
-            learned_alpha: self.learned_alpha, learned_gamma: self.learned_gamma,
-            beta: arr2_opt(&self.beta), theta: arr2_opt(&self.theta), corpus: self.corpus.clone(),
-            trace: self.trace.clone(),
-            topic_names: self.topic_names.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_HDP,
+            &HdpState {
+                alpha: self.alpha,
+                gamma: self.gamma,
+                eta: self.eta,
+                seed: self.seed,
+                resample_conc: self.resample_conc,
+                fitted: self.fitted,
+                num_topics: self.num_topics,
+                learned_alpha: self.learned_alpha,
+                learned_gamma: self.learned_gamma,
+                beta: arr2_opt(&self.beta),
+                theta: arr2_opt(&self.theta),
+                corpus: self.corpus.clone(),
+                trace: self.trace.clone(),
+                topic_names: self.topic_names.clone(),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -8943,11 +10090,19 @@ impl HDP {
             s.topic_names
         };
         Ok(HDP {
-            alpha: s.alpha, gamma: s.gamma, eta: s.eta, seed: s.seed,
-            resample_conc: s.resample_conc, fitted: s.fitted, num_topics: s.num_topics,
+            alpha: s.alpha,
+            gamma: s.gamma,
+            eta: s.eta,
+            seed: s.seed,
+            resample_conc: s.resample_conc,
+            fitted: s.fitted,
+            num_topics: s.num_topics,
             topic_names,
-            learned_alpha: s.learned_alpha, learned_gamma: s.learned_gamma,
-            beta: arr2_back(s.beta), theta: arr2_back(s.theta), corpus: s.corpus,
+            learned_alpha: s.learned_alpha,
+            learned_gamma: s.learned_gamma,
+            beta: arr2_back(s.beta),
+            theta: arr2_back(s.theta),
+            corpus: s.corpus,
             trace: s.trace,
             theta_draws: None,
         })
@@ -8955,9 +10110,15 @@ impl HDP {
 
     fn __repr__(&self) -> String {
         if self.fitted {
-            format!("HDP(num_topics={} [inferred], fitted=true)", self.num_topics)
+            format!(
+                "HDP(num_topics={} [inferred], fitted=true)",
+                self.num_topics
+            )
         } else {
-            format!("HDP(alpha={}, gamma={}, fitted=false)", self.alpha, self.gamma)
+            format!(
+                "HDP(alpha={}, gamma={}, fitted=false)",
+                self.alpha, self.gamma
+            )
         }
     }
 }
@@ -8995,7 +10156,9 @@ impl DTM {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -9068,7 +10231,17 @@ impl DTM {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -9104,15 +10277,23 @@ impl DTM {
 
         let (model, corpus) = py.allow_threads(move || {
             let m = dtm::fit_dtm(
-                &corpus.docs, &times_u, num_types, k, num_times, alpha, cv, ov, iters,
-                init_spectral, &mut rng,
+                &corpus.docs,
+                &times_u,
+                num_types,
+                k,
+                num_times,
+                alpha,
+                cv,
+                ov,
+                iters,
+                init_spectral,
+                &mut rng,
             );
             (m, corpus)
         });
 
         // Precompute p(word | topic, time) for every slice.
-        let tw: Vec<Vec<Vec<f64>>> =
-            (0..num_times).map(|t| model.topic_word_matrix(t)).collect();
+        let tw: Vec<Vec<Vec<f64>>> = (0..num_times).map(|t| model.topic_word_matrix(t)).collect();
 
         self.num_times = num_times;
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
@@ -9157,9 +10338,10 @@ impl DTM {
             i
         } else {
             let s = word.extract::<String>()?;
-            vocab.iter().position(|w| w == &s).ok_or_else(|| {
-                PyValueError::new_err(format!("word {:?} not in vocabulary", s))
-            })?
+            vocab
+                .iter()
+                .position(|w| w == &s)
+                .ok_or_else(|| PyValueError::new_err(format!("word {:?} not in vocabulary", s)))?
         };
         if wid >= vocab.len() {
             return Err(PyValueError::new_err("word id out of range"));
@@ -9171,12 +10353,7 @@ impl DTM {
 
     /// Top `n` words for a topic at one time slice as ``(word, probability)``.
     #[pyo3(signature = (topic, time, n=10))]
-    fn top_words(
-        &self,
-        topic: usize,
-        time: usize,
-        n: usize,
-    ) -> PyResult<Vec<(String, f64)>> {
+    fn top_words(&self, topic: usize, time: usize, n: usize) -> PyResult<Vec<(String, f64)>> {
         self.require_fitted()?;
         if topic >= self.num_topics {
             return Err(PyValueError::new_err("topic out of range"));
@@ -9188,7 +10365,11 @@ impl DTM {
         let row = &self.topic_words.as_ref().unwrap()[time][topic];
         let mut idx: Vec<usize> = (0..row.len()).collect();
         idx.sort_by(|&a, &b| f64::total_cmp(&row[b], &row[a]));
-        Ok(idx.into_iter().take(n).map(|w| (vocab[w].clone(), row[w])).collect())
+        Ok(idx
+            .into_iter()
+            .take(n)
+            .map(|w| (vocab[w].clone(), row[w]))
+            .collect())
     }
 
     /// Which words inside `topic` drift most between two time slices.
@@ -9224,13 +10405,27 @@ impl DTM {
         deltas.sort_by(|x, y| f64::total_cmp(&y.1, &x.1)); // descending by delta
 
         let to_pairs = |items: Vec<(usize, f64)>| -> Vec<(String, f64)> {
-            items.into_iter().map(|(w, d)| (vocab[w].clone(), d)).collect()
+            items
+                .into_iter()
+                .map(|(w, d)| (vocab[w].clone(), d))
+                .collect()
         };
         let rising = to_pairs(
-            deltas.iter().filter(|&&(_, d)| d > 0.0).take(n).copied().collect(),
+            deltas
+                .iter()
+                .filter(|&&(_, d)| d > 0.0)
+                .take(n)
+                .copied()
+                .collect(),
         );
         let falling = to_pairs(
-            deltas.iter().rev().filter(|&&(_, d)| d < 0.0).take(n).copied().collect(),
+            deltas
+                .iter()
+                .rev()
+                .filter(|&&(_, d)| d < 0.0)
+                .take(n)
+                .copied()
+                .collect(),
         );
 
         let out = PyDict::new_bound(py);
@@ -9302,14 +10497,24 @@ impl DTM {
     /// Save the fitted model to `path`. Reload with `DTM.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_DTM, &DtmState {
-            num_topics: self.num_topics, alpha: self.alpha, chain_variance: self.chain_variance,
-            obs_variance: self.obs_variance, seed: self.seed, fitted: self.fitted,
-            num_times: self.num_times, bound: self.bound,
-            topic_words: self.topic_words.clone(), corpus: self.corpus.clone(),
-            topic_names: self.topic_names.clone(),
-            init_spectral: self.init_spectral,
-        })
+        write_state(
+            path,
+            MODEL_TAG_DTM,
+            &DtmState {
+                num_topics: self.num_topics,
+                alpha: self.alpha,
+                chain_variance: self.chain_variance,
+                obs_variance: self.obs_variance,
+                seed: self.seed,
+                fitted: self.fitted,
+                num_times: self.num_times,
+                bound: self.bound,
+                topic_words: self.topic_words.clone(),
+                corpus: self.corpus.clone(),
+                topic_names: self.topic_names.clone(),
+                init_spectral: self.init_spectral,
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -9322,10 +10527,18 @@ impl DTM {
             s.topic_names
         };
         Ok(DTM {
-            num_topics: s.num_topics, alpha: s.alpha, chain_variance: s.chain_variance,
-            obs_variance: s.obs_variance, seed: s.seed, init_spectral: s.init_spectral,
-            fitted: s.fitted, topic_names,
-            num_times: s.num_times, bound: s.bound, topic_words: s.topic_words, corpus: s.corpus,
+            num_topics: s.num_topics,
+            alpha: s.alpha,
+            chain_variance: s.chain_variance,
+            obs_variance: s.obs_variance,
+            seed: s.seed,
+            init_spectral: s.init_spectral,
+            fitted: s.fitted,
+            topic_names,
+            num_times: s.num_times,
+            bound: s.bound,
+            topic_words: s.topic_words,
+            corpus: s.corpus,
         })
     }
 
@@ -9376,7 +10589,9 @@ impl SupervisedLDA {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -9387,7 +10602,11 @@ impl SupervisedLDA {
     /// concentration on document-topic proportions.
     #[new]
     #[pyo3(signature = (num_topics, *, alpha=0.1, seed=42))]
-    fn new(#[pyo3(from_py_with = "py_num_topics")] num_topics: usize, alpha: f64, seed: u64) -> PyResult<Self> {
+    fn new(
+        #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
+        alpha: f64,
+        seed: u64,
+    ) -> PyResult<Self> {
         if num_topics < 2 {
             return Err(PyValueError::new_err("num_topics must be >= 2"));
         }
@@ -9435,7 +10654,17 @@ impl SupervisedLDA {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -9459,8 +10688,16 @@ impl SupervisedLDA {
 
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
             let (m, hist, conv) = slda::fit_slda(
-                &corpus.docs, &y, num_types, k, alpha, iters, var_iters,
-                convergence_tol, check_every, &mut rng,
+                &corpus.docs,
+                &y,
+                num_types,
+                k,
+                alpha,
+                iters,
+                var_iters,
+                convergence_tol,
+                check_every,
+                &mut rng,
             );
             (m, hist, conv, corpus)
         });
@@ -9485,14 +10722,23 @@ impl SupervisedLDA {
         if draw_cap > 0 {
             let mut draw_rng = ChaCha8Rng::seed_from_u64(self.seed.wrapping_add(1));
             for _ in 0..draw_cap {
-                let snap: Vec<Vec<f32>> = model.gamma.iter().map(|gd| {
-                    let mut gammas: Vec<f64> = gd.iter()
-                        .map(|&g| hdp::sample_gamma(g.max(1e-12), &mut draw_rng))
-                        .collect();
-                    let s: f64 = gammas.iter().sum();
-                    if s > 0.0 { for x in gammas.iter_mut() { *x /= s; } }
-                    gammas.iter().map(|&g| g as f32).collect()
-                }).collect();
+                let snap: Vec<Vec<f32>> = model
+                    .gamma
+                    .iter()
+                    .map(|gd| {
+                        let mut gammas: Vec<f64> = gd
+                            .iter()
+                            .map(|&g| hdp::sample_gamma(g.max(1e-12), &mut draw_rng))
+                            .collect();
+                        let s: f64 = gammas.iter().sum();
+                        if s > 0.0 {
+                            for x in gammas.iter_mut() {
+                                *x /= s;
+                            }
+                        }
+                        gammas.iter().map(|&g| g as f32).collect()
+                    })
+                    .collect();
                 theta_draw_buf.push(snap);
             }
         }
@@ -9523,11 +10769,22 @@ impl SupervisedLDA {
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         let vocab = &self.corpus.as_ref().unwrap().id_to_word;
-        let word_id: std::collections::HashMap<&str, u32> =
-            vocab.iter().enumerate().map(|(i, w)| (w.as_str(), i as u32)).collect();
+        let word_id: std::collections::HashMap<&str, u32> = vocab
+            .iter()
+            .enumerate()
+            .map(|(i, w)| (w.as_str(), i as u32))
+            .collect();
 
         let docs: Vec<Vec<String>> = if let Ok(c) = data.extract::<Corpus>() {
-            c.inner.docs.iter().map(|d| d.iter().map(|&w| c.inner.id_to_word[w as usize].clone()).collect()).collect()
+            c.inner
+                .docs
+                .iter()
+                .map(|d| {
+                    d.iter()
+                        .map(|&w| c.inner.id_to_word[w as usize].clone())
+                        .collect()
+                })
+                .collect()
         } else {
             data.extract().map_err(|_| {
                 PyValueError::new_err("predict() expects a Corpus or a list of token lists")
@@ -9548,7 +10805,10 @@ impl SupervisedLDA {
         let preds: Vec<f64> = docs
             .iter()
             .map(|doc| {
-                let ids: Vec<u32> = doc.iter().filter_map(|w| word_id.get(w.as_str()).copied()).collect();
+                let ids: Vec<u32> = doc
+                    .iter()
+                    .filter_map(|w| word_id.get(w.as_str()).copied())
+                    .collect();
                 slda::predict_one(&model, &ids, var_iters)
             })
             .collect();
@@ -9590,7 +10850,11 @@ impl SupervisedLDA {
     #[getter]
     fn doc_lengths(&self) -> PyResult<Vec<usize>> {
         self.require_fitted()?;
-        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
     }
 
     /// Regression coefficients η, shape ``(num_topics,)`` — how each topic moves
@@ -9660,7 +10924,10 @@ impl SupervisedLDA {
             let items: Vec<Bound<'py, PyTuple>> = tops[t]
                 .iter()
                 .map(|&w| {
-                    PyTuple::new_bound(py, &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)])
+                    PyTuple::new_bound(
+                        py,
+                        &[vocab[w].clone().into_py(py), beta[[t, w]].into_py(py)],
+                    )
                 })
                 .collect();
             Ok(PyList::new_bound(py, items))
@@ -9706,8 +10973,15 @@ impl SupervisedLDA {
         self.require_fitted()?;
         let alpha = vec![self.alpha; self.num_topics];
         transform_gibbs(
-            py, data, &self.corpus.as_ref().unwrap().id_to_word, self.beta.as_ref().unwrap(),
-            &alpha, iters, burn_in, num_samples, sample_interval,
+            py,
+            data,
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.beta.as_ref().unwrap(),
+            &alpha,
+            iters,
+            burn_in,
+            num_samples,
+            sample_interval,
             seed.unwrap_or(self.seed),
         )
     }
@@ -9736,15 +11010,25 @@ impl SupervisedLDA {
     /// Save the fitted model to `path`. Reload with `SupervisedLDA.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_SLDA, &SldaState {
-            num_topics: self.num_topics, alpha: self.alpha, seed: self.seed, fitted: self.fitted,
-            sigma2: self.sigma2, eta: arr1_opt(&self.eta), beta: arr2_opt(&self.beta),
-            theta: arr2_opt(&self.theta), log_beta: self.log_beta.clone(),
-            corpus: self.corpus.clone(),
-            topic_names: self.topic_names.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-        })
+        write_state(
+            path,
+            MODEL_TAG_SLDA,
+            &SldaState {
+                num_topics: self.num_topics,
+                alpha: self.alpha,
+                seed: self.seed,
+                fitted: self.fitted,
+                sigma2: self.sigma2,
+                eta: arr1_opt(&self.eta),
+                beta: arr2_opt(&self.beta),
+                theta: arr2_opt(&self.theta),
+                log_beta: self.log_beta.clone(),
+                corpus: self.corpus.clone(),
+                topic_names: self.topic_names.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -9757,10 +11041,17 @@ impl SupervisedLDA {
             s.topic_names
         };
         Ok(SupervisedLDA {
-            num_topics: s.num_topics, alpha: s.alpha, seed: s.seed, fitted: s.fitted,
+            num_topics: s.num_topics,
+            alpha: s.alpha,
+            seed: s.seed,
+            fitted: s.fitted,
             topic_names,
-            sigma2: s.sigma2, eta: arr1_back(s.eta), beta: arr2_back(s.beta),
-            theta: arr2_back(s.theta), log_beta: s.log_beta, corpus: s.corpus,
+            sigma2: s.sigma2,
+            eta: arr1_back(s.eta),
+            beta: arr2_back(s.beta),
+            theta: arr2_back(s.theta),
+            log_beta: s.log_beta,
+            corpus: s.corpus,
             theta_draws: None,
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
@@ -9768,7 +11059,10 @@ impl SupervisedLDA {
     }
 
     fn __repr__(&self) -> String {
-        format!("SupervisedLDA(num_topics={}, fitted={})", self.num_topics, self.fitted)
+        format!(
+            "SupervisedLDA(num_topics={}, fitted={})",
+            self.num_topics, self.fitted
+        )
     }
 }
 
@@ -9804,7 +11098,9 @@ impl PT {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -9815,7 +11111,13 @@ impl PT {
     /// short texts are aggregated into (more = finer, fewer = more aggregation).
     #[new]
     #[pyo3(signature = (num_topics, *, num_pseudo=100, alpha=0.1, beta=0.01, seed=42))]
-    fn new(#[pyo3(from_py_with = "py_num_topics")] num_topics: usize, #[pyo3(from_py_with = "py_num_pseudo")] num_pseudo: usize, alpha: f64, beta: f64, seed: u64) -> PyResult<Self> {
+    fn new(
+        #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
+        #[pyo3(from_py_with = "py_num_pseudo")] num_pseudo: usize,
+        alpha: f64,
+        beta: f64,
+        seed: u64,
+    ) -> PyResult<Self> {
         if num_topics < 2 {
             return Err(PyValueError::new_err("num_topics must be >= 2"));
         }
@@ -9826,8 +11128,16 @@ impl PT {
             return Err(PyValueError::new_err("alpha and beta must be > 0"));
         }
         Ok(PT {
-            num_topics, num_pseudo, alpha, beta, seed,
-            fitted: false, topic_names: Vec::new(), phi: None, theta: None, corpus: None,
+            num_topics,
+            num_pseudo,
+            alpha,
+            beta,
+            seed,
+            fitted: false,
+            topic_names: Vec::new(),
+            phi: None,
+            theta: None,
+            corpus: None,
             theta_draws: None,
             log_likelihood_history: Vec::new(),
             converged: false,
@@ -9853,7 +11163,17 @@ impl PT {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -9868,8 +11188,17 @@ impl PT {
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
             let (m, hist, conv) = pt::fit_ptm_with_draws(
-                &corpus.docs, num_types, k, p, a, b, iters, draws_opts,
-                convergence_tol, check_every, &mut rng,
+                &corpus.docs,
+                num_types,
+                k,
+                p,
+                a,
+                b,
+                iters,
+                draws_opts,
+                convergence_tol,
+                check_every,
+                &mut rng,
             );
             (m, hist, conv, corpus)
         });
@@ -9912,7 +11241,11 @@ impl PT {
     #[getter]
     fn doc_lengths(&self) -> PyResult<Vec<usize>> {
         self.require_fitted()?;
-        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
     }
     #[getter]
     fn num_topics(&self) -> usize {
@@ -9963,28 +11296,53 @@ impl PT {
     }
 
     #[pyo3(signature = (n=10, *, topic=None))]
-    fn top_words<'py>(&self, py: Python<'py>, n: usize, topic: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
+    fn top_words<'py>(
+        &self,
+        py: Python<'py>,
+        n: usize,
+        topic: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
-        topic_words_helper(py, self.phi.as_ref().unwrap(), &self.corpus.as_ref().unwrap().id_to_word, self.num_topics, n, topic)
+        topic_words_helper(
+            py,
+            self.phi.as_ref().unwrap(),
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.num_topics,
+            n,
+            topic,
+        )
     }
     #[pyo3(signature = (n=10))]
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_topics, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path`. Reload with `PT.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_PT, &PtState {
-            num_topics: self.num_topics, num_pseudo: self.num_pseudo, alpha: self.alpha,
-            beta: self.beta, seed: self.seed, fitted: self.fitted,
-            phi: arr2_opt(&self.phi), theta: arr2_opt(&self.theta), corpus: self.corpus.clone(),
-            topic_names: self.topic_names.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-        })
+        write_state(
+            path,
+            MODEL_TAG_PT,
+            &PtState {
+                num_topics: self.num_topics,
+                num_pseudo: self.num_pseudo,
+                alpha: self.alpha,
+                beta: self.beta,
+                seed: self.seed,
+                fitted: self.fitted,
+                phi: arr2_opt(&self.phi),
+                theta: arr2_opt(&self.theta),
+                corpus: self.corpus.clone(),
+                topic_names: self.topic_names.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+            },
+        )
     }
     /// Load a model previously written by :meth:`save`.
     #[staticmethod]
@@ -9996,9 +11354,15 @@ impl PT {
             s.topic_names
         };
         Ok(PT {
-            num_topics: s.num_topics, num_pseudo: s.num_pseudo, alpha: s.alpha, beta: s.beta,
-            seed: s.seed, fitted: s.fitted, topic_names,
-            phi: arr2_back(s.phi), theta: arr2_back(s.theta),
+            num_topics: s.num_topics,
+            num_pseudo: s.num_pseudo,
+            alpha: s.alpha,
+            beta: s.beta,
+            seed: s.seed,
+            fitted: s.fitted,
+            topic_names,
+            phi: arr2_back(s.phi),
+            theta: arr2_back(s.theta),
             corpus: s.corpus,
             theta_draws: None,
             log_likelihood_history: s.log_likelihood_history,
@@ -10034,12 +11398,25 @@ impl PT {
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let phi = self.phi.as_ref().unwrap();
         let alpha = vec![self.alpha; self.num_topics];
-        transform_gibbs(py, data, id_to_word, phi, &alpha, iters, burn_in,
-                        num_samples, sample_interval, seed.unwrap_or(self.seed))
+        transform_gibbs(
+            py,
+            data,
+            id_to_word,
+            phi,
+            &alpha,
+            iters,
+            burn_in,
+            num_samples,
+            sample_interval,
+            seed.unwrap_or(self.seed),
+        )
     }
 
     fn __repr__(&self) -> String {
-        format!("PT(num_topics={}, num_pseudo={}, fitted={})", self.num_topics, self.num_pseudo, self.fitted)
+        format!(
+            "PT(num_topics={}, num_pseudo={}, fitted={})",
+            self.num_topics, self.num_pseudo, self.fitted
+        )
     }
 }
 
@@ -10062,9 +11439,9 @@ pub struct GSDMM {
     fitted: bool,
     num_used: usize,
     topic_names: Vec<String>,
-    phi: Option<Array2<f64>>,        // num_used × V (used clusters only)
-    theta: Option<Array2<f64>>,      // num_docs × num_used (soft assignment)
-    doc_cluster: Vec<usize>,         // hard assignment per doc, remapped to 0..num_used
+    phi: Option<Array2<f64>>,   // num_used × V (used clusters only)
+    theta: Option<Array2<f64>>, // num_docs × num_used (soft assignment)
+    doc_cluster: Vec<usize>,    // hard assignment per doc, remapped to 0..num_used
     corpus: Option<corpus::Corpus>,
     // Discovery/convergence trace: (iteration, num_clusters, log-likelihood).
     trace: Vec<(usize, usize, f64)>,
@@ -10075,7 +11452,9 @@ impl GSDMM {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -10088,18 +11467,33 @@ impl GSDMM {
     /// toward populous clusters; `beta` is the word-Dirichlet smoothing.
     #[new]
     #[pyo3(signature = (num_topics, *, alpha=0.1, beta=0.1, seed=42))]
-    fn new(#[pyo3(from_py_with = "py_num_topics")] num_topics: usize, alpha: f64, beta: f64, seed: u64) -> PyResult<Self> {
+    fn new(
+        #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
+        alpha: f64,
+        beta: f64,
+        seed: u64,
+    ) -> PyResult<Self> {
         if num_topics < 2 {
-            return Err(PyValueError::new_err("num_topics (max clusters) must be >= 2"));
+            return Err(PyValueError::new_err(
+                "num_topics (max clusters) must be >= 2",
+            ));
         }
         if !finite_pos(alpha) || !finite_pos(beta) {
             return Err(PyValueError::new_err("alpha and beta must be > 0"));
         }
         Ok(GSDMM {
-            k_max: num_topics, alpha, beta, seed,
-            fitted: false, num_used: 0, topic_names: Vec::new(),
-            phi: None, theta: None,
-            doc_cluster: Vec::new(), corpus: None, trace: Vec::new(),
+            k_max: num_topics,
+            alpha,
+            beta,
+            seed,
+            fitted: false,
+            num_used: 0,
+            topic_names: Vec::new(),
+            phi: None,
+            theta: None,
+            doc_cluster: Vec::new(),
+            corpus: None,
+            trace: Vec::new(),
         })
     }
 
@@ -10118,12 +11512,19 @@ impl GSDMM {
     ) -> PyResult<()> {
         let progress_interval = if let Some(old_val) = report_interval {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "GSDMM.fit(report_interval=) is deprecated; use progress_interval= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
-            if progress_interval != 0 { progress_interval } else { old_val }
+            warnings.call_method1(
+                "warn",
+                (
+                    "GSDMM.fit(report_interval=) is deprecated; use progress_interval= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
+            if progress_interval != 0 {
+                progress_interval
+            } else {
+                old_val
+            }
         } else {
             progress_interval
         };
@@ -10133,7 +11534,17 @@ impl GSDMM {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -10141,9 +11552,22 @@ impl GSDMM {
         let num_types = corpus.num_types();
         let (k, a, b) = (self.k_max, self.alpha, self.beta);
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
-        let ll_interval = if progress_interval == 0 { (iters / 50).max(1) } else { progress_interval };
+        let ll_interval = if progress_interval == 0 {
+            (iters / 50).max(1)
+        } else {
+            progress_interval
+        };
         let (model, corpus) = py.allow_threads(move || {
-            let m = gsdmm::fit_gsdmm(&corpus.docs, num_types, k, a, b, iters, ll_interval, &mut rng);
+            let m = gsdmm::fit_gsdmm(
+                &corpus.docs,
+                num_types,
+                k,
+                a,
+                b,
+                iters,
+                ll_interval,
+                &mut rng,
+            );
             (m, corpus)
         });
 
@@ -10268,27 +11692,53 @@ impl GSDMM {
     }
 
     #[pyo3(signature = (n=10, *, topic=None))]
-    fn top_words<'py>(&self, py: Python<'py>, n: usize, topic: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
+    fn top_words<'py>(
+        &self,
+        py: Python<'py>,
+        n: usize,
+        topic: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
-        topic_words_helper(py, self.phi.as_ref().unwrap(), &self.corpus.as_ref().unwrap().id_to_word, self.num_used, n, topic)
+        topic_words_helper(
+            py,
+            self.phi.as_ref().unwrap(),
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.num_used,
+            n,
+            topic,
+        )
     }
     #[pyo3(signature = (n=10))]
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_used, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path`. Reload with `GSDMM.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_GSDMM, &GsdmmState {
-            k_max: self.k_max, alpha: self.alpha, beta: self.beta, seed: self.seed,
-            fitted: self.fitted, num_used: self.num_used,
-            phi: arr2_opt(&self.phi), theta: arr2_opt(&self.theta),
-            doc_cluster: self.doc_cluster.clone(), corpus: self.corpus.clone(),
-            trace: self.trace.clone(), topic_names: self.topic_names.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_GSDMM,
+            &GsdmmState {
+                k_max: self.k_max,
+                alpha: self.alpha,
+                beta: self.beta,
+                seed: self.seed,
+                fitted: self.fitted,
+                num_used: self.num_used,
+                phi: arr2_opt(&self.phi),
+                theta: arr2_opt(&self.theta),
+                doc_cluster: self.doc_cluster.clone(),
+                corpus: self.corpus.clone(),
+                trace: self.trace.clone(),
+                topic_names: self.topic_names.clone(),
+            },
+        )
     }
     /// Load a model previously written by :meth:`save`.
     #[staticmethod]
@@ -10300,15 +11750,26 @@ impl GSDMM {
             s.topic_names
         };
         Ok(GSDMM {
-            k_max: s.k_max, alpha: s.alpha, beta: s.beta, seed: s.seed, fitted: s.fitted,
-            num_used: s.num_used, topic_names,
-            phi: arr2_back(s.phi), theta: arr2_back(s.theta),
-            doc_cluster: s.doc_cluster, corpus: s.corpus, trace: s.trace,
+            k_max: s.k_max,
+            alpha: s.alpha,
+            beta: s.beta,
+            seed: s.seed,
+            fitted: s.fitted,
+            num_used: s.num_used,
+            topic_names,
+            phi: arr2_back(s.phi),
+            theta: arr2_back(s.theta),
+            doc_cluster: s.doc_cluster,
+            corpus: s.corpus,
+            trace: s.trace,
         })
     }
 
     fn __repr__(&self) -> String {
-        format!("GSDMM(num_topics={}, k_max={}, fitted={})", self.num_used, self.k_max, self.fitted)
+        format!(
+            "GSDMM(num_topics={}, k_max={}, fitted={})",
+            self.num_used, self.k_max, self.fitted
+        )
     }
 }
 
@@ -10330,7 +11791,9 @@ fn parse_seed_dict(d: &Bound<'_, PyDict>) -> PyResult<(Vec<String>, Vec<Vec<Stri
         })?);
     }
     if names.is_empty() {
-        return Err(PyValueError::new_err("provide at least one seeded/keyword topic"));
+        return Err(PyValueError::new_err(
+            "provide at least one seeded/keyword topic",
+        ));
     }
     Ok((names, words))
 }
@@ -10342,11 +11805,18 @@ fn seed_word_ids(
     id_to_word: &[String],
     num_topics: usize,
 ) -> Vec<Vec<usize>> {
-    let index: HashMap<&str, usize> =
-        id_to_word.iter().enumerate().map(|(i, w)| (w.as_str(), i)).collect();
+    let index: HashMap<&str, usize> = id_to_word
+        .iter()
+        .enumerate()
+        .map(|(i, w)| (w.as_str(), i))
+        .collect();
     let mut out: Vec<Vec<usize>> = word_strings
         .iter()
-        .map(|ws| ws.iter().filter_map(|w| index.get(w.as_str()).copied()).collect())
+        .map(|ws| {
+            ws.iter()
+                .filter_map(|w| index.get(w.as_str()).copied())
+                .collect()
+        })
         .collect();
     out.resize(num_topics, Vec::new());
     out
@@ -10389,7 +11859,9 @@ impl SeededLDA {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
     fn num_topics_val(&self) -> usize {
@@ -10420,7 +11892,9 @@ impl SeededLDA {
             return Err(PyValueError::new_err("alpha and beta must be > 0"));
         }
         if names.len() + residual < 2 {
-            return Err(PyValueError::new_err("need at least 2 topics (seeded + residual)"));
+            return Err(PyValueError::new_err(
+                "need at least 2 topics (seeded + residual)",
+            ));
         }
         let (warp, cvb0) = match sampler {
             "sparse" => (false, false),
@@ -10433,10 +11907,23 @@ impl SeededLDA {
             }
         };
         Ok(SeededLDA {
-            seed_names: names, seed_words: words, residual, alpha, beta, weight, seed, warp, cvb0,
-            fitted: false, topic_names: Vec::new(), phi: None, theta: None,
-            theta_draws: None, corpus: None,
-            log_likelihood_history: Vec::new(), converged: false,
+            seed_names: names,
+            seed_words: words,
+            residual,
+            alpha,
+            beta,
+            weight,
+            seed,
+            warp,
+            cvb0,
+            fitted: false,
+            topic_names: Vec::new(),
+            phi: None,
+            theta: None,
+            theta_draws: None,
+            corpus: None,
+            log_likelihood_history: Vec::new(),
+            converged: false,
         })
     }
 
@@ -10474,7 +11961,17 @@ impl SeededLDA {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -10507,9 +12004,21 @@ impl SeededLDA {
             None => None,
         };
 
-        let check_every = if check_every == 0 { 0 } else if convergence_tol > 0.0 { check_every.max(1) } else { check_every };
+        let check_every = if check_every == 0 {
+            0
+        } else if convergence_tol > 0.0 {
+            check_every.max(1)
+        } else {
+            check_every
+        };
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
-        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, corpus.num_docs(), num_topics)?;
+        warn_theta_draw_memory(
+            py,
+            keep_theta_draws,
+            num_theta_draws,
+            corpus.num_docs(),
+            num_topics,
+        )?;
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
 
         if self.cvb0 {
@@ -10563,7 +12072,8 @@ impl SeededLDA {
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
                         let mut tmp = vec![vec![0.0f64; num_topics]; num_docs];
                         ws.theta_into(&corpus, &mut tmp);
-                        let snap = tmp.iter()
+                        let snap = tmp
+                            .iter()
                             .map(|r| r.iter().map(|&v| v as f32).collect())
                             .collect();
                         push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
@@ -10591,8 +12101,19 @@ impl SeededLDA {
 
         let (model, ll_history, converged, corpus) = py.allow_threads(move || {
             let (m, ll, conv) = seeded::fit_seeded_lda(
-                &corpus.docs, num_types, num_topics, &seeds, alpha, beta, seed_weight, doc_alpha,
-                iters, draws_opts, convergence_tol, check_every, &mut rng,
+                &corpus.docs,
+                num_types,
+                num_topics,
+                &seeds,
+                alpha,
+                beta,
+                seed_weight,
+                doc_alpha,
+                iters,
+                draws_opts,
+                convergence_tol,
+                check_every,
+                &mut rng,
             );
             (m, ll, conv, corpus)
         });
@@ -10698,33 +12219,59 @@ impl SeededLDA {
     }
 
     #[pyo3(signature = (n=10, *, topic=None))]
-    fn top_words<'py>(&self, py: Python<'py>, n: usize, topic: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
+    fn top_words<'py>(
+        &self,
+        py: Python<'py>,
+        n: usize,
+        topic: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
-        topic_words_helper(py, self.phi.as_ref().unwrap(), &self.corpus.as_ref().unwrap().id_to_word, self.num_topics_val(), n, topic)
+        topic_words_helper(
+            py,
+            self.phi.as_ref().unwrap(),
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.num_topics_val(),
+            n,
+            topic,
+        )
     }
     #[pyo3(signature = (n=10))]
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_topics_val(), n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path`. Reload with `SeededLDA.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_SEEDED, &SeededState {
-            num_topics: self.num_topics_val(), alpha: self.alpha, beta: self.beta,
-            weight: self.weight, seed: self.seed, fitted: self.fitted,
-            topic_names: self.topic_names.clone(), phi: arr2_opt(&self.phi),
-            theta: arr2_opt(&self.theta), corpus: self.corpus.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-            seed_names: self.seed_names.clone(),
-            seed_words: self.seed_words.clone(),
-            residual: self.residual,
-            warp: self.warp, cvb0: self.cvb0,
-            theta_draws: arr3f32_opt(&self.theta_draws),
-        })
+        write_state(
+            path,
+            MODEL_TAG_SEEDED,
+            &SeededState {
+                num_topics: self.num_topics_val(),
+                alpha: self.alpha,
+                beta: self.beta,
+                weight: self.weight,
+                seed: self.seed,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                phi: arr2_opt(&self.phi),
+                theta: arr2_opt(&self.theta),
+                corpus: self.corpus.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+                seed_names: self.seed_names.clone(),
+                seed_words: self.seed_words.clone(),
+                residual: self.residual,
+                warp: self.warp,
+                cvb0: self.cvb0,
+                theta_draws: arr3f32_opt(&self.theta_draws),
+            },
+        )
     }
     /// Load a model previously written by :meth:`save`.
     #[staticmethod]
@@ -10735,9 +12282,16 @@ impl SeededLDA {
             seed_names: s.seed_names,
             seed_words: s.seed_words,
             residual: s.residual,
-            alpha: s.alpha, beta: s.beta, weight: s.weight, seed: s.seed,
-            warp: s.warp, cvb0: s.cvb0, fitted: s.fitted,
-            topic_names: s.topic_names, phi: arr2_back(s.phi), theta: arr2_back(s.theta),
+            alpha: s.alpha,
+            beta: s.beta,
+            weight: s.weight,
+            seed: s.seed,
+            warp: s.warp,
+            cvb0: s.cvb0,
+            fitted: s.fitted,
+            topic_names: s.topic_names,
+            phi: arr2_back(s.phi),
+            theta: arr2_back(s.theta),
             theta_draws: arr3f32_back(s.theta_draws),
             corpus: s.corpus,
             log_likelihood_history: s.log_likelihood_history,
@@ -10773,12 +12327,27 @@ impl SeededLDA {
         let phi = self.phi.as_ref().unwrap();
         let k = self.num_topics_val();
         let alpha = vec![self.alpha; k];
-        transform_gibbs(py, data, id_to_word, phi, &alpha, iters, burn_in,
-                        num_samples, sample_interval, seed.unwrap_or(self.seed))
+        transform_gibbs(
+            py,
+            data,
+            id_to_word,
+            phi,
+            &alpha,
+            iters,
+            burn_in,
+            num_samples,
+            sample_interval,
+            seed.unwrap_or(self.seed),
+        )
     }
 
     fn __repr__(&self) -> String {
-        format!("SeededLDA(seeded={}, residual={}, fitted={})", self.seed_names.len(), self.residual, self.fitted)
+        format!(
+            "SeededLDA(seeded={}, residual={}, fitted={})",
+            self.seed_names.len(),
+            self.residual,
+            self.fitted
+        )
     }
 }
 
@@ -10801,7 +12370,10 @@ fn parse_reducer(reducer: &str) -> PyResult<bool> {
 /// default) discovers the topic count and leaves a `-1` noise bucket; `"kmeans"`
 /// and `"agglomerative"` assign every document to `num_clusters` clusters, so they
 /// require `num_clusters >= 1`.
-fn parse_clusterer(clusterer: &str, num_clusters: Option<i64>) -> PyResult<(String, Option<usize>)> {
+fn parse_clusterer(
+    clusterer: &str,
+    num_clusters: Option<i64>,
+) -> PyResult<(String, Option<usize>)> {
     match clusterer {
         "hdbscan" => Ok(("hdbscan".to_string(), None)),
         "kmeans" | "agglomerative" => {
@@ -10840,10 +12412,12 @@ fn umap_notice(py: Python<'_>, use_umap: bool) -> PyResult<()> {
     let warnings = py.import_bound("warnings")?;
     warnings.call_method1(
         "warn",
-        ("reducer='umap': the UMAP topic-discovery fit is not reproducible across runs \
+        (
+            "reducer='umap': the UMAP topic-discovery fit is not reproducible across runs \
           (the Rust UMAP optimizer's negative sampling is unseeded). The transform / \
           prediction phase is deterministic regardless. Use reducer='pca' (the default) \
-          for a reproducible fit.",),
+          for a reproducible fit.",
+        ),
     )?;
     Ok(())
 }
@@ -10896,7 +12470,8 @@ struct Top2VecState {
     seed: u64,
     fitted: bool,
     has_word_vectors: bool,
-    #[serde(default)] topic_names: Vec<String>,
+    #[serde(default)]
+    topic_names: Vec<String>,
     model: Option<top2vec::Top2VecModel>,
     id_to_word: Vec<String>,
     docs: Vec<Vec<u32>>,
@@ -10974,7 +12549,17 @@ impl Top2Vec {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -11007,8 +12592,11 @@ impl Top2Vec {
                 }
                 check_all_finite_2d("word_embeddings", &rows)?;
                 let e = rows.first().map(|r| r.len()).unwrap_or(0);
-                let map: std::collections::HashMap<&str, usize> =
-                    vocab.iter().enumerate().map(|(i, w)| (w.as_str(), i)).collect();
+                let map: std::collections::HashMap<&str, usize> = vocab
+                    .iter()
+                    .enumerate()
+                    .map(|(i, w)| (w.as_str(), i))
+                    .collect();
                 corpus
                     .id_to_word
                     .iter()
@@ -11026,23 +12614,40 @@ impl Top2Vec {
 
         umap_notice(py, self.use_umap)?;
         let (nc, uu, nn, mcs, ms, seed) = (
-            self.n_components, self.use_umap, self.n_neighbors,
-            self.min_cluster_size, self.min_samples, self.seed,
+            self.n_components,
+            self.use_umap,
+            self.n_neighbors,
+            self.min_cluster_size,
+            self.min_samples,
+            self.seed,
         );
         let clusterer = self.clusterer.clone();
         let num_clusters = self.num_clusters;
         let model = py.allow_threads(move || {
             top2vec::fit_top2vec(
-                &corpus.docs, &doc_emb, &word_vecs, num_types, nc, uu, nn, mcs, ms,
-                &clusterer, num_clusters, seed,
+                &corpus.docs,
+                &doc_emb,
+                &word_vecs,
+                num_types,
+                nc,
+                uu,
+                nn,
+                mcs,
+                ms,
+                &clusterer,
+                num_clusters,
+                seed,
             )
         });
         if model.num_topics == 0 {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "Top2Vec: clustering found no clusters (num_topics=0). Lower \
+            warnings.call_method1(
+                "warn",
+                (
+                    "Top2Vec: clustering found no clusters (num_topics=0). Lower \
                  min_cluster_size, add data, or check the scale of your embeddings.",
-            ))?;
+                ),
+            )?;
         }
         let k = model.num_topics;
         self.model = Some(model);
@@ -11211,15 +12816,27 @@ impl Top2Vec {
                 let mut df = vec![0u32; v];
                 for doc in &self.docs {
                     let mut seen = std::collections::HashSet::new();
-                    for &w in doc { seen.insert(w as usize); }
-                    for w in seen { if w < v { df[w] += 1; } }
+                    for &w in doc {
+                        seen.insert(w as usize);
+                    }
+                    for w in seen {
+                        if w < v {
+                            df[w] += 1;
+                        }
+                    }
                 }
                 df
             },
             total_freqs: {
                 let v = self.id_to_word.len();
                 let mut tf = vec![0u32; v];
-                for doc in &self.docs { for &w in doc { if (w as usize) < v { tf[w as usize] += 1; } } }
+                for doc in &self.docs {
+                    for &w in doc {
+                        if (w as usize) < v {
+                            tf[w as usize] += 1;
+                        }
+                    }
+                }
                 tf
             },
         };
@@ -11240,9 +12857,8 @@ impl Top2Vec {
                  min_cluster_size or more data",
             ));
         }
-        let de_obj = doc_embeddings.ok_or_else(|| {
-            PyValueError::new_err("Top2Vec.transform requires doc_embeddings")
-        })?;
+        let de_obj = doc_embeddings
+            .ok_or_else(|| PyValueError::new_err("Top2Vec.transform requires doc_embeddings"))?;
         let _ = data;
         let de = parse_features(de_obj)?;
         Ok(vecs_to_arr2(&m.assign(&de)).to_pyarray_bound(py))
@@ -11267,9 +12883,10 @@ impl Top2Vec {
     /// renumbered to a dense range.
     fn merge_topics(&mut self, groups: Vec<Vec<usize>>) -> PyResult<()> {
         let vocab = self.id_to_word.len();
-        let m = self.model.as_mut().ok_or_else(|| {
-            PyRuntimeError::new_err("model is not fitted yet; call fit() first")
-        })?;
+        let m = self
+            .model
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))?;
         m.merge_topics(&self.docs, &groups, vocab);
         Ok(())
     }
@@ -11278,9 +12895,10 @@ impl Top2Vec {
     /// the topic-word matrix. Returns how many documents were reassigned.
     fn reduce_outliers(&mut self) -> PyResult<usize> {
         let vocab = self.id_to_word.len();
-        let m = self.model.as_mut().ok_or_else(|| {
-            PyRuntimeError::new_err("model is not fitted yet; call fit() first")
-        })?;
+        let m = self
+            .model
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))?;
         let before = m.labels.iter().filter(|&&l| l < 0).count();
         m.reduce_outliers(&self.docs, vocab);
         Ok(before - m.labels.iter().filter(|&&l| l < 0).count())
@@ -11291,22 +12909,26 @@ impl Top2Vec {
     /// `reducer="umap"` discovery).
     fn save(&self, path: &str) -> PyResult<()> {
         self.fitted_model()?;
-        write_state(path, MODEL_TAG_TOP2VEC, &Top2VecState {
-            n_components: self.n_components,
-            use_umap: self.use_umap,
-            n_neighbors: self.n_neighbors,
-            min_cluster_size: self.min_cluster_size,
-            min_samples: self.min_samples,
-            clusterer: self.clusterer.clone(),
-            num_clusters: self.num_clusters,
-            seed: self.seed,
-            fitted: self.fitted,
-            has_word_vectors: self.has_word_vectors,
-            topic_names: self.topic_names.clone(),
-            model: self.model.clone(),
-            id_to_word: self.id_to_word.clone(),
-            docs: self.docs.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_TOP2VEC,
+            &Top2VecState {
+                n_components: self.n_components,
+                use_umap: self.use_umap,
+                n_neighbors: self.n_neighbors,
+                min_cluster_size: self.min_cluster_size,
+                min_samples: self.min_samples,
+                clusterer: self.clusterer.clone(),
+                num_clusters: self.num_clusters,
+                seed: self.seed,
+                fitted: self.fitted,
+                has_word_vectors: self.has_word_vectors,
+                topic_names: self.topic_names.clone(),
+                model: self.model.clone(),
+                id_to_word: self.id_to_word.clone(),
+                docs: self.docs.clone(),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -11405,7 +13027,8 @@ struct BertopicState {
     num_clusters: Option<usize>,
     seed: u64,
     fitted: bool,
-    #[serde(default)] topic_names: Vec<String>,
+    #[serde(default)]
+    topic_names: Vec<String>,
     model: Option<bertopic::BertopicModel>,
     id_to_word: Vec<String>,
     docs: Vec<Vec<u32>>,
@@ -11420,10 +13043,18 @@ impl BERTopic {
     /// Map token-list documents to id documents over the fitted vocabulary,
     /// dropping out-of-vocabulary words (used for `approximate_distribution`).
     fn to_ids(&self, docs: &[Vec<String>]) -> Vec<Vec<u32>> {
-        let map: std::collections::HashMap<&str, u32> =
-            self.id_to_word.iter().enumerate().map(|(i, w)| (w.as_str(), i as u32)).collect();
+        let map: std::collections::HashMap<&str, u32> = self
+            .id_to_word
+            .iter()
+            .enumerate()
+            .map(|(i, w)| (w.as_str(), i as u32))
+            .collect();
         docs.iter()
-            .map(|d| d.iter().filter_map(|w| map.get(w.as_str()).copied()).collect())
+            .map(|d| {
+                d.iter()
+                    .filter_map(|w| map.get(w.as_str()).copied())
+                    .collect()
+            })
             .collect()
     }
 }
@@ -11496,7 +13127,17 @@ impl BERTopic {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -11515,24 +13156,49 @@ impl BERTopic {
         self.docs = corpus.docs.clone();
         umap_notice(py, self.use_umap)?;
         let (nc, uu, nn, mcs, ms, nr, win, st, b25, rf, seed) = (
-            self.n_components, self.use_umap, self.n_neighbors, self.min_cluster_size,
-            self.min_samples, self.nr_topics, self.window, self.stride,
-            self.bm25, self.reduce_frequent, self.seed,
+            self.n_components,
+            self.use_umap,
+            self.n_neighbors,
+            self.min_cluster_size,
+            self.min_samples,
+            self.nr_topics,
+            self.window,
+            self.stride,
+            self.bm25,
+            self.reduce_frequent,
+            self.seed,
         );
         let clusterer = self.clusterer.clone();
         let num_clusters = self.num_clusters;
         let model = py.allow_threads(move || {
             bertopic::fit_bertopic(
-                &corpus.docs, &doc_emb, num_types, nc, uu, nn, mcs, ms, nr, win, st, b25, rf,
-                &clusterer, num_clusters, seed,
+                &corpus.docs,
+                &doc_emb,
+                num_types,
+                nc,
+                uu,
+                nn,
+                mcs,
+                ms,
+                nr,
+                win,
+                st,
+                b25,
+                rf,
+                &clusterer,
+                num_clusters,
+                seed,
             )
         });
         if model.num_topics == 0 {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "BERTopic: clustering found no clusters (num_topics=0). Lower \
+            warnings.call_method1(
+                "warn",
+                (
+                    "BERTopic: clustering found no clusters (num_topics=0). Lower \
                  min_cluster_size, add data, or check the scale of your embeddings.",
-            ))?;
+                ),
+            )?;
         }
         let k = model.num_topics;
         self.model = Some(model);
@@ -11617,15 +13283,27 @@ impl BERTopic {
                 let mut df = vec![0u32; v];
                 for doc in &self.docs {
                     let mut seen = std::collections::HashSet::new();
-                    for &w in doc { seen.insert(w as usize); }
-                    for w in seen { if w < v { df[w] += 1; } }
+                    for &w in doc {
+                        seen.insert(w as usize);
+                    }
+                    for w in seen {
+                        if w < v {
+                            df[w] += 1;
+                        }
+                    }
                 }
                 df
             },
             total_freqs: {
                 let v = self.id_to_word.len();
                 let mut tf = vec![0u32; v];
-                for doc in &self.docs { for &w in doc { if (w as usize) < v { tf[w as usize] += 1; } } }
+                for doc in &self.docs {
+                    for &w in doc {
+                        if (w as usize) < v {
+                            tf[w as usize] += 1;
+                        }
+                    }
+                }
                 tf
             },
         };
@@ -11651,7 +13329,15 @@ impl BERTopic {
             ));
         }
         let docs_str: Vec<Vec<String>> = if let Ok(c) = data.extract::<Corpus>() {
-            c.inner.docs.iter().map(|d| d.iter().map(|&w| c.inner.id_to_word[w as usize].clone()).collect()).collect()
+            c.inner
+                .docs
+                .iter()
+                .map(|d| {
+                    d.iter()
+                        .map(|&w| c.inner.id_to_word[w as usize].clone())
+                        .collect()
+                })
+                .collect()
         } else {
             data.extract().map_err(|_| {
                 PyValueError::new_err("approximate_distribution expects a Corpus or token lists")
@@ -11696,11 +13382,17 @@ impl BERTopic {
     /// Merge groups of topics into single topics, e.g. ``[[3, 7], [1, 2]]``,
     /// rebuilding the c-TF-IDF representation and the document-topic distribution.
     fn merge_topics(&mut self, groups: Vec<Vec<usize>>) -> PyResult<()> {
-        let (vocab, b25, rf, win, st) =
-            (self.id_to_word.len(), self.bm25, self.reduce_frequent, self.window, self.stride);
-        let m = self.model.as_mut().ok_or_else(|| {
-            PyRuntimeError::new_err("model is not fitted yet; call fit() first")
-        })?;
+        let (vocab, b25, rf, win, st) = (
+            self.id_to_word.len(),
+            self.bm25,
+            self.reduce_frequent,
+            self.window,
+            self.stride,
+        );
+        let m = self
+            .model
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))?;
         m.merge_topics(&self.docs, &groups, vocab, b25, rf, win, st);
         Ok(())
     }
@@ -11708,11 +13400,17 @@ impl BERTopic {
     /// Reassign noise documents (label ``-1``) to their nearest topic by c-TF-IDF
     /// fit and rebuild. Returns how many documents were reassigned.
     fn reduce_outliers(&mut self) -> PyResult<usize> {
-        let (vocab, b25, rf, win, st) =
-            (self.id_to_word.len(), self.bm25, self.reduce_frequent, self.window, self.stride);
-        let m = self.model.as_mut().ok_or_else(|| {
-            PyRuntimeError::new_err("model is not fitted yet; call fit() first")
-        })?;
+        let (vocab, b25, rf, win, st) = (
+            self.id_to_word.len(),
+            self.bm25,
+            self.reduce_frequent,
+            self.window,
+            self.stride,
+        );
+        let m = self
+            .model
+            .as_mut()
+            .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))?;
         let before = m.labels.iter().filter(|&&l| l < 0).count();
         m.reduce_outliers(&self.docs, vocab, b25, rf, win, st);
         Ok(before - m.labels.iter().filter(|&&l| l < 0).count())
@@ -11723,26 +13421,30 @@ impl BERTopic {
     /// `reducer="umap"` discovery).
     fn save(&self, path: &str) -> PyResult<()> {
         self.fitted_model()?;
-        write_state(path, MODEL_TAG_BERTOPIC, &BertopicState {
-            n_components: self.n_components,
-            use_umap: self.use_umap,
-            n_neighbors: self.n_neighbors,
-            min_cluster_size: self.min_cluster_size,
-            min_samples: self.min_samples,
-            nr_topics: self.nr_topics,
-            window: self.window,
-            stride: self.stride,
-            bm25: self.bm25,
-            reduce_frequent: self.reduce_frequent,
-            clusterer: self.clusterer.clone(),
-            num_clusters: self.num_clusters,
-            seed: self.seed,
-            fitted: self.fitted,
-            topic_names: self.topic_names.clone(),
-            model: self.model.clone(),
-            id_to_word: self.id_to_word.clone(),
-            docs: self.docs.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_BERTOPIC,
+            &BertopicState {
+                n_components: self.n_components,
+                use_umap: self.use_umap,
+                n_neighbors: self.n_neighbors,
+                min_cluster_size: self.min_cluster_size,
+                min_samples: self.min_samples,
+                nr_topics: self.nr_topics,
+                window: self.window,
+                stride: self.stride,
+                bm25: self.bm25,
+                reduce_frequent: self.reduce_frequent,
+                clusterer: self.clusterer.clone(),
+                num_clusters: self.num_clusters,
+                seed: self.seed,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                model: self.model.clone(),
+                id_to_word: self.id_to_word.clone(),
+                docs: self.docs.clone(),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -11898,7 +13600,9 @@ impl ETM {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 
@@ -11908,7 +13612,9 @@ impl ETM {
         match (&self.model, &self.vae) {
             (Some(m), _) => Ok(&m.beta),
             (_, Some(m)) => Ok(&m.beta),
-            _ => Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first")),
+            _ => Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            )),
         }
     }
 
@@ -11918,7 +13624,9 @@ impl ETM {
         match (&self.model, &self.vae) {
             (Some(m), _) => Ok(&m.alpha),
             (_, Some(m)) => Ok(&m.alpha),
-            _ => Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first")),
+            _ => Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            )),
         }
     }
 
@@ -11928,7 +13636,9 @@ impl ETM {
         match (&self.model, &self.vae) {
             (Some(m), _) => Ok(m.doc_topics()),
             (_, Some(m)) => Ok(m.doc_topic.clone()),
-            _ => Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first")),
+            _ => Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            )),
         }
     }
 
@@ -11937,7 +13647,9 @@ impl ETM {
         match (&self.model, &self.vae) {
             (Some(m), _) => Ok(m.bound),
             (_, Some(m)) => Ok(m.bound),
-            _ => Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first")),
+            _ => Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            )),
         }
     }
 
@@ -11946,7 +13658,9 @@ impl ETM {
         match (&self.model, &self.vae) {
             (Some(m), _) => Ok(m.converged),
             (_, Some(m)) => Ok(m.converged),
-            _ => Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first")),
+            _ => Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            )),
         }
     }
 
@@ -11955,7 +13669,9 @@ impl ETM {
         match (&self.model, &self.vae) {
             (Some(m), _) => Ok(m.bound_history.clone()),
             (_, Some(m)) => Ok(m.bound_history.clone()),
-            _ => Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first")),
+            _ => Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            )),
         }
     }
 }
@@ -11998,12 +13714,19 @@ impl ETM {
     ) -> PyResult<Self> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "ETM(em_tol=) is deprecated; use convergence_tol= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
-            if (convergence_tol - 1e-4_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+            warnings.call_method1(
+                "warn",
+                (
+                    "ETM(em_tol=) is deprecated; use convergence_tol= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
+            if (convergence_tol - 1e-4_f64).abs() > f64::EPSILON {
+                convergence_tol
+            } else {
+                old_val
+            }
         } else {
             convergence_tol
         };
@@ -12062,8 +13785,15 @@ impl ETM {
         let tol = convergence_tol.unwrap_or(self.em_tol);
         let (docs_str, corpus_opt): (Vec<Vec<String>>, Option<corpus::Corpus>) =
             if let Ok(c) = data.extract::<Corpus>() {
-                let strings = c.inner.docs.iter()
-                    .map(|d| d.iter().map(|&w| c.inner.id_to_word[w as usize].clone()).collect())
+                let strings = c
+                    .inner
+                    .docs
+                    .iter()
+                    .map(|d| {
+                        d.iter()
+                            .map(|&w| c.inner.id_to_word[w as usize].clone())
+                            .collect()
+                    })
                     .collect();
                 (strings, Some(c.inner.clone()))
             } else {
@@ -12082,16 +13812,27 @@ impl ETM {
         }
         check_all_finite_2d("word_embeddings", &rho)?;
         if vocabulary.len() < self.num_topics {
-            return Err(PyValueError::new_err("vocabulary must have at least num_topics words"));
+            return Err(PyValueError::new_err(
+                "vocabulary must have at least num_topics words",
+            ));
         }
-        let map: std::collections::HashMap<&str, u32> =
-            vocabulary.iter().enumerate().map(|(i, w)| (w.as_str(), i as u32)).collect();
+        let map: std::collections::HashMap<&str, u32> = vocabulary
+            .iter()
+            .enumerate()
+            .map(|(i, w)| (w.as_str(), i as u32))
+            .collect();
         let docs_ids: Vec<Vec<u32>> = docs_str
             .iter()
-            .map(|d| d.iter().filter_map(|w| map.get(w.as_str()).copied()).collect())
+            .map(|d| {
+                d.iter()
+                    .filter_map(|w| map.get(w.as_str()).copied())
+                    .collect()
+            })
             .collect();
         if docs_ids.iter().all(|d| d.is_empty()) {
-            return Err(PyValueError::new_err("no in-vocabulary tokens in the documents"));
+            return Err(PyValueError::new_err(
+                "no in-vocabulary tokens in the documents",
+            ));
         }
         let num_types = vocabulary.len();
         self.id_to_word = vocabulary.clone();
@@ -12100,22 +13841,34 @@ impl ETM {
         if self.inference == "vae" {
             let ep = iters.unwrap_or(150);
             let opts = build_avitm_options(
-                &self.prior, self.contrastive, self.contrastive_weight, self.contrastive_temp,
+                &self.prior,
+                self.contrastive,
+                self.contrastive_weight,
+                self.contrastive_temp,
             )?;
             let (k, h, bs, lr, wd, et) = (
-                self.num_topics, self.hidden_size, self.batch_size,
-                self.lr, self.wdecay, tol,
+                self.num_topics,
+                self.hidden_size,
+                self.batch_size,
+                self.lr,
+                self.wdecay,
+                tol,
             );
             let m = py.allow_threads(move || {
-                etm_vae::fit_etm_vae(&docs_ids, k, num_types, &rho, h, ep, bs, lr, wd, et, opts, &mut rng)
+                etm_vae::fit_etm_vae(
+                    &docs_ids, k, num_types, &rho, h, ep, bs, lr, wd, et, opts, &mut rng,
+                )
             });
             self.vae = Some(m);
             self.model = None;
         } else {
             let ei = iters.unwrap_or(100);
             let (k, et, ss, pv, mi) = (
-                self.num_topics, tol, self.sigma_shrink,
-                self.prior_variance, self.max_inner,
+                self.num_topics,
+                tol,
+                self.sigma_shrink,
+                self.prior_variance,
+                self.max_inner,
             );
             let model = py.allow_threads(move || {
                 etm::fit_etm(&docs_ids, k, num_types, &rho, ei, et, ss, pv, mi, &mut rng)
@@ -12132,7 +13885,8 @@ impl ETM {
             let mut tf = vec![0u32; v];
             let mut id_docs: Vec<Vec<u32>> = Vec::with_capacity(n);
             for doc in &docs_str {
-                let ids: Vec<u32> = doc.iter()
+                let ids: Vec<u32> = doc
+                    .iter()
                     .filter_map(|w| map.get(w.as_str()).copied())
                     .collect();
                 let mut seen = std::collections::HashSet::new();
@@ -12140,7 +13894,9 @@ impl ETM {
                     tf[id as usize] += 1;
                     seen.insert(id as usize);
                 }
-                for id in seen { df[id] += 1; }
+                for id in seen {
+                    df[id] += 1;
+                }
                 id_docs.push(ids);
             }
             corpus::Corpus {
@@ -12194,7 +13950,8 @@ impl ETM {
     /// :meth:`load` (bound_history is not persisted in the saved state).
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
-        Ok(self.surf_bound_history()?
+        Ok(self
+            .surf_bound_history()?
             .iter()
             .enumerate()
             .map(|(i, &b)| (i + 1, b))
@@ -12243,7 +14000,10 @@ impl ETM {
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         let phi = vecs_to_arr2(self.surf_beta()?);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path` (topica's binary format).
@@ -12251,52 +14011,106 @@ impl ETM {
         self.ensure_fitted()?;
         let (beta_em, alpha_em, mu_em, sigma_em, lambda_em, bound_em, converged_em) =
             if let Some(m) = &self.model {
-                (Some(m.beta.clone()), Some(m.alpha.clone()), Some(m.mu.clone()),
-                 Some(m.sigma.clone()), Some(m.lambda.clone()), Some(m.bound), Some(m.converged))
+                (
+                    Some(m.beta.clone()),
+                    Some(m.alpha.clone()),
+                    Some(m.mu.clone()),
+                    Some(m.sigma.clone()),
+                    Some(m.lambda.clone()),
+                    Some(m.bound),
+                    Some(m.converged),
+                )
             } else {
                 (None, None, None, None, None, None, None)
             };
-        let (beta_vae, alpha_vae, doc_topic_vae, bound_vae, converged_vae,
-             enc_v, enc_hidden, enc_w1, enc_b1, enc_w2, enc_b2,
-             enc_w_mu, enc_b_mu, enc_w_ls, enc_b_ls) =
-            if let Some(m) = &self.vae {
-                let enc = &m.encoder;
-                (Some(m.beta.clone()), Some(m.alpha.clone()), Some(m.doc_topic.clone()),
-                 Some(m.bound), Some(m.converged),
-                 Some(enc.v), Some(enc.hidden),
-                 Some(enc.w1.clone()), Some(enc.b1.clone()),
-                 Some(enc.w2.clone()), Some(enc.b2.clone()),
-                 Some(enc.w_mu.clone()), Some(enc.b_mu.clone()),
-                 Some(enc.w_ls.clone()), Some(enc.b_ls.clone()))
-            } else {
-                (None, None, None, None, None, None, None,
-                 None, None, None, None, None, None, None, None)
-            };
-        write_state(path, MODEL_TAG_ETM, &EtmState {
-            num_topics: self.num_topics,
-            inference: self.inference.clone(),
-            em_tol: self.em_tol,
-            sigma_shrink: self.sigma_shrink,
-            prior_variance: self.prior_variance,
-            max_inner: self.max_inner,
-            hidden_size: self.hidden_size,
-            batch_size: self.batch_size,
-            lr: self.lr,
-            wdecay: self.wdecay,
-            seed: self.seed,
-            prior: self.prior.clone(),
-            contrastive: self.contrastive,
-            contrastive_weight: self.contrastive_weight,
-            contrastive_temp: self.contrastive_temp,
-            fitted: self.fitted,
-            topic_names: self.topic_names.clone(),
-            id_to_word: self.id_to_word.clone(),
-            corpus: self.corpus.clone(),
-            beta_em, alpha_em, mu_em, sigma_em, lambda_em, bound_em, converged_em,
-            beta_vae, alpha_vae, doc_topic_vae, bound_vae, converged_vae,
-            enc_v, enc_hidden, enc_w1, enc_b1, enc_w2, enc_b2,
-            enc_w_mu, enc_b_mu, enc_w_ls, enc_b_ls,
-        })
+        let (
+            beta_vae,
+            alpha_vae,
+            doc_topic_vae,
+            bound_vae,
+            converged_vae,
+            enc_v,
+            enc_hidden,
+            enc_w1,
+            enc_b1,
+            enc_w2,
+            enc_b2,
+            enc_w_mu,
+            enc_b_mu,
+            enc_w_ls,
+            enc_b_ls,
+        ) = if let Some(m) = &self.vae {
+            let enc = &m.encoder;
+            (
+                Some(m.beta.clone()),
+                Some(m.alpha.clone()),
+                Some(m.doc_topic.clone()),
+                Some(m.bound),
+                Some(m.converged),
+                Some(enc.v),
+                Some(enc.hidden),
+                Some(enc.w1.clone()),
+                Some(enc.b1.clone()),
+                Some(enc.w2.clone()),
+                Some(enc.b2.clone()),
+                Some(enc.w_mu.clone()),
+                Some(enc.b_mu.clone()),
+                Some(enc.w_ls.clone()),
+                Some(enc.b_ls.clone()),
+            )
+        } else {
+            (
+                None, None, None, None, None, None, None, None, None, None, None, None, None, None,
+                None,
+            )
+        };
+        write_state(
+            path,
+            MODEL_TAG_ETM,
+            &EtmState {
+                num_topics: self.num_topics,
+                inference: self.inference.clone(),
+                em_tol: self.em_tol,
+                sigma_shrink: self.sigma_shrink,
+                prior_variance: self.prior_variance,
+                max_inner: self.max_inner,
+                hidden_size: self.hidden_size,
+                batch_size: self.batch_size,
+                lr: self.lr,
+                wdecay: self.wdecay,
+                seed: self.seed,
+                prior: self.prior.clone(),
+                contrastive: self.contrastive,
+                contrastive_weight: self.contrastive_weight,
+                contrastive_temp: self.contrastive_temp,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                id_to_word: self.id_to_word.clone(),
+                corpus: self.corpus.clone(),
+                beta_em,
+                alpha_em,
+                mu_em,
+                sigma_em,
+                lambda_em,
+                bound_em,
+                converged_em,
+                beta_vae,
+                alpha_vae,
+                doc_topic_vae,
+                bound_vae,
+                converged_vae,
+                enc_v,
+                enc_hidden,
+                enc_w1,
+                enc_b1,
+                enc_w2,
+                enc_b2,
+                enc_w_mu,
+                enc_b_mu,
+                enc_w_ls,
+                enc_b_ls,
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -12317,7 +14131,9 @@ impl ETM {
                 converged: s.converged_em.unwrap_or(false),
                 em_iters_run: 0,
             })
-        } else { None };
+        } else {
+            None
+        };
         let vae = if s.inference == "vae" {
             s.beta_vae.map(|beta| etm_vae::EtmVaeModel {
                 num_topics: s.num_topics,
@@ -12344,7 +14160,9 @@ impl ETM {
                 },
                 prior: prior_from_str(&s.prior),
             })
-        } else { None };
+        } else {
+            None
+        };
         Ok(ETM {
             num_topics: s.num_topics,
             inference: s.inference,
@@ -12542,7 +14360,9 @@ impl DETM {
         }
         if let Some(c) = grad_clip {
             if !(c > 0.0) || !c.is_finite() {
-                return Err(PyValueError::new_err("grad_clip must be a positive finite float or None"));
+                return Err(PyValueError::new_err(
+                    "grad_clip must be a positive finite float or None",
+                ));
             }
         }
         Ok(DETM {
@@ -12603,8 +14423,15 @@ impl DETM {
 
         let (docs_str, corpus_opt): (Vec<Vec<String>>, Option<corpus::Corpus>) =
             if let Ok(c) = data.extract::<Corpus>() {
-                let strings = c.inner.docs.iter()
-                    .map(|d| d.iter().map(|&w| c.inner.id_to_word[w as usize].clone()).collect())
+                let strings = c
+                    .inner
+                    .docs
+                    .iter()
+                    .map(|d| {
+                        d.iter()
+                            .map(|&w| c.inner.id_to_word[w as usize].clone())
+                            .collect()
+                    })
                     .collect();
                 (strings, Some(c.inner.clone()))
             } else {
@@ -12648,11 +14475,16 @@ impl DETM {
         }
         check_all_finite_2d("word_embeddings", &rho)?;
         if vocabulary.len() < self.num_topics {
-            return Err(PyValueError::new_err("vocabulary must have at least num_topics words"));
+            return Err(PyValueError::new_err(
+                "vocabulary must have at least num_topics words",
+            ));
         }
 
-        let map: std::collections::HashMap<&str, u32> =
-            vocabulary.iter().enumerate().map(|(i, w)| (w.as_str(), i as u32)).collect();
+        let map: std::collections::HashMap<&str, u32> = vocabulary
+            .iter()
+            .enumerate()
+            .map(|(i, w)| (w.as_str(), i as u32))
+            .collect();
         // Per-document sparse (tokens, counts) over the vocabulary ids.
         let mut tokens: Vec<Vec<u32>> = Vec::with_capacity(docs_str.len());
         let mut counts: Vec<Vec<u32>> = Vec::with_capacity(docs_str.len());
@@ -12667,7 +14499,9 @@ impl DETM {
             counts.push(m.values().copied().collect());
         }
         if tokens.iter().all(|d| d.is_empty()) {
-            return Err(PyValueError::new_err("no in-vocabulary tokens in the documents"));
+            return Err(PyValueError::new_err(
+                "no in-vocabulary tokens in the documents",
+            ));
         }
 
         let num_types = vocabulary.len();
@@ -12675,8 +14509,15 @@ impl DETM {
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
 
         let (k, delta, h, eh, enl, bs, lr, wd, gc) = (
-            self.num_topics, self.delta, self.hidden_size, self.eta_hidden_size,
-            self.eta_nlayers, self.batch_size, self.lr, self.wdecay, self.grad_clip,
+            self.num_topics,
+            self.delta,
+            self.hidden_size,
+            self.eta_hidden_size,
+            self.eta_nlayers,
+            self.batch_size,
+            self.lr,
+            self.wdecay,
+            self.grad_clip,
         );
         let model = py.allow_threads(move || {
             detm::fit_detm(
@@ -12695,8 +14536,10 @@ impl DETM {
             let mut tf = vec![0u32; v];
             let mut id_docs: Vec<Vec<u32>> = Vec::with_capacity(n);
             for doc in &docs_str {
-                let ids: Vec<u32> =
-                    doc.iter().filter_map(|w| map.get(w.as_str()).copied()).collect();
+                let ids: Vec<u32> = doc
+                    .iter()
+                    .filter_map(|w| map.get(w.as_str()).copied())
+                    .collect();
                 let mut s = std::collections::HashSet::new();
                 for &id in &ids {
                     tf[id as usize] += 1;
@@ -12786,7 +14629,15 @@ impl DETM {
     #[getter]
     fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray3<f64>>> {
         let m = self.fitted_model()?;
-        let (t, k, l) = (m.num_times, m.num_topics, if m.num_topics > 0 { m.alpha[0][0].len() } else { 0 });
+        let (t, k, l) = (
+            m.num_times,
+            m.num_topics,
+            if m.num_topics > 0 {
+                m.alpha[0][0].len()
+            } else {
+                0
+            },
+        );
         let mut arr = Array3::<f64>::zeros((t, k, l));
         for tt in 0..t {
             for kk in 0..k {
@@ -12819,7 +14670,11 @@ impl DETM {
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         let m = self.fitted_model()?;
-        Ok(m.bound_history.iter().enumerate().map(|(i, &b)| (i + 1, b)).collect())
+        Ok(m.bound_history
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| (i + 1, b))
+            .collect())
     }
 
     #[getter]
@@ -12892,37 +14747,44 @@ impl DETM {
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word_mean());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path`. Reload with `DETM.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         let m = self.fitted_model()?;
-        write_state(path, MODEL_TAG_DETM, &DetmState {
-            num_topics: self.num_topics,
-            delta: self.delta,
-            hidden_size: self.hidden_size,
-            eta_hidden_size: self.eta_hidden_size,
-            eta_nlayers: self.eta_nlayers,
-            batch_size: self.batch_size,
-            lr: self.lr,
-            wdecay: self.wdecay,
-            grad_clip: self.grad_clip,
-            convergence_tol: self.convergence_tol,
-            seed: self.seed,
-            fitted: self.fitted,
-            topic_names: self.topic_names.clone(),
-            num_times: self.num_times,
-            num_types: m.num_types,
-            id_to_word: self.id_to_word.clone(),
-            corpus: self.corpus.clone(),
-            beta_over_time: m.beta_over_time.clone(),
-            doc_topic: m.doc_topic.clone(),
-            alpha: m.alpha.clone(),
-            eta: m.eta.clone(),
-            bound: m.bound,
-            converged: m.converged,
-        })
+        write_state(
+            path,
+            MODEL_TAG_DETM,
+            &DetmState {
+                num_topics: self.num_topics,
+                delta: self.delta,
+                hidden_size: self.hidden_size,
+                eta_hidden_size: self.eta_hidden_size,
+                eta_nlayers: self.eta_nlayers,
+                batch_size: self.batch_size,
+                lr: self.lr,
+                wdecay: self.wdecay,
+                grad_clip: self.grad_clip,
+                convergence_tol: self.convergence_tol,
+                seed: self.seed,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                num_times: self.num_times,
+                num_types: m.num_types,
+                id_to_word: self.id_to_word.clone(),
+                corpus: self.corpus.clone(),
+                beta_over_time: m.beta_over_time.clone(),
+                doc_topic: m.doc_topic.clone(),
+                alpha: m.alpha.clone(),
+                eta: m.eta.clone(),
+                bound: m.bound,
+                converged: m.converged,
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -13024,11 +14886,20 @@ impl InfoCTM {
             .model
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))?;
-        Ok(if self.lang_index(lang)? == 0 { &m.model_a } else { &m.model_b })
+        Ok(if self.lang_index(lang)? == 0 {
+            &m.model_a
+        } else {
+            &m.model_b
+        })
     }
     fn corpus_for(&self, lang: &str) -> PyResult<&corpus::Corpus> {
-        let c = if self.lang_index(lang)? == 0 { &self.corpus_a } else { &self.corpus_b };
-        c.as_ref().ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+        let c = if self.lang_index(lang)? == 0 {
+            &self.corpus_a
+        } else {
+            &self.corpus_b
+        };
+        c.as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
     }
 }
 
@@ -13110,7 +14981,17 @@ impl InfoCTM {
                 let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                     PyValueError::new_err("fit() expects a Corpus or a list of token lists")
                 })?;
-                Ok(build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0)
+                Ok(build_corpus_from_docs(
+                    docs,
+                    None,
+                    None,
+                    std::collections::HashSet::new(),
+                    1,
+                    1.0,
+                    0,
+                    0,
+                )?
+                .0)
             }
         };
         let corpus_a = to_corpus(data_a)?;
@@ -13120,12 +15001,18 @@ impl InfoCTM {
             return Err(PyValueError::new_err("both corpora must contain documents"));
         }
         if va < self.num_topics || vb < self.num_topics {
-            return Err(PyValueError::new_err("each vocabulary must have at least num_topics words"));
+            return Err(PyValueError::new_err(
+                "each vocabulary must have at least num_topics words",
+            ));
         }
 
         // word -> id maps for each language.
         let wid = |c: &corpus::Corpus| -> std::collections::HashMap<String, usize> {
-            c.id_to_word.iter().enumerate().map(|(i, w)| (w.clone(), i)).collect()
+            c.id_to_word
+                .iter()
+                .enumerate()
+                .map(|(i, w)| (w.clone(), i))
+                .collect()
         };
         let wa = wid(&corpus_a);
         let wb = wid(&corpus_b);
@@ -13155,8 +15042,13 @@ impl InfoCTM {
         let emb_b = emb_matrix(embeddings_b, &corpus_b);
 
         let ep = iters.unwrap_or(500);
-        let (k, h, dp, lr, et) =
-            (self.num_topics, self.hidden_size, self.dropout, self.lr, self.em_tol);
+        let (k, h, dp, lr, et) = (
+            self.num_topics,
+            self.hidden_size,
+            self.dropout,
+            self.lr,
+            self.em_tol,
+        );
         let (mw, mt, pt) = (self.mi_weight, self.mi_temperature, self.pos_threshold);
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
 
@@ -13164,8 +15056,24 @@ impl InfoCTM {
         let docs_b = corpus_b.docs.clone();
         let model = py.allow_threads(move || {
             infoctm::fit_infoctm(
-                &docs_a, &docs_b, va, vb, &trans_ab, emb_a.as_deref(), emb_b.as_deref(),
-                k, h, dp, ep, batch_size, lr, mw, mt, pt, et, &mut rng,
+                &docs_a,
+                &docs_b,
+                va,
+                vb,
+                &trans_ab,
+                emb_a.as_deref(),
+                emb_b.as_deref(),
+                k,
+                h,
+                dp,
+                ep,
+                batch_size,
+                lr,
+                mw,
+                mt,
+                pt,
+                et,
+                &mut rng,
             )
         });
         self.model = Some(model);
@@ -13210,7 +15118,10 @@ impl InfoCTM {
             .map(|row| {
                 let mut idx: Vec<usize> = (0..row.len()).collect();
                 idx.sort_by(|&a, &b| row[b].total_cmp(&row[a]));
-                idx.into_iter().take(n).map(|j| (vocab[j].clone(), row[j])).collect()
+                idx.into_iter()
+                    .take(n)
+                    .map(|j| (vocab[j].clone(), row[j]))
+                    .collect()
             })
             .collect())
     }
@@ -13233,7 +15144,10 @@ impl InfoCTM {
     /// The per-epoch training ELBO (negative joint loss) trace.
     #[getter]
     fn fit_history(&self) -> Vec<f64> {
-        self.model.as_ref().map(|m| m.bound_history.clone()).unwrap_or_default()
+        self.model
+            .as_ref()
+            .map(|m| m.bound_history.clone())
+            .unwrap_or_default()
     }
 
     #[getter]
@@ -13373,10 +15287,14 @@ fn build_avitm_options(
     };
     if contrastive {
         if !(contrastive_weight >= 0.0 && contrastive_weight.is_finite()) {
-            return Err(PyValueError::new_err("contrastive_weight must be >= 0 and finite"));
+            return Err(PyValueError::new_err(
+                "contrastive_weight must be >= 0 and finite",
+            ));
         }
         if !(contrastive_temp > 0.0 && contrastive_temp.is_finite()) {
-            return Err(PyValueError::new_err("contrastive_temp must be > 0 and finite"));
+            return Err(PyValueError::new_err(
+                "contrastive_temp must be > 0 and finite",
+            ));
         }
     }
     Ok(prodlda::AvitmOptions {
@@ -13427,13 +15345,20 @@ impl ProdLDA {
     ) -> PyResult<Self> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "ProdLDA(em_tol=) is deprecated; use convergence_tol= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
+            warnings.call_method1(
+                "warn",
+                (
+                    "ProdLDA(em_tol=) is deprecated; use convergence_tol= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
             // ProdLDA default is 0.0; if unchanged, use the deprecated value.
-            if convergence_tol != 0.0 { convergence_tol } else { old_val }
+            if convergence_tol != 0.0 {
+                convergence_tol
+            } else {
+                old_val
+            }
         } else {
             convergence_tol
         };
@@ -13472,7 +15397,13 @@ impl ProdLDA {
     /// `iters` sets the number of training epochs (default 200).
     /// `convergence_tol` overrides the constructor value for this run (when given).
     #[pyo3(signature = (data, *, iters=None, convergence_tol=None))]
-    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>, iters: Option<usize>, convergence_tol: Option<f64>) -> PyResult<()> {
+    fn fit(
+        &mut self,
+        py: Python<'_>,
+        data: &Bound<'_, PyAny>,
+        iters: Option<usize>,
+        convergence_tol: Option<f64>,
+    ) -> PyResult<()> {
         let tol = convergence_tol.unwrap_or(self.em_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -13480,29 +15411,62 @@ impl ProdLDA {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
         let num_types = corpus.num_types();
         if num_types < self.num_topics {
-            return Err(PyValueError::new_err("vocabulary must have at least num_topics words"));
+            return Err(PyValueError::new_err(
+                "vocabulary must have at least num_topics words",
+            ));
         }
         let ep = iters.unwrap_or(200);
         let opts = build_avitm_options(
-            &self.prior, self.contrastive, self.contrastive_weight, self.contrastive_temp,
+            &self.prior,
+            self.contrastive,
+            self.contrastive_weight,
+            self.contrastive_temp,
         )?;
         let (k, h, a, dp, bs, lr, et) = (
-            self.num_topics, self.hidden_size, self.alpha, self.dropout,
-            self.batch_size, self.lr, tol,
+            self.num_topics,
+            self.hidden_size,
+            self.alpha,
+            self.dropout,
+            self.batch_size,
+            self.lr,
+            tol,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let empty: Vec<Vec<f64>> = vec![Vec::new(); corpus.docs.len()];
         let (model, corpus) = py.allow_threads(move || {
             let m = prodlda::fit_avitm(
-                &corpus.docs, &empty, prodlda::InputMode::BowOnly, k, num_types, 0, h, a, dp,
-                ep, bs, lr, et, opts, &mut rng,
+                &corpus.docs,
+                &empty,
+                prodlda::InputMode::BowOnly,
+                k,
+                num_types,
+                0,
+                h,
+                a,
+                dp,
+                ep,
+                bs,
+                lr,
+                et,
+                opts,
+                &mut rng,
             );
             (m, corpus)
         });
@@ -13545,7 +15509,8 @@ impl ProdLDA {
     /// epoch (same as :attr:`bound_history` but indexed).
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
-        Ok(self.fitted_model()?
+        Ok(self
+            .fitted_model()?
             .bound_history
             .iter()
             .enumerate()
@@ -13591,13 +15556,23 @@ impl ProdLDA {
         topic: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
-        topic_words_helper(py, &phi, &self.corpus.as_ref().unwrap().id_to_word, self.num_topics, n, topic)
+        topic_words_helper(
+            py,
+            &phi,
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.num_topics,
+            n,
+            topic,
+        )
     }
     #[pyo3(signature = (n=10))]
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Held-out topic proportions for new documents: one encoder forward pass each
@@ -13627,42 +15602,46 @@ impl ProdLDA {
     /// Save the fitted model to `path` (topica's binary format).
     fn save(&self, path: &str) -> PyResult<()> {
         let m = self.fitted_model()?;
-        write_state(path, MODEL_TAG_PRODLDA, &ProdldaState {
-            num_topics: self.num_topics,
-            hidden_size: self.hidden_size,
-            alpha: self.alpha,
-            dropout: self.dropout,
-            batch_size: self.batch_size,
-            lr: self.lr,
-            em_tol: self.em_tol,
-            seed: self.seed,
-            prior: self.prior.clone(),
-            contrastive: self.contrastive,
-            contrastive_weight: self.contrastive_weight,
-            contrastive_temp: self.contrastive_temp,
-            fitted: self.fitted,
-            topic_names: self.topic_names.clone(),
-            corpus: self.corpus.clone(),
-            doc_topic: Some(m.doc_topic.clone()),
-            bound: Some(m.bound),
-            bound_history: Some(m.bound_history.clone()),
-            converged: Some(m.converged),
-            epochs_run: Some(m.epochs_run),
-            w_v: Some(m.weights.v),
-            w_hidden: Some(m.weights.hidden),
-            w_k: Some(m.weights.k),
-            w_w1: Some(m.weights.w1.clone()),
-            w_b1: Some(m.weights.b1.clone()),
-            w_w2: Some(m.weights.w2.clone()),
-            w_b2: Some(m.weights.b2.clone()),
-            w_w_mu: Some(m.weights.w_mu.clone()),
-            w_b_mu: Some(m.weights.b_mu.clone()),
-            w_w_ls: Some(m.weights.w_ls.clone()),
-            w_b_ls: Some(m.weights.b_ls.clone()),
-            w_beta: Some(m.weights.beta.clone()),
-            bn_running_mean: Some(m.bn_mu.running_mean.clone()),
-            bn_running_var: Some(m.bn_mu.running_var.clone()),
-        })
+        write_state(
+            path,
+            MODEL_TAG_PRODLDA,
+            &ProdldaState {
+                num_topics: self.num_topics,
+                hidden_size: self.hidden_size,
+                alpha: self.alpha,
+                dropout: self.dropout,
+                batch_size: self.batch_size,
+                lr: self.lr,
+                em_tol: self.em_tol,
+                seed: self.seed,
+                prior: self.prior.clone(),
+                contrastive: self.contrastive,
+                contrastive_weight: self.contrastive_weight,
+                contrastive_temp: self.contrastive_temp,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                corpus: self.corpus.clone(),
+                doc_topic: Some(m.doc_topic.clone()),
+                bound: Some(m.bound),
+                bound_history: Some(m.bound_history.clone()),
+                converged: Some(m.converged),
+                epochs_run: Some(m.epochs_run),
+                w_v: Some(m.weights.v),
+                w_hidden: Some(m.weights.hidden),
+                w_k: Some(m.weights.k),
+                w_w1: Some(m.weights.w1.clone()),
+                w_b1: Some(m.weights.b1.clone()),
+                w_w2: Some(m.weights.w2.clone()),
+                w_b2: Some(m.weights.b2.clone()),
+                w_w_mu: Some(m.weights.w_mu.clone()),
+                w_b_mu: Some(m.weights.b_mu.clone()),
+                w_w_ls: Some(m.weights.w_ls.clone()),
+                w_b_ls: Some(m.weights.b_ls.clone()),
+                w_beta: Some(m.weights.beta.clone()),
+                bn_running_mean: Some(m.bn_mu.running_mean.clone()),
+                bn_running_var: Some(m.bn_mu.running_var.clone()),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -13682,7 +15661,11 @@ impl ProdLDA {
                 converged: s.converged.unwrap_or(false),
                 epochs_run: s.epochs_run.unwrap_or(0),
                 weights: prodlda::Weights {
-                    v, e: 0, hidden, k, mode: prodlda::InputMode::BowOnly,
+                    v,
+                    e: 0,
+                    hidden,
+                    k,
+                    mode: prodlda::InputMode::BowOnly,
                     w1: s.w_w1.unwrap_or_default(),
                     b1: s.w_b1.unwrap_or_default(),
                     w2: s.w_w2.unwrap_or_default(),
@@ -13700,7 +15683,9 @@ impl ProdLDA {
                 },
                 prior: prior_from_str(&s.prior),
             })
-        } else { None };
+        } else {
+            None
+        };
         Ok(ProdLDA {
             num_topics: s.num_topics,
             hidden_size: s.hidden_size,
@@ -13733,7 +15718,10 @@ impl ProdLDA {
     }
 
     fn __repr__(&self) -> String {
-        format!("ProdLDA(num_topics={}, fitted={})", self.num_topics, self.fitted)
+        format!(
+            "ProdLDA(num_topics={}, fitted={})",
+            self.num_topics, self.fitted
+        )
     }
 }
 
@@ -13814,10 +15802,7 @@ fn u8_to_mode(m: u8) -> prodlda::InputMode {
 
 /// Parse `doc_embeddings` into dense rows and check the row count matches the
 /// document count.
-fn parse_doc_embeddings(
-    data: &Bound<'_, PyAny>,
-    num_docs: usize,
-) -> PyResult<Vec<Vec<f64>>> {
+fn parse_doc_embeddings(data: &Bound<'_, PyAny>, num_docs: usize) -> PyResult<Vec<Vec<f64>>> {
     let embs = parse_features(data)?;
     if embs.len() != num_docs {
         return Err(PyValueError::new_err(format!(
@@ -13873,9 +15858,9 @@ macro_rules! ctm_embedding_model {
             /// to :meth:`fit` to set the number of epochs.
             #[new]
             #[pyo3(signature = (num_topics, *, alpha=1.0, hidden_size=100, dropout=0.2,
-                                batch_size=200, lr=0.002, convergence_tol=0.0, seed=42,
-                                prior="laplace".to_string(), contrastive=false,
-                                contrastive_weight=0.5, contrastive_temp=0.5))]
+                                        batch_size=200, lr=0.002, convergence_tol=0.0, seed=42,
+                                        prior="laplace".to_string(), contrastive=false,
+                                        contrastive_weight=0.5, contrastive_temp=0.5))]
             #[allow(clippy::too_many_arguments)]
             fn new(
                 #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
@@ -13946,7 +15931,14 @@ macro_rules! ctm_embedding_model {
                         PyValueError::new_err("fit() expects a Corpus or a list of token lists")
                     })?;
                     build_corpus_from_docs(
-                        docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0,
+                        docs,
+                        None,
+                        None,
+                        std::collections::HashSet::new(),
+                        1,
+                        1.0,
+                        0,
+                        0,
                     )?
                     .0
                 };
@@ -13962,23 +15954,44 @@ macro_rules! ctm_embedding_model {
                 let embs = parse_doc_embeddings(doc_embeddings, corpus.num_docs())?;
                 let emb_dim = embs.first().map(|r| r.len()).unwrap_or(0);
                 if emb_dim == 0 {
-                    return Err(PyValueError::new_err("doc_embeddings must have at least one column"));
+                    return Err(PyValueError::new_err(
+                        "doc_embeddings must have at least one column",
+                    ));
                 }
                 self.emb_dim = emb_dim;
                 let ep = iters.unwrap_or(200);
                 let opts = build_avitm_options(
-                    &self.prior, self.contrastive, self.contrastive_weight,
+                    &self.prior,
+                    self.contrastive,
+                    self.contrastive_weight,
                     self.contrastive_temp,
                 )?;
                 let (k, h, a, dp, bs, lr) = (
-                    self.num_topics, self.hidden_size, self.alpha, self.dropout,
-                    self.batch_size, self.lr,
+                    self.num_topics,
+                    self.hidden_size,
+                    self.alpha,
+                    self.dropout,
+                    self.batch_size,
+                    self.lr,
                 );
                 let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
                 let (model, corpus) = py.allow_threads(move || {
                     let m = prodlda::fit_avitm(
-                        &corpus.docs, &embs, $mode, k, num_types, emb_dim, h, a, dp, ep, bs,
-                        lr, tol, opts, &mut rng,
+                        &corpus.docs,
+                        &embs,
+                        $mode,
+                        k,
+                        num_types,
+                        emb_dim,
+                        h,
+                        a,
+                        dp,
+                        ep,
+                        bs,
+                        lr,
+                        tol,
+                        opts,
+                        &mut rng,
                     );
                     (m, corpus)
                 });
@@ -14077,11 +16090,17 @@ macro_rules! ctm_embedding_model {
                 )
             }
             #[pyo3(signature = (n=10))]
-            fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
+            fn coherence<'py>(
+                &self,
+                py: Python<'py>,
+                n: usize,
+            ) -> PyResult<Bound<'py, PyArray1<f64>>> {
                 let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
                 let tops = top_word_ids_phi(&phi, self.num_topics, n);
-                Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
-                    .to_pyarray_bound(py))
+                Ok(
+                    Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                        .to_pyarray_bound(py),
+                )
             }
 
             /// Held-out topic proportions for new documents: one encoder forward
@@ -14120,45 +16139,49 @@ macro_rules! ctm_embedding_model {
             /// Save the fitted model to `path` (topica's binary format).
             fn save(&self, path: &str) -> PyResult<()> {
                 let m = self.fitted_model()?;
-                write_state(path, $tag, &CtmEmbState {
-                    num_topics: self.num_topics,
-                    hidden_size: self.hidden_size,
-                    alpha: self.alpha,
-                    dropout: self.dropout,
-                    batch_size: self.batch_size,
-                    lr: self.lr,
-                    convergence_tol: self.convergence_tol,
-                    seed: self.seed,
-                    prior: self.prior.clone(),
-                    contrastive: self.contrastive,
-                    contrastive_weight: self.contrastive_weight,
-                    contrastive_temp: self.contrastive_temp,
-                    fitted: self.fitted,
-                    topic_names: self.topic_names.clone(),
-                    corpus: self.corpus.clone(),
-                    emb_dim: self.emb_dim,
-                    mode: mode_to_u8($mode),
-                    doc_topic: Some(m.doc_topic.clone()),
-                    bound: Some(m.bound),
-                    bound_history: Some(m.bound_history.clone()),
-                    converged: Some(m.converged),
-                    epochs_run: Some(m.epochs_run),
-                    w_v: Some(m.weights.v),
-                    w_e: Some(m.weights.e),
-                    w_hidden: Some(m.weights.hidden),
-                    w_k: Some(m.weights.k),
-                    w_w1: Some(m.weights.w1.clone()),
-                    w_b1: Some(m.weights.b1.clone()),
-                    w_w2: Some(m.weights.w2.clone()),
-                    w_b2: Some(m.weights.b2.clone()),
-                    w_w_mu: Some(m.weights.w_mu.clone()),
-                    w_b_mu: Some(m.weights.b_mu.clone()),
-                    w_w_ls: Some(m.weights.w_ls.clone()),
-                    w_b_ls: Some(m.weights.b_ls.clone()),
-                    w_beta: Some(m.weights.beta.clone()),
-                    bn_running_mean: Some(m.bn_mu.running_mean.clone()),
-                    bn_running_var: Some(m.bn_mu.running_var.clone()),
-                })
+                write_state(
+                    path,
+                    $tag,
+                    &CtmEmbState {
+                        num_topics: self.num_topics,
+                        hidden_size: self.hidden_size,
+                        alpha: self.alpha,
+                        dropout: self.dropout,
+                        batch_size: self.batch_size,
+                        lr: self.lr,
+                        convergence_tol: self.convergence_tol,
+                        seed: self.seed,
+                        prior: self.prior.clone(),
+                        contrastive: self.contrastive,
+                        contrastive_weight: self.contrastive_weight,
+                        contrastive_temp: self.contrastive_temp,
+                        fitted: self.fitted,
+                        topic_names: self.topic_names.clone(),
+                        corpus: self.corpus.clone(),
+                        emb_dim: self.emb_dim,
+                        mode: mode_to_u8($mode),
+                        doc_topic: Some(m.doc_topic.clone()),
+                        bound: Some(m.bound),
+                        bound_history: Some(m.bound_history.clone()),
+                        converged: Some(m.converged),
+                        epochs_run: Some(m.epochs_run),
+                        w_v: Some(m.weights.v),
+                        w_e: Some(m.weights.e),
+                        w_hidden: Some(m.weights.hidden),
+                        w_k: Some(m.weights.k),
+                        w_w1: Some(m.weights.w1.clone()),
+                        w_b1: Some(m.weights.b1.clone()),
+                        w_w2: Some(m.weights.w2.clone()),
+                        w_b2: Some(m.weights.b2.clone()),
+                        w_w_mu: Some(m.weights.w_mu.clone()),
+                        w_b_mu: Some(m.weights.b_mu.clone()),
+                        w_w_ls: Some(m.weights.w_ls.clone()),
+                        w_b_ls: Some(m.weights.b_ls.clone()),
+                        w_beta: Some(m.weights.beta.clone()),
+                        bn_running_mean: Some(m.bn_mu.running_mean.clone()),
+                        bn_running_var: Some(m.bn_mu.running_var.clone()),
+                    },
+                )
             }
 
             /// Load a model previously written by :meth:`save`.
@@ -14237,7 +16260,10 @@ macro_rules! ctm_embedding_model {
             }
 
             fn __repr__(&self) -> String {
-                format!(concat!($repr, "(num_topics={}, fitted={})"), self.num_topics, self.fitted)
+                format!(
+                    concat!($repr, "(num_topics={}, fitted={})"),
+                    self.num_topics, self.fitted
+                )
             }
         }
     };
@@ -14399,7 +16425,13 @@ impl NMF {
     /// number of multiplicative-update iterations (default 200). `convergence_tol`
     /// overrides the constructor value for this run (when given).
     #[pyo3(signature = (data, *, iters=None, convergence_tol=None))]
-    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>, iters: Option<usize>, convergence_tol: Option<f64>) -> PyResult<()> {
+    fn fit(
+        &mut self,
+        py: Python<'_>,
+        data: &Bound<'_, PyAny>,
+        iters: Option<usize>,
+        convergence_tol: Option<f64>,
+    ) -> PyResult<()> {
         let tol = convergence_tol.unwrap_or(self.convergence_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -14407,18 +16439,35 @@ impl NMF {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
         let num_types = corpus.num_types();
         if num_types < self.num_topics {
-            return Err(PyValueError::new_err("vocabulary must have at least num_topics words"));
+            return Err(PyValueError::new_err(
+                "vocabulary must have at least num_topics words",
+            ));
         }
         let it = iters.unwrap_or(200);
-        let (k, bl, ini, tfidf, seed) =
-            (self.num_topics, self.beta_loss, self.init, self.weighting_tfidf, self.seed);
+        let (k, bl, ini, tfidf, seed) = (
+            self.num_topics,
+            self.beta_loss,
+            self.init,
+            self.weighting_tfidf,
+            self.seed,
+        );
         let (model, corpus) = py.allow_threads(move || {
             let m = nmf::fit_nmf(&corpus.docs, k, num_types, bl, ini, tfidf, it, tol, seed);
             (m, corpus)
@@ -14463,7 +16512,8 @@ impl NMF {
     /// entry (`iter = 1`) is the initial error before any update.
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
-        Ok(self.fitted_model()?
+        Ok(self
+            .fitted_model()?
             .error_history
             .iter()
             .enumerate()
@@ -14509,44 +16559,58 @@ impl NMF {
         topic: Option<usize>,
     ) -> PyResult<Bound<'py, PyAny>> {
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
-        topic_words_helper(py, &phi, &self.corpus.as_ref().unwrap().id_to_word, self.num_topics, n, topic)
+        topic_words_helper(
+            py,
+            &phi,
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.num_topics,
+            n,
+            topic,
+        )
     }
     #[pyo3(signature = (n=10))]
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path` (topica's binary format).
     fn save(&self, path: &str) -> PyResult<()> {
         let m = self.fitted_model()?;
-        write_state(path, MODEL_TAG_NMF, &NmfState {
-            num_topics: self.num_topics,
-            beta_loss: match self.beta_loss {
-                nmf::BetaLoss::Frobenius => 0,
-                nmf::BetaLoss::KullbackLeibler => 1,
+        write_state(
+            path,
+            MODEL_TAG_NMF,
+            &NmfState {
+                num_topics: self.num_topics,
+                beta_loss: match self.beta_loss {
+                    nmf::BetaLoss::Frobenius => 0,
+                    nmf::BetaLoss::KullbackLeibler => 1,
+                },
+                init: match self.init {
+                    nmf::Init::Nndsvd => 0,
+                    nmf::Init::Random => 1,
+                },
+                weighting_tfidf: self.weighting_tfidf,
+                convergence_tol: self.convergence_tol,
+                seed: self.seed,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                corpus: self.corpus.clone(),
+                num_types: Some(m.num_types),
+                topic_word: Some(m.topic_word.clone()),
+                doc_topic: Some(m.doc_topic.clone()),
+                h: Some(m.h.clone()),
+                w: Some(m.w.clone()),
+                reconstruction_error: Some(m.reconstruction_error),
+                error_history: Some(m.error_history.clone()),
+                converged: Some(m.converged),
+                iters_run: Some(m.iters_run),
             },
-            init: match self.init {
-                nmf::Init::Nndsvd => 0,
-                nmf::Init::Random => 1,
-            },
-            weighting_tfidf: self.weighting_tfidf,
-            convergence_tol: self.convergence_tol,
-            seed: self.seed,
-            fitted: self.fitted,
-            topic_names: self.topic_names.clone(),
-            corpus: self.corpus.clone(),
-            num_types: Some(m.num_types),
-            topic_word: Some(m.topic_word.clone()),
-            doc_topic: Some(m.doc_topic.clone()),
-            h: Some(m.h.clone()),
-            w: Some(m.w.clone()),
-            reconstruction_error: Some(m.reconstruction_error),
-            error_history: Some(m.error_history.clone()),
-            converged: Some(m.converged),
-            iters_run: Some(m.iters_run),
-        })
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -14574,7 +16638,11 @@ impl NMF {
         } else {
             nmf::BetaLoss::Frobenius
         };
-        let init = if s.init == 1 { nmf::Init::Random } else { nmf::Init::Nndsvd };
+        let init = if s.init == 1 {
+            nmf::Init::Random
+        } else {
+            nmf::Init::Nndsvd
+        };
         Ok(NMF {
             num_topics: s.num_topics,
             beta_loss,
@@ -14590,7 +16658,10 @@ impl NMF {
     }
 
     fn __repr__(&self) -> String {
-        format!("NMF(num_topics={}, fitted={})", self.num_topics, self.fitted)
+        format!(
+            "NMF(num_topics={}, fitted={})",
+            self.num_topics, self.fitted
+        )
     }
 }
 
@@ -14676,7 +16747,17 @@ impl LSA {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -14811,24 +16892,31 @@ impl LSA {
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
         let absphi = phi.mapv(f64::abs);
         let tops = top_word_ids_phi(&absphi, self.num_topics, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path` (topica's binary format).
     fn save(&self, path: &str) -> PyResult<()> {
         let m = self.fitted_model()?;
-        write_state(path, MODEL_TAG_LSA, &LsaState {
-            num_topics: self.num_topics,
-            weighting_tfidf: self.weighting_tfidf,
-            seed: self.seed,
-            fitted: self.fitted,
-            topic_names: self.topic_names.clone(),
-            corpus: self.corpus.clone(),
-            num_types: Some(m.num_types),
-            topic_word: Some(m.topic_word.clone()),
-            doc_topic: Some(m.doc_topic.clone()),
-            singular_values: Some(m.singular_values.clone()),
-        })
+        write_state(
+            path,
+            MODEL_TAG_LSA,
+            &LsaState {
+                num_topics: self.num_topics,
+                weighting_tfidf: self.weighting_tfidf,
+                seed: self.seed,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                corpus: self.corpus.clone(),
+                num_types: Some(m.num_types),
+                topic_word: Some(m.topic_word.clone()),
+                doc_topic: Some(m.doc_topic.clone()),
+                singular_values: Some(m.singular_values.clone()),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -14858,7 +16946,10 @@ impl LSA {
     }
 
     fn __repr__(&self) -> String {
-        format!("LSA(num_topics={}, fitted={})", self.num_topics, self.fitted)
+        format!(
+            "LSA(num_topics={}, fitted={})",
+            self.num_topics, self.fitted
+        )
     }
 }
 
@@ -14953,12 +17044,19 @@ impl FASTopic {
     ) -> PyResult<Self> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "FASTopic(em_tol=) is deprecated; use convergence_tol= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
-            if (convergence_tol - 1e-6_f64).abs() > f64::EPSILON { convergence_tol } else { old_val }
+            warnings.call_method1(
+                "warn",
+                (
+                    "FASTopic(em_tol=) is deprecated; use convergence_tol= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
+            if (convergence_tol - 1e-6_f64).abs() > f64::EPSILON {
+                convergence_tol
+            } else {
+                old_val
+            }
         } else {
             convergence_tol
         };
@@ -15007,7 +17105,17 @@ impl FASTopic {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -15023,15 +17131,23 @@ impl FASTopic {
         check_all_finite_2d("doc_embeddings", &doc_emb)?;
         let num_types = corpus.num_types();
         if num_types < self.num_topics {
-            return Err(PyValueError::new_err("vocabulary must have at least num_topics words"));
+            return Err(PyValueError::new_err(
+                "vocabulary must have at least num_topics words",
+            ));
         }
         self.id_to_word = corpus.id_to_word.clone();
         let docs_ids = corpus.docs.clone();
         let ep = iters.unwrap_or(200);
 
         let (k, lr, dta, twa, tt, et, si, st) = (
-            self.num_topics, self.lr, self.dt_alpha, self.tw_alpha,
-            self.theta_temp, tol, self.sinkhorn_iters, self.sinkhorn_tol,
+            self.num_topics,
+            self.lr,
+            self.dt_alpha,
+            self.tw_alpha,
+            self.theta_temp,
+            tol,
+            self.sinkhorn_iters,
+            self.sinkhorn_tol,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let model = py.allow_threads(move || {
@@ -15083,7 +17199,8 @@ impl FASTopic {
     /// objective is the negated OT loss (so higher = better), indexed from 1.
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
-        Ok(self.fitted_model()?
+        Ok(self
+            .fitted_model()?
             .loss_history
             .iter()
             .enumerate()
@@ -15135,7 +17252,10 @@ impl FASTopic {
         let m = self.fitted_model()?;
         let phi = vecs_to_arr2(&m.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Held-out topic proportions for new documents from their embeddings
@@ -15151,9 +17271,8 @@ impl FASTopic {
         doc_embeddings: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
         let _ = data;
-        let de_obj = doc_embeddings.ok_or_else(|| {
-            PyValueError::new_err("FASTopic.transform requires doc_embeddings")
-        })?;
+        let de_obj = doc_embeddings
+            .ok_or_else(|| PyValueError::new_err("FASTopic.transform requires doc_embeddings"))?;
         let m = self.fitted_model()?;
         let doc_emb = parse_features(de_obj)?;
         Ok(vecs_to_arr2(&m.transform(&doc_emb)).to_pyarray_bound(py))
@@ -15174,29 +17293,33 @@ impl FASTopic {
     /// Save the fitted model to `path` (topica's binary format).
     fn save(&self, path: &str) -> PyResult<()> {
         let m = self.fitted_model()?;
-        write_state(path, MODEL_TAG_FASTOPIC, &FastopicState {
-            num_topics: self.num_topics,
-            lr: self.lr,
-            dt_alpha: self.dt_alpha,
-            tw_alpha: self.tw_alpha,
-            theta_temp: self.theta_temp,
-            em_tol: self.em_tol,
-            sinkhorn_iters: self.sinkhorn_iters,
-            sinkhorn_tol: self.sinkhorn_tol,
-            seed: self.seed,
-            fitted: self.fitted,
-            topic_names: self.topic_names.clone(),
-            id_to_word: self.id_to_word.clone(),
-            corpus: self.corpus.clone(),
-            topic_word: Some(m.topic_word.clone()),
-            doc_topic: Some(m.doc_topic.clone()),
-            topic_embeddings: Some(m.topic_embeddings.clone()),
-            word_embeddings: Some(m.word_embeddings.clone()),
-            train_doc_embeddings: Some(m.train_doc_embeddings.clone()),
-            loss_history: Some(m.loss_history.clone()),
-            converged: Some(m.converged),
-            epochs_run: Some(m.epochs_run),
-        })
+        write_state(
+            path,
+            MODEL_TAG_FASTOPIC,
+            &FastopicState {
+                num_topics: self.num_topics,
+                lr: self.lr,
+                dt_alpha: self.dt_alpha,
+                tw_alpha: self.tw_alpha,
+                theta_temp: self.theta_temp,
+                em_tol: self.em_tol,
+                sinkhorn_iters: self.sinkhorn_iters,
+                sinkhorn_tol: self.sinkhorn_tol,
+                seed: self.seed,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                id_to_word: self.id_to_word.clone(),
+                corpus: self.corpus.clone(),
+                topic_word: Some(m.topic_word.clone()),
+                doc_topic: Some(m.doc_topic.clone()),
+                topic_embeddings: Some(m.topic_embeddings.clone()),
+                word_embeddings: Some(m.word_embeddings.clone()),
+                train_doc_embeddings: Some(m.train_doc_embeddings.clone()),
+                loss_history: Some(m.loss_history.clone()),
+                converged: Some(m.converged),
+                epochs_run: Some(m.epochs_run),
+            },
+        )
     }
 
     /// Load a model previously written by :meth:`save`.
@@ -15217,7 +17340,9 @@ impl FASTopic {
                 converged: s.converged.unwrap_or(false),
                 epochs_run: s.epochs_run.unwrap_or(0),
             })
-        } else { None };
+        } else {
+            None
+        };
         Ok(FASTopic {
             num_topics: s.num_topics,
             lr: s.lr,
@@ -15237,7 +17362,10 @@ impl FASTopic {
     }
 
     fn __repr__(&self) -> String {
-        format!("FASTopic(num_topics={}, fitted={})", self.num_topics, self.fitted)
+        format!(
+            "FASTopic(num_topics={}, fitted={})",
+            self.num_topics, self.fitted
+        )
     }
 }
 
@@ -15305,7 +17433,9 @@ impl KeyATM {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -15347,8 +17477,15 @@ impl KeyATM {
         }
         // Default to R keyATM's base prior 1/K.
         let alpha = alpha.unwrap_or(1.0 / k as f64);
-        if !finite_pos(alpha) || !finite_pos(beta) || !finite_pos(beta_keyword) || !finite_pos(gamma1) || !finite_pos(gamma2) {
-            return Err(PyValueError::new_err("alpha, beta, beta_keyword, gamma1, gamma2 must be > 0"));
+        if !finite_pos(alpha)
+            || !finite_pos(beta)
+            || !finite_pos(beta_keyword)
+            || !finite_pos(gamma1)
+            || !finite_pos(gamma2)
+        {
+            return Err(PyValueError::new_err(
+                "alpha, beta, beta_keyword, gamma1, gamma2 must be > 0",
+            ));
         }
         let cvb0 = match sampler {
             "sparse" => false,
@@ -15360,14 +17497,35 @@ impl KeyATM {
             }
         };
         Ok(KeyATM {
-            key_names: names, keywords: words, num_topics: k, alpha, beta, beta_keyword,
-            gamma1, gamma2, seed, estimate_alpha, num_threads: num_threads.max(1),
-            cvb0, fitted: false, topic_names: Vec::new(),
-            keyword_rate: Vec::new(), phi: None, theta: None, corpus: None,
-            feature_effects: None, feature_names: Vec::new(),
-            time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
-            transition_matrix: None, log_likelihood_history: Vec::new(), converged: false,
-            alpha_history: Vec::new(), pi_history: Vec::new(), alpha_vec: None,
+            key_names: names,
+            keywords: words,
+            num_topics: k,
+            alpha,
+            beta,
+            beta_keyword,
+            gamma1,
+            gamma2,
+            seed,
+            estimate_alpha,
+            num_threads: num_threads.max(1),
+            cvb0,
+            fitted: false,
+            topic_names: Vec::new(),
+            keyword_rate: Vec::new(),
+            phi: None,
+            theta: None,
+            corpus: None,
+            feature_effects: None,
+            feature_names: Vec::new(),
+            time_state: Vec::new(),
+            time_prevalence: None,
+            time_labels: Vec::new(),
+            transition_matrix: None,
+            log_likelihood_history: Vec::new(),
+            converged: false,
+            alpha_history: Vec::new(),
+            pi_history: Vec::new(),
+            alpha_vec: None,
             theta_draws: None,
         })
     }
@@ -15380,7 +17538,12 @@ impl KeyATM {
     /// keyword-specific outputs (``keyword_rate``, ``pi_history``) are empty.
     #[staticmethod]
     #[pyo3(signature = (num_topics, *, alpha=0.1, beta=0.01, seed=42))]
-    fn weighted_lda(#[pyo3(from_py_with = "py_num_topics")] num_topics: usize, alpha: f64, beta: f64, seed: u64) -> PyResult<Self> {
+    fn weighted_lda(
+        #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
+        alpha: f64,
+        beta: f64,
+        seed: u64,
+    ) -> PyResult<Self> {
         if num_topics < 2 {
             return Err(PyValueError::new_err("need at least 2 topics"));
         }
@@ -15388,16 +17551,35 @@ impl KeyATM {
             return Err(PyValueError::new_err("alpha and beta must be > 0"));
         }
         Ok(KeyATM {
-            key_names: Vec::new(), keywords: Vec::new(), num_topics, alpha, beta,
-            beta_keyword: 0.1, gamma1: 1.0, gamma2: 1.0, seed, estimate_alpha: true,
+            key_names: Vec::new(),
+            keywords: Vec::new(),
+            num_topics,
+            alpha,
+            beta,
+            beta_keyword: 0.1,
+            gamma1: 1.0,
+            gamma2: 1.0,
+            seed,
+            estimate_alpha: true,
             num_threads: 1,
             cvb0: false,
             fitted: false,
-            topic_names: Vec::new(), keyword_rate: Vec::new(), phi: None, theta: None,
-            corpus: None, feature_effects: None, feature_names: Vec::new(),
-            time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
-            transition_matrix: None, log_likelihood_history: Vec::new(), converged: false,
-            alpha_history: Vec::new(), pi_history: Vec::new(), alpha_vec: None,
+            topic_names: Vec::new(),
+            keyword_rate: Vec::new(),
+            phi: None,
+            theta: None,
+            corpus: None,
+            feature_effects: None,
+            feature_names: Vec::new(),
+            time_state: Vec::new(),
+            time_prevalence: None,
+            time_labels: Vec::new(),
+            transition_matrix: None,
+            log_likelihood_history: Vec::new(),
+            converged: false,
+            alpha_history: Vec::new(),
+            pi_history: Vec::new(),
+            alpha_vec: None,
             theta_draws: None,
         })
     }
@@ -15466,17 +17648,22 @@ impl KeyATM {
             (Some(t), None) | (None, Some(t)) => Some(t),
             (None, None) => None,
         };
-        let progress_interval = if let Some(old_val) = report_interval {
-            let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
+        let progress_interval =
+            if let Some(old_val) = report_interval {
+                let warnings = py.import_bound("warnings")?;
+                warnings.call_method1("warn", (
                 "KeyATM.fit(report_interval=) is deprecated; use progress_interval= instead",
                 py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
                 2_i32,
             ))?;
-            if progress_interval != 0 { progress_interval } else { old_val }
-        } else {
-            progress_interval
-        };
+                if progress_interval != 0 {
+                    progress_interval
+                } else {
+                    old_val
+                }
+            } else {
+                progress_interval
+            };
         // num_threads: fit()-level value overrides the constructor default.
         let nthreads_fit = num_threads.unwrap_or(self.num_threads).max(1);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -15485,7 +17672,17 @@ impl KeyATM {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -15494,7 +17691,13 @@ impl KeyATM {
         let num_types = corpus.num_types();
         // Thinned θ-draw retention schedule (issue #31), shared by all three fits.
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
-        warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, corpus.num_docs(), num_topics)?;
+        warn_theta_draw_memory(
+            py,
+            keep_theta_draws,
+            num_theta_draws,
+            corpus.num_docs(),
+            num_topics,
+        )?;
         // Warn about keywords absent from the (pruned) vocabulary: a "seeded"
         // topic whose keywords were all dropped was never actually seeded, and
         // pruning (rm_top / min_doc_freq) or a typo/stemming mismatch silently
@@ -15503,12 +17706,18 @@ impl KeyATM {
             let vocab: HashSet<&str> = corpus.id_to_word.iter().map(|s| s.as_str()).collect();
             let mut notes: Vec<String> = Vec::new();
             for (name, words) in self.key_names.iter().zip(self.keywords.iter()) {
-                let oov: Vec<&str> =
-                    words.iter().map(|w| w.as_str()).filter(|w| !vocab.contains(w)).collect();
+                let oov: Vec<&str> = words
+                    .iter()
+                    .map(|w| w.as_str())
+                    .filter(|w| !vocab.contains(w))
+                    .collect();
                 if !oov.is_empty() {
                     notes.push(format!(
                         "'{}' ({} of {} not in vocabulary, ignored: {})",
-                        name, oov.len(), words.len(), oov.join(", ")
+                        name,
+                        oov.len(),
+                        words.len(),
+                        oov.join(", ")
                     ));
                 }
             }
@@ -15516,13 +17725,21 @@ impl KeyATM {
                 let warnings = py.import_bound("warnings")?;
                 warnings.call_method1(
                     "warn",
-                    (format!("KeyATM: some keywords were dropped — {}", notes.join("; ")),),
+                    (format!(
+                        "KeyATM: some keywords were dropped — {}",
+                        notes.join("; ")
+                    ),),
                 )?;
             }
         }
         let keys = seed_word_ids(&self.keywords, &corpus.id_to_word, num_topics);
-        let (alpha, beta, beta_key, g1, g2) =
-            (self.alpha, self.beta, self.beta_keyword, self.gamma1, self.gamma2);
+        let (alpha, beta, beta_key, g1, g2) = (
+            self.alpha,
+            self.beta,
+            self.beta_keyword,
+            self.gamma1,
+            self.gamma2,
+        );
         let estimate_alpha = self.estimate_alpha;
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
         let nthreads = nthreads_fit;
@@ -15532,8 +17749,8 @@ impl KeyATM {
             "none" => keyatm::WeightScheme::None,
             other => {
                 return Err(PyValueError::new_err(format!(
-                    "unknown weights={other:?}; expected 'information-theory', 'inv-freq', or 'none'"
-                )))
+                "unknown weights={other:?}; expected 'information-theory', 'inv-freq', or 'none'"
+            )))
             }
         };
         // Convergence trace cadence (keyATM's model_fit). 0 = auto: ~50 evenly
@@ -15585,15 +17802,33 @@ impl KeyATM {
             // keyATM requires documents ordered by time; sort, fit, then unsort θ.
             let mut order: Vec<usize> = (0..corpus.num_docs()).collect();
             order.sort_by_key(|&d| time_raw[d]);
-            let sorted_docs: Vec<Vec<u32>> = order.iter().map(|&d| corpus.docs[d].clone()).collect();
+            let sorted_docs: Vec<Vec<u32>> =
+                order.iter().map(|&d| corpus.docs[d].clone()).collect();
             let sorted_time: Vec<usize> = order.iter().map(|&d| time_raw[d]).collect();
 
             let model = py.allow_threads(move || {
                 keyatm::fit_keyatm_dynamic(
-                    &sorted_docs, num_types, num_topics, &keys, &sorted_time, num_states,
-                    beta, beta_key, g1, g2,
-                    1.0, 1.0, 2.0, 1.0, // keyATM α-prior defaults: eta_1, eta_2, eta_1_reg, eta_2_reg
-                    iters, ll_interval, weight_scheme, nthreads, draws_opts, convergence_tol, &mut rng,
+                    &sorted_docs,
+                    num_types,
+                    num_topics,
+                    &keys,
+                    &sorted_time,
+                    num_states,
+                    beta,
+                    beta_key,
+                    g1,
+                    g2,
+                    1.0,
+                    1.0,
+                    2.0,
+                    1.0, // keyATM α-prior defaults: eta_1, eta_2, eta_1_reg, eta_2_reg
+                    iters,
+                    ll_interval,
+                    weight_scheme,
+                    nthreads,
+                    draws_opts,
+                    convergence_tol,
+                    &mut rng,
                 )
             });
 
@@ -15605,8 +17840,12 @@ impl KeyATM {
             }
             self.theta = Some(vecs_to_arr2(&theta));
             // θ draws are also sorted; unsort their rows via `order` to match θ.
-            self.theta_draws =
-                draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, Some(&order));
+            self.theta_draws = draws_to_array3(
+                &model.theta_draws,
+                corpus.num_docs(),
+                num_topics,
+                Some(&order),
+            );
             self.phi = Some(vecs_to_arr2(&model.topic_word_all()));
             self.keyword_rate = model.keyword_rate();
             self.time_prevalence = model.time_prevalence().map(|tp| vecs_to_arr2(&tp));
@@ -15645,13 +17884,16 @@ impl KeyATM {
                 check_all_finite_2d("covariates", &raw)?;
                 let f_in = raw.first().map(|r| r.len()).unwrap_or(0);
                 if raw.iter().any(|r| r.len() != f_in) {
-                    return Err(PyValueError::new_err("all covariate rows must have the same length"));
+                    return Err(PyValueError::new_err(
+                        "all covariate rows must have the same length",
+                    ));
                 }
                 if let Some(n) = &feature_names {
                     if n.len() != f_in {
                         return Err(PyValueError::new_err(format!(
                             "feature_names has {} entries but covariates has {} columns",
-                            n.len(), f_in
+                            n.len(),
+                            f_in
                         )));
                     }
                 }
@@ -15666,7 +17908,8 @@ impl KeyATM {
                     .collect();
                 let mut names = vec!["intercept".to_string()];
                 names.extend(
-                    feature_names.unwrap_or_else(|| (0..f_in).map(|i| format!("feature_{}", i)).collect()),
+                    feature_names
+                        .unwrap_or_else(|| (0..f_in).map(|i| format!("feature_{}", i)).collect()),
                 );
                 (Some(feats), names)
             }
@@ -15708,26 +17951,69 @@ impl KeyATM {
         let (model, corpus) = py.allow_threads(move || {
             let m = match &feats {
                 Some(f) => keyatm::fit_keyatm_cov(
-                    &corpus.docs, num_types, num_topics, &keys, f, f[0].len(),
-                    beta, beta_key, g1, g2, iters, optimize_interval, burn_in,
-                    prior_variance, lbfgs_iters, ll_interval, weight_scheme, nthreads,
-                    offset.as_deref(), draws_opts, convergence_tol, &mut rng,
+                    &corpus.docs,
+                    num_types,
+                    num_topics,
+                    &keys,
+                    f,
+                    f[0].len(),
+                    beta,
+                    beta_key,
+                    g1,
+                    g2,
+                    iters,
+                    optimize_interval,
+                    burn_in,
+                    prior_variance,
+                    lbfgs_iters,
+                    ll_interval,
+                    weight_scheme,
+                    nthreads,
+                    offset.as_deref(),
+                    draws_opts,
+                    convergence_tol,
+                    &mut rng,
                 ),
                 None if cvb0 => keyatm::fit_keyatm_cvb0(
-                    &corpus.docs, num_types, num_topics, &keys, alpha, beta, beta_key, g1, g2,
-                    iters, weight_scheme, &mut rng,
+                    &corpus.docs,
+                    num_types,
+                    num_topics,
+                    &keys,
+                    alpha,
+                    beta,
+                    beta_key,
+                    g1,
+                    g2,
+                    iters,
+                    weight_scheme,
+                    &mut rng,
                 ),
                 None => keyatm::fit_keyatm(
-                    &corpus.docs, num_types, num_topics, &keys, alpha, beta, beta_key, g1, g2,
-                    iters, ll_interval, estimate_alpha, weight_scheme, nthreads, draws_opts, convergence_tol, turbo_alpha_stride, &mut rng,
+                    &corpus.docs,
+                    num_types,
+                    num_topics,
+                    &keys,
+                    alpha,
+                    beta,
+                    beta_key,
+                    g1,
+                    g2,
+                    iters,
+                    ll_interval,
+                    estimate_alpha,
+                    weight_scheme,
+                    nthreads,
+                    draws_opts,
+                    convergence_tol,
+                    turbo_alpha_stride,
+                    &mut rng,
                 ),
             };
             (m, corpus)
         });
         self.phi = Some(vecs_to_arr2(&model.topic_word_all()));
         self.theta = Some(vecs_to_arr2(&model.doc_topic()));
-        self.theta_draws =
-            draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
+        self.theta_draws = draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
         self.keyword_rate = model.keyword_rate();
         self.log_likelihood_history = model.log_likelihood_history.clone();
         self.converged = model.converged;
@@ -15873,7 +18159,8 @@ impl KeyATM {
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         self.require_fitted()?;
-        Ok(self.log_likelihood_history
+        Ok(self
+            .log_likelihood_history
             .iter()
             .map(|&(it, ll, _)| (it, ll))
             .collect())
@@ -15943,51 +18230,97 @@ impl KeyATM {
     }
 
     #[pyo3(signature = (n=10, *, topic=None))]
-    fn top_words<'py>(&self, py: Python<'py>, n: usize, topic: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
+    fn top_words<'py>(
+        &self,
+        py: Python<'py>,
+        n: usize,
+        topic: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
-        topic_words_helper(py, self.phi.as_ref().unwrap(), &self.corpus.as_ref().unwrap().id_to_word, self.num_topics, n, topic)
+        topic_words_helper(
+            py,
+            self.phi.as_ref().unwrap(),
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.num_topics,
+            n,
+            topic,
+        )
     }
     #[pyo3(signature = (n=10))]
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_topics, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path`. Reload with `KeyATM.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_KEYATM, &KeyAtmState {
-            num_topics: self.num_topics, alpha: self.alpha, beta: self.beta,
-            beta_keyword: self.beta_keyword, gamma1: self.gamma1, gamma2: self.gamma2,
-            seed: self.seed, fitted: self.fitted, topic_names: self.topic_names.clone(),
-            keyword_rate: self.keyword_rate.clone(), phi: arr2_opt(&self.phi),
-            theta: arr2_opt(&self.theta), corpus: self.corpus.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-            alpha_history: self.alpha_history.clone(),
-            pi_history: self.pi_history.clone(),
-            alpha_vec: self.alpha_vec.clone(),
-            num_threads: self.num_threads,
-            theta_draws: arr3f32_opt(&self.theta_draws),
-        })
+        write_state(
+            path,
+            MODEL_TAG_KEYATM,
+            &KeyAtmState {
+                num_topics: self.num_topics,
+                alpha: self.alpha,
+                beta: self.beta,
+                beta_keyword: self.beta_keyword,
+                gamma1: self.gamma1,
+                gamma2: self.gamma2,
+                seed: self.seed,
+                fitted: self.fitted,
+                topic_names: self.topic_names.clone(),
+                keyword_rate: self.keyword_rate.clone(),
+                phi: arr2_opt(&self.phi),
+                theta: arr2_opt(&self.theta),
+                corpus: self.corpus.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+                alpha_history: self.alpha_history.clone(),
+                pi_history: self.pi_history.clone(),
+                alpha_vec: self.alpha_vec.clone(),
+                num_threads: self.num_threads,
+                theta_draws: arr3f32_opt(&self.theta_draws),
+            },
+        )
     }
     /// Load a model previously written by :meth:`save`.
     #[staticmethod]
     fn load(path: &str) -> PyResult<Self> {
         let s: KeyAtmState = read_state(path, MODEL_TAG_KEYATM)?;
         Ok(KeyATM {
-            key_names: Vec::new(), keywords: Vec::new(), num_topics: s.num_topics,
-            alpha: s.alpha, beta: s.beta, beta_keyword: s.beta_keyword, gamma1: s.gamma1,
-            gamma2: s.gamma2, seed: s.seed, estimate_alpha: true, cvb0: false, fitted: s.fitted,
-            topic_names: s.topic_names, num_threads: s.num_threads,
-            keyword_rate: s.keyword_rate, phi: arr2_back(s.phi), theta: arr2_back(s.theta),
-            corpus: s.corpus, feature_effects: None, feature_names: Vec::new(),
-            time_state: Vec::new(), time_prevalence: None, time_labels: Vec::new(),
-            transition_matrix: None, log_likelihood_history: s.log_likelihood_history,
+            key_names: Vec::new(),
+            keywords: Vec::new(),
+            num_topics: s.num_topics,
+            alpha: s.alpha,
+            beta: s.beta,
+            beta_keyword: s.beta_keyword,
+            gamma1: s.gamma1,
+            gamma2: s.gamma2,
+            seed: s.seed,
+            estimate_alpha: true,
+            cvb0: false,
+            fitted: s.fitted,
+            topic_names: s.topic_names,
+            num_threads: s.num_threads,
+            keyword_rate: s.keyword_rate,
+            phi: arr2_back(s.phi),
+            theta: arr2_back(s.theta),
+            corpus: s.corpus,
+            feature_effects: None,
+            feature_names: Vec::new(),
+            time_state: Vec::new(),
+            time_prevalence: None,
+            time_labels: Vec::new(),
+            transition_matrix: None,
+            log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
-            alpha_history: s.alpha_history, pi_history: s.pi_history,
-            alpha_vec: s.alpha_vec, theta_draws: arr3f32_back(s.theta_draws),
+            alpha_history: s.alpha_history,
+            pi_history: s.pi_history,
+            alpha_vec: s.alpha_vec,
+            theta_draws: arr3f32_back(s.theta_draws),
         })
     }
 
@@ -16023,12 +18356,27 @@ impl KeyATM {
             Some(v) => v.clone(),
             None => vec![self.alpha; self.num_topics],
         };
-        transform_gibbs(py, data, id_to_word, phi, &alpha, iters, burn_in,
-                        num_samples, sample_interval, seed.unwrap_or(self.seed))
+        transform_gibbs(
+            py,
+            data,
+            id_to_word,
+            phi,
+            &alpha,
+            iters,
+            burn_in,
+            num_samples,
+            sample_interval,
+            seed.unwrap_or(self.seed),
+        )
     }
 
     fn __repr__(&self) -> String {
-        format!("KeyATM(keyword_topics={}, num_topics={}, fitted={})", self.key_names.len(), self.num_topics, self.fitted)
+        format!(
+            "KeyATM(keyword_topics={}, num_topics={}, fitted={})",
+            self.key_names.len(),
+            self.num_topics,
+            self.fitted
+        )
     }
 }
 
@@ -16065,7 +18413,9 @@ impl PA {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -16076,17 +18426,33 @@ impl PA {
     /// sub-topics (the sub-topics are the word-level topics).
     #[new]
     #[pyo3(signature = (num_super, num_sub, *, alpha=0.1, beta=0.01, seed=42))]
-    fn new(#[pyo3(from_py_with = "py_num_super")] num_super: usize, #[pyo3(from_py_with = "py_num_sub")] num_sub: usize, alpha: f64, beta: f64, seed: u64) -> PyResult<Self> {
+    fn new(
+        #[pyo3(from_py_with = "py_num_super")] num_super: usize,
+        #[pyo3(from_py_with = "py_num_sub")] num_sub: usize,
+        alpha: f64,
+        beta: f64,
+        seed: u64,
+    ) -> PyResult<Self> {
         if num_super < 1 || num_sub < 2 {
-            return Err(PyValueError::new_err("num_super must be >= 1 and num_sub >= 2"));
+            return Err(PyValueError::new_err(
+                "num_super must be >= 1 and num_sub >= 2",
+            ));
         }
         if !finite_pos(alpha) || !finite_pos(beta) {
             return Err(PyValueError::new_err("alpha and beta must be > 0"));
         }
         Ok(PA {
-            num_super, num_sub, alpha, beta, seed,
-            fitted: false, topic_names: Vec::new(),
-            phi: None, theta: None, super_sub: None, corpus: None,
+            num_super,
+            num_sub,
+            alpha,
+            beta,
+            seed,
+            fitted: false,
+            topic_names: Vec::new(),
+            phi: None,
+            theta: None,
+            super_sub: None,
+            corpus: None,
             theta_draws: None,
             log_likelihood_history: Vec::new(),
             converged: false,
@@ -16112,7 +18478,17 @@ impl PA {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -16127,8 +18503,17 @@ impl PA {
         let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
             let (m, hist, conv) = pa::fit_pam_with_draws(
-                &corpus.docs, num_types, s, k, a, b, iters, draws_opts,
-                convergence_tol, check_every, &mut rng,
+                &corpus.docs,
+                num_types,
+                s,
+                k,
+                a,
+                b,
+                iters,
+                draws_opts,
+                convergence_tol,
+                check_every,
+                &mut rng,
             );
             (m, hist, conv, corpus)
         });
@@ -16174,7 +18559,11 @@ impl PA {
     #[getter]
     fn doc_lengths(&self) -> PyResult<Vec<usize>> {
         self.require_fitted()?;
-        Ok(self.corpus.as_ref().map(|c| c.docs.iter().map(|d| d.len()).collect()).unwrap_or_default())
+        Ok(self
+            .corpus
+            .as_ref()
+            .map(|c| c.docs.iter().map(|d| d.len()).collect())
+            .unwrap_or_default())
     }
     /// Super-topic → sub-topic association, shape ``(num_super, num_sub)``; row s
     /// shows which sub-topics super-topic s groups together (the correlations).
@@ -16239,28 +18628,54 @@ impl PA {
     }
 
     #[pyo3(signature = (n=10, *, topic=None))]
-    fn top_words<'py>(&self, py: Python<'py>, n: usize, topic: Option<usize>) -> PyResult<Bound<'py, PyAny>> {
+    fn top_words<'py>(
+        &self,
+        py: Python<'py>,
+        n: usize,
+        topic: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
-        topic_words_helper(py, self.phi.as_ref().unwrap(), &self.corpus.as_ref().unwrap().id_to_word, self.num_sub, n, topic)
+        topic_words_helper(
+            py,
+            self.phi.as_ref().unwrap(),
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.num_sub,
+            n,
+            topic,
+        )
     }
     #[pyo3(signature = (n=10))]
     fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_sub, n);
-        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+        Ok(
+            Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops))
+                .to_pyarray_bound(py),
+        )
     }
 
     /// Save the fitted model to `path`. Reload with `PA.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_PA, &PaState {
-            num_super: self.num_super, num_sub: self.num_sub, alpha: self.alpha, beta: self.beta,
-            seed: self.seed, fitted: self.fitted, phi: arr2_opt(&self.phi),
-            theta: arr2_opt(&self.theta), super_sub: arr2_opt(&self.super_sub),
-            corpus: self.corpus.clone(), topic_names: self.topic_names.clone(),
-            log_likelihood_history: self.log_likelihood_history.clone(),
-            converged: self.converged,
-        })
+        write_state(
+            path,
+            MODEL_TAG_PA,
+            &PaState {
+                num_super: self.num_super,
+                num_sub: self.num_sub,
+                alpha: self.alpha,
+                beta: self.beta,
+                seed: self.seed,
+                fitted: self.fitted,
+                phi: arr2_opt(&self.phi),
+                theta: arr2_opt(&self.theta),
+                super_sub: arr2_opt(&self.super_sub),
+                corpus: self.corpus.clone(),
+                topic_names: self.topic_names.clone(),
+                log_likelihood_history: self.log_likelihood_history.clone(),
+                converged: self.converged,
+            },
+        )
     }
     /// Load a model previously written by :meth:`save`.
     #[staticmethod]
@@ -16272,10 +18687,17 @@ impl PA {
             s.topic_names
         };
         Ok(PA {
-            num_super: s.num_super, num_sub: s.num_sub, alpha: s.alpha, beta: s.beta,
-            seed: s.seed, fitted: s.fitted, topic_names,
-            phi: arr2_back(s.phi), theta: arr2_back(s.theta),
-            super_sub: arr2_back(s.super_sub), corpus: s.corpus,
+            num_super: s.num_super,
+            num_sub: s.num_sub,
+            alpha: s.alpha,
+            beta: s.beta,
+            seed: s.seed,
+            fitted: s.fitted,
+            topic_names,
+            phi: arr2_back(s.phi),
+            theta: arr2_back(s.theta),
+            super_sub: arr2_back(s.super_sub),
+            corpus: s.corpus,
             theta_draws: None,
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
@@ -16310,12 +18732,25 @@ impl PA {
         let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
         let phi = self.phi.as_ref().unwrap();
         let alpha = vec![self.alpha; self.num_sub];
-        transform_gibbs(py, data, id_to_word, phi, &alpha, iters, burn_in,
-                        num_samples, sample_interval, seed.unwrap_or(self.seed))
+        transform_gibbs(
+            py,
+            data,
+            id_to_word,
+            phi,
+            &alpha,
+            iters,
+            burn_in,
+            num_samples,
+            sample_interval,
+            seed.unwrap_or(self.seed),
+        )
     }
 
     fn __repr__(&self) -> String {
-        format!("PA(num_super={}, num_sub={}, fitted={})", self.num_super, self.num_sub, self.fitted)
+        format!(
+            "PA(num_super={}, num_sub={}, fitted={})",
+            self.num_super, self.num_sub, self.fitted
+        )
     }
 }
 
@@ -16350,7 +18785,9 @@ impl HLDA {
         if self.fitted {
             Ok(())
         } else {
-            Err(PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+            Err(PyRuntimeError::new_err(
+                "model is not fitted yet; call fit() first",
+            ))
         }
     }
 }
@@ -16362,15 +18799,30 @@ impl HLDA {
     /// topic-word Dirichlet; `alpha` the per-document level distribution.
     #[new]
     #[pyo3(signature = (*, depth=3, gamma=1.0, beta=0.01, alpha=0.1, seed=42, eta=None))]
-    fn new(py: Python<'_>, #[pyo3(from_py_with = "py_depth")] depth: usize, gamma: f64, beta: f64, alpha: f64, seed: u64, eta: Option<f64>) -> PyResult<Self> {
+    fn new(
+        py: Python<'_>,
+        #[pyo3(from_py_with = "py_depth")] depth: usize,
+        gamma: f64,
+        beta: f64,
+        alpha: f64,
+        seed: u64,
+        eta: Option<f64>,
+    ) -> PyResult<Self> {
         let beta = if let Some(old_val) = eta {
             let warnings = py.import_bound("warnings")?;
-            warnings.call_method1("warn", (
-                "HLDA(eta=) is deprecated; use beta= instead",
-                py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
-                2_i32,
-            ))?;
-            if (beta - 0.01_f64).abs() > f64::EPSILON { beta } else { old_val }
+            warnings.call_method1(
+                "warn",
+                (
+                    "HLDA(eta=) is deprecated; use beta= instead",
+                    py.get_type_bound::<pyo3::exceptions::PyDeprecationWarning>(),
+                    2_i32,
+                ),
+            )?;
+            if (beta - 0.01_f64).abs() > f64::EPSILON {
+                beta
+            } else {
+                old_val
+            }
         } else {
             beta
         };
@@ -16381,10 +18833,19 @@ impl HLDA {
             return Err(PyValueError::new_err("gamma, beta, alpha must be > 0"));
         }
         Ok(HLDA {
-            depth, gamma, eta: beta, alpha, seed,
-            fitted: false, num_nodes: 0, topic_names: Vec::new(),
+            depth,
+            gamma,
+            eta: beta,
+            alpha,
+            seed,
+            fitted: false,
+            num_nodes: 0,
+            topic_names: Vec::new(),
             node_topic_word: None,
-            node_levels: Vec::new(), node_parents: Vec::new(), doc_paths: Vec::new(), corpus: None,
+            node_levels: Vec::new(),
+            node_parents: Vec::new(),
+            doc_paths: Vec::new(),
+            corpus: None,
         })
     }
 
@@ -16397,7 +18858,17 @@ impl HLDA {
             let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
                 PyValueError::new_err("fit() expects a Corpus or a list of token lists")
             })?;
-            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+            build_corpus_from_docs(
+                docs,
+                None,
+                None,
+                std::collections::HashSet::new(),
+                1,
+                1.0,
+                0,
+                0,
+            )?
+            .0
         };
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
@@ -16406,7 +18877,16 @@ impl HLDA {
         let (depth, gamma, eta, alpha) = (self.depth, self.gamma, self.eta, self.alpha);
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
         let (model, corpus) = py.allow_threads(move || {
-            let m = hlda::fit_hlda(&corpus.docs, num_types, depth, gamma, eta, alpha, iters, &mut rng);
+            let m = hlda::fit_hlda(
+                &corpus.docs,
+                num_types,
+                depth,
+                gamma,
+                eta,
+                alpha,
+                iters,
+                &mut rng,
+            );
             (m, corpus)
         });
 
@@ -16421,7 +18901,9 @@ impl HLDA {
         self.topic_names = (0..nn).map(|i| format!("topic_{i}")).collect();
         self.node_topic_word = Some(tw);
         self.node_levels = (0..nn).map(|i| model.node_level(i)).collect();
-        self.node_parents = (0..nn).map(|i| model.node_parent(i).map(|p| p as i64).unwrap_or(-1)).collect();
+        self.node_parents = (0..nn)
+            .map(|i| model.node_parent(i).map(|p| p as i64).unwrap_or(-1))
+            .collect();
         self.doc_paths = (0..corpus.num_docs()).map(|d| model.doc_path(d)).collect();
         self.corpus = Some(corpus);
         self.fitted = true;
@@ -16480,7 +18962,9 @@ impl HLDA {
     fn leaves(&self) -> PyResult<Vec<usize>> {
         self.require_fitted()?;
         let parents: HashSet<i64> = self.node_parents.iter().copied().collect();
-        Ok((0..self.num_nodes).filter(|&i| !parents.contains(&(i as i64))).collect())
+        Ok((0..self.num_nodes)
+            .filter(|&i| !parents.contains(&(i as i64)))
+            .collect())
     }
     #[getter]
     fn vocabulary(&self) -> PyResult<Vec<String>> {
@@ -16514,19 +18998,35 @@ impl HLDA {
         let v = tw.shape()[1];
         let mut idx: Vec<usize> = (0..v).collect();
         idx.sort_by(|&a, &b| f64::total_cmp(&tw[[node, b]], &tw[[node, a]]));
-        Ok(idx.into_iter().take(n).map(|w| (vocab[w].clone(), tw[[node, w]])).collect())
+        Ok(idx
+            .into_iter()
+            .take(n)
+            .map(|w| (vocab[w].clone(), tw[[node, w]]))
+            .collect())
     }
 
     /// Save the fitted model to `path`. Reload with `HLDA.load`.
     fn save(&self, path: &str) -> PyResult<()> {
         self.require_fitted()?;
-        write_state(path, MODEL_TAG_HLDA, &HldaState {
-            depth: self.depth, gamma: self.gamma, eta: self.eta, alpha: self.alpha,
-            seed: self.seed, fitted: self.fitted, num_nodes: self.num_nodes,
-            node_topic_word: arr2_opt(&self.node_topic_word), node_levels: self.node_levels.clone(),
-            node_parents: self.node_parents.clone(), doc_paths: self.doc_paths.clone(),
-            corpus: self.corpus.clone(), topic_names: self.topic_names.clone(),
-        })
+        write_state(
+            path,
+            MODEL_TAG_HLDA,
+            &HldaState {
+                depth: self.depth,
+                gamma: self.gamma,
+                eta: self.eta,
+                alpha: self.alpha,
+                seed: self.seed,
+                fitted: self.fitted,
+                num_nodes: self.num_nodes,
+                node_topic_word: arr2_opt(&self.node_topic_word),
+                node_levels: self.node_levels.clone(),
+                node_parents: self.node_parents.clone(),
+                doc_paths: self.doc_paths.clone(),
+                corpus: self.corpus.clone(),
+                topic_names: self.topic_names.clone(),
+            },
+        )
     }
     /// Load a model previously written by :meth:`save`.
     #[staticmethod]
@@ -16538,17 +19038,28 @@ impl HLDA {
             s.topic_names
         };
         Ok(HLDA {
-            depth: s.depth, gamma: s.gamma, eta: s.eta, alpha: s.alpha, seed: s.seed,
-            fitted: s.fitted, num_nodes: s.num_nodes, topic_names,
+            depth: s.depth,
+            gamma: s.gamma,
+            eta: s.eta,
+            alpha: s.alpha,
+            seed: s.seed,
+            fitted: s.fitted,
+            num_nodes: s.num_nodes,
+            topic_names,
             node_topic_word: arr2_back(s.node_topic_word),
-            node_levels: s.node_levels, node_parents: s.node_parents, doc_paths: s.doc_paths,
+            node_levels: s.node_levels,
+            node_parents: s.node_parents,
+            doc_paths: s.doc_paths,
             corpus: s.corpus,
         })
     }
 
     fn __repr__(&self) -> String {
         if self.fitted {
-            format!("HLDA(depth={}, num_nodes={}, fitted=true)", self.depth, self.num_nodes)
+            format!(
+                "HLDA(depth={}, num_nodes={}, fitted=true)",
+                self.depth, self.num_nodes
+            )
         } else {
             format!("HLDA(depth={}, fitted=false)", self.depth)
         }
@@ -16571,7 +19082,10 @@ static EXPERIMENTAL_INIT: Once = Once::new();
 
 fn experimental_env_truthy() -> bool {
     match std::env::var("TOPICA_EXPERIMENTAL") {
-        Ok(v) => matches!(v.trim().to_ascii_lowercase().as_str(), "1" | "true" | "yes" | "on"),
+        Ok(v) => matches!(
+            v.trim().to_ascii_lowercase().as_str(),
+            "1" | "true" | "yes" | "on"
+        ),
         Err(_) => false,
     }
 }
@@ -16677,8 +19191,14 @@ mod tests {
         let rows = vec![vec![1.0, f64::NAN], vec![3.0, 4.0]];
         let err = check_all_finite_2d("prevalence", &rows).unwrap_err();
         let msg = err.to_string();
-        assert!(msg.contains("prevalence"), "message should name the parameter");
-        assert!(msg.contains("non-finite"), "message should mention non-finite");
+        assert!(
+            msg.contains("prevalence"),
+            "message should name the parameter"
+        );
+        assert!(
+            msg.contains("non-finite"),
+            "message should mention non-finite"
+        );
         assert!(msg.contains("row 0"), "message should include row number");
     }
 

--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -53,7 +53,12 @@ pub fn reduce(
 /// layout, and run the crate's layout optimization. Returns `n_rows ×
 /// n_components`, deterministic for a fixed `seed`. Only built under `umap`.
 #[cfg(feature = "umap")]
-pub fn umap(data: &[Vec<f64>], n_components: usize, n_neighbors: usize, seed: u64) -> Vec<Vec<f64>> {
+pub fn umap(
+    data: &[Vec<f64>],
+    n_components: usize,
+    n_neighbors: usize,
+    seed: u64,
+) -> Vec<Vec<f64>> {
     use ndarray::Array2;
     use rayon::prelude::*;
     use umap_rs::{GraphParams, Umap, UmapConfig};
@@ -67,7 +72,10 @@ pub fn umap(data: &[Vec<f64>], n_components: usize, n_neighbors: usize, seed: u6
     // we can supply at most n-1 neighbors.
     let k = n_neighbors.clamp(1, n.saturating_sub(1).max(1));
 
-    let data_f32: Vec<f32> = data.iter().flat_map(|r| r.iter().map(|&v| v as f32)).collect();
+    let data_f32: Vec<f32> = data
+        .iter()
+        .flat_map(|r| r.iter().map(|&v| v as f32))
+        .collect();
     let data_arr = Array2::from_shape_vec((n, dim), data_f32).expect("data shape");
 
     // Brute-force kNN graph, self excluded (umap-rs treats column 0 as a genuine
@@ -88,7 +96,10 @@ pub fn umap(data: &[Vec<f64>], n_components: usize, n_neighbors: usize, seed: u6
                 .collect();
             d.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
             d.truncate(k);
-            (d.iter().map(|&(_, j)| j).collect(), d.iter().map(|&(dd, _)| dd).collect())
+            (
+                d.iter().map(|&(_, j)| j).collect(),
+                d.iter().map(|&(dd, _)| dd).collect(),
+            )
         })
         .collect();
     let mut idx = Vec::with_capacity(n * k);
@@ -102,20 +113,37 @@ pub fn umap(data: &[Vec<f64>], n_components: usize, n_neighbors: usize, seed: u6
 
     // Random initial layout in a small range; the layout optimization expands it.
     let mut rng = ChaCha8Rng::seed_from_u64(seed);
-    let init_vec: Vec<f32> = (0..n * n_components).map(|_| rng.gen_range(-1.0f32..1.0)).collect();
+    let init_vec: Vec<f32> = (0..n * n_components)
+        .map(|_| rng.gen_range(-1.0f32..1.0))
+        .collect();
     let init = Array2::from_shape_vec((n, n_components), init_vec).expect("init shape");
 
     use umap_rs::{ManifoldParams, OptimizationParams};
     let config = UmapConfig {
         n_components,
-        graph: GraphParams { n_neighbors: k, ..Default::default() },
-        manifold: ManifoldParams { min_dist: 0.0, ..Default::default() },
-        optimization: OptimizationParams { n_epochs: Some(500), ..Default::default() },
+        graph: GraphParams {
+            n_neighbors: k,
+            ..Default::default()
+        },
+        manifold: ManifoldParams {
+            min_dist: 0.0,
+            ..Default::default()
+        },
+        optimization: OptimizationParams {
+            n_epochs: Some(500),
+            ..Default::default()
+        },
     };
-    let fitted =
-        Umap::new(config).fit(data_arr.view(), knn_indices.view(), knn_dists.view(), init.view());
+    let fitted = Umap::new(config).fit(
+        data_arr.view(),
+        knn_indices.view(),
+        knn_dists.view(),
+        init.view(),
+    );
     let emb = fitted.into_embedding();
-    (0..n).map(|i| (0..n_components).map(|c| emb[[i, c]] as f64).collect()).collect()
+    (0..n)
+        .map(|i| (0..n_components).map(|c| emb[[i, c]] as f64).collect())
+        .collect()
 }
 
 /// Whether the Barnes-Hut t-SNE reducer is compiled in (the `tsne` feature).
@@ -157,7 +185,11 @@ pub fn tsne(
         .collect();
     let samples: Vec<&[f32]> = owned.iter().map(|r| r.as_slice()).collect();
     let metric = |a: &&[f32], b: &&[f32]| -> f32 {
-        a.iter().zip(b.iter()).map(|(x, y)| (x - y).powi(2)).sum::<f32>().sqrt()
+        a.iter()
+            .zip(b.iter())
+            .map(|(x, y)| (x - y).powi(2))
+            .sum::<f32>()
+            .sqrt()
     };
 
     let mut t = bhtsne::tSNE::new(&samples);
@@ -171,7 +203,11 @@ pub fn tsne(
     }
     let flat = t.embedding(); // row-major Vec<f32>, length n * n_components
     (0..n)
-        .map(|i| (0..n_components).map(|c| flat[i * n_components + c] as f64).collect())
+        .map(|i| {
+            (0..n_components)
+                .map(|c| flat[i * n_components + c] as f64)
+                .collect()
+        })
         .collect()
 }
 
@@ -482,7 +518,7 @@ pub fn jacobi_eigen_symmetric(a: &[f64], l: usize) -> (Vec<f64>, Vec<Vec<f64>>) 
         return (Vec::new(), Vec::new());
     }
     let mut m = a.to_vec(); // working copy, modified in place
-    // Accumulated rotations; v starts as the identity, columns end as eigenvectors.
+                            // Accumulated rotations; v starts as the identity, columns end as eigenvectors.
     let mut v = vec![0.0f64; l * l];
     for i in 0..l {
         v[i * l + i] = 1.0;
@@ -548,7 +584,11 @@ pub fn jacobi_eigen_symmetric(a: &[f64], l: usize) -> (Vec<f64>, Vec<Vec<f64>>) 
     // Diagonal of m holds the eigenvalues; column k of v is its eigenvector.
     let mut order: Vec<usize> = (0..l).collect();
     let diag: Vec<f64> = (0..l).map(|i| m[i * l + i]).collect();
-    order.sort_by(|&i, &j| diag[j].partial_cmp(&diag[i]).unwrap_or(std::cmp::Ordering::Equal));
+    order.sort_by(|&i, &j| {
+        diag[j]
+            .partial_cmp(&diag[i])
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
 
     let eigenvalues: Vec<f64> = order.iter().map(|&k| diag[k]).collect();
     let eigenvectors: Vec<Vec<f64>> = order
@@ -572,10 +612,7 @@ mod tests {
     /// Build points that lie on a 2-D plane embedded in 5-D: random 2-D
     /// coordinates pushed through a fixed 2×5 basis, plus a constant offset.
     fn plane_in_5d(n: usize) -> (Vec<[f64; 2]>, Vec<Vec<f64>>) {
-        let basis: [[f64; 5]; 2] = [
-            [1.0, 0.5, -0.3, 0.2, 0.8],
-            [-0.4, 1.2, 0.7, -0.6, 0.1],
-        ];
+        let basis: [[f64; 5]; 2] = [[1.0, 0.5, -0.3, 0.2, 0.8], [-0.4, 1.2, 0.7, -0.6, 0.1]];
         let offset = [3.0, -1.0, 2.0, 0.5, -2.5];
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let mut coords = Vec::with_capacity(n);
@@ -689,10 +726,16 @@ mod tests {
         // Leading eigenvector aligns with (1, 1) up to sign.
         let v = &vecs[0];
         assert!((v[0].abs() - v[1].abs()).abs() < 1e-9);
-        assert!(v[0] * v[1] > 0.0, "leading eigenvector should have equal signs");
+        assert!(
+            v[0] * v[1] > 0.0,
+            "leading eigenvector should have equal signs"
+        );
         // Second eigenvector aligns with (1, -1).
         let w = &vecs[1];
-        assert!(w[0] * w[1] < 0.0, "second eigenvector should have opposite signs");
+        assert!(
+            w[0] * w[1] < 0.0,
+            "second eigenvector should have opposite signs"
+        );
     }
 
     #[test]
@@ -737,7 +780,10 @@ mod umap_tests {
         let emb = umap(&data, 2, 10, 1);
         assert_eq!(emb.len(), data.len());
         assert_eq!(emb[0].len(), 2);
-        assert!(emb.iter().all(|r| r.iter().all(|v| v.is_finite())), "embedding has NaN");
+        assert!(
+            emb.iter().all(|r| r.iter().all(|v| v.is_finite())),
+            "embedding has NaN"
+        );
         // Note: we do not assert clean cluster separation here. umap-rs embeds a
         // fully disconnected kNN graph (which cleanly separated blobs produce)
         // poorly; separation is validated on real connected embeddings instead.
@@ -761,8 +807,9 @@ mod tsne_tests {
             let mut center = vec![0.0; dim];
             center[c] = 20.0;
             for _ in 0..30 {
-                let row: Vec<f64> =
-                    (0..dim).map(|t| center[t] + (rng.gen::<f64>() - 0.5) * 4.0).collect();
+                let row: Vec<f64> = (0..dim)
+                    .map(|t| center[t] + (rng.gen::<f64>() - 0.5) * 4.0)
+                    .collect();
                 data.push(row);
                 truth.push(c);
             }
@@ -770,7 +817,10 @@ mod tsne_tests {
         let emb = tsne(&data, 2, 30.0, 0.5, 500, 0);
         assert_eq!(emb.len(), data.len());
         assert_eq!(emb[0].len(), 2);
-        assert!(emb.iter().all(|r| r.iter().all(|v| v.is_finite())), "embedding has NaN");
+        assert!(
+            emb.iter().all(|r| r.iter().all(|v| v.is_finite())),
+            "embedding has NaN"
+        );
         // Per-blob 2-D centroids, then check each point is nearest its own.
         let mut cents = vec![[0.0f64; 2]; 3];
         let mut counts = vec![0.0f64; 3];
@@ -797,17 +847,23 @@ mod tsne_tests {
             }
         }
         // Allow a few stragglers; the embedding is stochastic and unseeded.
-        assert!(correct as f64 / truth.len() as f64 > 0.9, "t-SNE did not separate blobs");
+        assert!(
+            correct as f64 / truth.len() as f64 > 0.9,
+            "t-SNE did not separate blobs"
+        );
     }
 
     // The dispatcher routes "tsne" to the t-SNE reducer and yields finite 2-D points.
     #[test]
     fn project_routes_tsne() {
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        let data: Vec<Vec<f64>> =
-            (0..20).map(|_| (0..6).map(|_| rng.gen::<f64>()).collect()).collect();
+        let data: Vec<Vec<f64>> = (0..20)
+            .map(|_| (0..6).map(|_| rng.gen::<f64>()).collect())
+            .collect();
         let emb = project(&data, 2, "tsne", 15, 30.0, 0.5, 250, 0);
         assert_eq!(emb.len(), 20);
-        assert!(emb.iter().all(|r| r.len() == 2 && r.iter().all(|v| v.is_finite())));
+        assert!(emb
+            .iter()
+            .all(|r| r.len() == 2 && r.iter().all(|v| v.is_finite())));
     }
 }

--- a/src/represent.rs
+++ b/src/represent.rs
@@ -51,7 +51,12 @@ pub fn ctfidf(docs: &[Vec<u32>], labels: &[i64], vocab_size: usize) -> Vec<Vec<f
 
 /// Number of topics implied by a label vector (max non-noise label + 1).
 fn label_count(labels: &[i64]) -> usize {
-    labels.iter().filter(|&&l| l >= 0).map(|&l| l as usize + 1).max().unwrap_or(0)
+    labels
+        .iter()
+        .filter(|&&l| l >= 0)
+        .map(|&l| l as usize + 1)
+        .max()
+        .unwrap_or(0)
 }
 
 /// Relabel after merging topics: every id in a group collapses to one cluster,
@@ -85,8 +90,11 @@ pub fn merge_labels(labels: &[i64], groups: &[Vec<usize>]) -> Vec<i64> {
     let mut distinct: Vec<usize> = rep.clone();
     distinct.sort_unstable();
     distinct.dedup();
-    let dense: std::collections::HashMap<usize, i64> =
-        distinct.iter().enumerate().map(|(i, &r)| (r, i as i64)).collect();
+    let dense: std::collections::HashMap<usize, i64> = distinct
+        .iter()
+        .enumerate()
+        .map(|(i, &r)| (r, i as i64))
+        .collect();
     labels
         .iter()
         .map(|&l| if l < 0 { -1 } else { dense[&rep[l as usize]] })
@@ -332,7 +340,10 @@ mod tests {
         assert_ne!(merged[0], merged[1]);
         assert_eq!(merged[4], -1);
         // dense range 0..2
-        assert!(merged.iter().filter(|&&l| l >= 0).all(|&l| l == 0 || l == 1));
+        assert!(merged
+            .iter()
+            .filter(|&&l| l >= 0)
+            .all(|&l| l == 0 || l == 1));
     }
 
     #[test]
@@ -352,12 +363,7 @@ mod tests {
         // Vocab: 0 = shared, 1 = distinctive-A, 2 = distinctive-B.
         // Class 0 is all word 1 plus some shared word 0; class 1 is all word 2
         // plus the same shared word 0.
-        let docs = vec![
-            vec![0, 1, 1],
-            vec![0, 1, 1],
-            vec![0, 2, 2],
-            vec![0, 2, 2],
-        ];
+        let docs = vec![vec![0, 1, 1], vec![0, 1, 1], vec![0, 2, 2], vec![0, 2, 2]];
         let labels = vec![0, 0, 1, 1];
         let m = ctfidf(&docs, &labels, 3);
 
@@ -376,12 +382,7 @@ mod tests {
     #[test]
     fn ctfidf_weighted_default_matches_ctfidf() {
         // With both knobs off, ctfidf_weighted must reproduce ctfidf exactly.
-        let docs = vec![
-            vec![0, 1, 1],
-            vec![0, 1, 1],
-            vec![0, 2, 2],
-            vec![0, 2, 2],
-        ];
+        let docs = vec![vec![0, 1, 1], vec![0, 1, 1], vec![0, 2, 2], vec![0, 2, 2]];
         let labels = vec![0, 0, 1, 1];
         let base = ctfidf(&docs, &labels, 3);
         let weighted = ctfidf_weighted(&docs, &labels, 3, false, false);
@@ -420,12 +421,7 @@ mod tests {
     #[test]
     fn ctfidf_bm25_is_finite_nonneg_and_downweights_ubiquitous() {
         // Word 0 appears in every class; words 1 and 2 are class-specific.
-        let docs = vec![
-            vec![0, 1, 1],
-            vec![0, 1, 1],
-            vec![0, 2, 2],
-            vec![0, 2, 2],
-        ];
+        let docs = vec![vec![0, 1, 1], vec![0, 1, 1], vec![0, 2, 2], vec![0, 2, 2]];
         let labels = vec![0, 0, 1, 1];
         let m = ctfidf_weighted(&docs, &labels, 3, true, false);
 
@@ -453,10 +449,10 @@ mod tests {
     fn centroids_average_each_cluster() {
         let vectors = vec![
             vec![0.0, 0.0],
-            vec![2.0, 0.0],  // cluster 0 mean -> (1, 0)
+            vec![2.0, 0.0], // cluster 0 mean -> (1, 0)
             vec![0.0, 4.0],
-            vec![0.0, 6.0],  // cluster 1 mean -> (0, 5)
-            vec![9.0, 9.0],  // noise, excluded
+            vec![0.0, 6.0], // cluster 1 mean -> (0, 5)
+            vec![9.0, 9.0], // noise, excluded
         ];
         let labels = vec![0, 0, 1, 1, -1];
         let c = centroids(&vectors, &labels, 2);
@@ -481,9 +477,9 @@ mod tests {
     fn nearest_by_cosine_ranks_aligned_first() {
         let query = vec![1.0, 0.0];
         let candidates = vec![
-            vec![0.0, 1.0],  // orthogonal, sim 0
-            vec![1.0, 0.0],  // aligned, sim 1
-            vec![0.5, 0.5],  // 45 degrees
+            vec![0.0, 1.0], // orthogonal, sim 0
+            vec![1.0, 0.0], // aligned, sim 1
+            vec![0.5, 0.5], // 45 degrees
         ];
         let ranked = nearest_by_cosine(&query, &candidates, 3);
         assert_eq!(ranked[0].0, 1);
@@ -497,7 +493,7 @@ mod tests {
     fn nearest_by_cosine_tolerates_zero_norm() {
         let query = vec![1.0, 0.0];
         let candidates = vec![
-            vec![0.0, 0.0],  // zero norm: sim 0, no panic
+            vec![0.0, 0.0], // zero norm: sim 0, no panic
             vec![1.0, 0.0],
         ];
         let ranked = nearest_by_cosine(&query, &candidates, 2);

--- a/src/sage.rs
+++ b/src/sage.rs
@@ -26,19 +26,25 @@ pub struct SageModel {
     pub alpha: Vec<f64>,
     pub prior_variance: f64,
 
-    pub m: Vec<f64>,              // background log-freq, len V
-    pub kappa_t: Vec<Vec<f64>>,  // [K][V]
-    pub kappa_c: Vec<Vec<f64>>,  // [G][V]
-    pub kappa_i: Vec<Vec<f64>>,  // [K*G][V]  (index k*G+g)
+    pub m: Vec<f64>,            // background log-freq, len V
+    pub kappa_t: Vec<Vec<f64>>, // [K][V]
+    pub kappa_c: Vec<Vec<f64>>, // [G][V]
+    pub kappa_i: Vec<Vec<f64>>, // [K*G][V]  (index k*G+g)
 
-    pub beta: Vec<Vec<f64>>,     // [K*G][V] cached normalized topic-word dists
-    pub counts: Vec<Vec<u32>>,   // [K*G][V] token counts n_{k,g,v}
-    pub totals: Vec<u32>,        // [K*G] = Σ_v counts
+    pub beta: Vec<Vec<f64>>,   // [K*G][V] cached normalized topic-word dists
+    pub counts: Vec<Vec<u32>>, // [K*G][V] token counts n_{k,g,v}
+    pub totals: Vec<u32>,      // [K*G] = Σ_v counts
     pub doc_topics: Vec<Vec<u32>>,
 }
 
 impl SageModel {
-    pub fn new(num_topics: usize, num_groups: usize, num_types: usize, alpha: f64, prior_variance: f64) -> Self {
+    pub fn new(
+        num_topics: usize,
+        num_groups: usize,
+        num_types: usize,
+        alpha: f64,
+        prior_variance: f64,
+    ) -> Self {
         let kg = num_topics * num_groups;
         SageModel {
             num_topics,
@@ -84,7 +90,8 @@ impl SageModel {
                 let c = self.cell(k, g);
                 let mut max = f64::NEG_INFINITY;
                 for v in 0..self.num_types {
-                    let eta = self.m[v] + self.kappa_t[k][v] + self.kappa_c[g][v] + self.kappa_i[c][v];
+                    let eta =
+                        self.m[v] + self.kappa_t[k][v] + self.kappa_c[g][v] + self.kappa_i[c][v];
                     self.beta[c][v] = eta;
                     if eta > max {
                         max = eta;
@@ -108,7 +115,11 @@ impl SageModel {
         self.recompute_beta();
         self.doc_topics = docs
             .iter()
-            .map(|doc| doc.iter().map(|_| rng.gen_range(0..self.num_topics) as u32).collect())
+            .map(|doc| {
+                doc.iter()
+                    .map(|_| rng.gen_range(0..self.num_topics) as u32)
+                    .collect()
+            })
             .collect();
         for (d, doc) in docs.iter().enumerate() {
             let g = groups[d];
@@ -275,7 +286,7 @@ pub fn optimize_kappa(model: &mut SageModel, max_iter: usize) {
     model.recompute_beta();
 }
 
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 
 impl Estimator for SageModel {
     fn num_topics(&self) -> usize {
@@ -284,26 +295,39 @@ impl Estimator for SageModel {
 
     fn topic_word(&self) -> Vec<Vec<f64>> {
         // Average the cached beta (shape (K*G)×V, indexed k*num_groups+g) over groups.
-        (0..self.num_topics).map(|k| {
-            let mut avg = vec![0.0f64; self.num_types];
-            for g in 0..self.num_groups {
-                let row = &self.beta[k * self.num_groups + g];
-                for v in 0..self.num_types { avg[v] += row[v]; }
-            }
-            for v in 0..self.num_types { avg[v] /= self.num_groups as f64; }
-            avg
-        }).collect()
+        (0..self.num_topics)
+            .map(|k| {
+                let mut avg = vec![0.0f64; self.num_types];
+                for g in 0..self.num_groups {
+                    let row = &self.beta[k * self.num_groups + g];
+                    for v in 0..self.num_types {
+                        avg[v] += row[v];
+                    }
+                }
+                for v in 0..self.num_types {
+                    avg[v] /= self.num_groups as f64;
+                }
+                avg
+            })
+            .collect()
     }
 
     fn doc_topic(&self) -> Vec<Vec<f64>> {
         // Smoothed proportions from per-token topic ids with per-topic alpha.
         let alpha_sum: f64 = self.alpha.iter().sum();
-        self.doc_topics.iter().map(|toks| {
-            let mut cnt = vec![0.0f64; self.num_topics];
-            for &t in toks { cnt[t as usize] += 1.0; }
-            let denom = toks.len() as f64 + alpha_sum;
-            (0..self.num_topics).map(|t| (cnt[t] + self.alpha[t]) / denom).collect()
-        }).collect()
+        self.doc_topics
+            .iter()
+            .map(|toks| {
+                let mut cnt = vec![0.0f64; self.num_topics];
+                for &t in toks {
+                    cnt[t as usize] += 1.0;
+                }
+                let denom = toks.len() as f64 + alpha_sum;
+                (0..self.num_topics)
+                    .map(|t| (cnt[t] + self.alpha[t]) / denom)
+                    .collect()
+            })
+            .collect()
     }
 
     fn fit_history(&self) -> Vec<(usize, f64)> {

--- a/src/sampler.rs
+++ b/src/sampler.rs
@@ -1,6 +1,6 @@
-use rand::Rng;
 use crate::corpus::Corpus;
 use crate::model::TopicModel;
+use rand::Rng;
 
 /// Run one full Gibbs sweep over all documents.
 pub fn run_iteration<R: Rng>(model: &mut TopicModel, corpus: &Corpus, rng: &mut R) {
@@ -88,26 +88,28 @@ pub fn run_sweep<R: Rng>(
 #[allow(clippy::too_many_arguments)]
 pub(crate) fn sample_doc<R: Rng>(
     type_topic_counts: &mut [Vec<u32>],
-    tokens_per_topic:  &mut [u32],
-    doc_topics:        &mut [Vec<u32>],
-    alpha:             &[f64],
-    beta:              f64,
-    beta_sum:          f64,
-    topic_mask:        u32,
-    topic_bits:        u32,
-    num_topics:        usize,
-    corpus_doc:        &[u32],
-    doc_idx:           usize,
-    rng:               &mut R,
+    tokens_per_topic: &mut [u32],
+    doc_topics: &mut [Vec<u32>],
+    alpha: &[f64],
+    beta: f64,
+    beta_sum: f64,
+    topic_mask: u32,
+    topic_bits: u32,
+    num_topics: usize,
+    corpus_doc: &[u32],
+    doc_idx: usize,
+    rng: &mut R,
     smoothing_only_mass: &mut f64,
     cached_coefficients: &mut [f64],
-    local_topic_counts:  &mut [u32],
-    local_topic_index:   &mut [u32],
-    scored_positions:    &mut [usize],
-    scored_values:       &mut [f64],
+    local_topic_counts: &mut [u32],
+    local_topic_index: &mut [u32],
+    scored_positions: &mut [usize],
+    scored_values: &mut [f64],
 ) {
     let doc_len = corpus_doc.len();
-    if doc_len == 0 { return; }
+    if doc_len == 0 {
+        return;
+    }
 
     // --- Populate local topic counts for this document ---
     //
@@ -142,12 +144,12 @@ pub(crate) fn sample_doc<R: Rng>(
 
     // --- Sample each token ---
     for pos in 0..doc_len {
-        let word_id   = corpus_doc[pos] as usize;
+        let word_id = corpus_doc[pos] as usize;
         let old_topic = doc_topics[doc_idx][pos] as usize;
 
         // --- Phase A: remove old token from all counts ---
-        *smoothing_only_mass -= alpha[old_topic] * beta
-            / (tokens_per_topic[old_topic] as f64 + beta_sum);
+        *smoothing_only_mass -=
+            alpha[old_topic] * beta / (tokens_per_topic[old_topic] as f64 + beta_sum);
         topic_beta_mass -= beta * local_topic_counts[old_topic] as f64
             / (tokens_per_topic[old_topic] as f64 + beta_sum);
 
@@ -155,7 +157,9 @@ pub(crate) fn sample_doc<R: Rng>(
 
         if local_topic_counts[old_topic] == 0 {
             let mut di = 0;
-            while local_topic_index[di] as usize != old_topic { di += 1; }
+            while local_topic_index[di] as usize != old_topic {
+                di += 1;
+            }
             while di + 1 < non_zero_topics {
                 local_topic_index[di] = local_topic_index[di + 1];
                 di += 1;
@@ -165,8 +169,8 @@ pub(crate) fn sample_doc<R: Rng>(
 
         tokens_per_topic[old_topic] -= 1;
 
-        *smoothing_only_mass += alpha[old_topic] * beta
-            / (tokens_per_topic[old_topic] as f64 + beta_sum);
+        *smoothing_only_mass +=
+            alpha[old_topic] * beta / (tokens_per_topic[old_topic] as f64 + beta_sum);
         topic_beta_mass += beta * local_topic_counts[old_topic] as f64
             / (tokens_per_topic[old_topic] as f64 + beta_sum);
         cached_coefficients[old_topic] = (alpha[old_topic] + local_topic_counts[old_topic] as f64)
@@ -234,7 +238,9 @@ pub(crate) fn sample_doc<R: Rng>(
             let mut i = 0;
             while sample > 0.0 && i < num_scored {
                 sample -= scored_values[i];
-                if sample > 0.0 { i += 1; }
+                if sample > 0.0 {
+                    i += 1;
+                }
             }
             let array_idx = scored_positions[i.min(num_scored - 1)];
             let entry = type_counts[array_idx];
@@ -257,9 +263,12 @@ pub(crate) fn sample_doc<R: Rng>(
                 let mut chosen = local_topic_index[non_zero_topics - 1] as usize;
                 for di in 0..non_zero_topics {
                     let t = local_topic_index[di] as usize;
-                    sample -= local_topic_counts[t] as f64
-                        / (tokens_per_topic[t] as f64 + beta_sum);
-                    if sample <= 0.0 { chosen = t; break; }
+                    sample -=
+                        local_topic_counts[t] as f64 / (tokens_per_topic[t] as f64 + beta_sum);
+                    if sample <= 0.0 {
+                        chosen = t;
+                        break;
+                    }
                 }
                 new_topic = chosen;
             } else {
@@ -269,7 +278,10 @@ pub(crate) fn sample_doc<R: Rng>(
                 let mut chosen = num_topics - 1;
                 for t in 0..num_topics {
                     sample -= alpha[t] / (tokens_per_topic[t] as f64 + beta_sum);
-                    if sample <= 0.0 { chosen = t; break; }
+                    if sample <= 0.0 {
+                        chosen = t;
+                        break;
+                    }
                 }
                 new_topic = chosen;
             }
@@ -277,7 +289,9 @@ pub(crate) fn sample_doc<R: Rng>(
             // Find or create the slot for new_topic and increment.
             let mut idx = 0;
             while idx < entries_len && type_counts[idx] > 0 {
-                if (type_counts[idx] & topic_mask) as usize == new_topic { break; }
+                if (type_counts[idx] & topic_mask) as usize == new_topic {
+                    break;
+                }
                 idx += 1;
             }
             if idx == entries_len {
@@ -297,8 +311,8 @@ pub(crate) fn sample_doc<R: Rng>(
         // --- Phase C: assign new topic and update all counts ---
         doc_topics[doc_idx][pos] = new_topic as u32;
 
-        *smoothing_only_mass -= alpha[new_topic] * beta
-            / (tokens_per_topic[new_topic] as f64 + beta_sum);
+        *smoothing_only_mass -=
+            alpha[new_topic] * beta / (tokens_per_topic[new_topic] as f64 + beta_sum);
         topic_beta_mass -= beta * local_topic_counts[new_topic] as f64
             / (tokens_per_topic[new_topic] as f64 + beta_sum);
 
@@ -319,8 +333,8 @@ pub(crate) fn sample_doc<R: Rng>(
         cached_coefficients[new_topic] = (alpha[new_topic] + local_topic_counts[new_topic] as f64)
             / (tokens_per_topic[new_topic] as f64 + beta_sum);
 
-        *smoothing_only_mass += alpha[new_topic] * beta
-            / (tokens_per_topic[new_topic] as f64 + beta_sum);
+        *smoothing_only_mass +=
+            alpha[new_topic] * beta / (tokens_per_topic[new_topic] as f64 + beta_sum);
         topic_beta_mass += beta * local_topic_counts[new_topic] as f64
             / (tokens_per_topic[new_topic] as f64 + beta_sum);
     }

--- a/src/saveformat.rs
+++ b/src/saveformat.rs
@@ -52,8 +52,7 @@ pub fn decode_state<S: serde::de::DeserializeOwned>(
             tag_name(expected_tag),
         ));
     }
-    bincode::deserialize(&bytes[8..])
-        .map_err(|e| format!("not a valid topica model file: {e}"))
+    bincode::deserialize(&bytes[8..]).map_err(|e| format!("not a valid topica model file: {e}"))
 }
 
 #[cfg(test)]
@@ -66,7 +65,11 @@ mod tests {
     const TAG_BAR: u8 = 2;
 
     fn tag_name(t: u8) -> &'static str {
-        match t { TAG_FOO => "Foo", TAG_BAR => "Bar", _ => "unknown" }
+        match t {
+            TAG_FOO => "Foo",
+            TAG_BAR => "Bar",
+            _ => "unknown",
+        }
     }
 
     #[derive(Serialize, Deserialize, PartialEq, Debug)]
@@ -88,7 +91,12 @@ mod tests {
 
     #[test]
     fn foo_state_round_trip() {
-        let orig = FooState { x: 42, y: 3.14, flags: true, draws: Some(vec![0.1, 0.2, 0.3]) };
+        let orig = FooState {
+            x: 42,
+            y: 3.14,
+            flags: true,
+            draws: Some(vec![0.1, 0.2, 0.3]),
+        };
         let buf = encode_state(TAG_FOO, &orig).unwrap();
         let loaded: FooState = decode_state(&buf, TAG_FOO, tag_name).unwrap();
         assert_eq!(loaded, orig);
@@ -112,7 +120,12 @@ mod tests {
     #[test]
     fn theta_draws_survive_round_trip() {
         let draws: Vec<f32> = (0..30).map(|i| i as f32 / 30.0).collect();
-        let orig = FooState { x: 1, y: 0.0, flags: false, draws: Some(draws.clone()) };
+        let orig = FooState {
+            x: 1,
+            y: 0.0,
+            flags: false,
+            draws: Some(draws.clone()),
+        };
         let buf = encode_state(TAG_FOO, &orig).unwrap();
         let loaded: FooState = decode_state(&buf, TAG_FOO, tag_name).unwrap();
         assert_eq!(loaded.draws.unwrap(), draws);
@@ -122,14 +135,25 @@ mod tests {
 
     #[test]
     fn wrong_model_tag_gives_clear_error() {
-        let orig = FooState { x: 1, y: 2.0, flags: false, draws: None };
+        let orig = FooState {
+            x: 1,
+            y: 2.0,
+            flags: false,
+            draws: None,
+        };
         let buf = encode_state(TAG_FOO, &orig).unwrap();
 
         let result: Result<BarState, String> = decode_state(&buf, TAG_BAR, tag_name);
         assert!(result.is_err());
         let msg = result.unwrap_err();
-        assert!(msg.contains("Foo"), "error should mention the file's model: {msg}");
-        assert!(msg.contains("Bar"), "error should mention the expected model: {msg}");
+        assert!(
+            msg.contains("Foo"),
+            "error should mention the file's model: {msg}"
+        );
+        assert!(
+            msg.contains("Bar"),
+            "error should mention the expected model: {msg}"
+        );
     }
 
     // --- Garbage / truncated buffers give 'not a topica model file' ---
@@ -158,7 +182,12 @@ mod tests {
 
     #[test]
     fn wrong_version_gives_clear_error() {
-        let orig = FooState { x: 1, y: 2.0, flags: false, draws: None };
+        let orig = FooState {
+            x: 1,
+            y: 2.0,
+            flags: false,
+            draws: None,
+        };
         let mut buf = encode_state(TAG_FOO, &orig).unwrap();
         // Overwrite the version byte with an unsupported value.
         buf[6] = 99;

--- a/src/seeded.rs
+++ b/src/seeded.rs
@@ -24,9 +24,9 @@
 //!    `score(t) = (α + ndk[d][t]) × (β_{t,w} + nkw[t][w]) / (β_sum[t] + nk[t])`
 //! 3. Sample a new topic proportionally; increment counts.
 
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 use rand::Rng;
 use std::collections::HashSet;
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
 
 // ---------------------------------------------------------------------------
 // Model struct
@@ -170,7 +170,10 @@ impl SeededModel {
                     let n_d: u32 = row.iter().sum();
                     let a_sum: f64 = a.iter().sum();
                     let denom = n_d as f64 + a_sum;
-                    row.iter().zip(a).map(|(&c, &av)| (c as f64 + av) / denom).collect()
+                    row.iter()
+                        .zip(a)
+                        .map(|(&c, &av)| (c as f64 + av) / denom)
+                        .collect()
                 })
                 .collect();
         }
@@ -189,23 +192,45 @@ impl SeededModel {
 }
 
 impl Estimator for SeededModel {
-    fn num_topics(&self) -> usize { self.num_topics }
-    fn topic_word(&self) -> Vec<Vec<f64>> { self.topic_word_all() }
-    fn doc_topic(&self) -> Vec<Vec<f64>> { self.doc_topic() }
-    fn fit_history(&self) -> Vec<(usize, f64)> { Vec::new() }
-    fn converged(&self) -> Option<bool> { None }
-    fn model_family(&self) -> ModelFamily { ModelFamily::Dirichlet }
+    fn num_topics(&self) -> usize {
+        self.num_topics
+    }
+    fn topic_word(&self) -> Vec<Vec<f64>> {
+        self.topic_word_all()
+    }
+    fn doc_topic(&self) -> Vec<Vec<f64>> {
+        self.doc_topic()
+    }
+    fn fit_history(&self) -> Vec<(usize, f64)> {
+        Vec::new()
+    }
+    fn converged(&self) -> Option<bool> {
+        None
+    }
+    fn model_family(&self) -> ModelFamily {
+        ModelFamily::Dirichlet
+    }
 }
 
 impl DirichletModel for SeededModel {
-    fn alpha(&self) -> Vec<f64> { vec![self.alpha; self.num_topics] }
+    fn alpha(&self) -> Vec<f64> {
+        vec![self.alpha; self.num_topics]
+    }
     fn theta_draws(&self) -> Vec<Vec<Vec<f64>>> {
-        self.theta_draws.iter().map(|d| {
-            d.iter().map(|r| r.iter().map(|&x| x as f64).collect()).collect()
-        }).collect()
+        self.theta_draws
+            .iter()
+            .map(|d| {
+                d.iter()
+                    .map(|r| r.iter().map(|&x| x as f64).collect())
+                    .collect()
+            })
+            .collect()
     }
     fn doc_lengths(&self) -> Vec<usize> {
-        self.ndk.iter().map(|r| r.iter().map(|&c| c as usize).sum()).collect()
+        self.ndk
+            .iter()
+            .map(|r| r.iter().map(|&c| c as usize).sum())
+            .collect()
     }
 }
 
@@ -257,7 +282,9 @@ fn seeded_theta_snapshot(
                 }
                 None => {
                     let denom = n_d as f64 + k as f64 * alpha;
-                    row.iter().map(|&c| ((c as f64 + alpha) / denom) as f32).collect()
+                    row.iter()
+                        .map(|&c| ((c as f64 + alpha) / denom) as f32)
+                        .collect()
                 }
             }
         })
@@ -305,8 +332,15 @@ pub fn fit_seeded_lda<R: Rng>(
     let v = num_types;
     let d_count = docs.len();
     if let Some(da) = &doc_alpha {
-        assert_eq!(da.len(), d_count, "doc_alpha must have one row per document");
-        assert!(da.iter().all(|r| r.len() == k), "each doc_alpha row must have num_topics entries");
+        assert_eq!(
+            da.len(),
+            d_count,
+            "doc_alpha must have one row per document"
+        );
+        assert!(
+            da.iter().all(|r| r.len() == k),
+            "each doc_alpha row must have num_topics entries"
+        );
     }
 
     // Normalise seeds: sort and de-dup so `contains` scans are minimal.
@@ -407,7 +441,11 @@ pub fn fit_seeded_lda<R: Rng>(
             for w in 0..v {
                 let n_tw = nkw[t][w] as f64;
                 if n_tw > 0.0 {
-                    let beta_tw = if seed_sets[t].contains(&w) { beta + seed_weight } else { beta };
+                    let beta_tw = if seed_sets[t].contains(&w) {
+                        beta + seed_weight
+                    } else {
+                        beta
+                    };
                     ll += digamma(beta_tw + n_tw) - digamma(beta_tw);
                 }
             }
@@ -439,8 +477,7 @@ pub fn fit_seeded_lda<R: Rng>(
                         beta
                     };
                     let a_t = a_row.map_or(alpha, |r| r[t]);
-                    scores[t] = (a_t + ndk[d][t] as f64)
-                        * (beta_tw + nkw[t][w] as f64)
+                    scores[t] = (a_t + ndk[d][t] as f64) * (beta_tw + nkw[t][w] as f64)
                         / (beta_sum_k[t] + nk[t] as f64);
                 }
 
@@ -559,17 +596,27 @@ mod tests {
         // topic with its block; seed_weight=50 gives each seed word ~50x the
         // base beta prior, which is far stronger than the random-init pull.
         let seeds = vec![
-            vec![0usize, 1usize, 2usize, 3usize],   // first 4 words of block 0
+            vec![0usize, 1usize, 2usize, 3usize], // first 4 words of block 0
             vec![10usize, 11usize, 12usize, 13usize], // first 4 words of block 1
-            vec![],                                   // unseeded / residual
+            vec![],                               // unseeded / residual
         ];
         let seed_blocks = [0usize, 1usize]; // expected dominant block for topics 0 and 1
 
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         let (model, _, _) = fit_seeded_lda(
-            &docs, v, 3, &seeds,
-            0.1, 0.01, 50.0, None, 300, crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
-            0.0, 0, &mut rng,
+            &docs,
+            v,
+            3,
+            &seeds,
+            0.1,
+            0.01,
+            50.0,
+            None,
+            300,
+            crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            0,
+            &mut rng,
         );
 
         // For each seeded topic (0 and 1), the seed words' total φ mass should
@@ -579,15 +626,19 @@ mod tests {
         for (ki, &expected_block) in seed_blocks.iter().enumerate() {
             let phi_ki = model.topic_word(ki);
             // Mass on the seed words' block in topic ki.
-            let mass_ki: f64 = phi_ki[expected_block * block_size..(expected_block + 1) * block_size]
+            let mass_ki: f64 = phi_ki
+                [expected_block * block_size..(expected_block + 1) * block_size]
                 .iter()
                 .sum();
             // Check that no other topic has MORE mass on this block than topic ki does.
             // (Equivalently: ki is the topic most concentrated on its seed block.)
             for other in 0..3usize {
-                if other == ki { continue; }
+                if other == ki {
+                    continue;
+                }
                 let phi_other = model.topic_word(other);
-                let mass_other: f64 = phi_other[expected_block * block_size..(expected_block + 1) * block_size]
+                let mass_other: f64 = phi_other
+                    [expected_block * block_size..(expected_block + 1) * block_size]
                     .iter()
                     .sum();
                 assert!(
@@ -612,12 +663,30 @@ mod tests {
         let seeds: Vec<Vec<usize>> = vec![vec![]; k];
 
         let mut rng = ChaCha8Rng::seed_from_u64(123);
-        let (model, _, _) = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 0.0, None, 50, crate::keyatm::ThetaDrawOpts::new(false, 0, 0), 0.0, 0, &mut rng);
+        let (model, _, _) = fit_seeded_lda(
+            &docs,
+            v,
+            k,
+            &seeds,
+            0.1,
+            0.1,
+            0.0,
+            None,
+            50,
+            crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            0,
+            &mut rng,
+        );
 
         // topic_word rows sum to 1.
         for t in 0..k {
             let phi = model.topic_word(t);
-            assert_eq!(phi.len(), v, "topic_word({t}) length should equal num_types");
+            assert_eq!(
+                phi.len(),
+                v,
+                "topic_word({t}) length should equal num_types"
+            );
             let s: f64 = phi.iter().sum();
             assert!(
                 (s - 1.0).abs() < 1e-10,
@@ -627,7 +696,11 @@ mod tests {
 
         // doc_topic rows sum to 1.
         let theta = model.doc_topic();
-        assert_eq!(theta.len(), docs.len(), "doc_topic() row count should equal D");
+        assert_eq!(
+            theta.len(),
+            docs.len(),
+            "doc_topic() row count should equal D"
+        );
         for (d, row) in theta.iter().enumerate() {
             assert_eq!(row.len(), k, "doc_topic row {d} length should equal K");
             let s: f64 = row.iter().sum();
@@ -650,8 +723,36 @@ mod tests {
 
         let mut r1 = ChaCha8Rng::seed_from_u64(55);
         let mut r2 = ChaCha8Rng::seed_from_u64(55);
-        let (m1, _, _) = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 2.0, None, 80, crate::keyatm::ThetaDrawOpts::new(false, 0, 0), 0.0, 0, &mut r1);
-        let (m2, _, _) = fit_seeded_lda(&docs, v, k, &seeds, 0.1, 0.1, 2.0, None, 80, crate::keyatm::ThetaDrawOpts::new(false, 0, 0), 0.0, 0, &mut r2);
+        let (m1, _, _) = fit_seeded_lda(
+            &docs,
+            v,
+            k,
+            &seeds,
+            0.1,
+            0.1,
+            2.0,
+            None,
+            80,
+            crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            0,
+            &mut r1,
+        );
+        let (m2, _, _) = fit_seeded_lda(
+            &docs,
+            v,
+            k,
+            &seeds,
+            0.1,
+            0.1,
+            2.0,
+            None,
+            80,
+            crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            0,
+            &mut r2,
+        );
 
         assert_eq!(
             m1.topic_word_all(),
@@ -675,8 +776,19 @@ mod tests {
         let seeds: Vec<Vec<usize>> = vec![vec![]; k];
         let mut rng = ChaCha8Rng::seed_from_u64(99);
         let (m, _, _) = fit_seeded_lda(
-            &docs, v, k, &seeds, 0.1, 0.1, 0.0, None, 20,
-            crate::keyatm::ThetaDrawOpts::new(false, 0, 0), 0.0, 0, &mut rng,
+            &docs,
+            v,
+            k,
+            &seeds,
+            0.1,
+            0.1,
+            0.0,
+            None,
+            20,
+            crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
+            0.0,
+            0,
+            &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/src/slda.rs
+++ b/src/slda.rs
@@ -35,7 +35,10 @@ pub struct SldaModel {
 impl SldaModel {
     /// Topic-word distributions β = exp(log_beta), shape K×V.
     pub fn topic_word(&self) -> Vec<Vec<f64>> {
-        self.log_beta.iter().map(|row| row.iter().map(|&l| l.exp()).collect()).collect()
+        self.log_beta
+            .iter()
+            .map(|row| row.iter().map(|&l| l.exp()).collect())
+            .collect()
     }
 
     /// Document-topic mixtures θ_d = γ_d / Σγ_d, shape D×K.
@@ -151,10 +154,19 @@ pub fn predict_one(model: &SldaModel, doc: &[u32], var_iters: usize) -> f64 {
     if bag.is_empty() {
         return 0.0;
     }
-    let (_, _, sum_phi) =
-        infer_doc(&bag, &model.log_beta, &model.eta, model.sigma2, model.alpha, None, var_iters);
+    let (_, _, sum_phi) = infer_doc(
+        &bag,
+        &model.log_beta,
+        &model.eta,
+        model.sigma2,
+        model.alpha,
+        None,
+        var_iters,
+    );
     let n: f64 = bag.iter().map(|&(_, c)| c).sum();
-    (0..model.num_topics).map(|k| model.eta[k] * sum_phi[k] / n).sum()
+    (0..model.num_topics)
+        .map(|k| model.eta[k] * sum_phi[k] / n)
+        .sum()
 }
 
 /// Per-EM-iteration objective: the Gaussian log-likelihood of the response
@@ -304,9 +316,7 @@ pub fn fit_slda<R: Rng>(
 
         // Bound trace and optional convergence check (uses current η/σ²/log_beta).
         if check_every > 0 && em_iter % check_every == 0 {
-            let bnd = response_log_likelihood(
-                &bags, y, &log_beta, &eta, sigma2, alpha, var_iters,
-            );
+            let bnd = response_log_likelihood(&bags, y, &log_beta, &eta, sigma2, alpha, var_iters);
             bound_history.push((em_iter, bnd));
             if convergence_tol > 0.0 && bound_history.len() >= 2 {
                 let prev = bound_history[bound_history.len() - 2].1;
@@ -319,11 +329,22 @@ pub fn fit_slda<R: Rng>(
         }
     }
 
-    (SldaModel { num_topics: k, num_types: v, alpha, log_beta, eta, sigma2, gamma },
-     bound_history, converged)
+    (
+        SldaModel {
+            num_topics: k,
+            num_types: v,
+            alpha,
+            log_beta,
+            eta,
+            sigma2,
+            gamma,
+        },
+        bound_history,
+        converged,
+    )
 }
 
-use crate::estimator::{Estimator, ModelFamily, DirichletModel};
+use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 
 impl Estimator for SldaModel {
     fn num_topics(&self) -> usize {
@@ -364,10 +385,13 @@ impl DirichletModel for SldaModel {
     fn doc_lengths(&self) -> Vec<usize> {
         // doc_lengths reconstructed from γ (sLDA stores no raw token counts):
         // γ[d] = α + token-topic counts, so N_d ≈ Σγ[d] − α·K.
-        self.gamma.iter().map(|g| {
-            let s: f64 = g.iter().sum();
-            (s - self.alpha * self.num_topics as f64).round().max(0.0) as usize
-        }).collect()
+        self.gamma
+            .iter()
+            .map(|g| {
+                let s: f64 = g.iter().sum();
+                (s - self.alpha * self.num_topics as f64).round().max(0.0) as usize
+            })
+            .collect()
     }
 }
 
@@ -416,7 +440,11 @@ mod tests {
             // Which topic puts more mass on this vocabulary block.
             let m0: f64 = block.iter().map(|&w| tw[0][w]).sum();
             let m1: f64 = block.iter().map(|&w| tw[1][w]).sum();
-            if m0 > m1 { 0 } else { 1 }
+            if m0 > m1 {
+                0
+            } else {
+                1
+            }
         };
         let k0 = topic_of_block(&[0, 1, 2, 3, 4, 5]);
         let k1 = topic_of_block(&[6, 7, 8, 9, 10, 11]);

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -71,9 +71,18 @@ fn doc_beta(alpha: &[f64], kappa: &Kappa, mv: &[f64], k: usize) -> DocBeta {
     let theta: Vec<f64> = expeta.iter().map(|&e| e / sum_e).collect();
     let mut beta = Vec::with_capacity(k);
     for t in 0..k {
-        beta.push(topic_beta(mv, &kappa.kappa_t[t], &kappa.kappa_s[t], alpha[k - 1 + t]));
+        beta.push(topic_beta(
+            mv,
+            &kappa.kappa_t[t],
+            &kappa.kappa_s[t],
+            alpha[k - 1 + t],
+        ));
     }
-    DocBeta { beta, expeta, theta }
+    DocBeta {
+        beta,
+        expeta,
+        theta,
+    }
 }
 
 /// Per-document log-posterior `f(α)` (to MAXIMIZE), `opt.alpha.R::log_posterior_byDoc`.
@@ -122,7 +131,7 @@ pub fn sts_lhood(
 /// for each document word, plus the column sums `Σ_v κ^(s)_{k,v} β_{k,v}` used by
 /// the gradient and Hessian.
 struct DocResp {
-    beta_bar: Vec<Vec<f64>>, // ntok × K
+    beta_bar: Vec<Vec<f64>>,  // ntok × K
     kappa_bar: Vec<Vec<f64>>, // K × V  (κ^(s) minus its β-weighted mean)
     ks_beta_mean: Vec<f64>,   // K
 }
@@ -152,7 +161,11 @@ fn doc_resp(db: &DocBeta, kappa: &Kappa, words: &[usize], k: usize, v: usize) ->
         ks_beta_mean[t] = m;
         kappa_bar.push(kappa.kappa_s[t].iter().map(|&x| x - m).collect());
     }
-    DocResp { beta_bar, kappa_bar, ks_beta_mean }
+    DocResp {
+        beta_bar,
+        kappa_bar,
+        ks_beta_mean,
+    }
 }
 
 /// Gradient of [`sts_lhood`] w.r.t. `α` (length `2K-1`),
@@ -276,7 +289,8 @@ pub fn sts_precision(
         }
         let mut s_a = 0.0;
         for (wi, &w) in words.iter().enumerate() {
-            s_a += counts[wi] * dr.beta_bar[wi][a] * (dr.kappa_bar[a][w] * dr.kappa_bar[a][w] - kbks);
+            s_a +=
+                counts[wi] * dr.beta_bar[wi][a] * (dr.kappa_bar[a][w] * dr.kappa_bar[a][w] - kbks);
         }
         h_ss[a * k + a] += s_a;
     }
@@ -313,10 +327,12 @@ pub fn sts_precision(
 // Fitted model + EM driver (PR1: κ held fixed; the Poisson κ M-step is PR2)
 // ---------------------------------------------------------------------------
 
-use crate::variational::{lbfgs_minimize, doc_sparse, fit_gamma_ridge};
-use crate::linalg::{cholesky, half_logdet, make_diagonally_dominant, spd_inverse, spd_inverse_from_chol};
 use crate::estimator::{Estimator, ModelFamily};
+use crate::linalg::{
+    cholesky, half_logdet, make_diagonally_dominant, spd_inverse, spd_inverse_from_chol,
+};
 use crate::variational::LogisticNormalModel;
+use crate::variational::{doc_sparse, fit_gamma_ridge, lbfgs_minimize};
 use rand::Rng;
 
 /// A fitted STS model. With the E-step done and `κ` held fixed, this carries the
@@ -325,25 +341,25 @@ use rand::Rng;
 pub struct StsModel {
     pub k: usize,
     pub num_types: usize,
-    pub alpha: Vec<Vec<f64>>,         // D × (2K-1): [α^(p)_{1..K-1}, α^(s)_{1..K}]
+    pub alpha: Vec<Vec<f64>>, // D × (2K-1): [α^(p)_{1..K-1}, α^(s)_{1..K}]
     /// Per-document variational covariance ν = H⁻¹ ((2K-1)² flattened, row-major).
     /// Empty when the model was fit with `keep_nu = false`; use `recompute_nu_sts`
     /// to regenerate on demand.
-    pub nu: Vec<Vec<f64>>,            // D × (2K-1)²: Laplace covariance per doc
+    pub nu: Vec<Vec<f64>>, // D × (2K-1)²: Laplace covariance per doc
     pub gamma: Option<Vec<Vec<f64>>>, // F × (2K-1): prevalence+sentiment regression
-    pub sigma: Vec<f64>,             // (2K-1)²
+    pub sigma: Vec<f64>,      // (2K-1)²
     /// The prior covariance Σ that was used in the final E-step (sigma before the
     /// final M-step). Used by `recompute_nu_sts` to exactly reproduce the stored ν.
     pub sigma_estep: Vec<f64>,
-    pub kappa_t: Vec<Vec<f64>>,      // K × V (final, after last M-step)
-    pub kappa_s: Vec<Vec<f64>>,      // K × V (final, after last M-step)
+    pub kappa_t: Vec<Vec<f64>>, // K × V (final, after last M-step)
+    pub kappa_s: Vec<Vec<f64>>, // K × V (final, after last M-step)
     /// The topic-word coefficients κ_t, κ_s that were used in the final E-step
     /// (before the κ M-step updated `kappa_t`/`kappa_s`). Used by `recompute_nu_sts`
     /// to reproduce ν exactly.
     pub kappa_t_estep: Vec<Vec<f64>>,
     pub kappa_s_estep: Vec<Vec<f64>>,
-    pub mv: Vec<f64>,                // V
-    pub beta: Vec<Vec<f64>>,         // K × V baseline topic-word at α^(s)=0
+    pub mv: Vec<f64>,        // V
+    pub beta: Vec<Vec<f64>>, // K × V baseline topic-word at α^(s)=0
     pub bound_history: Vec<f64>,
     pub converged: bool,
     pub em_iters_run: usize,
@@ -368,28 +384,46 @@ impl StsModel {
         let k = self.k;
         self.alpha.iter().map(|a| a[k - 1..].to_vec()).collect()
     }
-
 }
 
 impl Estimator for StsModel {
-    fn num_topics(&self) -> usize { self.k }
-    fn topic_word(&self) -> Vec<Vec<f64>> { self.beta.clone() }
-    fn doc_topic(&self) -> Vec<Vec<f64>> { self.doc_topics() }
-    fn fit_history(&self) -> Vec<(usize, f64)> {
-        self.bound_history.iter().enumerate().map(|(i, &b)| (i + 1, b)).collect()
+    fn num_topics(&self) -> usize {
+        self.k
     }
-    fn converged(&self) -> Option<bool> { Some(self.converged) }
-    fn model_family(&self) -> ModelFamily { ModelFamily::LogisticNormal }
+    fn topic_word(&self) -> Vec<Vec<f64>> {
+        self.beta.clone()
+    }
+    fn doc_topic(&self) -> Vec<Vec<f64>> {
+        self.doc_topics()
+    }
+    fn fit_history(&self) -> Vec<(usize, f64)> {
+        self.bound_history
+            .iter()
+            .enumerate()
+            .map(|(i, &b)| (i + 1, b))
+            .collect()
+    }
+    fn converged(&self) -> Option<bool> {
+        Some(self.converged)
+    }
+    fn model_family(&self) -> ModelFamily {
+        ModelFamily::LogisticNormal
+    }
 }
 
 impl LogisticNormalModel for StsModel {
-    fn eta_dim(&self) -> usize { 2 * self.k - 1 }
-    fn eta_mean(&self) -> &[Vec<f64>] { &self.alpha }
+    fn eta_dim(&self) -> usize {
+        2 * self.k - 1
+    }
+    fn eta_mean(&self) -> &[Vec<f64>] {
+        &self.alpha
+    }
     /// Returns the stored per-document covariances. Returns `&[]` when the model
     /// was fit with `keep_nu = false` (use `recompute_nu_sts` to regenerate).
-    fn eta_cov(&self) -> &[Vec<f64>] { &self.nu }
+    fn eta_cov(&self) -> &[Vec<f64>] {
+        &self.nu
+    }
 }
-
 
 /// Infer per-document prevalence θ (D×K) for *new* documents against fixed
 /// global parameters (κ_t, κ_s, m, Σ) by the same Laplace E-step used in fitting,
@@ -408,7 +442,10 @@ pub fn sts_infer(
     k: usize,
 ) -> Vec<Vec<f64>> {
     let n = 2 * k - 1;
-    let kappa = Kappa { kappa_t: kappa_t.to_vec(), kappa_s: kappa_s.to_vec() };
+    let kappa = Kappa {
+        kappa_t: kappa_t.to_vec(),
+        kappa_s: kappa_s.to_vec(),
+    };
     let siginv = spd_inverse(sigma, n).unwrap_or_else(|| {
         let mut s = sigma.to_vec();
         make_diagonally_dominant(&mut s, n);
@@ -501,7 +538,11 @@ fn poisson_deviance(y: &[f64], mu: &[f64]) -> f64 {
     let mut d = 0.0;
     for i in 0..y.len() {
         let yi = y[i];
-        let term = if yi > 0.0 { yi * (yi / mu[i]).ln() } else { 0.0 };
+        let term = if yi > 0.0 {
+            yi * (yi / mu[i]).ln()
+        } else {
+            0.0
+        };
         d += term - (yi - mu[i]);
     }
     2.0 * d
@@ -522,7 +563,13 @@ fn soft_threshold(z: f64, g: f64) -> f64 {
 /// `alpha=1`, `intercept=FALSE`, `standardize=FALSE`). Fit by IRLS with inner
 /// coordinate descent (Friedman, Hastie & Tibshirani 2010); warm-started down the
 /// path. `x` is `n×p`, with a fixed `offset`. Returns the AIC-selected coefficients.
-fn poisson_lasso(x: &[Vec<f64>], y: &[f64], offset: &[f64], nlambda: usize, lambda_min_ratio: f64) -> Vec<f64> {
+fn poisson_lasso(
+    x: &[Vec<f64>],
+    y: &[f64],
+    offset: &[f64],
+    nlambda: usize,
+    lambda_min_ratio: f64,
+) -> Vec<f64> {
     let n = x.len();
     let p = if n > 0 { x[0].len() } else { 0 };
     if p == 0 {
@@ -595,7 +642,9 @@ fn poisson_lasso(x: &[Vec<f64>], y: &[f64], offset: &[f64], nlambda: usize, lamb
             }
         }
 
-        let mu: Vec<f64> = (0..n).map(|i| (offset[i] + xbeta[i]).clamp(-30.0, 30.0).exp()).collect();
+        let mu: Vec<f64> = (0..n)
+            .map(|i| (offset[i] + xbeta[i]).clamp(-30.0, 30.0).exp())
+            .collect();
         let dev = poisson_deviance(y, &mu);
         let df = beta.iter().filter(|&&b| b != 0.0).count();
         let aic = dev + 2.0 * df as f64;
@@ -614,7 +663,10 @@ pub enum KappaEst {
     Ridge(f64),
     /// L1 (lasso) Poisson over a λ path with AIC-selected penalty — the reference
     /// `opt.kappa.R` default (glmnet). Sparser κ; closer to the R `sts` solution.
-    Lasso { nlambda: usize, lambda_min_ratio: f64 },
+    Lasso {
+        nlambda: usize,
+        lambda_min_ratio: f64,
+    },
 }
 
 /// M-step for the topic-word coefficients `κ` (Chen & Mankad §4.2; `opt.kappa.R`).
@@ -669,7 +721,10 @@ fn opt_kappa(
                 }
             }
         }
-        KappaEst::Lasso { nlambda, lambda_min_ratio } => {
+        KappaEst::Lasso {
+            nlambda,
+            lambda_min_ratio,
+        } => {
             // Joint (G·K)×(2K) design, word-independent: row (g,t) carries a 1 in
             // the topic-t dummy column and α^(s)_agg in the topic-t slope column.
             let n = num_groups * k;
@@ -891,10 +946,13 @@ pub fn fit_sts<R: Rng>(
 
     for em in 0..em_iters {
         em_iters_run = em + 1;
-        sigma_estep = sigma.clone();        // capture sigma before E-step
-        kappa_t_estep = kappa_t.clone();   // capture kappa before E-step
+        sigma_estep = sigma.clone(); // capture sigma before E-step
+        kappa_t_estep = kappa_t.clone(); // capture kappa before E-step
         kappa_s_estep = kappa_s.clone();
-        let kappa = Kappa { kappa_t: kappa_t.clone(), kappa_s: kappa_s.clone() };
+        let kappa = Kappa {
+            kappa_t: kappa_t.clone(),
+            kappa_s: kappa_s.clone(),
+        };
         let siginv = spd_inverse(&sigma, n).unwrap_or_else(|| {
             let mut s = sigma.clone();
             make_diagonally_dominant(&mut s, n);
@@ -965,7 +1023,11 @@ pub fn fit_sts<R: Rng>(
         // (so the Σ M-step is bit-identical whether or not we retain per-doc ν).
         let mut phi_by_group = vec![vec![vec![0.0f64; k]; v]; num_groups];
         let mut total_bound = 0.0;
-        let mut nu_sum_sstat = if keep_nu { Vec::new() } else { vec![0.0f64; n * n] };
+        let mut nu_sum_sstat = if keep_nu {
+            Vec::new()
+        } else {
+            vec![0.0f64; n * n]
+        };
         for (di, (a_hat, nu_d, bound_contrib, phi_contrib)) in doc_results {
             let g = group[di];
             for (w, row) in &phi_contrib {
@@ -1066,10 +1128,7 @@ pub fn fit_sts<R: Rng>(
 /// but not `mu`). So ν is independent of the per-document μ. We evaluate using
 /// `sigma_estep` and `kappa_t_estep`/`kappa_s_estep` (the globals that were active
 /// during the last E-step) to reproduce the stored ν exactly.
-pub fn recompute_nu_sts(
-    model: &StsModel,
-    sparse: &[(Vec<usize>, Vec<f64>)],
-) -> Vec<Vec<f64>> {
+pub fn recompute_nu_sts(model: &StsModel, sparse: &[(Vec<usize>, Vec<f64>)]) -> Vec<Vec<f64>> {
     use rayon::prelude::*;
     let d = sparse.len();
     let k = model.k;
@@ -1091,7 +1150,15 @@ pub fn recompute_nu_sts(
         .into_par_iter()
         .map(|di| {
             let (words, counts) = &sparse[di];
-            let mut prec = sts_precision(&model.alpha[di], &kappa, &model.mv, words, counts, &siginv, k);
+            let mut prec = sts_precision(
+                &model.alpha[di],
+                &kappa,
+                &model.mv,
+                words,
+                counts,
+                &siginv,
+                k,
+            );
             match cholesky(&prec, n) {
                 Some(l) => spd_inverse_from_chol(&l, n),
                 None => {
@@ -1108,7 +1175,16 @@ pub fn recompute_nu_sts(
 mod tests {
     use super::*;
 
-    fn setup() -> (usize, usize, Kappa, Vec<f64>, Vec<usize>, Vec<f64>, Vec<f64>, Vec<f64>) {
+    fn setup() -> (
+        usize,
+        usize,
+        Kappa,
+        Vec<f64>,
+        Vec<usize>,
+        Vec<f64>,
+        Vec<f64>,
+        Vec<f64>,
+    ) {
         // Small deterministic problem: K=3 topics, V=6 vocabulary.
         let k = 3usize;
         let v = 6usize;
@@ -1121,7 +1197,10 @@ mod tests {
                 ks[t][i] = 0.20 * (((i + 2 * t) % 4) as f64) - 0.3;
             }
         }
-        let kappa = Kappa { kappa_t: kt, kappa_s: ks };
+        let kappa = Kappa {
+            kappa_t: kt,
+            kappa_s: ks,
+        };
         let mv: Vec<f64> = (0..v).map(|i| -1.0 - 0.1 * i as f64).collect();
         let words = vec![0usize, 2, 3, 5];
         let counts = vec![3.0, 1.0, 4.0, 2.0];
@@ -1213,7 +1292,9 @@ mod tests {
         for d in 0..60 {
             let a = d % 2 == 0;
             let block = if a { &block_a } else { &block_b };
-            let doc: Vec<u32> = (0..12).map(|_| block[rng.gen_range(0..block.len())]).collect();
+            let doc: Vec<u32> = (0..12)
+                .map(|_| block[rng.gen_range(0..block.len())])
+                .collect();
             docs.push(doc);
             x.push(vec![1.0, if a { 0.0 } else { 1.0 }]); // intercept + indicator
             truth.push(if a { 0 } else { 1 });
@@ -1225,7 +1306,19 @@ mod tests {
     fn em_bound_increases_and_recovers_topics() {
         let (docs, x, truth, v) = planted_corpus();
         let mut rng = StdRng::seed_from_u64(1);
-        let m = fit_sts(&docs, 2, v, 40, 1e-6, Some(&x), None, KappaEst::Ridge(1e-3), true, true, &mut rng);
+        let m = fit_sts(
+            &docs,
+            2,
+            v,
+            40,
+            1e-6,
+            Some(&x),
+            None,
+            KappaEst::Ridge(1e-3),
+            true,
+            true,
+            &mut rng,
+        );
 
         // The variational bound increases monotonically (allowing tiny slack).
         for w in m.bound_history.windows(2) {
@@ -1236,19 +1329,28 @@ mod tests {
         // top words come from one block. Map topics to blocks by their heaviest
         // word, then check prevalence separates the document groups.
         let tw = m.topic_word();
-        let top0 = (0..v).max_by(|&a, &b| tw[0][a].partial_cmp(&tw[0][b]).unwrap()).unwrap();
+        let top0 = (0..v)
+            .max_by(|&a, &b| tw[0][a].partial_cmp(&tw[0][b]).unwrap())
+            .unwrap();
         let topic_for_block_a = if top0 < 4 { 0 } else { 1 };
 
         let theta = m.doc_topics();
         let mut correct = 0;
         for (d, th) in theta.iter().enumerate() {
             let dominant = if th[0] >= th[1] { 0 } else { 1 };
-            let expected = if truth[d] == 0 { topic_for_block_a } else { 1 - topic_for_block_a };
+            let expected = if truth[d] == 0 {
+                topic_for_block_a
+            } else {
+                1 - topic_for_block_a
+            };
             if dominant == expected {
                 correct += 1;
             }
         }
-        assert!(correct as f64 / theta.len() as f64 > 0.9, "only {correct}/60 docs separated");
+        assert!(
+            correct as f64 / theta.len() as f64 > 0.9,
+            "only {correct}/60 docs separated"
+        );
     }
 
     #[test]
@@ -1256,8 +1358,32 @@ mod tests {
         let (docs, x, _truth, v) = planted_corpus();
         let mut r1 = StdRng::seed_from_u64(1);
         let mut r2 = StdRng::seed_from_u64(1);
-        let m1 = fit_sts(&docs, 2, v, 15, 0.0, Some(&x), None, KappaEst::Ridge(1e-3), true, true, &mut r1);
-        let m2 = fit_sts(&docs, 2, v, 15, 0.0, Some(&x), None, KappaEst::Ridge(1e-3), true, true, &mut r2);
+        let m1 = fit_sts(
+            &docs,
+            2,
+            v,
+            15,
+            0.0,
+            Some(&x),
+            None,
+            KappaEst::Ridge(1e-3),
+            true,
+            true,
+            &mut r1,
+        );
+        let m2 = fit_sts(
+            &docs,
+            2,
+            v,
+            15,
+            0.0,
+            Some(&x),
+            None,
+            KappaEst::Ridge(1e-3),
+            true,
+            true,
+            &mut r2,
+        );
         for (a, b) in m1.alpha.iter().flatten().zip(m2.alpha.iter().flatten()) {
             assert!((a - b).abs() < 1e-12);
         }
@@ -1310,8 +1436,17 @@ mod tests {
             off.push(o);
         }
         let coef = poisson_lasso(&x, &y, &off, 100, 0.001);
-        assert!((coef[0] - b0_true).abs() < 0.25, "signal coef {} vs {}", coef[0], b0_true);
-        assert!(coef[1].abs() < 0.1, "noise coef should be ~0, got {}", coef[1]);
+        assert!(
+            (coef[0] - b0_true).abs() < 0.25,
+            "signal coef {} vs {}",
+            coef[0],
+            b0_true
+        );
+        assert!(
+            coef[1].abs() < 0.1,
+            "noise coef should be ~0, got {}",
+            coef[1]
+        );
     }
 
     #[test]
@@ -1333,7 +1468,19 @@ mod tests {
         let (docs, x, _truth, v) = planted_corpus();
         let seed: Vec<f64> = x.iter().map(|row| row[1]).collect();
         let mut rng = StdRng::seed_from_u64(2);
-        let m = fit_sts(&docs, 2, v, 30, 1e-6, Some(&x), Some(&seed), KappaEst::Ridge(1e-3), true, true, &mut rng);
+        let m = fit_sts(
+            &docs,
+            2,
+            v,
+            30,
+            1e-6,
+            Some(&x),
+            Some(&seed),
+            KappaEst::Ridge(1e-3),
+            true,
+            true,
+            &mut rng,
+        );
 
         let ks_max = m
             .kappa_s
@@ -1353,11 +1500,28 @@ mod tests {
         let (docs, x, truth, v) = planted_corpus();
         let seed: Vec<f64> = x.iter().map(|row| row[1]).collect();
         let mut rng = StdRng::seed_from_u64(3);
-        let est = KappaEst::Lasso { nlambda: 60, lambda_min_ratio: 0.001 };
-        let m = fit_sts(&docs, 2, v, 20, 1e-6, Some(&x), Some(&seed), est, true, true, &mut rng);
+        let est = KappaEst::Lasso {
+            nlambda: 60,
+            lambda_min_ratio: 0.001,
+        };
+        let m = fit_sts(
+            &docs,
+            2,
+            v,
+            20,
+            1e-6,
+            Some(&x),
+            Some(&seed),
+            est,
+            true,
+            true,
+            &mut rng,
+        );
 
         let tw = m.topic_word();
-        let top0 = (0..v).max_by(|&a, &b| tw[0][a].partial_cmp(&tw[0][b]).unwrap()).unwrap();
+        let top0 = (0..v)
+            .max_by(|&a, &b| tw[0][a].partial_cmp(&tw[0][b]).unwrap())
+            .unwrap();
         let topic_for_a = if top0 < 4 { 0 } else { 1 };
         let theta = m.doc_topics();
         let correct = theta
@@ -1365,11 +1529,18 @@ mod tests {
             .enumerate()
             .filter(|(d, th)| {
                 let dominant = if th[0] >= th[1] { 0 } else { 1 };
-                let expected = if truth[*d] == 0 { topic_for_a } else { 1 - topic_for_a };
+                let expected = if truth[*d] == 0 {
+                    topic_for_a
+                } else {
+                    1 - topic_for_a
+                };
                 dominant == expected
             })
             .count();
-        assert!(correct as f64 / theta.len() as f64 > 0.85, "lasso fit only {correct}/60 separated");
+        assert!(
+            correct as f64 / theta.len() as f64 > 0.85,
+            "lasso fit only {correct}/60 separated"
+        );
     }
 
     #[test]
@@ -1378,7 +1549,19 @@ mod tests {
         let (docs, x, _truth, v) = planted_corpus();
         let seed: Vec<f64> = x.iter().map(|row| row[1]).collect();
         let mut rng = StdRng::seed_from_u64(7);
-        let m = fit_sts(&docs, 3, v, 5, 0.0, Some(&x), Some(&seed), KappaEst::Ridge(1e-3), true, true, &mut rng);
+        let m = fit_sts(
+            &docs,
+            3,
+            v,
+            5,
+            0.0,
+            Some(&x),
+            Some(&seed),
+            KappaEst::Ridge(1e-3),
+            true,
+            true,
+            &mut rng,
+        );
         let base = check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
         let ln = check_logistic_normal(&m);

--- a/src/top2vec.rs
+++ b/src/top2vec.rs
@@ -178,7 +178,11 @@ pub fn fit_top2vec(
     seed: u64,
 ) -> Top2VecModel {
     let n_docs = doc_embeddings.len();
-    let emb_dim = if n_docs > 0 { doc_embeddings[0].len() } else { 0 };
+    let emb_dim = if n_docs > 0 {
+        doc_embeddings[0].len()
+    } else {
+        0
+    };
 
     // (1) Reduce, unless the embeddings are already at or below the target dim.
     let reduced: Vec<Vec<f64>> = if emb_dim > n_components && n_components > 0 {
@@ -190,7 +194,12 @@ pub fn fit_top2vec(
     // (2) Cluster the reduced points. HDBSCAN (the default) leaves sparse points
     // as `-1` noise; KMeans / agglomerative assign every document instead.
     let labels = cluster::cluster_points(
-        &reduced, clusterer, num_clusters, min_cluster_size, min_samples, seed,
+        &reduced,
+        clusterer,
+        num_clusters,
+        min_cluster_size,
+        min_samples,
+        seed,
     );
     let num_topics = labels
         .iter()
@@ -235,7 +244,10 @@ fn soft_doc_topic(doc_embeddings: &[Vec<f64>], topic_vectors: &[Vec<f64>]) -> Ve
             if k == 0 {
                 return Vec::new();
             }
-            let mut row: Vec<f64> = topic_vectors.iter().map(|t| cosine(d, t).max(0.0)).collect();
+            let mut row: Vec<f64> = topic_vectors
+                .iter()
+                .map(|t| cosine(d, t).max(0.0))
+                .collect();
             let sum: f64 = row.iter().sum();
             if sum > 0.0 {
                 for v in row.iter_mut() {
@@ -320,7 +332,12 @@ mod tests {
         let mut doc_emb = Vec::new();
         for d in 0..40 {
             if d % 2 == 0 {
-                docs.push(vec![0u32, 1, 2, 3, 4].into_iter().map(|w| w as u32).collect::<Vec<_>>());
+                docs.push(
+                    vec![0u32, 1, 2, 3, 4]
+                        .into_iter()
+                        .map(|w| w as u32)
+                        .collect::<Vec<_>>(),
+                );
                 doc_emb.push(jitter(&mut rng, &center_a));
             } else {
                 docs.push((5u32..10).collect::<Vec<_>>());
@@ -334,12 +351,22 @@ mod tests {
             word_emb.push(jitter(&mut rng, c));
         }
 
-        let m = fit_top2vec(&docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1);
-        assert!(m.num_topics >= 2, "expected >=2 topics, got {}", m.num_topics);
+        let m = fit_top2vec(
+            &docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1,
+        );
+        assert!(
+            m.num_topics >= 2,
+            "expected >=2 topics, got {}",
+            m.num_topics
+        );
 
         // Each topic's nearest words should come from a single block.
         for t in 0..m.num_topics {
-            let words: Vec<usize> = m.topic_neighbors(4, t).into_iter().map(|(w, _)| w).collect();
+            let words: Vec<usize> = m
+                .topic_neighbors(4, t)
+                .into_iter()
+                .map(|(w, _)| w)
+                .collect();
             let low = words.iter().filter(|&&w| w < 5).count();
             assert!(
                 low == 0 || low == words.len(),
@@ -360,7 +387,9 @@ mod tests {
         let doc_emb: Vec<Vec<f64>> = (0..5).map(|i| vec![i as f64 * 10.0, 0.0]).collect();
         let docs: Vec<Vec<u32>> = (0..5).map(|_| vec![0u32]).collect();
         let word_emb = vec![vec![1.0, 0.0]];
-        let m = fit_top2vec(&docs, &doc_emb, &word_emb, 1, 2, false, 15, 5, 2, "hdbscan", None, 1);
+        let m = fit_top2vec(
+            &docs, &doc_emb, &word_emb, 1, 2, false, 15, 5, 2, "hdbscan", None, 1,
+        );
         assert_eq!(m.num_topics, 0);
         assert!(m.topic_vectors.is_empty());
     }
@@ -394,7 +423,9 @@ mod tests {
             let c = if w < 5 { &center_a } else { &center_b };
             word_emb.push(jitter(&mut rng, c));
         }
-        let m = fit_top2vec(&docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1);
+        let m = fit_top2vec(
+            &docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1,
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/warplda.rs
+++ b/src/warplda.rs
@@ -167,7 +167,11 @@ impl WarpLda {
         for row in inv_seeds.iter_mut() {
             row.sort_unstable();
         }
-        self.seed = Some(SeedBeta { seed_weight, beta_sum_k, inv_seeds });
+        self.seed = Some(SeedBeta {
+            seed_weight,
+            beta_sum_k,
+            inv_seeds,
+        });
     }
 
     /// β_{k,w}: the base β plus the seed boost when word `w` seeds topic `k`.
@@ -381,10 +385,8 @@ impl WarpLda {
                 // delayed snapshot, so exclude it with a -1 on the `cur` side.
                 let mut new = cur;
                 if prop != cur {
-                    let num = (c_w[prop] as f64 + beta)
-                        * (self.n_k[cur] as f64 - 1.0 + beta_sum);
-                    let den = (c_w[cur] as f64 - 1.0 + beta)
-                        * (self.n_k[prop] as f64 + beta_sum);
+                    let num = (c_w[prop] as f64 + beta) * (self.n_k[cur] as f64 - 1.0 + beta_sum);
+                    let den = (c_w[cur] as f64 - 1.0 + beta) * (self.n_k[prop] as f64 + beta_sum);
                     if num >= den || rng.gen::<f64>() * den < num {
                         new = prop;
                     }
@@ -493,8 +495,8 @@ impl WarpLda {
                 c_w[self.z[d as usize][pos as usize] as usize] += 1;
             }
             for t in 0..k {
-                phi[t][w] =
-                    (c_w[t] as f64 + self.beta_at(t, w)) / (self.n_k[t] as f64 + self.beta_sum_at(t));
+                phi[t][w] = (c_w[t] as f64 + self.beta_at(t, w))
+                    / (self.n_k[t] as f64 + self.beta_sum_at(t));
             }
         }
         phi
@@ -541,8 +543,7 @@ impl WarpLda {
     /// (optimisation, save/load, log-likelihood, held-out inference) is reused
     /// unchanged. Mirrors [`crate::lightlda::LightLda::to_topic_model`].
     pub fn to_topic_model(&self) -> TopicModel {
-        let mut model =
-            TopicModel::new(self.num_topics, self.alpha_sum, self.beta, self.num_types);
+        let mut model = TopicModel::new(self.num_topics, self.alpha_sum, self.beta, self.num_types);
         model.alpha.copy_from_slice(&self.alpha);
         model.alpha_sum = self.alpha_sum;
         model.beta = self.beta;
@@ -649,8 +650,7 @@ mod tests {
             idx.sort_by(|&a, &b| phi[t][b].partial_cmp(&phi[t][a]).unwrap());
             let top: std::collections::HashSet<usize> = idx[..wpb].iter().copied().collect();
             for b in 0..n_blocks {
-                let block: std::collections::HashSet<usize> =
-                    (b * wpb..(b + 1) * wpb).collect();
+                let block: std::collections::HashSet<usize> = (b * wpb..(b + 1) * wpb).collect();
                 if block.is_subset(&top) {
                     covered.insert(b);
                 }
@@ -689,8 +689,7 @@ mod tests {
             idx.sort_by(|&a, &b| phi[t][b].partial_cmp(&phi[t][a]).unwrap());
             let top: std::collections::HashSet<usize> = idx[..wpb].iter().copied().collect();
             for b in 0..n_blocks {
-                let block: std::collections::HashSet<usize> =
-                    (b * wpb..(b + 1) * wpb).collect();
+                let block: std::collections::HashSet<usize> = (b * wpb..(b + 1) * wpb).collect();
                 if block.is_subset(&top) {
                     covered.insert(b);
                 }
@@ -725,8 +724,7 @@ mod tests {
             idx.sort_by(|&a, &b| phi[t][b].partial_cmp(&phi[t][a]).unwrap());
             let top: std::collections::HashSet<usize> = idx[..wpb].iter().copied().collect();
             for b in 0..n_blocks {
-                let block: std::collections::HashSet<usize> =
-                    (b * wpb..(b + 1) * wpb).collect();
+                let block: std::collections::HashSet<usize> = (b * wpb..(b + 1) * wpb).collect();
                 if block.is_subset(&top) {
                     covered.insert(b);
                 }

--- a/topica-core/src/corpus.rs
+++ b/topica-core/src/corpus.rs
@@ -14,8 +14,7 @@ use regex::Regex;
 ///   ·  U+00B7  middle dot     (Catalan col·legi, Welsh, other scripts)
 ///
 /// Em-dash (U+2014), en-dash (U+2013), and all other punctuation break tokens.
-pub const DEFAULT_TOKEN_REGEX: &str =
-    r"\p{L}[-'\u{2019}.\u{00B7}\p{L}]*\p{L}";
+pub const DEFAULT_TOKEN_REGEX: &str = r"\p{L}[-'\u{2019}.\u{00B7}\p{L}]*\p{L}";
 
 // Version 2 adds per-document labels.
 const MAGIC: &[u8; 4] = b"CRP2";
@@ -35,9 +34,15 @@ pub struct Corpus {
 }
 
 impl Corpus {
-    pub fn num_types(&self) -> usize { self.id_to_word.len() }
-    pub fn num_docs(&self)  -> usize { self.docs.len() }
-    pub fn total_tokens(&self) -> usize { self.docs.iter().map(|d| d.len()).sum() }
+    pub fn num_types(&self) -> usize {
+        self.id_to_word.len()
+    }
+    pub fn num_docs(&self) -> usize {
+        self.docs.len()
+    }
+    pub fn total_tokens(&self) -> usize {
+        self.docs.iter().map(|d| d.len()).sum()
+    }
 
     /// True when at least one document has a non-empty label.
     pub fn has_labels(&self) -> bool {
@@ -116,7 +121,9 @@ pub fn load_text_file(path: &Path, opts: &LoadOptions) -> io::Result<Corpus> {
     for (line_idx, line) in reader.lines().enumerate() {
         let line = line?;
         let line = line.trim();
-        if line.is_empty() { continue; }
+        if line.is_empty() {
+            continue;
+        }
 
         let (doc_name, doc_label, text_slice): (String, String, &str) = match &opts.format {
             InputFormat::Plain { id_field } => {
@@ -124,19 +131,26 @@ pub fn load_text_file(path: &Path, opts: &LoadOptions) -> io::Result<Corpus> {
                     // First whitespace token is the name; rest is text.
                     match line.find(|c: char| c.is_whitespace()) {
                         Some(pos) => (line[..pos].to_string(), String::new(), line[pos..].trim()),
-                        None      => (format!("doc_{}", line_idx), String::new(), line),
+                        None => (format!("doc_{}", line_idx), String::new(), line),
                     }
                 } else {
                     (format!("doc_{}", line_idx), String::new(), line)
                 }
             }
 
-            InputFormat::Tsv { id_column, label_column, text_column } => {
-                let cols: Vec<&str> = line.splitn(
-                    // Only need to split up to max column + 1; splitn remainder holds the rest.
-                    // For safety just collect all tabs and index into the vec.
-                    usize::MAX, '\t'
-                ).collect();
+            InputFormat::Tsv {
+                id_column,
+                label_column,
+                text_column,
+            } => {
+                let cols: Vec<&str> = line
+                    .splitn(
+                        // Only need to split up to max column + 1; splitn remainder holds the rest.
+                        // For safety just collect all tabs and index into the vec.
+                        usize::MAX,
+                        '\t',
+                    )
+                    .collect();
 
                 let max_needed = [*id_column, *text_column]
                     .iter()
@@ -150,11 +164,11 @@ pub fn load_text_file(path: &Path, opts: &LoadOptions) -> io::Result<Corpus> {
                     continue;
                 }
 
-                let name  = cols[*id_column].trim().to_string();
+                let name = cols[*id_column].trim().to_string();
                 let label = label_column
                     .map(|c| cols[c].trim().to_string())
                     .unwrap_or_default();
-                let text  = cols[*text_column];
+                let text = cols[*text_column];
                 (name, label, text)
             }
         };
@@ -164,7 +178,9 @@ pub fn load_text_file(path: &Path, opts: &LoadOptions) -> io::Result<Corpus> {
 
         for m in re.find_iter(text_slice) {
             let token_lower = m.as_str().to_lowercase();
-            if opts.stopwords.contains(&token_lower) { continue; }
+            if opts.stopwords.contains(&token_lower) {
+                continue;
+            }
 
             let id = if let Some(&eid) = vocab.get(&token_lower) {
                 eid
@@ -194,7 +210,7 @@ pub fn load_text_file(path: &Path, opts: &LoadOptions) -> io::Result<Corpus> {
     }
 
     let num_types = id_to_word.len();
-    let num_docs  = docs.len();
+    let num_docs = docs.len();
 
     // Accumulate document frequencies.
     let mut doc_freqs = vec![0u32; num_types];
@@ -211,14 +227,21 @@ pub fn load_text_file(path: &Path, opts: &LoadOptions) -> io::Result<Corpus> {
         .collect();
 
     if keep.iter().all(|&k| k) {
-        return Ok(Corpus { id_to_word, docs, doc_names, doc_labels, doc_freqs, total_freqs });
+        return Ok(Corpus {
+            id_to_word,
+            docs,
+            doc_names,
+            doc_labels,
+            doc_freqs,
+            total_freqs,
+        });
     }
 
     // Remap vocabulary.
     let mut remap: Vec<Option<usize>> = vec![None; num_types];
     let mut new_id_to_word: Vec<String> = Vec::new();
-    let mut new_doc_freqs:  Vec<u32>    = Vec::new();
-    let mut new_total_freqs: Vec<u32>   = Vec::new();
+    let mut new_doc_freqs: Vec<u32> = Vec::new();
+    let mut new_total_freqs: Vec<u32> = Vec::new();
 
     for id in 0..num_types {
         if keep[id] {
@@ -231,13 +254,17 @@ pub fn load_text_file(path: &Path, opts: &LoadOptions) -> io::Result<Corpus> {
 
     let new_docs: Vec<Vec<u32>> = docs
         .into_iter()
-        .map(|doc| doc.into_iter().filter_map(|id| remap[id as usize].map(|r| r as u32)).collect())
+        .map(|doc| {
+            doc.into_iter()
+                .filter_map(|id| remap[id as usize].map(|r| r as u32))
+                .collect()
+        })
         .collect();
 
     // Drop documents emptied by pruning, keeping labels aligned.
-    let mut final_docs:   Vec<Vec<u32>> = Vec::new();
-    let mut final_names:  Vec<String>     = Vec::new();
-    let mut final_labels: Vec<String>     = Vec::new();
+    let mut final_docs: Vec<Vec<u32>> = Vec::new();
+    let mut final_names: Vec<String> = Vec::new();
+    let mut final_labels: Vec<String> = Vec::new();
 
     for ((doc, name), label) in new_docs
         .into_iter()
@@ -274,7 +301,7 @@ pub fn save_corpus(corpus: &Corpus, path: &Path) -> io::Result<()> {
 
     w.write_all(MAGIC)?;
     write_u32(&mut w, corpus.num_types() as u32)?;
-    write_u32(&mut w, corpus.num_docs()  as u32)?;
+    write_u32(&mut w, corpus.num_docs() as u32)?;
 
     for id in 0..corpus.num_types() {
         write_str(&mut w, &corpus.id_to_word[id])?;
@@ -313,10 +340,10 @@ pub fn load_corpus(path: &Path) -> io::Result<Corpus> {
     }
 
     let num_types = read_u32(&mut f)? as usize;
-    let num_docs  = read_u32(&mut f)? as usize;
+    let num_docs = read_u32(&mut f)? as usize;
 
-    let mut id_to_word  = Vec::with_capacity(num_types);
-    let mut doc_freqs   = Vec::with_capacity(num_types);
+    let mut id_to_word = Vec::with_capacity(num_types);
+    let mut doc_freqs = Vec::with_capacity(num_types);
     let mut total_freqs = Vec::with_capacity(num_types);
 
     for _ in 0..num_types {
@@ -325,8 +352,8 @@ pub fn load_corpus(path: &Path) -> io::Result<Corpus> {
         total_freqs.push(read_u32(&mut f)?);
     }
 
-    let mut docs       = Vec::with_capacity(num_docs);
-    let mut doc_names  = Vec::with_capacity(num_docs);
+    let mut docs = Vec::with_capacity(num_docs);
+    let mut doc_names = Vec::with_capacity(num_docs);
     let mut doc_labels = Vec::with_capacity(num_docs);
 
     for _ in 0..num_docs {
@@ -340,7 +367,14 @@ pub fn load_corpus(path: &Path) -> io::Result<Corpus> {
         docs.push(tokens);
     }
 
-    Ok(Corpus { id_to_word, docs, doc_names, doc_labels, doc_freqs, total_freqs })
+    Ok(Corpus {
+        id_to_word,
+        docs,
+        doc_names,
+        doc_labels,
+        doc_freqs,
+        total_freqs,
+    })
 }
 
 // ---------------------------------------------------------------------------

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -15,10 +15,12 @@
 
 use rand::Rng;
 
-use crate::variational::{lbfgs_minimize, doc_sparse, fit_gamma_ridge};
-use crate::linalg::{cholesky, half_logdet, make_diagonally_dominant, spd_inverse, spd_inverse_from_chol};
 use crate::estimator::{Estimator, ModelFamily};
+use crate::linalg::{
+    cholesky, half_logdet, make_diagonally_dominant, spd_inverse, spd_inverse_from_chol,
+};
 use crate::variational::LogisticNormalModel;
+use crate::variational::{doc_sparse, fit_gamma_ridge, lbfgs_minimize};
 
 /// Prior on the prevalence coefficients γ in the STM M-step.
 ///
@@ -195,8 +197,8 @@ pub fn ctm_grad(
 /// Result of STM `hpbcpp`: the Laplace covariance, expected token-topic counts,
 /// and the per-document evidence bound.
 pub struct HpbResult {
-    pub nu: Vec<f64>,        // (K-1)×(K-1) variational covariance H⁻¹
-    pub phi: Vec<Vec<f64>>,  // K×W expected token-topic counts for the doc's words
+    pub nu: Vec<f64>,       // (K-1)×(K-1) variational covariance H⁻¹
+    pub phi: Vec<Vec<f64>>, // K×W expected token-topic counts for the doc's words
     pub bound: f64,
 }
 
@@ -371,9 +373,9 @@ pub struct ContentKappa {
 pub struct CtmModel {
     pub num_topics: usize,
     pub num_types: usize,
-    pub beta: Vec<Vec<f64>>, // K×V topic-word
-    pub mu: Vec<f64>,        // K-1 prior mean (no-covariate case)
-    pub sigma: Vec<f64>,     // (K-1)² prior covariance
+    pub beta: Vec<Vec<f64>>,   // K×V topic-word
+    pub mu: Vec<f64>,          // K-1 prior mean (no-covariate case)
+    pub sigma: Vec<f64>,       // (K-1)² prior covariance
     pub lambda: Vec<Vec<f64>>, // per-doc variational means η (K-1)
     /// Per-document variational covariance ν = H⁻¹ ((K-1)² flattened, row-major),
     /// from the final E-step — the Laplace posterior of η used for
@@ -719,23 +721,34 @@ fn fit_gamma_enet(
         col_mean[j] = s / n_f64;
     }
     for j in 0..p {
-        let var: f64 = x.iter().map(|row| {
-            let d = row[j + 1] - col_mean[j];
-            d * d
-        }).sum::<f64>() / n_f64;
+        let var: f64 = x
+            .iter()
+            .map(|row| {
+                let d = row[j + 1] - col_mean[j];
+                d * d
+            })
+            .sum::<f64>()
+            / n_f64;
         col_std[j] = if var > 1e-12 { var.sqrt() } else { 1.0 };
     }
 
     // Build standardised design matrix (n × p), excluding the intercept column.
-    let xs: Vec<Vec<f64>> = x.iter().map(|row| {
-        (0..p).map(|j| (row[j + 1] - col_mean[j]) / col_std[j]).collect()
-    }).collect();
+    let xs: Vec<Vec<f64>> = x
+        .iter()
+        .map(|row| {
+            (0..p)
+                .map(|j| (row[j + 1] - col_mean[j]) / col_std[j])
+                .collect()
+        })
+        .collect();
 
     // Pre-compute column norms² of the standardised design (all = n for unit-variance).
     let mut xj_norm2 = vec![0.0f64; p];
     for j in 0..p {
         xj_norm2[j] = xs.iter().map(|row| row[j] * row[j]).sum();
-        if xj_norm2[j] < 1e-12 { xj_norm2[j] = 1.0; } // constant column guard
+        if xj_norm2[j] < 1e-12 {
+            xj_norm2[j] = 1.0;
+        } // constant column guard
     }
 
     // Coordinate-descent loop for one response column y (length n).
@@ -797,7 +810,9 @@ fn fit_gamma_enet(
                 let delta_int = r_mean;
                 if delta_int.abs() > 1e-14 {
                     coef[0] += delta_int;
-                    for ri in r.iter_mut() { *ri -= delta_int; }
+                    for ri in r.iter_mut() {
+                        *ri -= delta_int;
+                    }
                     max_change = max_change.max(delta_int.abs());
                 }
 
@@ -805,7 +820,11 @@ fn fit_gamma_enet(
                 for j in 0..p {
                     let old = coef[j + 1];
                     // Partial residual: add back contribution of current coef.
-                    let rj_dot: f64 = xs.iter().zip(r.iter()).map(|(row, &ri)| row[j] * (ri + old * row[j])).sum();
+                    let rj_dot: f64 = xs
+                        .iter()
+                        .zip(r.iter())
+                        .map(|(row, &ri)| row[j] * (ri + old * row[j]))
+                        .sum();
                     // Soft-threshold update.
                     let z = rj_dot / xj_norm2[j];
                     let thresh = lam * alpha_safe;
@@ -827,7 +846,9 @@ fn fit_gamma_enet(
                     }
                 }
 
-                if max_change < 1e-7 { break; }
+                if max_change < 1e-7 {
+                    break;
+                }
             }
 
             // AIC = n * ln(RSS/n) + 2 * df
@@ -864,7 +885,6 @@ fn fit_gamma_enet(
     }
     g
 }
-
 
 /// `μ_d = X_d γ` (length K-1).
 fn mu_from(x_d: &[f64], gamma: &[Vec<f64>], km1: usize) -> Vec<f64> {
@@ -987,7 +1007,9 @@ pub fn fit_ctm<R: Rng>(
                 kappa_t[t][v] = beta[t][v].max(1e-12).ln() - m_bg[v];
             }
         }
-        content_beta = build_content_beta(&m_bg, &kappa_t, &kappa_c, &kappa_i, k, num_groups, num_types);
+        content_beta = build_content_beta(
+            &m_bg, &kappa_t, &kappa_c, &kappa_i, k, num_groups, num_types,
+        );
     }
 
     let mut mu_shared = vec![0.0f64; km1];
@@ -1029,8 +1051,8 @@ pub fn fit_ctm<R: Rng>(
 
     for em in 0..em_iters {
         em_iters_run = em + 1;
-        sigma_estep = sigma.clone();  // capture sigma before E-step
-        beta_estep = beta.clone();    // capture beta before E-step
+        sigma_estep = sigma.clone(); // capture sigma before E-step
+        beta_estep = beta.clone(); // capture beta before E-step
         let siginv = spd_inverse(&sigma, km1).unwrap_or_else(|| {
             let mut s = sigma.clone();
             make_diagonally_dominant(&mut s, km1);
@@ -1082,7 +1104,9 @@ pub fn fit_ctm<R: Rng>(
                         7,
                         1e-5,
                     );
-                    let res = ctm_hpb(&opt, beta_doc, words, counts, &mu_d, &siginv, entropy, diagonal);
+                    let res = ctm_hpb(
+                        &opt, beta_doc, words, counts, &mu_d, &siginv, entropy, diagonal,
+                    );
                     (opt, res)
                 });
 
@@ -1350,7 +1374,9 @@ pub fn fit_ctm_svi<R: Rng>(
                     7,
                     1e-5,
                 );
-                let res = ctm_hpb(&opt, &beta, words, counts, &mu_shared, &siginv, entropy, diagonal);
+                let res = ctm_hpb(
+                    &opt, &beta, words, counts, &mu_shared, &siginv, entropy, diagonal,
+                );
                 for (wi, &w) in words.iter().enumerate() {
                     for tt in 0..k {
                         beta_ss[tt][w] += res.phi[tt][wi];
@@ -1424,7 +1450,9 @@ pub fn fit_ctm_svi<R: Rng>(
             7,
             1e-5,
         );
-        let res = ctm_hpb(&opt, &beta, words, counts, &mu_shared, &siginv, entropy, diagonal);
+        let res = ctm_hpb(
+            &opt, &beta, words, counts, &mu_shared, &siginv, entropy, diagonal,
+        );
         lambda[di] = opt;
         if keep_nu {
             nu_store[di] = res.nu;
@@ -1468,10 +1496,7 @@ pub fn fit_ctm_svi<R: Rng>(
 /// μ cancels out of the Hessian — so we evaluate at the shared `model.mu` and the
 /// E-step β/Σ (`beta_estep`/`sigma_estep`) to reproduce the stored ν exactly.
 /// `sparse` is the same `(words, counts)` representation built from the raw docs.
-pub fn recompute_nu(
-    model: &CtmModel,
-    sparse: &[(Vec<usize>, Vec<f64>)],
-) -> Vec<Vec<f64>> {
+pub fn recompute_nu(model: &CtmModel, sparse: &[(Vec<usize>, Vec<f64>)]) -> Vec<Vec<f64>> {
     use rayon::prelude::*;
     let d = sparse.len();
     let km1 = model.num_topics - 1;
@@ -1524,13 +1549,31 @@ mod tests {
         use rand::SeedableRng;
         use rand_chacha::ChaCha8Rng;
         let docs: Vec<Vec<u32>> = vec![
-            vec![0, 1, 0, 1, 2, 2], vec![1, 2, 1, 2, 0, 0], vec![2, 0, 2, 0, 1, 1],
-            vec![3, 4, 3, 4, 5, 5], vec![4, 5, 4, 5, 3, 3], vec![5, 3, 5, 3, 4, 4],
+            vec![0, 1, 0, 1, 2, 2],
+            vec![1, 2, 1, 2, 0, 0],
+            vec![2, 0, 2, 0, 1, 1],
+            vec![3, 4, 3, 4, 5, 5],
+            vec![4, 5, 4, 5, 3, 3],
+            vec![5, 3, 5, 3, 4, 4],
         ];
         let fit = || {
             let mut rng = ChaCha8Rng::seed_from_u64(123);
-            fit_ctm(&docs, 2, 6, 30, 0.0, 0.0, None, None, false, None,
-                    GammaPrior::Pooled, true, false, &mut rng)
+            fit_ctm(
+                &docs,
+                2,
+                6,
+                30,
+                0.0,
+                0.0,
+                None,
+                None,
+                false,
+                None,
+                GammaPrior::Pooled,
+                true,
+                false,
+                &mut rng,
+            )
         };
         let a = fit();
         let b = fit();
@@ -1539,16 +1582,14 @@ mod tests {
         // Frozen reference: each topic concentrates on one disjoint 3-word block.
         let on = 0.333_333_332_8_f64;
         let off = 0.000_000_000_6_f64;
-        let expected = [
-            [off, off, off, on, on, on],
-            [on, on, on, off, off, off],
-        ];
+        let expected = [[off, off, off, on, on, on], [on, on, on, off, off, off]];
         for k in 0..2 {
             for v in 0..6 {
                 assert!(
                     (a.beta[k][v] - expected[k][v]).abs() < 1e-9,
                     "beta[{k}][{v}] = {} drifted from frozen {}",
-                    a.beta[k][v], expected[k][v]
+                    a.beta[k][v],
+                    expected[k][v]
                 );
             }
         }
@@ -1585,7 +1626,13 @@ mod tests {
             let num = (ctm_lhood(&ep, &beta, &words, &counts, &mu, &siginv)
                 - ctm_lhood(&em, &beta, &words, &counts, &mu, &siginv))
                 / (2.0 * eps);
-            assert!((num - g[i]).abs() < 1e-4, "grad[{}]: {} vs {}", i, g[i], num);
+            assert!(
+                (num - g[i]).abs() < 1e-4,
+                "grad[{}]: {} vs {}",
+                i,
+                g[i],
+                num
+            );
         }
     }
 
@@ -1606,7 +1653,9 @@ mod tests {
                 doc
             })
             .collect();
-        let m = fit_ctm_svi(&docs, nb, v, 20, 32, 16.0, 0.7, 0.0, false, true, false, &mut rng);
+        let m = fit_ctm_svi(
+            &docs, nb, v, 20, 32, 16.0, 0.7, 0.0, false, true, false, &mut rng,
+        );
         // Each planted block is the top of some topic.
         let mut covered = std::collections::HashSet::new();
         for t in 0..nb {
@@ -1630,7 +1679,10 @@ mod tests {
             .collect();
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(7);
-            fit_ctm_svi(&docs, 3, 9, 10, 16, 16.0, 0.7, 0.0, false, true, false, &mut rng).beta
+            fit_ctm_svi(
+                &docs, 3, 9, 10, 16, 16.0, 0.7, 0.0, false, true, false, &mut rng,
+            )
+            .beta
         };
         let (a, b) = (run(), run());
         for (ra, rb) in a.iter().zip(b.iter()) {
@@ -1655,7 +1707,22 @@ mod tests {
                 docs.push(vec![6, 7, 8, 6, 7, 8, 6, 7, 8, 6]);
             }
         }
-        let model = fit_ctm(&docs, 3, 9, 25, 0.0, 0.0, None, None, true, None, GammaPrior::Pooled, true, false, &mut rng);
+        let model = fit_ctm(
+            &docs,
+            3,
+            9,
+            25,
+            0.0,
+            0.0,
+            None,
+            None,
+            true,
+            None,
+            GammaPrior::Pooled,
+            true,
+            false,
+            &mut rng,
+        );
         let theta = model.doc_topics();
         // Sanity: θ rows sum to 1 and are valid.
         for row in &theta {
@@ -1686,7 +1753,22 @@ mod tests {
             }
         }
         // K=2 (CTM needs >=2 topics); content groups = 2.
-        let model = fit_ctm(&docs, 2, 4, 30, 0.0, 0.0, None, Some((&groups, 2)), false, None, GammaPrior::Pooled, true, false, &mut rng);
+        let model = fit_ctm(
+            &docs,
+            2,
+            4,
+            30,
+            0.0,
+            0.0,
+            None,
+            Some((&groups, 2)),
+            false,
+            None,
+            GammaPrior::Pooled,
+            true,
+            false,
+            &mut rng,
+        );
         let cb = model.content_beta.expect("content_beta present");
         // cb[group][topic][word]. The dominant topic for group 0 should favour
         // {0,1}; for group 1 {2,3}. Check that for each group some topic does.
@@ -1696,8 +1778,16 @@ mod tests {
         let g1_best = (0..2)
             .map(|t| cb[1][t][2] + cb[1][t][3])
             .fold(0.0f64, f64::max);
-        assert!(g0_best > 0.8, "group 0 top topic mass on its words = {}", g0_best);
-        assert!(g1_best > 0.8, "group 1 top topic mass on its words = {}", g1_best);
+        assert!(
+            g0_best > 0.8,
+            "group 0 top topic mass on its words = {}",
+            g0_best
+        );
+        assert!(
+            g1_best > 0.8,
+            "group 1 top topic mass on its words = {}",
+            g1_best
+        );
     }
 
     #[test]
@@ -1714,20 +1804,53 @@ mod tests {
             }
         }
 
-        let converged = fit_ctm(&docs, 2, 6, 100, 1e-5, 0.0, None, None, true, None, GammaPrior::Pooled, true, false, &mut rng);
+        let converged = fit_ctm(
+            &docs,
+            2,
+            6,
+            100,
+            1e-5,
+            0.0,
+            None,
+            None,
+            true,
+            None,
+            GammaPrior::Pooled,
+            true,
+            false,
+            &mut rng,
+        );
         // The bound trajectory is (weakly) monotone increasing.
         let h = &converged.bound_history;
         assert!(h.len() >= 2);
         for w in h.windows(2) {
             assert!(w[1] >= w[0] - 1e-6, "bound decreased: {} -> {}", w[0], w[1]);
         }
-        assert!(converged.converged, "should meet em_tol before the 100-iter cap");
+        assert!(
+            converged.converged,
+            "should meet em_tol before the 100-iter cap"
+        );
         assert_eq!(converged.em_iters_run, h.len());
         assert!(converged.bound.is_finite());
 
         // em_tol = 0 disables early stopping: run the full cap.
         let mut rng2 = ChaCha8Rng::seed_from_u64(7);
-        let capped = fit_ctm(&docs, 2, 6, 8, 0.0, 0.0, None, None, true, None, GammaPrior::Pooled, true, false, &mut rng2);
+        let capped = fit_ctm(
+            &docs,
+            2,
+            6,
+            8,
+            0.0,
+            0.0,
+            None,
+            None,
+            true,
+            None,
+            GammaPrior::Pooled,
+            true,
+            false,
+            &mut rng2,
+        );
         assert!(!capped.converged);
         assert_eq!(capped.em_iters_run, 8);
         assert_eq!(capped.bound_history.len(), 8);
@@ -1751,7 +1874,20 @@ mod tests {
             })
             .collect();
         let model = fit_ctm(
-            &docs, nb, v, 30, 0.0, 0.0, None, None, true, None, GammaPrior::Pooled, true, true, &mut rng,
+            &docs,
+            nb,
+            v,
+            30,
+            0.0,
+            0.0,
+            None,
+            None,
+            true,
+            None,
+            GammaPrior::Pooled,
+            true,
+            true,
+            &mut rng,
         );
         assert!(model.diagonal, "model should record diagonal mode");
 
@@ -1765,7 +1901,10 @@ mod tests {
         let h_max = h.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
         let total_range = h_max - h[0];
         assert!(total_range > 0.0, "diagonal bound did not improve overall");
-        assert!(h[h.len() - 1] > h[0], "diagonal bound did not improve overall");
+        assert!(
+            h[h.len() - 1] > h[0],
+            "diagonal bound did not improve overall"
+        );
         let mut max_decrease = 0.0f64;
         for w in h.windows(2) {
             let dec = w[0] - w[1];
@@ -1776,7 +1915,8 @@ mod tests {
         assert!(
             max_decrease < 0.01 * total_range,
             "max per-step decrease {} too large vs total improvement {}",
-            max_decrease, total_range
+            max_decrease,
+            total_range
         );
 
         // ν is purely diagonal (off-diagonals exactly zero, diagonals positive).
@@ -1806,7 +1946,11 @@ mod tests {
                 }
             }
         }
-        assert_eq!(covered.len(), nb, "diagonal mode only recovered {covered:?}");
+        assert_eq!(
+            covered.len(),
+            nb,
+            "diagonal mode only recovered {covered:?}"
+        );
     }
 
     // Build a synthetic regression problem with n observations, p predictors
@@ -1822,7 +1966,9 @@ mod tests {
         // at test time.  Generates uniform [0,1) floats.
         let mut state = seed ^ 0xdeadbeef_cafef00d;
         let mut rand_f64 = move || -> f64 {
-            state = state.wrapping_mul(6364136223846793005).wrapping_add(1442695040888963407);
+            state = state
+                .wrapping_mul(6364136223846793005)
+                .wrapping_add(1442695040888963407);
             (state >> 33) as f64 / (u32::MAX as f64)
         };
 

--- a/topica-core/src/cvb0.rs
+++ b/topica-core/src/cvb0.rs
@@ -224,7 +224,11 @@ impl Cvb0 {
         for row in inv_seeds.iter_mut() {
             row.sort_unstable();
         }
-        self.seed = Some(CvbSeedBeta { seed_weight, beta_sum_k, inv_seeds });
+        self.seed = Some(CvbSeedBeta {
+            seed_weight,
+            beta_sum_k,
+            inv_seeds,
+        });
     }
 
     /// Expected document-topic counts `E[n_dk]` — the soft input the DMR λ
@@ -295,7 +299,11 @@ impl Cvb0 {
 
                 // Normalize, accumulate |Δγ|, and add the new mass back.
                 for &t in topics {
-                    let new = if sum > 0.0 { self.gamma[d][i][t] / sum } else { uniform };
+                    let new = if sum > 0.0 {
+                        self.gamma[d][i][t] / sum
+                    } else {
+                        uniform
+                    };
                     self.gamma[d][i][t] = new;
                     total_change += (new - old[t]).abs();
                     self.n_dk[d][t] += cf * new;
@@ -489,8 +497,7 @@ mod tests {
         let mut rng = Pcg64Mcg::seed_from_u64(1);
         let mut m = Cvb0::new(&corpus, k, &alpha, 0.01, &mut rng);
         // doc d (block d % n_blocks) is allowed only topic (d % n_blocks).
-        let allowed: Vec<Vec<usize>> =
-            (0..corpus.docs.len()).map(|d| vec![d % n_blocks]).collect();
+        let allowed: Vec<Vec<usize>> = (0..corpus.docs.len()).map(|d| vec![d % n_blocks]).collect();
         m.set_allowed(allowed.clone());
         for _ in 0..60 {
             m.sweep();

--- a/topica-core/src/lib.rs
+++ b/topica-core/src/lib.rs
@@ -12,10 +12,10 @@
 //! consumers (e.g. the faSTM R package, which vendors a minimal crate for CRAN)
 //! can depend on `topica-core` alone.
 
-pub mod linalg;
 pub mod corpus;
-pub mod spectral;
-pub mod variational;
-pub mod estimator;
 pub mod ctm;
 pub mod cvb0;
+pub mod estimator;
+pub mod linalg;
+pub mod spectral;
+pub mod variational;

--- a/topica-core/src/linalg.rs
+++ b/topica-core/src/linalg.rs
@@ -83,10 +83,7 @@ pub fn spd_inverse(a: &[f64], n: usize) -> Option<Vec<f64>> {
 pub fn make_diagonally_dominant(a: &mut [f64], n: usize) {
     let diag: Vec<f64> = (0..n).map(|i| a[i * n + i]).collect();
     for i in 0..n {
-        let off: f64 = (0..n)
-            .filter(|&j| j != i)
-            .map(|j| a[i * n + j].abs())
-            .sum();
+        let off: f64 = (0..n).filter(|&j| j != i).map(|j| a[i * n + j].abs()).sum();
         if diag[i] < off {
             a[i * n + i] = off;
         }

--- a/topica-core/src/spectral.rs
+++ b/topica-core/src/spectral.rs
@@ -94,7 +94,11 @@ fn fast_anchor_words(qbar: &[Vec<f64>], p: &[f64], k: usize, min_p: f64) -> Opti
     let mut anchors = Vec::with_capacity(k);
     let first = *candidates
         .iter()
-        .max_by(|&&a, &&b| dot(&qbar[a], &qbar[a]).partial_cmp(&dot(&qbar[b], &qbar[b])).unwrap())
+        .max_by(|&&a, &&b| {
+            dot(&qbar[a], &qbar[a])
+                .partial_cmp(&dot(&qbar[b], &qbar[b]))
+                .unwrap()
+        })
         .unwrap();
     anchors.push(first);
 
@@ -189,7 +193,9 @@ fn recover(qbar: &[Vec<f64>], p: &[f64], anchors: &[usize], k: usize, v: usize) 
             let bvec: Vec<f64> = (0..k).map(|t| dot(anchor_rows[t], &qbar[w])).collect();
             let mut sse_old = f64::INFINITY;
             for _ in 0..MAX_ITS {
-                let gc: Vec<f64> = (0..k).map(|i| (0..k).map(|j| g[i][j] * c[j]).sum()).collect();
+                let gc: Vec<f64> = (0..k)
+                    .map(|i| (0..k).map(|j| g[i][j] * c[j]).sum())
+                    .collect();
                 // residual b − Gc and its squared norm (the convergence metric).
                 let resid: Vec<f64> = (0..k).map(|i| bvec[i] - gc[i]).collect();
                 let sse: f64 = resid.iter().map(|r| r * r).sum();
@@ -256,7 +262,11 @@ fn cooccurrence_projected(
     let mut rng = ChaCha8Rng::seed_from_u64(PROJ_SEED);
     let scale = 1.0 / (m as f64).sqrt();
     let r: Vec<Vec<f64>> = (0..v)
-        .map(|_| (0..m).map(|_| if rng.gen::<bool>() { scale } else { -scale }).collect())
+        .map(|_| {
+            (0..m)
+                .map(|_| if rng.gen::<bool>() { scale } else { -scale })
+                .collect()
+        })
         .collect();
 
     let mut qp = vec![vec![0.0f64; m]; v];
@@ -350,7 +360,9 @@ mod tests {
         let nb = 10usize;
         let bs = 400usize;
         let v = nb * bs; // 4000
-        let blocks: Vec<Vec<u32>> = (0..nb).map(|b| (b * bs..b * bs + bs).map(|w| w as u32).collect()).collect();
+        let blocks: Vec<Vec<u32>> = (0..nb)
+            .map(|b| (b * bs..b * bs + bs).map(|w| w as u32).collect())
+            .collect();
         let mut docs = Vec::new();
         for i in 0..(nb * 200) {
             let blk = &blocks[i % nb];
@@ -366,8 +378,16 @@ mod tests {
             idx.sort_by(|&a, &b| beta[t][b].partial_cmp(&beta[t][a]).unwrap());
             let block_of = |w: usize| w / bs;
             let top_block = block_of(idx[0]);
-            let same = idx[..10].iter().filter(|&&w| block_of(w) == top_block).count();
-            assert!(same >= 8, "topic {} top words not concentrated in one block ({}/10)", t, same);
+            let same = idx[..10]
+                .iter()
+                .filter(|&&w| block_of(w) == top_block)
+                .count();
+            assert!(
+                same >= 8,
+                "topic {} top words not concentrated in one block ({}/10)",
+                t,
+                same
+            );
             covered.insert(top_block);
         }
         // Every topic is cleanly block-localized (asserted above); a strong
@@ -375,7 +395,11 @@ mod tests {
         // block separation isn't guaranteed at K=10 — greedy anchor selection can
         // pick two anchors from one block — and that's true of the exact path too,
         // so we don't demand it of the approximate projected path.)
-        assert!(covered.len() >= 7, "too few blocks separated: {:?}", covered);
+        assert!(
+            covered.len() >= 7,
+            "too few blocks separated: {:?}",
+            covered
+        );
     }
 
     #[test]
@@ -397,7 +421,12 @@ mod tests {
             let is_block = blocks
                 .iter()
                 .any(|blk| blk.iter().all(|&w| top.contains(&(w as usize))));
-            assert!(is_block, "topic {} top words not a single block: {:?}", t, &idx[..3]);
+            assert!(
+                is_block,
+                "topic {} top words not a single block: {:?}",
+                t,
+                &idx[..3]
+            );
         }
     }
 }

--- a/topica-core/src/variational/lbfgs.rs
+++ b/topica-core/src/variational/lbfgs.rs
@@ -7,7 +7,13 @@ fn dot(a: &[f64], b: &[f64]) -> f64 {
 /// Minimize `f` (value + gradient) with limited-memory BFGS and a backtracking
 /// Armijo line search. Compact by design: DMR re-optimizes frequently between
 /// sampling sweeps, so a short history and iteration budget suffice.
-pub fn lbfgs_minimize<F>(x0: Vec<f64>, mut f: F, max_iter: usize, history: usize, tol: f64) -> Vec<f64>
+pub fn lbfgs_minimize<F>(
+    x0: Vec<f64>,
+    mut f: F,
+    max_iter: usize,
+    history: usize,
+    tol: f64,
+) -> Vec<f64>
 where
     F: FnMut(&[f64]) -> (f64, Vec<f64>),
 {


### PR DESCRIPTION
First step of the post-release hardening (review findings #1 + #6). **Mechanical, no behavior change.**

## What

- `cargo fmt --all` across the whole repo (it had never been formatted to rustfmt defaults). Isolated to one commit so it doesn't bury logic or scatter `git blame`.
- **CI gates added:**
  - `cargo fmt --all --check` (finding #6 — hygiene was reviewer-discipline-only)
  - `cargo test --lib` → `cargo test --workspace --lib` (finding #1 — `topica-core` was never tested in CI and could regress while green)

## Verification (behavior-neutral)

- `cargo fmt --all --check` clean
- `cargo test --workspace --lib`: topica **133**, topica-core **16**
- `maturin develop --features python` compiles `python.rs` unchanged

## faSTM

Touches no public signatures — `fit_ctm`/`infer_theta`/`GammaPrior`/`CtmModel`/`Corpus` are unchanged, so faSTM is unaffected.

## Follow-ups (separate PRs)

- clippy fixes (~40) + `clippy -D warnings` gate
- robustness: CLI arg panics (#2), loader shape `unwrap`s (#5), core post-repair `unwrap`/`expect` fallbacks (#3), spectral NaN sort (#4)
- mechanical `python.rs` → `python/` module split (Round 2), one family per PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)