### PR TITLE
refactor(python): split python.rs into a directory module (+ arrays.rs)

### DIFF
--- a/src/python/arrays.rs
+++ b/src/python/arrays.rs
@@ -1,0 +1,90 @@
+//! ndarray <-> serializable-state adapters used by every model's save/load.
+//!
+//! `*_opt` pack an optional ndarray into a `serde`-friendly shape+data record;
+//! `*_back` reconstruct the ndarray, returning a `ValueError` (not a panic) on a
+//! shape/length mismatch in a corrupt payload.
+
+use numpy::ndarray::{Array1, Array2, Array3};
+use pyo3::exceptions::PyValueError;
+use pyo3::PyResult;
+
+/// Serializable form of an ndarray `Array2` (shape + row-major data).
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct Arr2 {
+    pub rows: usize,
+    pub cols: usize,
+    pub data: Vec<f64>,
+}
+/// Serializable form of an ndarray `Array3` (f64).
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct Arr3 {
+    pub d0: usize,
+    pub d1: usize,
+    pub d2: usize,
+    pub data: Vec<f64>,
+}
+/// Serializable form of an ndarray `Array3<f32>` (used for theta_draws).
+#[derive(serde::Serialize, serde::Deserialize)]
+pub(crate) struct Arr3f32 {
+    pub d0: usize,
+    pub d1: usize,
+    pub d2: usize,
+    pub data: Vec<f32>,
+}
+
+pub(crate) fn arr2_opt(a: &Option<Array2<f64>>) -> Option<Arr2> {
+    a.as_ref().map(|m| Arr2 {
+        rows: m.nrows(),
+        cols: m.ncols(),
+        data: m.iter().copied().collect(),
+    })
+}
+pub(crate) fn arr2_back(s: Option<Arr2>) -> PyResult<Option<Array2<f64>>> {
+    s.map(|a| {
+        Array2::from_shape_vec((a.rows, a.cols), a.data)
+            .map_err(|e| PyValueError::new_err(format!("corrupt saved 2-D array: {e}")))
+    })
+    .transpose()
+}
+pub(crate) fn arr3_opt(a: &Option<Array3<f64>>) -> Option<Arr3> {
+    a.as_ref().map(|m| {
+        let d = m.dim();
+        Arr3 {
+            d0: d.0,
+            d1: d.1,
+            d2: d.2,
+            data: m.iter().copied().collect(),
+        }
+    })
+}
+pub(crate) fn arr3_back(s: Option<Arr3>) -> PyResult<Option<Array3<f64>>> {
+    s.map(|a| {
+        Array3::from_shape_vec((a.d0, a.d1, a.d2), a.data)
+            .map_err(|e| PyValueError::new_err(format!("corrupt saved 3-D array: {e}")))
+    })
+    .transpose()
+}
+pub(crate) fn arr3f32_opt(a: &Option<Array3<f32>>) -> Option<Arr3f32> {
+    a.as_ref().map(|m| {
+        let d = m.dim();
+        Arr3f32 {
+            d0: d.0,
+            d1: d.1,
+            d2: d.2,
+            data: m.iter().copied().collect(),
+        }
+    })
+}
+pub(crate) fn arr3f32_back(s: Option<Arr3f32>) -> PyResult<Option<Array3<f32>>> {
+    s.map(|a| {
+        Array3::from_shape_vec((a.d0, a.d1, a.d2), a.data)
+            .map_err(|e| PyValueError::new_err(format!("corrupt saved 3-D array: {e}")))
+    })
+    .transpose()
+}
+pub(crate) fn arr1_opt(a: &Option<Array1<f64>>) -> Option<Vec<f64>> {
+    a.as_ref().map(|m| m.to_vec())
+}
+pub(crate) fn arr1_back(s: Option<Vec<f64>>) -> Option<Array1<f64>> {
+    s.map(Array1::from)
+}

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -59,6 +59,10 @@ use crate::{
     coherence as coh, ctm, cvb0, lightlda, optimize, output, sampler, spectral, sts, warplda,
 };
 
+// ndarray <-> serializable-state adapters (Arr2/Arr3/Arr3f32 + arr*_opt/arr*_back).
+mod arrays;
+use arrays::*;
+
 // ---------------------------------------------------------------------------
 // Error helpers
 // ---------------------------------------------------------------------------
@@ -148,67 +152,6 @@ fn py_num_topics_opt(ob: &Bound<'_, PyAny>) -> PyResult<Option<usize>> {
     Ok(Some(require_count(ob.extract()?, 1, "num_topics")?))
 }
 
