### PR TITLE
Cross-language FREX/score/lift parity (#260) + fix main's broken python build

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -47,6 +47,30 @@ def project(
     ...
 
 
+def inspect_frex_scores(
+    beta: list[list[float]],
+    word_counts: list[int],
+    w: float = 0.5,
+) -> list[list[float]]:
+    """stm-faithful FREX score matrix (K x V) from topica-core's `inspect` (internal).
+
+    `word_counts` (length V) enables stm's James-Stein exclusivity shrinkage when
+    non-empty; pass [] to skip it. Backs the cross-language FREX parity check
+    against the pure-Python topica.frex.
+    """
+    ...
+
+def inspect_lift_scores(
+    beta: list[list[float]],
+    word_counts: list[int],
+) -> list[list[float]]:
+    """stm-faithful lift matrix (K x V): log(beta) - log(empirical word freq) (internal)."""
+    ...
+
+def inspect_score_scores(beta: list[list[float]]) -> list[list[float]]:
+    """stm-faithful score matrix (K x V): beta * (log beta - mean_k log beta) (internal)."""
+    ...
+
 def window_cooccurrence(
     docs: list[list[int]],
     num_relevant: int,

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -138,6 +138,7 @@ impl Corpus {
             stopwords: stop,
             min_doc_freq,
             max_doc_fraction,
+            lowercase: true,
         };
         let inner = corpus::load_text_file(Path::new(path), &opts).map_err(io_err)?;
         let kept_indices = (0..inner.num_docs()).collect();

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -8167,6 +8167,41 @@ fn window_cooccurrence(
     py.allow_threads(move || coh::cooccurrence(&docs, num_relevant, &pairs, window))
 }
 
+/// stm-faithful FREX score matrix (K×V) from the `topica-core` `inspect` module
+/// (the same port faSTM and the Stata plugin use). `beta` is the K×V topic-word
+/// probability matrix as a list of lists; `word_counts` (length V) enables stm's
+/// James-Stein exclusivity shrinkage when non-empty (pass `[]` to skip it); `w`
+/// is the frequency/exclusivity weight. Internal: backs the cross-language FREX
+/// parity check against the pure-Python `topica.frex` (issue #260).
+#[pyfunction]
+#[pyo3(signature = (beta, word_counts, w=0.5))]
+fn inspect_frex_scores(
+    py: Python<'_>,
+    beta: Vec<Vec<f64>>,
+    word_counts: Vec<u32>,
+    w: f64,
+) -> Vec<Vec<f64>> {
+    py.allow_threads(move || topica_core::inspect::frex_scores(&beta, &word_counts, w))
+}
+
+/// stm-faithful lift score matrix (K×V): `log(beta) - log(empirical word freq)`
+/// (`topica-core` `inspect::lift_scores`). Internal; see [`inspect_frex_scores`].
+#[pyfunction]
+fn inspect_lift_scores(
+    py: Python<'_>,
+    beta: Vec<Vec<f64>>,
+    word_counts: Vec<u32>,
+) -> Vec<Vec<f64>> {
+    py.allow_threads(move || topica_core::inspect::lift_scores(&beta, &word_counts))
+}
+
+/// stm-faithful score matrix (K×V): `beta * (log beta - mean_k log beta)`
+/// (`topica-core` `inspect::score_scores`). Internal; see [`inspect_frex_scores`].
+#[pyfunction]
+fn inspect_score_scores(py: Python<'_>, beta: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
+    py.allow_threads(move || topica_core::inspect::score_scores(&beta))
+}
+
 /// Warn that a neighbor-preserving projection (UMAP / t-SNE) distorts global
 /// geometry and is not reproducible across runs, so PCA stays the honest default.
 fn warn_stochastic(py: Python<'_>, method: &str) -> PyResult<()> {
@@ -18054,6 +18089,9 @@ fn _topica(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_class::<Corpus>()?;
     m.add_function(wrap_pyfunction!(tokenize, m)?)?;
     m.add_function(wrap_pyfunction!(window_cooccurrence, m)?)?;
+    m.add_function(wrap_pyfunction!(inspect_frex_scores, m)?)?;
+    m.add_function(wrap_pyfunction!(inspect_lift_scores, m)?)?;
+    m.add_function(wrap_pyfunction!(inspect_score_scores, m)?)?;
     m.add_function(wrap_pyfunction!(project, m)?)?;
     m.add_function(wrap_pyfunction!(set_experimental, m)?)?;
     m.add_function(wrap_pyfunction!(experimental_is_enabled, m)?)?;

--- a/tests/test_frex_cross_lang.py
+++ b/tests/test_frex_cross_lang.py
@@ -1,0 +1,116 @@
+"""Cross-language FREX/score/lift parity: topica-core's Rust ``inspect`` module
+vs the pure-Python ``topica.validation`` scorers (issue #260).
+
+The Rust ``inspect`` module (``frex_scores`` / ``lift_scores`` / ``score_scores``)
+is the stm-faithful port that faSTM and the Stata plugin use; topica's Python
+layer has its own implementations in ``topica.validation``. These tests pin down
+where the two agree so the definitions cannot silently drift, and document (via
+xfail) the one place they intentionally differ today.
+
+Findings locked in here:
+
+- **FREX** (no James-Stein shrinkage, the comparable mode): **bit-for-bit
+  identical**. Same ECDF/average rank on continuous data, same harmonic mean.
+- **score**: identical up to the log floor (Rust floors at ``f64::EPSILON``,
+  Python at ``1e-12``), which only moves negligible-probability words; the
+  selected top words match exactly.
+- **lift**: *different by definition* — Python ``label_topics`` reports a
+  mean-beta ratio ``beta / mean_k beta``; stm/Rust reports the empirical-frequency
+  log-lift ``log(beta) - log(wordfreq)``. Captured as an xfail until unified.
+
+These call the internal ``topica._topica.inspect_*`` bindings (added for exactly
+this comparison) and need no R or external data.
+"""
+
+import numpy as np
+import pytest
+
+from topica import _topica
+from topica import validation as val
+
+
+def _continuous_beta(seed=0, K=6, V=200):
+    """A K x V topic-word matrix with no ties (so ranks are unambiguous)."""
+    rng = np.random.default_rng(seed)
+    beta = rng.gamma(0.3, size=(K, V))
+    beta /= beta.sum(axis=1, keepdims=True)
+    vocab = [f"w{i}" for i in range(V)]
+    return beta, vocab
+
+
+def _py_frex_matrix(beta, vocab, w=0.5):
+    """Full (K, V) FREX score matrix from the Python scorer (n=V returns all)."""
+    K, V = beta.shape
+    top = val.frex(beta, vocab, w=w, n=V)
+    mat = np.zeros((K, V))
+    for t in range(K):
+        for word, score in top[t]:
+            mat[t, int(word[1:])] = score
+    return mat
+
+
+def test_frex_matches_rust_inspect_bitwise():
+    beta, vocab = _continuous_beta()
+    rust = np.array(_topica.inspect_frex_scores(beta.tolist(), [], 0.5))
+    py = _py_frex_matrix(beta, vocab, w=0.5)
+    # Continuous beta -> no ties -> the two rank methods coincide exactly.
+    np.testing.assert_allclose(rust, py, atol=1e-12, rtol=0)
+
+
+@pytest.mark.parametrize("w", [0.3, 0.5, 0.7])
+def test_frex_top_words_agree(w):
+    beta, vocab = _continuous_beta(seed=1)
+    rust = np.array(_topica.inspect_frex_scores(beta.tolist(), [], w))
+    py = _py_frex_matrix(beta, vocab, w=w)
+    for t in range(beta.shape[0]):
+        r_top = set(np.argsort(rust[t])[::-1][:10])
+        p_top = set(np.argsort(py[t])[::-1][:10])
+        assert r_top == p_top
+
+
+def test_frex_shrinkage_is_an_option_only_in_rust():
+    # Passing word_counts engages stm's James-Stein exclusivity shrinkage, which
+    # changes the scores; the Python scorer has no such mode (no-shrink only).
+    beta, _ = _continuous_beta(seed=2)
+    rng = np.random.default_rng(2)
+    wc = rng.integers(1, 500, beta.shape[1]).tolist()
+    no_shrink = np.array(_topica.inspect_frex_scores(beta.tolist(), [], 0.5))
+    shrink = np.array(_topica.inspect_frex_scores(beta.tolist(), wc, 0.5))
+    assert not np.allclose(no_shrink, shrink)
+
+
+def test_score_top_words_agree():
+    # Top-word agreement on a realistic (sparse) beta: ranking is robust to the
+    # differing log floors (which only touch negligible-probability words).
+    beta, vocab = _continuous_beta(seed=3)
+    rust = np.array(_topica.inspect_score_scores(beta.tolist()))
+    log_phi = np.log(np.clip(beta, 1e-12, None))
+    py = beta * (log_phi - log_phi.mean(axis=0))
+    for t in range(beta.shape[0]):
+        assert (set(np.argsort(rust[t])[::-1][:10])
+                == set(np.argsort(py[t])[::-1][:10]))
+
+
+def test_score_matches_rust_inspect_on_dense_beta():
+    # With no near-zero entries, the two log floors (Rust f64::EPSILON, Python
+    # 1e-12) never bite, so the score formula matches bit-for-bit.
+    rng = np.random.default_rng(5)
+    beta = rng.uniform(0.5, 1.5, size=(6, 200))
+    beta /= beta.sum(axis=1, keepdims=True)  # all entries ~1/V, far above any floor
+    rust = np.array(_topica.inspect_score_scores(beta.tolist()))
+    log_phi = np.log(beta)
+    py = beta * (log_phi - log_phi.mean(axis=0))
+    np.testing.assert_allclose(rust, py, atol=1e-12, rtol=0)
+
+
+@pytest.mark.xfail(reason="Python label_topics lift = beta/mean_k beta; stm/Rust "
+                          "lift = log(beta) - log(empirical word freq). Different "
+                          "definitions until unified (#260).", strict=True)
+def test_lift_matches_rust_inspect():
+    beta, _ = _continuous_beta(seed=4)
+    rng = np.random.default_rng(4)
+    wc = rng.integers(1, 500, beta.shape[1]).tolist()
+    rust = np.array(_topica.inspect_lift_scores(beta.tolist(), wc))
+    marginal = beta.mean(axis=0)
+    py = beta / np.where(marginal > 0, marginal, 1e-12)
+    np.testing.assert_allclose(rust, py, atol=1e-8)


### PR DESCRIPTION
Closes the first cut of #260: pin down where topica-core's stm-faithful Rust `inspect` scorers (the ones faSTM and the Stata plugin use) agree with topica's pure-Python `validation` scorers, so the two definitions can't silently drift.

## What's here

- **Internal bindings** `_topica.inspect_{frex,lift,score}_scores` exposing the `topica-core::inspect` K×V score matrices to Python. These are the groundwork for the #260 part-2 step (routing Python through the Rust core for a single source of truth).
- **`tests/test_frex_cross_lang.py`** — cross-language parity, no R/data deps:
  - **FREX** (no James-Stein shrinkage, the comparable mode): **bit-for-bit identical**.
  - **score**: bit-for-bit on dense beta; selected top words match exactly on sparse beta (the two log floors — Rust `f64::EPSILON`, Python `1e-12` — only move negligible-probability words).
  - **FREX shrinkage**: confirmed a Rust-only stm option (Python has no-shrink only).
  - **lift**: captured as a **strict xfail** — Python `label_topics` lift is `beta / mean_k beta`; stm/Rust is `log(beta) − log(word freq)`. Different definitions, surfaced for a decision (unify later, #260 part 2).

## Drive-by fix: main's CI was red

#261 added `LoadOptions.lowercase` to topica-core but left `src/python/corpus.rs`'s struct literal without the field, breaking the `--features python` build (and the `--all-features` clippy gate). main's last CI run is failing. This restores `lowercase: true` (the prior always-lowercase behavior), so this PR also gets main green again.

## Validation

Full suite: 2797 passed, 27 skipped, 1 xfailed. `cargo fmt --all --check` + `cargo clippy --workspace --all-targets --all-features -D warnings` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)