### PR TITLE
topica-core: from_texts + inspect + effects (the stmata engine)

### DIFF
--- a/topica-core/src/effects.rs
+++ b/topica-core/src/effects.rs
@@ -191,7 +191,7 @@ mod tests {
         assert!(coef[1] > 0.1, "slope should be positive, got {}", coef[1]);
         // Diagonal of vcov is the variance of each coef.
         let p = 2;
-        assert!(vcov[1 * p + 1] >= 0.0 && vcov[1 * p + 1].is_finite());
+        assert!(vcov[p + 1] >= 0.0 && vcov[p + 1].is_finite());
     }
 
     #[test]
@@ -210,8 +210,8 @@ mod tests {
         let p = 2;
         let (_c0, v0) = estimate_effect_topic(&lambda, &Vec::new(), &x, 0, 100, &mut rng);
         let (_c1, v1) = estimate_effect_topic(&lambda, &nu, &x, 0, 200, &mut rng);
-        let se0 = v0[1 * p + 1].sqrt();
-        let se1 = v1[1 * p + 1].sqrt();
+        let se0 = v0[p + 1].sqrt();
+        let se1 = v1[p + 1].sqrt();
         // Propagating per-doc uncertainty should not shrink the SE below the
         // no-uncertainty case.
         assert!(se1 + 1e-9 >= se0, "se with nu {} vs without {}", se1, se0);

--- a/topica-core/src/effects.rs
+++ b/topica-core/src/effects.rs
@@ -28,8 +28,9 @@ fn theta_from_eta(eta: &[f64]) -> Vec<f64> {
     e.iter().map(|x| x / s).collect()
 }
 
-/// estimateEffect for one topic. Returns `(coef, se)`, each length P (the design
-/// columns, e.g. intercept + covariates).
+/// estimateEffect for one topic. Returns `(coef, vcov)` where `coef` has length P
+/// (the design columns, e.g. intercept + covariates) and `vcov` is the P×P pooled
+/// covariance (row-major). The standard errors are `sqrt(vcov[j*P+j])`.
 ///
 /// - `lambda`: D × (K-1) variational means.
 /// - `nu`: D × (K-1)² row-major Laplace covariances; pass empty to treat the
@@ -48,7 +49,7 @@ pub fn estimate_effect_topic<R: Rng>(
     let km1 = if d > 0 { lambda[0].len() } else { 0 };
     let p = if d > 0 { x[0].len() } else { 0 };
     if d == 0 || p == 0 || d <= p {
-        return (vec![0.0; p], vec![0.0; p]);
+        return (vec![0.0; p], vec![0.0; p * p]);
     }
 
     // (X'X)^-1, and M = (X'X)^-1 X'  (P×D) — fixed across draws.
@@ -133,7 +134,7 @@ pub fn estimate_effect_topic<R: Rng>(
         sigma2_draws.push(sigma2);
     }
 
-    // Pool by Rubin's rules.
+    // Pool by Rubin's rules into the full P×P covariance.
     let b = sims as f64;
     let mut coef = vec![0.0f64; p];
     for draw in &beta_draws {
@@ -141,22 +142,26 @@ pub fn estimate_effect_topic<R: Rng>(
             coef[j] += draw[j] / b;
         }
     }
-    let mut se = vec![0.0f64; p];
-    for j in 0..p {
-        // within: mean over draws of sigma2 * (X'X)^-1_jj
-        let within: f64 =
-            sigma2_draws.iter().sum::<f64>() / b * xtxinv[j * p + j];
-        // between: sample variance of beta_j across draws
-        let between = if sims > 1 {
-            let m = coef[j];
-            beta_draws.iter().map(|d2| (d2[j] - m).powi(2)).sum::<f64>() / (b - 1.0)
-        } else {
-            0.0
-        };
-        let total = within + (1.0 + 1.0 / b) * between;
-        se[j] = total.max(0.0).sqrt();
+    let sigbar: f64 = sigma2_draws.iter().sum::<f64>() / b;
+    let mut vcov = vec![0.0f64; p * p];
+    for i in 0..p {
+        for j in 0..p {
+            // within = mean_b sigma2_b * (X'X)^-1_ij  (sigma2 averaged over draws)
+            let within = sigbar * xtxinv[i * p + j];
+            // between = sample covariance of (beta_i, beta_j) across draws
+            let between = if sims > 1 {
+                beta_draws
+                    .iter()
+                    .map(|dr| (dr[i] - coef[i]) * (dr[j] - coef[j]))
+                    .sum::<f64>()
+                    / (b - 1.0)
+            } else {
+                0.0
+            };
+            vcov[i * p + j] = within + (1.0 + 1.0 / b) * between;
+        }
     }
-    (coef, se)
+    (coef, vcov)
 }
 
 #[cfg(test)]
@@ -181,10 +186,12 @@ mod tests {
         }
         let nu: Vec<Vec<f64>> = Vec::new(); // no uncertainty -> single OLS
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        let (coef, se) = estimate_effect_topic(&lambda, &nu, &x, 0, 50, &mut rng);
+        let (coef, vcov) = estimate_effect_topic(&lambda, &nu, &x, 0, 50, &mut rng);
         // Proportion clearly increases with the covariate: positive slope.
         assert!(coef[1] > 0.1, "slope should be positive, got {}", coef[1]);
-        assert!(se.iter().all(|s| s.is_finite() && *s >= 0.0));
+        // Diagonal of vcov is the variance of each coef.
+        let p = 2;
+        assert!(vcov[1 * p + 1] >= 0.0 && vcov[1 * p + 1].is_finite());
     }
 
     #[test]
@@ -200,10 +207,13 @@ mod tests {
             x.push(vec![1.0, cov]);
         }
         let mut rng = ChaCha8Rng::seed_from_u64(7);
-        let (_c0, se0) = estimate_effect_topic(&lambda, &Vec::new(), &x, 0, 100, &mut rng);
-        let (_c1, se1) = estimate_effect_topic(&lambda, &nu, &x, 0, 200, &mut rng);
+        let p = 2;
+        let (_c0, v0) = estimate_effect_topic(&lambda, &Vec::new(), &x, 0, 100, &mut rng);
+        let (_c1, v1) = estimate_effect_topic(&lambda, &nu, &x, 0, 200, &mut rng);
+        let se0 = v0[1 * p + 1].sqrt();
+        let se1 = v1[1 * p + 1].sqrt();
         // Propagating per-doc uncertainty should not shrink the SE below the
         // no-uncertainty case.
-        assert!(se1[1] + 1e-9 >= se0[1], "se with nu {} vs without {}", se1[1], se0[1]);
+        assert!(se1 + 1e-9 >= se0, "se with nu {} vs without {}", se1, se0);
     }
 }

