### PR TITLE
release: 0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-06-19
+
+### Fixed
+
+- STM/CTM `gamma_prior="pooled"` is now empirical Bayes, a faithful port of R
+  `stm`'s `vb.variational.reg` (`gamma.prior="Pooled"`): the prevalence
+  regression estimates its coefficient and noise precisions from the data
+  (adaptive shrinkage, intercept unpenalised) instead of applying a fixed 1e-6
+  ridge. On a wide prevalence design (a `s(day)` spline, or many one-hot
+  covariate levels) the old near-OLS coefficients refit freely each M-step, so
+  EM took noticeably more iterations to converge than `stm`. The fit is
+  unchanged (topic-word cosine vs R `stm` stays 0.958 on poliblog5k K=20), the
+  bound is still monotone, and convergence is faster on covariate-rich designs.
+  Golden-tested bit-close to stm 1.3.8 (#247).
+
+### Added
+
+- `parity/stm_spline_iters_247.py`: a skip-clean cross-engine EM-iteration anchor
+  (topica vs R `stm`, with a QR-orthonormal control) documenting #247, plus a
+  `docs/benchmarks.md` note to time covariate-rich STM to convergence rather than
+  at a fixed iteration count.
+
 ## [0.25.0] - 2026-06-18
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.25.0
+version: 0.26.0
 date-released: 2026-06-18
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.25.0"
+version = "0.26.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.25.0"
+version = "0.26.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.25.0"
+version = "0.26.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.26.0**.

## Headline
Empirical-Bayes `pooled` prevalence prior for STM/CTM (#247, merged in #253): the prevalence regression now ports R `stm`'s `vb.variational.reg` faithfully (estimates coefficient + noise precisions from the data, intercept unpenalised) instead of a fixed 1e-6 ridge. EM converges in fewer iterations on covariate-rich designs (spline, many one-hot levels); the **fit is unchanged** (topic-word cosine vs R `stm` stays 0.958 on poliblog5k K=20, bound still monotone).

Speed to convergence on poliblog5k K=20 `~rating+s(day)`: **~7× all-cores, ~2× single-core** vs R `stm`.

## Version bumps
- `Cargo.toml` / `Cargo.lock` / `pyproject.toml`: 0.25.0 → 0.26.0
- `CHANGELOG.md`: new `[0.26.0]` section

## Release flow
Squash-merge → tag `v0.26.0` → CI publishes to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)