### PR TITLE
fix: panic-hardening — CLI, numerical kernels, float sort, loaders (#2-#5)

### DIFF
--- a/src/bin/analyze.rs
+++ b/src/bin/analyze.rs
@@ -2,6 +2,7 @@ use std::collections::HashSet;
 use std::fs;
 use std::io::{self, BufWriter, Write};
 use std::path::Path;
+use topica::cli::{next_val, parse_val};
 use topica::corpus;
 
 fn print_usage() {
@@ -55,30 +56,12 @@ fn parse_args() -> Option<Args> {
     let mut i = 0;
     while i < raw.len() {
         match raw[i].as_str() {
-            "--corpus" => {
-                i += 1;
-                args.corpus = Some(raw[i].clone());
-            }
-            "--max-doc-fraction" => {
-                i += 1;
-                args.max_doc_fraction = raw[i].parse().ok()?;
-            }
-            "--max-word-length" => {
-                i += 1;
-                args.max_word_length = raw[i].parse().ok()?;
-            }
-            "--min-doc-freq" => {
-                i += 1;
-                args.min_doc_freq = raw[i].parse().ok()?;
-            }
-            "--num-candidates" => {
-                i += 1;
-                args.num_candidates = raw[i].parse().ok()?;
-            }
-            "--output-stoplist" => {
-                i += 1;
-                args.output_stoplist = Some(raw[i].clone());
-            }
+            "--corpus" => args.corpus = Some(next_val(&raw, &mut i)?),
+            "--max-doc-fraction" => args.max_doc_fraction = parse_val(&raw, &mut i)?,
+            "--max-word-length" => args.max_word_length = parse_val(&raw, &mut i)?,
+            "--min-doc-freq" => args.min_doc_freq = parse_val(&raw, &mut i)?,
+            "--num-candidates" => args.num_candidates = parse_val(&raw, &mut i)?,
+            "--output-stoplist" => args.output_stoplist = Some(next_val(&raw, &mut i)?),
             "--help" | "-h" => return None,
             other => {
                 eprintln!("Unknown argument: {}", other);

--- a/src/bin/preprocess.rs
+++ b/src/bin/preprocess.rs
@@ -1,4 +1,5 @@
 use std::path::Path;
+use topica::cli::{next_val, parse_val};
 use topica::corpus::{self, InputFormat, LoadOptions, DEFAULT_TOKEN_REGEX};
 
 fn print_usage() {
@@ -72,59 +73,29 @@ fn parse_args() -> Option<Args> {
     let mut i = 0;
     while i < raw.len() {
         match raw[i].as_str() {
-            "--input" => {
-                i += 1;
-                args.input = Some(raw[i].clone());
-            }
-            "--output" => {
-                i += 1;
-                args.output = Some(raw[i].clone());
-            }
-            "--stoplist" => {
-                i += 1;
-                args.stoplist = Some(raw[i].clone());
-            }
-            "--format" => {
-                i += 1;
-                match raw[i].as_str() {
-                    "tsv" => args.tsv_mode = true,
-                    "plain" => args.tsv_mode = false,
-                    other => {
-                        eprintln!("Unknown format: {} (use 'plain' or 'tsv')", other);
-                        return None;
-                    }
+            "--input" => args.input = Some(next_val(&raw, &mut i)?),
+            "--output" => args.output = Some(next_val(&raw, &mut i)?),
+            "--stoplist" => args.stoplist = Some(next_val(&raw, &mut i)?),
+            "--format" => match next_val(&raw, &mut i)?.as_str() {
+                "tsv" => args.tsv_mode = true,
+                "plain" => args.tsv_mode = false,
+                other => {
+                    eprintln!("Unknown format: {} (use 'plain' or 'tsv')", other);
+                    return None;
                 }
-            }
+            },
             "--id-field" => {
                 args.id_field = true;
             }
-            "--id-column" => {
-                i += 1;
-                args.id_column = raw[i].parse().ok()?;
-            }
-            "--label-column" => {
-                i += 1;
-                args.label_column = Some(raw[i].parse().ok()?);
-            }
+            "--id-column" => args.id_column = parse_val(&raw, &mut i)?,
+            "--label-column" => args.label_column = Some(parse_val(&raw, &mut i)?),
             "--no-label" => {
                 args.label_column = None;
             }
-            "--text-column" => {
-                i += 1;
-                args.text_column = raw[i].parse().ok()?;
-            }
-            "--token-regex" => {
-                i += 1;
-                args.token_regex = raw[i].clone();
-            }
-            "--min-doc-freq" => {
-                i += 1;
-                args.min_doc_freq = raw[i].parse().ok()?;
-            }
-            "--max-doc-fraction" => {
-                i += 1;
-                args.max_doc_fraction = raw[i].parse().ok()?;
-            }
+            "--text-column" => args.text_column = parse_val(&raw, &mut i)?,
+            "--token-regex" => args.token_regex = next_val(&raw, &mut i)?,
+            "--min-doc-freq" => args.min_doc_freq = parse_val(&raw, &mut i)?,
+            "--max-doc-fraction" => args.max_doc_fraction = parse_val(&raw, &mut i)?,
             "--help" | "-h" => return None,
             other => {
                 eprintln!("Unknown argument: {}", other);

--- a/src/bin/show.rs
+++ b/src/bin/show.rs
@@ -4,6 +4,7 @@ use std::collections::BTreeMap;
 use std::fs;
 use std::io::{self, BufRead};
 use std::path::Path;
+use topica::cli::{next_val, parse_val};
 
 fn print_usage() {
     eprintln!(
@@ -45,26 +46,11 @@ fn parse_args() -> Option<Args> {
     let mut i = 0;
     while i < raw.len() {
         match raw[i].as_str() {
-            "--topic-word" => {
-                i += 1;
-                args.topic_word = raw[i].clone();
-            }
-            "--doc-topic" => {
-                i += 1;
-                args.doc_topic = raw[i].clone();
-            }
-            "--words" => {
-                i += 1;
-                args.words = raw[i].parse().ok()?;
-            }
-            "--doc-topics" => {
-                i += 1;
-                args.doc_topics = raw[i].parse().ok()?;
-            }
-            "--threshold" => {
-                i += 1;
-                args.threshold = raw[i].parse().ok()?;
-            }
+            "--topic-word" => args.topic_word = next_val(&raw, &mut i)?,
+            "--doc-topic" => args.doc_topic = next_val(&raw, &mut i)?,
+            "--words" => args.words = parse_val(&raw, &mut i)?,
+            "--doc-topics" => args.doc_topics = parse_val(&raw, &mut i)?,
+            "--threshold" => args.threshold = parse_val(&raw, &mut i)?,
             "--help" | "-h" => return None,
             other => {
                 eprintln!("Unknown argument: {}", other);

--- a/src/bin/train.rs
+++ b/src/bin/train.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 use std::time::Instant;
+use topica::cli::{next_val, parse_val};
 use topica::{corpus, model, optimize, output, sampler};
 
 use rand::SeedableRng;
@@ -84,62 +85,20 @@ fn parse_args() -> Option<Args> {
     let mut i = 0;
     while i < raw.len() {
         match raw[i].as_str() {
-            "--corpus" => {
-                i += 1;
-                args.corpus = Some(raw[i].clone());
-            }
-            "--num-topics" => {
-                i += 1;
-                args.num_topics = raw[i].parse().ok()?;
-            }
-            "--iterations" => {
-                i += 1;
-                args.iterations = raw[i].parse().ok()?;
-            }
-            "--burn-in" => {
-                i += 1;
-                args.burn_in = raw[i].parse().ok()?;
-            }
-            "--optimize-interval" => {
-                i += 1;
-                args.optimize_interval = raw[i].parse().ok()?;
-            }
-            "--num-samples" => {
-                i += 1;
-                args.num_samples = raw[i].parse().ok()?;
-            }
-            "--sample-interval" => {
-                i += 1;
-                args.sample_interval = raw[i].parse().ok()?;
-            }
-            "--topic-word" => {
-                i += 1;
-                args.topic_word_output = raw[i].clone();
-            }
-            "--doc-topic" => {
-                i += 1;
-                args.doc_topic_output = raw[i].clone();
-            }
-            "--alpha-sum" => {
-                i += 1;
-                args.alpha_sum = Some(raw[i].parse().ok()?);
-            }
-            "--beta" => {
-                i += 1;
-                args.beta = raw[i].parse().ok()?;
-            }
-            "--seed" => {
-                i += 1;
-                args.seed = raw[i].parse().ok()?;
-            }
-            "--show-topics-interval" => {
-                i += 1;
-                args.show_topics_interval = raw[i].parse().ok()?;
-            }
-            "--words-per-topic" => {
-                i += 1;
-                args.words_per_topic = raw[i].parse().ok()?;
-            }
+            "--corpus" => args.corpus = Some(next_val(&raw, &mut i)?),
+            "--num-topics" => args.num_topics = parse_val(&raw, &mut i)?,
+            "--iterations" => args.iterations = parse_val(&raw, &mut i)?,
+            "--burn-in" => args.burn_in = parse_val(&raw, &mut i)?,
+            "--optimize-interval" => args.optimize_interval = parse_val(&raw, &mut i)?,
+            "--num-samples" => args.num_samples = parse_val(&raw, &mut i)?,
+            "--sample-interval" => args.sample_interval = parse_val(&raw, &mut i)?,
+            "--topic-word" => args.topic_word_output = next_val(&raw, &mut i)?,
+            "--doc-topic" => args.doc_topic_output = next_val(&raw, &mut i)?,
+            "--alpha-sum" => args.alpha_sum = Some(parse_val(&raw, &mut i)?),
+            "--beta" => args.beta = parse_val(&raw, &mut i)?,
+            "--seed" => args.seed = parse_val(&raw, &mut i)?,
+            "--show-topics-interval" => args.show_topics_interval = parse_val(&raw, &mut i)?,
+            "--words-per-topic" => args.words_per_topic = parse_val(&raw, &mut i)?,
             "--help" | "-h" => return None,
             other => {
                 eprintln!("Unknown argument: {}", other);

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,33 @@
+//! Tiny argument helpers shared by the CLI binaries (train/analyze/preprocess/
+//! show). They bounds-check option values so a missing or unparseable value
+//! prints a usage error and returns `None` (the binaries' "show usage" signal),
+//! instead of panicking on an out-of-range `raw[i]` index.
+//!
+//! Doc-hidden: this is binary-support glue, not part of the public API.
+
+/// Advance `i` to the value following a flag and return it, or print an error
+/// and return `None` if the flag was the final token.
+pub fn next_val(raw: &[String], i: &mut usize) -> Option<String> {
+    *i += 1;
+    match raw.get(*i) {
+        Some(v) => Some(v.clone()),
+        None => {
+            eprintln!("error: '{}' requires a value", raw[*i - 1]);
+            None
+        }
+    }
+}
+
+/// Like [`next_val`], but parse the value into `T`; prints an error and returns
+/// `None` on a missing or unparseable value.
+pub fn parse_val<T: std::str::FromStr>(raw: &[String], i: &mut usize) -> Option<T> {
+    let flag_pos = *i;
+    let v = next_val(raw, i)?;
+    match v.parse() {
+        Ok(x) => Some(x),
+        Err(_) => {
+            eprintln!("error: '{}' got an invalid value: {:?}", raw[flag_pos], v);
+            None
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,8 @@ pub use topica_core::{corpus, ctm, cvb0, estimator, linalg, spectral, variationa
 // because `TopicModel` stays in `topica`).
 pub mod cvb0_ext;
 
+#[doc(hidden)]
+pub mod cli; // argument helpers for the CLI binaries (not part of the public API)
 pub mod coherence;
 pub mod conformance;
 pub mod detm;

--- a/src/python.rs
+++ b/src/python.rs
@@ -183,8 +183,12 @@ fn arr2_opt(a: &Option<Array2<f64>>) -> Option<Arr2> {
         data: m.iter().copied().collect(),
     })
 }
-fn arr2_back(s: Option<Arr2>) -> Option<Array2<f64>> {
-    s.map(|a| Array2::from_shape_vec((a.rows, a.cols), a.data).unwrap())
+fn arr2_back(s: Option<Arr2>) -> PyResult<Option<Array2<f64>>> {
+    s.map(|a| {
+        Array2::from_shape_vec((a.rows, a.cols), a.data)
+            .map_err(|e| PyValueError::new_err(format!("corrupt saved 2-D array: {e}")))
+    })
+    .transpose()
 }
 fn arr3_opt(a: &Option<Array3<f64>>) -> Option<Arr3> {
     a.as_ref().map(|m| {
@@ -197,8 +201,12 @@ fn arr3_opt(a: &Option<Array3<f64>>) -> Option<Arr3> {
         }
     })
 }
-fn arr3_back(s: Option<Arr3>) -> Option<Array3<f64>> {
-    s.map(|a| Array3::from_shape_vec((a.d0, a.d1, a.d2), a.data).unwrap())
+fn arr3_back(s: Option<Arr3>) -> PyResult<Option<Array3<f64>>> {
+    s.map(|a| {
+        Array3::from_shape_vec((a.d0, a.d1, a.d2), a.data)
+            .map_err(|e| PyValueError::new_err(format!("corrupt saved 3-D array: {e}")))
+    })
+    .transpose()
 }
 
 /// Run `f` on a rayon pool of `num_threads` workers, or on the global pool (all
@@ -225,8 +233,12 @@ fn arr3f32_opt(a: &Option<Array3<f32>>) -> Option<Arr3f32> {
         }
     })
 }
-fn arr3f32_back(s: Option<Arr3f32>) -> Option<Array3<f32>> {
-    s.map(|a| Array3::from_shape_vec((a.d0, a.d1, a.d2), a.data).unwrap())
+fn arr3f32_back(s: Option<Arr3f32>) -> PyResult<Option<Array3<f32>>> {
+    s.map(|a| {
+        Array3::from_shape_vec((a.d0, a.d1, a.d2), a.data)
+            .map_err(|e| PyValueError::new_err(format!("corrupt saved 3-D array: {e}")))
+    })
+    .transpose()
 }
 fn arr1_opt(a: &Option<Array1<f64>>) -> Option<Vec<f64>> {
     a.as_ref().map(|m| m.to_vec())
@@ -2699,9 +2711,9 @@ impl LDA {
             use_symmetric_alpha: s.use_symmetric_alpha,
             init_spectral: s.init_spectral,
             topic_names,
-            phi: arr2_back(s.phi),
-            theta: arr2_back(s.theta),
-            theta_draws: arr3f32_back(s.theta_draws),
+            phi: arr2_back(s.phi)?,
+            theta: arr2_back(s.theta)?,
+            theta_draws: arr3f32_back(s.theta_draws)?,
             model: s.model,
             corpus: s.corpus,
             log_likelihood_history: s.log_likelihood_history,
@@ -4621,12 +4633,12 @@ impl DMR {
             cvb0: false,
             fitted: s.fitted,
             topic_names,
-            phi: arr2_back(s.phi),
-            theta: arr2_back(s.theta),
-            feature_effects: arr2_back(s.feature_effects),
+            phi: arr2_back(s.phi)?,
+            theta: arr2_back(s.theta)?,
+            feature_effects: arr2_back(s.feature_effects)?,
             feature_names: s.feature_names,
             corpus: s.corpus,
-            theta_draws: arr3f32_back(s.theta_draws),
+            theta_draws: arr3f32_back(s.theta_draws)?,
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
         })
@@ -5232,11 +5244,11 @@ impl LabeledLDA {
             fitted: s.fitted,
             num_topics: s.num_topics,
             topic_names,
-            phi: arr2_back(s.phi),
-            theta: arr2_back(s.theta),
+            phi: arr2_back(s.phi)?,
+            theta: arr2_back(s.theta)?,
             label_vocab: s.label_vocab,
             corpus: s.corpus,
-            theta_draws: arr3f32_back(s.theta_draws),
+            theta_draws: arr3f32_back(s.theta_draws)?,
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
         })
@@ -5854,10 +5866,10 @@ impl SAGE {
             num_groups: s.num_groups,
             topic_names,
             beta: s.beta,
-            theta: arr2_back(s.theta),
+            theta: arr2_back(s.theta)?,
             group_names: s.group_names,
             corpus: s.corpus,
-            theta_draws: arr3f32_back(s.theta_draws),
+            theta_draws: arr3f32_back(s.theta_draws)?,
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
         })
@@ -6721,7 +6733,7 @@ impl CTM {
             s.topic_names
         };
         // eta_cov is saved as f64 for format compatibility; downcast to f32 in memory.
-        let eta_cov = arr3_back(s.eta_cov).map(|c| c.mapv(|x| x as f32));
+        let eta_cov = arr3_back(s.eta_cov)?.map(|c| c.mapv(|x| x as f32));
         Ok(CTM {
             num_topics: s.num_topics,
             sigma_shrink: s.sigma_shrink,
@@ -6730,10 +6742,10 @@ impl CTM {
             variational: s.variational,
             fitted: s.fitted,
             topic_names,
-            beta: arr2_back(s.beta),
-            theta: arr2_back(s.theta),
-            corr: arr2_back(s.corr),
-            eta_mean: arr2_back(s.eta_mean),
+            beta: arr2_back(s.beta)?,
+            theta: arr2_back(s.theta)?,
+            corr: arr2_back(s.corr)?,
+            eta_mean: arr2_back(s.eta_mean)?,
             eta_cov,
             mu: s.mu,
             sigma: s.sigma,
@@ -7741,7 +7753,7 @@ impl STM {
             s.topic_names
         };
         // eta_cov is saved as f64 for format compatibility; downcast to f32 in memory.
-        let eta_cov = arr3_back(s.eta_cov).map(|c| c.mapv(|x| x as f32));
+        let eta_cov = arr3_back(s.eta_cov)?.map(|c| c.mapv(|x| x as f32));
         Ok(STM {
             num_topics: s.num_topics,
             sigma_shrink: s.sigma_shrink,
@@ -7750,12 +7762,12 @@ impl STM {
             variational: s.variational,
             fitted: s.fitted,
             topic_names,
-            beta: arr2_back(s.beta),
-            theta: arr2_back(s.theta),
-            corr: arr2_back(s.corr),
-            eta_mean: arr2_back(s.eta_mean),
+            beta: arr2_back(s.beta)?,
+            theta: arr2_back(s.theta)?,
+            corr: arr2_back(s.corr)?,
+            eta_mean: arr2_back(s.eta_mean)?,
             eta_cov,
-            gamma: arr2_back(s.gamma),
+            gamma: arr2_back(s.gamma)?,
             feature_names: s.feature_names,
             content_beta: s.content_beta,
             content_kappa: s.content_kappa,
@@ -8566,7 +8578,7 @@ impl ECTM {
         } else {
             s.topic_names
         };
-        let eta_cov = arr3_back(s.eta_cov).map(|c| c.mapv(|x| x as f32));
+        let eta_cov = arr3_back(s.eta_cov)?.map(|c| c.mapv(|x| x as f32));
         Ok(ECTM {
             num_topics: s.num_topics,
             sigma_shrink: s.sigma_shrink,
@@ -8575,16 +8587,16 @@ impl ECTM {
             init_spectral: s.init_spectral,
             fitted: s.fitted,
             topic_names,
-            beta: arr2_back(s.beta),
-            theta: arr2_back(s.theta),
+            beta: arr2_back(s.beta)?,
+            theta: arr2_back(s.theta)?,
             content_beta: s.content_beta,
             num_groups: s.num_groups,
             num_periods: s.num_periods,
             group_names: s.group_names,
             period_names: s.period_names,
-            eta_mean: arr2_back(s.eta_mean),
+            eta_mean: arr2_back(s.eta_mean)?,
             eta_cov,
-            gamma: arr2_back(s.gamma),
+            gamma: arr2_back(s.gamma)?,
             feature_names: s.feature_names,
             mu: s.mu,
             sigma: s.sigma,
@@ -9471,18 +9483,18 @@ impl STS {
             s.topic_names
         };
         // eta_cov is saved as f64 for format compatibility; downcast to f32 in memory.
-        let eta_cov = arr3_back(s.eta_cov).map(|c| c.mapv(|x| x as f32));
+        let eta_cov = arr3_back(s.eta_cov)?.map(|c| c.mapv(|x| x as f32));
         Ok(STS {
             num_topics: s.num_topics,
             seed: s.seed,
             init_spectral: s.init_spectral,
             fitted: s.fitted,
             topic_names,
-            beta: arr2_back(s.beta),
-            theta: arr2_back(s.theta),
-            sentiment: arr2_back(s.sentiment),
-            gamma: arr2_back(s.gamma),
-            eta_mean: arr2_back(s.eta_mean),
+            beta: arr2_back(s.beta)?,
+            theta: arr2_back(s.theta)?,
+            sentiment: arr2_back(s.sentiment)?,
+            gamma: arr2_back(s.gamma)?,
+            eta_mean: arr2_back(s.eta_mean)?,
             eta_cov,
             feature_names: s.feature_names,
             kappa_t: s.kappa_t,
@@ -10100,8 +10112,8 @@ impl HDP {
             topic_names,
             learned_alpha: s.learned_alpha,
             learned_gamma: s.learned_gamma,
-            beta: arr2_back(s.beta),
-            theta: arr2_back(s.theta),
+            beta: arr2_back(s.beta)?,
+            theta: arr2_back(s.theta)?,
             corpus: s.corpus,
             trace: s.trace,
             theta_draws: None,
@@ -11048,8 +11060,8 @@ impl SupervisedLDA {
             topic_names,
             sigma2: s.sigma2,
             eta: arr1_back(s.eta),
-            beta: arr2_back(s.beta),
-            theta: arr2_back(s.theta),
+            beta: arr2_back(s.beta)?,
+            theta: arr2_back(s.theta)?,
             log_beta: s.log_beta,
             corpus: s.corpus,
             theta_draws: None,
@@ -11361,8 +11373,8 @@ impl PT {
             seed: s.seed,
             fitted: s.fitted,
             topic_names,
-            phi: arr2_back(s.phi),
-            theta: arr2_back(s.theta),
+            phi: arr2_back(s.phi)?,
+            theta: arr2_back(s.theta)?,
             corpus: s.corpus,
             theta_draws: None,
             log_likelihood_history: s.log_likelihood_history,
@@ -11757,8 +11769,8 @@ impl GSDMM {
             fitted: s.fitted,
             num_used: s.num_used,
             topic_names,
-            phi: arr2_back(s.phi),
-            theta: arr2_back(s.theta),
+            phi: arr2_back(s.phi)?,
+            theta: arr2_back(s.theta)?,
             doc_cluster: s.doc_cluster,
             corpus: s.corpus,
             trace: s.trace,
@@ -12290,9 +12302,9 @@ impl SeededLDA {
             cvb0: s.cvb0,
             fitted: s.fitted,
             topic_names: s.topic_names,
-            phi: arr2_back(s.phi),
-            theta: arr2_back(s.theta),
-            theta_draws: arr3f32_back(s.theta_draws),
+            phi: arr2_back(s.phi)?,
+            theta: arr2_back(s.theta)?,
+            theta_draws: arr3f32_back(s.theta_draws)?,
             corpus: s.corpus,
             log_likelihood_history: s.log_likelihood_history,
             converged: s.converged,
@@ -18306,8 +18318,8 @@ impl KeyATM {
             topic_names: s.topic_names,
             num_threads: s.num_threads,
             keyword_rate: s.keyword_rate,
-            phi: arr2_back(s.phi),
-            theta: arr2_back(s.theta),
+            phi: arr2_back(s.phi)?,
+            theta: arr2_back(s.theta)?,
             corpus: s.corpus,
             feature_effects: None,
             feature_names: Vec::new(),
@@ -18320,7 +18332,7 @@ impl KeyATM {
             alpha_history: s.alpha_history,
             pi_history: s.pi_history,
             alpha_vec: s.alpha_vec,
-            theta_draws: arr3f32_back(s.theta_draws),
+            theta_draws: arr3f32_back(s.theta_draws)?,
         })
     }
 
@@ -18694,9 +18706,9 @@ impl PA {
             seed: s.seed,
             fitted: s.fitted,
             topic_names,
-            phi: arr2_back(s.phi),
-            theta: arr2_back(s.theta),
-            super_sub: arr2_back(s.super_sub),
+            phi: arr2_back(s.phi)?,
+            theta: arr2_back(s.theta)?,
+            super_sub: arr2_back(s.super_sub)?,
             corpus: s.corpus,
             theta_draws: None,
             log_likelihood_history: s.log_likelihood_history,
@@ -19046,7 +19058,7 @@ impl HLDA {
             fitted: s.fitted,
             num_nodes: s.num_nodes,
             topic_names,
-            node_topic_word: arr2_back(s.node_topic_word),
+            node_topic_word: arr2_back(s.node_topic_word)?,
             node_levels: s.node_levels,
             node_parents: s.node_parents,
             doc_paths: s.doc_paths,

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -329,7 +329,8 @@ pub fn sts_precision(
 
 use crate::estimator::{Estimator, ModelFamily};
 use crate::linalg::{
-    cholesky, half_logdet, make_diagonally_dominant, spd_inverse, spd_inverse_from_chol,
+    cholesky, cholesky_jitter, half_logdet, make_diagonally_dominant, spd_inverse,
+    spd_inverse_from_chol, spd_inverse_jitter,
 };
 use crate::variational::LogisticNormalModel;
 use crate::variational::{doc_sparse, fit_gamma_ridge, lbfgs_minimize};
@@ -449,7 +450,7 @@ pub fn sts_infer(
     let siginv = spd_inverse(sigma, n).unwrap_or_else(|| {
         let mut s = sigma.to_vec();
         make_diagonally_dominant(&mut s, n);
-        spd_inverse(&s, n).unwrap()
+        spd_inverse_jitter(&s, n)
     });
     let mu = vec![0.0f64; n];
     let sparse: Vec<(Vec<usize>, Vec<f64>)> = docs.iter().map(|d| doc_sparse(d)).collect();
@@ -956,7 +957,7 @@ pub fn fit_sts<R: Rng>(
         let siginv = spd_inverse(&sigma, n).unwrap_or_else(|| {
             let mut s = sigma.clone();
             make_diagonally_dominant(&mut s, n);
-            spd_inverse(&s, n).unwrap()
+            spd_inverse_jitter(&s, n)
         });
         let entropy = match cholesky(&sigma, n) {
             Some(l) => half_logdet(&l, n),
@@ -992,7 +993,7 @@ pub fn fit_sts<R: Rng>(
                     Some(l) => (spd_inverse_from_chol(&l, n), half_logdet(&l, n)),
                     None => {
                         make_diagonally_dominant(&mut prec, n);
-                        let l = cholesky(&prec, n).expect("PD after diagonal dominance");
+                        let l = cholesky_jitter(&prec, n);
                         (spd_inverse_from_chol(&l, n), half_logdet(&l, n))
                     }
                 };
@@ -1139,7 +1140,7 @@ pub fn recompute_nu_sts(model: &StsModel, sparse: &[(Vec<usize>, Vec<f64>)]) -> 
     let siginv = spd_inverse(sig, n).unwrap_or_else(|| {
         let mut s = sig.clone();
         make_diagonally_dominant(&mut s, n);
-        spd_inverse(&s, n).unwrap()
+        spd_inverse_jitter(&s, n)
     });
     // Use kappa from the last E-step (before the final κ M-step updated kappa_t/kappa_s).
     let kappa = Kappa {
@@ -1163,7 +1164,7 @@ pub fn recompute_nu_sts(model: &StsModel, sparse: &[(Vec<usize>, Vec<f64>)]) -> 
                 Some(l) => spd_inverse_from_chol(&l, n),
                 None => {
                     make_diagonally_dominant(&mut prec, n);
-                    let l = cholesky(&prec, n).expect("PD after diagonal dominance");
+                    let l = cholesky_jitter(&prec, n);
                     spd_inverse_from_chol(&l, n)
                 }
             }

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -17,7 +17,8 @@ use rand::Rng;
 
 use crate::estimator::{Estimator, ModelFamily};
 use crate::linalg::{
-    cholesky, half_logdet, make_diagonally_dominant, spd_inverse, spd_inverse_from_chol,
+    cholesky, cholesky_jitter, half_logdet, make_diagonally_dominant, spd_inverse,
+    spd_inverse_from_chol, spd_inverse_jitter,
 };
 use crate::variational::LogisticNormalModel;
 use crate::variational::{doc_sparse, fit_gamma_ridge, lbfgs_minimize};
@@ -321,7 +322,7 @@ pub fn ctm_hpb(
             Some(l) => (spd_inverse_from_chol(&l, km1), half_logdet(&l, km1)),
             None => {
                 make_diagonally_dominant(&mut h, km1);
-                let l = cholesky(&h, km1).expect("PD after diagonal dominance");
+                let l = cholesky_jitter(&h, km1);
                 (spd_inverse_from_chol(&l, km1), half_logdet(&l, km1))
             }
         };
@@ -1056,7 +1057,7 @@ pub fn fit_ctm<R: Rng>(
         let siginv = spd_inverse(&sigma, km1).unwrap_or_else(|| {
             let mut s = sigma.clone();
             make_diagonally_dominant(&mut s, km1);
-            spd_inverse(&s, km1).unwrap()
+            spd_inverse_jitter(&s, km1)
         });
         let entropy = match cholesky(&sigma, km1) {
             Some(l) => half_logdet(&l, km1),
@@ -1352,7 +1353,7 @@ pub fn fit_ctm_svi<R: Rng>(
             let siginv = spd_inverse(&sigma, km1).unwrap_or_else(|| {
                 let mut s = sigma.clone();
                 make_diagonally_dominant(&mut s, km1);
-                spd_inverse(&s, km1).unwrap()
+                spd_inverse_jitter(&s, km1)
             });
             let entropy = match cholesky(&sigma, km1) {
                 Some(l) => half_logdet(&l, km1),
@@ -1433,7 +1434,7 @@ pub fn fit_ctm_svi<R: Rng>(
     let siginv = spd_inverse(&sigma, km1).unwrap_or_else(|| {
         let mut s = sigma.clone();
         make_diagonally_dominant(&mut s, km1);
-        spd_inverse(&s, km1).unwrap()
+        spd_inverse_jitter(&s, km1)
     });
     let entropy = match cholesky(&sigma, km1) {
         Some(l) => half_logdet(&l, km1),
@@ -1506,7 +1507,7 @@ pub fn recompute_nu(model: &CtmModel, sparse: &[(Vec<usize>, Vec<f64>)]) -> Vec<
     let siginv = crate::linalg::spd_inverse(sig, km1).unwrap_or_else(|| {
         let mut s = sig.clone();
         crate::linalg::make_diagonally_dominant(&mut s, km1);
-        crate::linalg::spd_inverse(&s, km1).unwrap()
+        crate::linalg::spd_inverse_jitter(&s, km1)
     });
     let entropy = match crate::linalg::cholesky(sig, km1) {
         Some(l) => crate::linalg::half_logdet(&l, km1),

--- a/topica-core/src/linalg.rs
+++ b/topica-core/src/linalg.rs
@@ -77,6 +77,42 @@ pub fn spd_inverse(a: &[f64], n: usize) -> Option<Vec<f64>> {
     cholesky(a, n).map(|l| spd_inverse_from_chol(&l, n))
 }
 
+/// Cholesky that never fails. If `a` is not positive-definite even after the
+/// caller's diagonal-dominance repair, escalate a ridge on the diagonal until it
+/// factors (a degraded but finite fallback for the "should be impossible" path,
+/// instead of panicking). In the happy path (already PD) the result is identical
+/// to [`cholesky`]; only a genuinely non-PD input is perturbed.
+pub fn cholesky_jitter(a: &[f64], n: usize) -> Vec<f64> {
+    if let Some(l) = cholesky(a, n) {
+        return l;
+    }
+    let mut m = a.to_vec();
+    let scale = (0..n).map(|i| a[i * n + i].abs()).sum::<f64>() / (n.max(1) as f64);
+    let mut jit = 1e-10 * (1.0 + scale);
+    for _ in 0..16 {
+        for i in 0..n {
+            m[i * n + i] += jit;
+        }
+        if let Some(l) = cholesky(&m, n) {
+            return l;
+        }
+        jit *= 10.0;
+    }
+    // Last resort: a diagonal (always-PD) surrogate from the clamped diagonal.
+    let mut d = vec![0.0f64; n * n];
+    for i in 0..n {
+        d[i * n + i] = a[i * n + i].abs().max(1e-8).sqrt();
+    }
+    d
+}
+
+/// SPD inverse that never fails (see [`cholesky_jitter`]). Identical to
+/// [`spd_inverse`] when `a` is positive-definite; otherwise ridge-jittered rather
+/// than `None`/panic.
+pub fn spd_inverse_jitter(a: &[f64], n: usize) -> Vec<f64> {
+    spd_inverse_from_chol(&cholesky_jitter(a, n), n)
+}
+
 /// Force a symmetric matrix to be positive definite by diagonal dominance
 /// (STM's fallback when the Hessian is indefinite): if a diagonal entry is
 /// smaller than the sum of the magnitudes of its off-diagonal entries, raise it.

--- a/topica-core/src/spectral.rs
+++ b/topica-core/src/spectral.rs
@@ -94,11 +94,7 @@ fn fast_anchor_words(qbar: &[Vec<f64>], p: &[f64], k: usize, min_p: f64) -> Opti
     let mut anchors = Vec::with_capacity(k);
     let first = *candidates
         .iter()
-        .max_by(|&&a, &&b| {
-            dot(&qbar[a], &qbar[a])
-                .partial_cmp(&dot(&qbar[b], &qbar[b]))
-                .unwrap()
-        })
+        .max_by(|&&a, &&b| dot(&qbar[a], &qbar[a]).total_cmp(&dot(&qbar[b], &qbar[b])))
         .unwrap();
     anchors.push(first);
 
@@ -133,7 +129,7 @@ fn fast_anchor_words(qbar: &[Vec<f64>], p: &[f64], k: usize, min_p: f64) -> Opti
             .enumerate()
             .filter(|(pos, _)| !anchors.contains(&candidates[*pos]))
             .map(|(pos, r)| (pos, dot(r, r)))
-            .max_by(|a, b| a.1.partial_cmp(&b.1).unwrap())?;
+            .max_by(|a, b| a.1.total_cmp(&b.1))?;
         if dot(&residual[best_pos], &residual[best_pos]) < 1e-12 {
             return None; // can't find K independent anchors
         }
@@ -375,7 +371,7 @@ mod tests {
         let mut covered = std::collections::HashSet::new();
         for t in 0..nb {
             let mut idx: Vec<usize> = (0..v).collect();
-            idx.sort_by(|&a, &b| beta[t][b].partial_cmp(&beta[t][a]).unwrap());
+            idx.sort_by(|&a, &b| beta[t][b].total_cmp(&beta[t][a]));
             let block_of = |w: usize| w / bs;
             let top_block = block_of(idx[0]);
             let same = idx[..10]
@@ -416,7 +412,7 @@ mod tests {
         // Each topic concentrates on one block (its top-3 words are one block).
         for t in 0..3 {
             let mut idx: Vec<usize> = (0..9).collect();
-            idx.sort_by(|&a, &b| beta[t][b].partial_cmp(&beta[t][a]).unwrap());
+            idx.sort_by(|&a, &b| beta[t][b].total_cmp(&beta[t][a]));
             let top: std::collections::HashSet<usize> = idx[..3].iter().copied().collect();
             let is_block = blocks
                 .iter()


### PR DESCRIPTION
Review findings **#2–#5**. No behavior change on valid input/data — verified by the golden CTM test + full suites.

## Fixes

- **#2 CLI panics** — `train`/`analyze`/`preprocess`/`show` no longer index `raw[i]` out of bounds when an option value is missing. A shared, doc-hidden `topica::cli` module adds bounds-checked `next_val`/`parse_val`; bad input now prints a usage error and exits, e.g. `topica train --corpus` → `error: '--corpus' requires a value`.
- **#3 numerical-core panics** — the CTM/STS kernels no longer `unwrap()`/`expect("PD after diagonal dominance")` on the post-repair inverse/Cholesky. New never-failing `linalg::cholesky_jitter` / `spd_inverse_jitter` escalate a diagonal ridge until the factorization succeeds (identical to the plain path when already PD; degraded-but-finite otherwise).
- **#4 NaN float sort** — spectral anchor selection + top-word sorts use `f64::total_cmp`, not `partial_cmp(...).unwrap()`.
- **#5 untrusted load shapes** — `arr2_back`/`arr3_back`/`arr3f32_back` return `PyResult` and raise `ValueError` ("corrupt saved N-D array") on a shape mismatch instead of `unwrap`-panicking.

## Verification

- `cargo build --all-targets`, `cargo fmt --all --check`, `cargo test --workspace --lib` (topica 133, topica-core 16, incl. `fit_ctm_golden`)
- `maturin develop --features python`; `pytest` 2782 passed, 26 skipped
- CLI manually confirmed to error (not panic) on missing/invalid values

## faSTM

Untouched — `fit_ctm`/`infer_theta`/`GammaPrior`/`CtmModel`/`Corpus` signatures unchanged; the #3 fix is internal to the kernels.

## Remaining from the review

clippy fixes + `clippy -D warnings` gate (the rest of #6) and the mechanical `python.rs` → `python/` split (Round 2) follow in separate PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)