-// ---------------------------------------------------------------------------
-// Model serialization (save / load)
-// ---------------------------------------------------------------------------
-
-/// Serializable form of an ndarray `Array2` (shape + row-major data).
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Arr2 {
-    rows: usize,
-    cols: usize,
-    data: Vec<f64>,
-}
-/// Serializable form of an ndarray `Array3` (f64).
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Arr3 {
-    d0: usize,
-    d1: usize,
-    d2: usize,
-    data: Vec<f64>,
-}
-/// Serializable form of an ndarray `Array3<f32>` (used for theta_draws).
-#[derive(serde::Serialize, serde::Deserialize)]
-struct Arr3f32 {
-    d0: usize,
-    d1: usize,
-    d2: usize,
-    data: Vec<f32>,
-}
-
-fn arr2_opt(a: &Option<Array2<f64>>) -> Option<Arr2> {
-    a.as_ref().map(|m| Arr2 {
-        rows: m.nrows(),
-        cols: m.ncols(),
-        data: m.iter().copied().collect(),
-    })
-}
-fn arr2_back(s: Option<Arr2>) -> PyResult<Option<Array2<f64>>> {
-    s.map(|a| {
-        Array2::from_shape_vec((a.rows, a.cols), a.data)
-            .map_err(|e| PyValueError::new_err(format!("corrupt saved 2-D array: {e}")))
-    })
-    .transpose()
-}
-fn arr3_opt(a: &Option<Array3<f64>>) -> Option<Arr3> {
-    a.as_ref().map(|m| {
-        let d = m.dim();
-        Arr3 {
-            d0: d.0,
-            d1: d.1,
-            d2: d.2,
-            data: m.iter().copied().collect(),
-        }
-    })
-}
-fn arr3_back(s: Option<Arr3>) -> PyResult<Option<Array3<f64>>> {
-    s.map(|a| {
-        Array3::from_shape_vec((a.d0, a.d1, a.d2), a.data)
-            .map_err(|e| PyValueError::new_err(format!("corrupt saved 3-D array: {e}")))
-    })
-    .transpose()
-}
-
 /// Run `f` on a rayon pool of `num_threads` workers, or on the global pool (all
 /// cores) when `num_threads` is `None`/0. The variational fits are deterministic
 /// regardless of worker count, so this controls only resource use, not output.
@@ -221,30 +164,6 @@ fn run_with_threads<T: Send, F: FnOnce() -> T + Send>(num_threads: Option<usize>
         },
         _ => f(),
     }
-}
-fn arr3f32_opt(a: &Option<Array3<f32>>) -> Option<Arr3f32> {
-    a.as_ref().map(|m| {
-        let d = m.dim();
-        Arr3f32 {
-            d0: d.0,
-            d1: d.1,
-            d2: d.2,
-            data: m.iter().copied().collect(),
-        }
-    })
-}
-fn arr3f32_back(s: Option<Arr3f32>) -> PyResult<Option<Array3<f32>>> {
-    s.map(|a| {
-        Array3::from_shape_vec((a.d0, a.d1, a.d2), a.data)
-            .map_err(|e| PyValueError::new_err(format!("corrupt saved 3-D array: {e}")))
-    })
-    .transpose()
-}
-fn arr1_opt(a: &Option<Array1<f64>>) -> Option<Vec<f64>> {
-    a.as_ref().map(|m| m.to_vec())
-}
-fn arr1_back(s: Option<Vec<f64>>) -> Option<Array1<f64>> {
-    s.map(Array1::from)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
First step of the **`python.rs` decomposition** (review Round 2). The 19k-line `src/python.rs` is now a directory module `src/python/mod.rs`, and the most self-contained helper group is extracted to `src/python/arrays.rs`.

## What moved
`Arr2`/`Arr3`/`Arr3f32` + `arr2_opt`/`arr2_back`/`arr3_opt`/`arr3_back`/`arr3f32_opt`/`arr3f32_back`/`arr1_opt`/`arr1_back` → `python/arrays.rs` (`pub(crate)`, glob-imported by `mod.rs`). These are the ndarray↔serialized-state adapters every model's save/load uses.

This proves the directory-module pattern on the cohesive, lowest-risk group. Following PRs (per your 6-step plan): `error.rs` (validators), `save.rs` (read/write_state + tags), then `corpus.rs`, one model (NMF) to prove the model pattern, then families (Gibbs / variational / embeddings).

## Pure move — no behavior change
Public Python names unchanged; save/load round-trips verified (LDA + CTM). Fenced by the gates from the earlier PRs:
- `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean
- `cargo fmt --all --check` clean
- `cargo test --workspace --lib` (133 + 16)
- `maturin develop --features python`

faSTM untouched (no core/`topica-core` changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)