--- a/topica-core/src/effects.rs
+++ b/topica-core/src/effects.rs
@@ -1,0 +1,209 @@
+//! Covariate-effect estimation by the method of composition (R `stm`'s
+//! `estimateEffect`). Regresses sampled topic proportions on a prevalence design
+//! and pools across draws by Rubin's rules, so the reported standard errors
+//! propagate the per-document topic-estimation uncertainty (the Laplace
+//! posterior N(lambda_d, nu_d)).
+//!
+//! This lives in the engine so faSTM, topica, and the Stata plugin share one
+//! implementation. Linear (Gaussian) effects on the topic proportions, matching
+//! stm's default.
+
+use rand::Rng;
+
+use crate::linalg::{cholesky_jitter, spd_inverse};
+
+/// Draw a standard normal via Box-Muller (avoids a rand_distr dependency).
+fn next_normal<R: Rng>(rng: &mut R) -> f64 {
+    let u1: f64 = rng.gen::<f64>().max(1e-300);
+    let u2: f64 = rng.gen::<f64>();
+    (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
+}
+
+/// Topic proportions theta (length K = km1+1) from variational means eta (km1):
+/// softmax of [eta, 0] (the last topic is the reference).
+fn theta_from_eta(eta: &[f64]) -> Vec<f64> {
+    let mut e: Vec<f64> = eta.iter().map(|x| x.exp()).collect();
+    let s: f64 = e.iter().sum::<f64>() + 1.0;
+    e.push(1.0);
+    e.iter().map(|x| x / s).collect()
+}
+
+/// estimateEffect for one topic. Returns `(coef, se)`, each length P (the design
+/// columns, e.g. intercept + covariates).
+///
+/// - `lambda`: D × (K-1) variational means.
+/// - `nu`: D × (K-1)² row-major Laplace covariances; pass empty to treat the
+///   topic proportions as fixed (no uncertainty propagation → single OLS).
+/// - `x`: D × P design (include an intercept column yourself).
+/// - `topic`: 0..K.
+pub fn estimate_effect_topic<R: Rng>(
+    lambda: &[Vec<f64>],
+    nu: &[Vec<f64>],
+    x: &[Vec<f64>],
+    topic: usize,
+    n_sims: usize,
+    rng: &mut R,
+) -> (Vec<f64>, Vec<f64>) {
+    let d = lambda.len();
+    let km1 = if d > 0 { lambda[0].len() } else { 0 };
+    let p = if d > 0 { x[0].len() } else { 0 };
+    if d == 0 || p == 0 || d <= p {
+        return (vec![0.0; p], vec![0.0; p]);
+    }
+
+    // (X'X)^-1, and M = (X'X)^-1 X'  (P×D) — fixed across draws.
+    let mut xtx = vec![0.0f64; p * p];
+    for row in x.iter() {
+        for i in 0..p {
+            for j in 0..p {
+                xtx[i * p + j] += row[i] * row[j];
+            }
+        }
+    }
+    let xtxinv = spd_inverse(&xtx, p).unwrap_or_else(|| {
+        // Fall back to a jittered inverse if X'X is near-singular.
+        let l = cholesky_jitter(&xtx, p);
+        crate::linalg::spd_inverse_from_chol(&l, p)
+    });
+    let mut m = vec![0.0f64; p * d]; // P×D
+    for pp in 0..p {
+        for dd in 0..d {
+            let mut s = 0.0;
+            for j in 0..p {
+                s += xtxinv[pp * p + j] * x[dd][j];
+            }
+            m[pp * d + dd] = s;
+        }
+    }
+
+    // Per-document Cholesky of nu (for the MVN draw); None when nu is absent.
+    let have_nu = nu.len() == d && km1 > 0;
+    let chols: Vec<Vec<f64>> = if have_nu {
+        nu.iter().map(|nd| cholesky_jitter(nd, km1)).collect()
+    } else {
+        Vec::new()
+    };
+
+    let sims = if have_nu { n_sims.max(1) } else { 1 };
+    let mut beta_draws: Vec<Vec<f64>> = Vec::with_capacity(sims);
+    let mut sigma2_draws: Vec<f64> = Vec::with_capacity(sims);
+
+    for _ in 0..sims {
+        // Sampled outcome y_d = sampled proportion of `topic` in doc d.
+        let mut y = vec![0.0f64; d];
+        for dd in 0..d {
+            let eta: Vec<f64> = if have_nu {
+                let l = &chols[dd];
+                let z: Vec<f64> = (0..km1).map(|_| next_normal(rng)).collect();
+                (0..km1)
+                    .map(|i| {
+                        let mut v = lambda[dd][i];
+                        for j in 0..=i {
+                            v += l[i * km1 + j] * z[j];
+                        }
+                        v
+                    })
+                    .collect()
+            } else {
+                lambda[dd].clone()
+            };
+            y[dd] = theta_from_eta(&eta)[topic];
+        }
+
+        // beta = M y
+        let mut beta = vec![0.0f64; p];
+        for pp in 0..p {
+            let mut s = 0.0;
+            for dd in 0..d {
+                s += m[pp * d + dd] * y[dd];
+            }
+            beta[pp] = s;
+        }
+        // RSS, sigma2
+        let mut rss = 0.0;
+        for dd in 0..d {
+            let mut fit = 0.0;
+            for j in 0..p {
+                fit += x[dd][j] * beta[j];
+            }
+            rss += (y[dd] - fit).powi(2);
+        }
+        let sigma2 = rss / (d - p) as f64;
+        beta_draws.push(beta);
+        sigma2_draws.push(sigma2);
+    }
+
+    // Pool by Rubin's rules.
+    let b = sims as f64;
+    let mut coef = vec![0.0f64; p];
+    for draw in &beta_draws {
+        for j in 0..p {
+            coef[j] += draw[j] / b;
+        }
+    }
+    let mut se = vec![0.0f64; p];
+    for j in 0..p {
+        // within: mean over draws of sigma2 * (X'X)^-1_jj
+        let within: f64 =
+            sigma2_draws.iter().sum::<f64>() / b * xtxinv[j * p + j];
+        // between: sample variance of beta_j across draws
+        let between = if sims > 1 {
+            let m = coef[j];
+            beta_draws.iter().map(|d2| (d2[j] - m).powi(2)).sum::<f64>() / (b - 1.0)
+        } else {
+            0.0
+        };
+        let total = within + (1.0 + 1.0 / b) * between;
+        se[j] = total.max(0.0).sqrt();
+    }
+    (coef, se)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn recovers_a_planted_linear_effect() {
+        // K=2 (km1=1): topic-0 proportion rises with covariate x.
+        // Build lambda so that softmax([eta,0])[0] tracks a linear signal in x.
+        let d = 200;
+        let mut lambda = Vec::new();
+        let mut x = Vec::new();
+        for i in 0..d {
+            let cov = (i as f64) / (d as f64); // 0..1
+                                               // eta chosen so proportion increases with cov
+            let eta = -2.0 + 4.0 * cov;
+            lambda.push(vec![eta]);
+            x.push(vec![1.0, cov]); // intercept + covariate
+        }
+        let nu: Vec<Vec<f64>> = Vec::new(); // no uncertainty -> single OLS
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let (coef, se) = estimate_effect_topic(&lambda, &nu, &x, 0, 50, &mut rng);
+        // Proportion clearly increases with the covariate: positive slope.
+        assert!(coef[1] > 0.1, "slope should be positive, got {}", coef[1]);
+        assert!(se.iter().all(|s| s.is_finite() && *s >= 0.0));
+    }
+
+    #[test]
+    fn uncertainty_widens_se() {
+        let d = 100;
+        let mut lambda = Vec::new();
+        let mut nu = Vec::new();
+        let mut x = Vec::new();
+        for i in 0..d {
+            let cov = (i % 2) as f64;
+            lambda.push(vec![0.5 * cov]);
+            nu.push(vec![0.5]); // 1x1 covariance per doc
+            x.push(vec![1.0, cov]);
+        }
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let (_c0, se0) = estimate_effect_topic(&lambda, &Vec::new(), &x, 0, 100, &mut rng);
+        let (_c1, se1) = estimate_effect_topic(&lambda, &nu, &x, 0, 200, &mut rng);
+        // Propagating per-doc uncertainty should not shrink the SE below the
+        // no-uncertainty case.
+        assert!(se1[1] + 1e-9 >= se0[1], "se with nu {} vs without {}", se1[1], se0[1]);
+    }
+}

--- a/topica-core/src/inspect.rs
+++ b/topica-core/src/inspect.rs
@@ -91,7 +91,9 @@ pub fn js_estimate(prob: &[f64], ct: f64) -> Vec<f64> {
         return vec![unif; n];
     }
     lambda = lambda.clamp(0.0, 1.0);
-    prob.iter().map(|&p| lambda * unif + (1.0 - lambda) * p).collect()
+    prob.iter()
+        .map(|&p| lambda * unif + (1.0 - lambda) * p)
+        .collect()
 }
 
 /// Indices of the top `n` words per topic by `scoremat` (K rows of n indices).
@@ -164,7 +166,11 @@ pub fn score_scores(beta: &[Vec<f64>]) -> Vec<Vec<f64>> {
         .map(|vv| (0..k).map(|kk| logbeta[kk][vv]).sum::<f64>() / k as f64)
         .collect();
     (0..k)
-        .map(|kk| (0..v).map(|vv| beta[kk][vv] * (logbeta[kk][vv] - colmean[vv])).collect())
+        .map(|kk| {
+            (0..v)
+                .map(|vv| beta[kk][vv] * (logbeta[kk][vv] - colmean[vv]))
+                .collect()
+        })
         .collect()
 }
 
@@ -184,8 +190,8 @@ pub fn semantic_coherence(beta: &[Vec<f64>], docs: &[Vec<u32>], m: usize) -> Vec
     let mut wordlist: Vec<usize> = Vec::new();
     for row in &topw {
         for &word in row {
-            if !pos_of_word.contains_key(&word) {
-                pos_of_word.insert(word, wordlist.len());
+            if let std::collections::hash_map::Entry::Vacant(e) = pos_of_word.entry(word) {
+                e.insert(wordlist.len());
                 wordlist.push(word);
             }
         }
@@ -278,7 +284,10 @@ mod tests {
     #[test]
     fn rank_avg_handles_ties() {
         // values: 10, 20, 20, 40 -> ranks 1, 2.5, 2.5, 4
-        assert_eq!(rank_avg(&[10.0, 20.0, 20.0, 40.0]), vec![1.0, 2.5, 2.5, 4.0]);
+        assert_eq!(
+            rank_avg(&[10.0, 20.0, 20.0, 40.0]),
+            vec![1.0, 2.5, 2.5, 4.0]
+        );
     }
 
     fn toy_beta() -> Vec<Vec<f64>> {

--- a/topica-core/src/inspect.rs
+++ b/topica-core/src/inspect.rs
@@ -1,0 +1,325 @@
+//! Post-fit topic inspection: FREX / lift / score scores, top words, semantic
+//! coherence, and exclusivity. Ports of R `stm`'s `calcfrex` / `calclift` /
+//! `calcscore` / `semCoh1beta` / `exclusivity` (and `js.estimate`), the same
+//! formulas faSTM uses, so a host (e.g. the Stata plugin) gets stm-faithful
+//! labels and diagnostics from the engine instead of reimplementing them.
+//!
+//! All functions take `beta`, the K×V topic-word probability matrix
+//! (`CtmModel.beta`, rows sum to ~1). `word_counts` is the corpus
+//! `total_freqs` (length V); `docs` are the corpus token-id lists.
+
+use std::collections::HashMap;
+
+const EPS: f64 = f64::EPSILON;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+#[inline]
+fn safelog(x: f64) -> f64 {
+    x.max(EPS).ln()
+}
+
+fn logbeta_of(beta: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    beta.iter()
+        .map(|row| row.iter().map(|&x| safelog(x)).collect())
+        .collect()
+}
+
+/// Average-tie ranks (R's `rank`), 1-based.
+fn rank_avg(x: &[f64]) -> Vec<f64> {
+    let n = x.len();
+    let mut idx: Vec<usize> = (0..n).collect();
+    idx.sort_by(|&a, &b| x[a].partial_cmp(&x[b]).unwrap_or(std::cmp::Ordering::Equal));
+    let mut ranks = vec![0.0; n];
+    let mut i = 0;
+    while i < n {
+        let mut j = i;
+        while j + 1 < n && x[idx[j + 1]] == x[idx[i]] {
+            j += 1;
+        }
+        let avg = ((i + 1) + (j + 1)) as f64 / 2.0; // average of the 1-based positions
+        for t in idx.iter().take(j + 1).skip(i) {
+            ranks[*t] = avg;
+        }
+        i = j + 1;
+    }
+    ranks
+}
+
+/// Indices of the top `n` entries of `row`, descending (ties by ascending index).
+fn top_indices(row: &[f64], n: usize) -> Vec<usize> {
+    let mut idx: Vec<usize> = (0..row.len()).collect();
+    idx.sort_by(|&a, &b| {
+        row[b]
+            .partial_cmp(&row[a])
+            .unwrap_or(std::cmp::Ordering::Equal)
+            .then(a.cmp(&b))
+    });
+    idx.truncate(n.min(row.len()));
+    idx
+}
+
+/// Column log-sum-exp over topics: for each word v, lse over k of `logbeta[k][v]`.
+fn lse_cols(logbeta: &[Vec<f64>]) -> Vec<f64> {
+    let k = logbeta.len();
+    let v = if k > 0 { logbeta[0].len() } else { 0 };
+    (0..v)
+        .map(|vv| {
+            let m = (0..k).fold(f64::NEG_INFINITY, |acc, kk| acc.max(logbeta[kk][vv]));
+            let s: f64 = (0..k).map(|kk| (logbeta[kk][vv] - m).exp()).sum();
+            m + s.ln()
+        })
+        .collect()
+}
+
+/// stm `js.estimate`: James-Stein shrinkage of a probability vector toward uniform.
+pub fn js_estimate(prob: &[f64], ct: f64) -> Vec<f64> {
+    let n = prob.len();
+    let unif = 1.0 / n as f64;
+    if ct <= 1.0 {
+        return vec![unif; n];
+    }
+    let mlvar: f64 = prob.iter().map(|&p| p * (1.0 - p) / (ct - 1.0)).sum();
+    let dev: f64 = prob.iter().map(|&p| (p - unif).powi(2)).sum();
+    if dev == 0.0 {
+        return prob.to_vec();
+    }
+    let mut lambda = mlvar / dev;
+    if lambda.is_nan() {
+        return vec![unif; n];
+    }
+    lambda = lambda.clamp(0.0, 1.0);
+    prob.iter().map(|&p| lambda * unif + (1.0 - lambda) * p).collect()
+}
+
+/// Indices of the top `n` words per topic by `scoremat` (K rows of n indices).
+pub fn top_words(scoremat: &[Vec<f64>], n: usize) -> Vec<Vec<usize>> {
+    scoremat.iter().map(|row| top_indices(row, n)).collect()
+}
+
+// ---------------------------------------------------------------------------
+// Score matrices (K×V)
+// ---------------------------------------------------------------------------
+
+/// FREX scores (K×V): the rank-harmonic-mean of word frequency and exclusivity
+/// (Bischof & Airoldi). `w` is the frequency/exclusivity weight (0.5 = equal).
+/// Pass non-empty `word_counts` to James-Stein-shrink exclusivity (stm default).
+pub fn frex_scores(beta: &[Vec<f64>], word_counts: &[u32], w: f64) -> Vec<Vec<f64>> {
+    let k = beta.len();
+    let v = if k > 0 { beta[0].len() } else { 0 };
+    let logbeta = logbeta_of(beta);
+    let lse = lse_cols(&logbeta);
+    let mut excl: Vec<Vec<f64>> = (0..k)
+        .map(|kk| (0..v).map(|vv| logbeta[kk][vv] - lse[vv]).collect())
+        .collect();
+
+    if word_counts.len() == v && v > 0 {
+        for vv in 0..v {
+            let col: Vec<f64> = (0..k).map(|kk| excl[kk][vv].exp()).collect();
+            let shr = js_estimate(&col, word_counts[vv] as f64);
+            for kk in 0..k {
+                excl[kk][vv] = safelog(shr[kk]);
+            }
+        }
+    }
+
+    let mut frex = vec![vec![0.0; v]; k];
+    for kk in 0..k {
+        let fr = rank_avg(&logbeta[kk]);
+        let ex = rank_avg(&excl[kk]);
+        for vv in 0..v {
+            let f = fr[vv] / v as f64;
+            let e = ex[vv] / v as f64;
+            frex[kk][vv] = 1.0 / (w / f + (1.0 - w) / e);
+        }
+    }
+    frex
+}
+
+/// Lift (K×V): `log(beta) - log(empirical word probability)`.
+pub fn lift_scores(beta: &[Vec<f64>], word_counts: &[u32]) -> Vec<Vec<f64>> {
+    let sumwc: f64 = word_counts.iter().map(|&c| c as f64).sum::<f64>().max(1.0);
+    let lsum = sumwc.ln();
+    beta.iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(vv, &x)| {
+                    let wc = *word_counts.get(vv).unwrap_or(&1) as f64;
+                    safelog(x) - (wc.max(1.0).ln() - lsum)
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Score (K×V): `beta * (log beta - mean_topics log beta)` (stm `calcscore`).
+pub fn score_scores(beta: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    let k = beta.len();
+    let v = if k > 0 { beta[0].len() } else { 0 };
+    let logbeta = logbeta_of(beta);
+    let colmean: Vec<f64> = (0..v)
+        .map(|vv| (0..k).map(|kk| logbeta[kk][vv]).sum::<f64>() / k as f64)
+        .collect();
+    (0..k)
+        .map(|kk| (0..v).map(|vv| beta[kk][vv] * (logbeta[kk][vv] - colmean[vv])).collect())
+        .collect()
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+/// stm `semCoh1beta`: UMass semantic coherence per topic over each topic's top-M
+/// words. Pair direction is by global word-list index (the union of all topics'
+/// top words), with stm's 0.01 smoothing. Returns K values (higher = better).
+pub fn semantic_coherence(beta: &[Vec<f64>], docs: &[Vec<u32>], m: usize) -> Vec<f64> {
+    let k = beta.len();
+    let topw = top_words(beta, m); // K x M word ids, by beta (= by logbeta)
+
+    // Build the word list in stm's order: topic 0's top words, then topic 1's, ...
+    let mut pos_of_word: HashMap<usize, usize> = HashMap::new();
+    let mut wordlist: Vec<usize> = Vec::new();
+    for row in &topw {
+        for &word in row {
+            if !pos_of_word.contains_key(&word) {
+                pos_of_word.insert(word, wordlist.len());
+                wordlist.push(word);
+            }
+        }
+    }
+    let r = wordlist.len();
+
+    // Document co-occurrence over the word list: co[a][b] = #docs containing both;
+    // co[a][a] = document frequency of word a.
+    let mut co = vec![vec![0.0f64; r]; r];
+    for doc in docs {
+        let mut present: Vec<usize> = doc
+            .iter()
+            .filter_map(|&t| pos_of_word.get(&(t as usize)).copied())
+            .collect();
+        present.sort_unstable();
+        present.dedup();
+        for &a in &present {
+            co[a][a] += 1.0;
+        }
+        for i in 0..present.len() {
+            for j in (i + 1)..present.len() {
+                let (a, b) = (present[i], present[j]);
+                co[a][b] += 1.0;
+                co[b][a] += 1.0;
+            }
+        }
+    }
+
+    let mut coh = vec![0.0f64; k];
+    for kk in 0..k {
+        let idx: Vec<usize> = topw[kk].iter().map(|&w| pos_of_word[&w]).collect();
+        let mut s = 0.0;
+        for a in 0..idx.len() {
+            for b in 0..idx.len() {
+                if idx[a] > idx[b] {
+                    s += (0.01 + co[idx[a]][idx[b]]).ln() - (0.01 + co[idx[b]][idx[b]]).ln();
+                }
+            }
+        }
+        coh[kk] = s;
+    }
+    coh
+}
+
+/// stm `exclusivity`: the FREX-summary exclusivity per topic over top-M words.
+/// `frexw` is the frequency/exclusivity weight (stm default 0.7). Returns K values.
+pub fn exclusivity(beta: &[Vec<f64>], m: usize, frexw: f64) -> Vec<f64> {
+    let k = beta.len();
+    let v = if k > 0 { beta[0].len() } else { 0 };
+    // Column sums over topics, per word: sum_k beta[k][v].
+    let colsum: Vec<f64> = (0..v)
+        .map(|vv| (0..k).map(|kk| beta[kk][vv]).sum::<f64>().max(EPS))
+        .collect();
+
+    let mut excl = vec![0.0; k];
+    for kk in 0..k {
+        let tcol = &beta[kk]; // length V (= tbeta column for this topic)
+        let matcol: Vec<f64> = (0..v).map(|vv| tcol[vv] / colsum[vv]).collect();
+        let ex = rank_avg(&matcol);
+        let fr = rank_avg(tcol);
+        let frex: Vec<f64> = (0..v)
+            .map(|vv| {
+                let exr = ex[vv] / v as f64;
+                let frr = fr[vv] / v as f64;
+                1.0 / (frexw / exr + (1.0 - frexw) / frr)
+            })
+            .collect();
+        let top = top_indices(tcol, m);
+        excl[kk] = top.iter().map(|&vv| frex[vv]).sum();
+    }
+    excl
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn js_estimate_shrinks_to_uniform_for_small_counts() {
+        let p = vec![0.7, 0.2, 0.1];
+        assert_eq!(js_estimate(&p, 1.0), vec![1.0 / 3.0; 3]); // ct<=1 -> uniform
+        let s = js_estimate(&p, 1000.0); // large count -> close to p
+        assert!((s[0] - 0.7).abs() < 0.05);
+    }
+
+    #[test]
+    fn rank_avg_handles_ties() {
+        // values: 10, 20, 20, 40 -> ranks 1, 2.5, 2.5, 4
+        assert_eq!(rank_avg(&[10.0, 20.0, 20.0, 40.0]), vec![1.0, 2.5, 2.5, 4.0]);
+    }
+
+    fn toy_beta() -> Vec<Vec<f64>> {
+        // 2 topics, 4 words. Topic 0 loves words 0,1; topic 1 loves words 2,3.
+        vec![vec![0.45, 0.45, 0.05, 0.05], vec![0.05, 0.05, 0.45, 0.45]]
+    }
+
+    #[test]
+    fn frex_and_score_pick_each_topics_words() {
+        let beta = toy_beta();
+        let wc = vec![10u32, 10, 10, 10];
+        let frex = frex_scores(&beta, &wc, 0.5);
+        let tw = top_words(&frex, 2);
+        // topic 0's top-2 FREX words are {0,1}; topic 1's are {2,3}.
+        let mut t0 = tw[0].clone();
+        t0.sort_unstable();
+        let mut t1 = tw[1].clone();
+        t1.sort_unstable();
+        assert_eq!(t0, vec![0, 1]);
+        assert_eq!(t1, vec![2, 3]);
+
+        let sc = score_scores(&beta);
+        assert!(sc[0][0] > sc[0][2]); // topic 0 scores word 0 above word 2
+    }
+
+    #[test]
+    fn coherence_higher_when_top_words_co_occur() {
+        let beta = toy_beta();
+        // Docs where each topic's words co-occur cleanly.
+        let docs = vec![
+            vec![0u32, 1, 0, 1],
+            vec![0, 1],
+            vec![2, 3, 2, 3],
+            vec![2, 3],
+        ];
+        let coh = semantic_coherence(&beta, &docs, 2);
+        assert_eq!(coh.len(), 2);
+        assert!(coh.iter().all(|c| c.is_finite()));
+
+        let excl = exclusivity(&beta, 2, 0.7);
+        assert_eq!(excl.len(), 2);
+        assert!(excl.iter().all(|e| e.is_finite() && *e > 0.0));
+    }
+}

--- a/topica-core/src/lib.rs
+++ b/topica-core/src/lib.rs
@@ -33,6 +33,7 @@ pub mod corpus;
 pub mod ctm;
 pub mod cvb0;
 pub mod estimator;
+pub mod inspect;
 pub mod linalg;
 pub mod spectral;
 pub mod variational;

--- a/topica-core/src/lib.rs
+++ b/topica-core/src/lib.rs
@@ -32,6 +32,7 @@
 pub mod corpus;
 pub mod ctm;
 pub mod cvb0;
+pub mod effects;
 pub mod estimator;
 pub mod inspect;
 pub mod linalg;


### PR DESCRIPTION
Adds the engine pieces behind **stmata** (Structural Topic Models in Stata) to `topica-core`, all reusable by faSTM (R) and topica (Python) too.

## What's in `topica-core`
- **`corpus::from_texts`** — in-memory tokeniser (same tokenisation/stopword/doc-freq filtering as `load_text_file`) for hosts that already hold the text in memory.
- **`inspect` module** — stm-faithful `frex_scores` / `lift_scores` / `score_scores` / `top_words` / `semantic_coherence` (`semCoh1beta`) / `exclusivity` (+ `js_estimate`, average-tie ranks). Ports of stm's `calcfrex`/`calclift`/`calcscore`/`semCoh1beta`/`exclusivity`, matching faSTM.
- **`effects` module** — `estimate_effect_topic`: method-of-composition `estimateEffect` returning the coefficient and the full Rubin-pooled covariance, so consumers can build `e(b)`/`e(V)` and run `test`/`lincom`/`margins`.

## Notes
- Pure-Rust, vendorable (no new deps); `cargo fmt`/`clippy` clean; lib suite **25/0**.
- This branch was cut from the tip of `effects/survey-weights-ame`, so it also carries the already-committed **survey-weights AME** work (`acb3804`) and its CI fixes. Those are the same commits as on that branch (no-op if it merges separately).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013X9AJPij7q4JAd3yWaKccu
