### PR TITLE
Route exclusivity through stm core + add stm semantic_coherence (#260)

### DIFF
--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -15,6 +15,8 @@ and in the `topica.validation` module.
 
 ::: topica.coherence
 
+::: topica.semantic_coherence
+
 ::: topica.topic_diversity
 
 ::: topica.topic_semantic_diversity

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -170,6 +170,7 @@ from .keyatm import time_prevalence_ci  # noqa: E402  (dynamic keyATM credible b
 from . import phrases  # noqa: E402
 from .coherence import (  # noqa: E402
     coherence,
+    semantic_coherence,
     topic_diversity,
     topic_semantic_diversity,
     exclusivity,
@@ -304,6 +305,7 @@ __all__ = [
     "topic_diversity",
     "topic_semantic_diversity",
     "exclusivity",
+    "semantic_coherence",
     "word_intrusion",
     "document_intrusion",
     "llm",

--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -122,9 +122,23 @@ def topic_semantic_diversity(topics: Any, topn: int = 25) -> float:
     ...
 
 
-def exclusivity(model_or_phi: Any, *, n: int = 10) -> numpy.typing.NDArray[numpy.float64]:
-    """Per-topic exclusivity of the top-n words, shape (num_topics,). Pair with
-    per-topic coherence for the coherence-vs-exclusivity quality plot."""
+def exclusivity(model_or_phi: Any, *, n: int = 10, w: float = 0.7) -> numpy.typing.NDArray[numpy.float64]:
+    """Per-topic exclusivity (stm's FREX summary over the top-n words), shape
+    (num_topics,). Pair with per-topic coherence for the coherence-vs-exclusivity
+    quality plot. From topica's stm-faithful Rust core."""
+    ...
+
+
+def semantic_coherence(
+    model_or_phi: Any,
+    texts: Any,
+    vocabulary: list[str] | None = None,
+    *,
+    n: int = 10,
+) -> numpy.typing.NDArray[numpy.float64]:
+    """Per-topic semantic coherence (stm's semCoh1beta, UMass with 0.01 smoothing)
+    over the top-n words, shape (num_topics,). ``texts`` is a Corpus or list of
+    token lists. From topica's stm-faithful Rust core."""
     ...
 
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -71,6 +71,22 @@ def inspect_score_scores(beta: list[list[float]]) -> list[list[float]]:
     """stm-faithful score matrix (K x V): beta * (log beta - mean_k log beta) (internal)."""
     ...
 
+def inspect_exclusivity(
+    beta: list[list[float]],
+    m: int,
+    frexw: float = 0.7,
+) -> list[float]:
+    """stm-faithful per-topic exclusivity (FREX summary over top-m words) (internal)."""
+    ...
+
+def inspect_semantic_coherence(
+    beta: list[list[float]],
+    docs: list[list[int]],
+    m: int,
+) -> list[float]:
+    """stm-faithful per-topic semantic coherence (semCoh1beta) over top-m words (internal)."""
+    ...
+
 def window_cooccurrence(
     docs: list[list[int]],
     num_relevant: int,

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -460,28 +460,62 @@ def _vocabulary_of(obj, vocabulary):
     raise ValueError("vocabulary is required when the model/array carries none")
 
 
-def exclusivity(model_or_phi, *, n=10):
-    """Per-topic exclusivity, shape ``(num_topics,)``.
+def exclusivity(model_or_phi, *, n=10, w=0.7):
+    """Per-topic exclusivity, shape ``(num_topics,)`` — stm's ``exclusivity``.
 
-    For each topic, the mean over its top-``n`` words (by probability) of the
-    exclusivity ``φ_{t,v} / Σ_k φ_{k,v}`` — how concentrated a word is in this
-    topic rather than shared across topics. Pair with per-topic coherence (e.g.
-    a model's ``coherence(n)``) to make stm's coherence-vs-exclusivity quality
-    plot: good topics sit toward the upper-right (coherent *and* distinctive).
+    For each topic, the **FREX summary** over its top-``n`` words (by probability):
+    the sum of each word's frequency–exclusivity score (the rank harmonic mean of
+    probability and exclusivity ``φ_{t,v} / Σ_k φ_{k,v}``, weighted by ``w``, stm's
+    default 0.7). Higher means the topic's top words are more distinctive. Pair with
+    per-topic coherence to make stm's coherence-vs-exclusivity quality plot: good
+    topics sit toward the upper-right (coherent *and* distinctive).
+
+    The scores come from the single stm-faithful implementation in topica's Rust
+    core (``topica-core``'s ``inspect``), shared with faSTM and the Stata plugin.
+
+    .. note::
+       This is stm's exclusivity (a sum of FREX scores over the top ``n`` words,
+       roughly in ``[0, n]``), not a mean exclusivity in ``[0, 1]``. The scale
+       changed in the move to the shared stm-faithful core.
 
     `model_or_phi` is a fitted model (uses its ``topic_word``) or a ``(K, V)``
     array.
     """
+    from ._topica import inspect_exclusivity
+
     phi = _as_topic_word(model_or_phi)
-    K, _ = phi.shape
-    col = phi.sum(axis=0)
-    col[col == 0] = 1.0
-    excl = phi / col
-    out = np.empty(K, dtype=np.float64)
-    for t in range(K):
-        top = np.argsort(phi[t])[::-1][:n]
-        out[t] = excl[t, top].mean()
-    return out
+    return np.asarray(
+        inspect_exclusivity(phi.tolist(), int(n), float(w)), dtype=np.float64
+    )
+
+
+def semantic_coherence(model_or_phi, texts, vocabulary=None, *, n=10):
+    """Per-topic semantic coherence, shape ``(num_topics,)`` — stm's ``semCoh1beta``.
+
+    The UMass document-co-occurrence coherence over each topic's top-``n`` words,
+    with stm's 0.01 smoothing (higher = better). This is stm's exact semantic
+    coherence, from topica's Rust core (``topica-core``'s ``inspect``), shared with
+    faSTM and the Stata plugin. For the broader, gensim-aligned coherence measures
+    (``c_v``, ``c_npmi``, ``u_mass``) use :func:`coherence` instead.
+
+    `model_or_phi` is a fitted model (uses its ``topic_word`` / ``vocabulary``) or a
+    ``(K, V)`` array (then pass ``vocabulary``). ``texts`` is the reference corpus:
+    a :class:`topica.Corpus`, or a list of token lists (the words per document).
+    """
+    from ._topica import inspect_semantic_coherence
+
+    phi = _as_topic_word(model_or_phi)
+    # Fall back to the corpus's own vocabulary when the model/array carries none.
+    if vocabulary is None and not hasattr(model_or_phi, "vocabulary") \
+            and hasattr(texts, "vocabulary"):
+        vocabulary = list(texts.vocabulary)
+    vocab_list = _vocabulary_of(model_or_phi, vocabulary)
+    vocab = {w: i for i, w in enumerate(vocab_list)}
+    docs = texts.documents() if hasattr(texts, "documents") else texts
+    docs_ids = [[vocab[w] for w in d if w in vocab] for d in docs]
+    return np.asarray(
+        inspect_semantic_coherence(phi.tolist(), docs_ids, int(n)), dtype=np.float64
+    )
 
 
 def word_intrusion(model_or_phi, vocabulary=None, *, n_words=5, seed=0):

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -8202,6 +8202,28 @@ fn inspect_score_scores(py: Python<'_>, beta: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
     py.allow_threads(move || topica_core::inspect::score_scores(&beta))
 }
 
+/// stm-faithful per-topic exclusivity (`topica-core` `inspect::exclusivity`): the
+/// FREX-summary over each topic's top-`m` words, with frequency/exclusivity weight
+/// `frexw` (stm default 0.7). Returns K values. Internal; see [`inspect_frex_scores`].
+#[pyfunction]
+#[pyo3(signature = (beta, m, frexw=0.7))]
+fn inspect_exclusivity(py: Python<'_>, beta: Vec<Vec<f64>>, m: usize, frexw: f64) -> Vec<f64> {
+    py.allow_threads(move || topica_core::inspect::exclusivity(&beta, m, frexw))
+}
+
+/// stm-faithful semantic coherence (`topica-core` `inspect::semantic_coherence`,
+/// stm's `semCoh1beta`): UMass over each topic's top-`m` words with stm's 0.01
+/// smoothing. `docs` are token-id lists. Returns K values. Internal.
+#[pyfunction]
+fn inspect_semantic_coherence(
+    py: Python<'_>,
+    beta: Vec<Vec<f64>>,
+    docs: Vec<Vec<u32>>,
+    m: usize,
+) -> Vec<f64> {
+    py.allow_threads(move || topica_core::inspect::semantic_coherence(&beta, &docs, m))
+}
+
 /// Warn that a neighbor-preserving projection (UMAP / t-SNE) distorts global
 /// geometry and is not reproducible across runs, so PCA stays the honest default.
 fn warn_stochastic(py: Python<'_>, method: &str) -> PyResult<()> {
@@ -18092,6 +18114,8 @@ fn _topica(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(inspect_frex_scores, m)?)?;
     m.add_function(wrap_pyfunction!(inspect_lift_scores, m)?)?;
     m.add_function(wrap_pyfunction!(inspect_score_scores, m)?)?;
+    m.add_function(wrap_pyfunction!(inspect_exclusivity, m)?)?;
+    m.add_function(wrap_pyfunction!(inspect_semantic_coherence, m)?)?;
     m.add_function(wrap_pyfunction!(project, m)?)?;
     m.add_function(wrap_pyfunction!(set_experimental, m)?)?;
     m.add_function(wrap_pyfunction!(experimental_is_enabled, m)?)?;

--- a/tests/test_frex_cross_lang.py
+++ b/tests/test_frex_cross_lang.py
@@ -116,6 +116,41 @@ def test_corpus_supplies_word_counts():
         val.frex(beta, vocab, word_counts=wc, corpus=corpus)
 
 
+def test_exclusivity_routes_through_core():
+    beta, _ = _continuous_beta(seed=6)
+    rust = np.array(_topica.inspect_exclusivity(beta.tolist(), 10, 0.7))
+    py = topica.exclusivity(beta, n=10, w=0.7)
+    np.testing.assert_allclose(py, rust, atol=1e-12, rtol=0)
+    # stm's exclusivity is a FREX summary (~[0, n]), not a [0, 1] mean.
+    assert np.all(py >= 0.0) and py.max() > 1.0
+
+
+def test_semantic_coherence_routes_through_core():
+    beta, vocab = _continuous_beta(seed=7, K=4, V=60)
+    rng = np.random.default_rng(7)
+    docs = [[f"w{i}" for i in rng.integers(0, 60, rng.integers(5, 20))]
+            for _ in range(200)]
+    py = topica.semantic_coherence(beta, docs, vocab, n=10)
+    vmap = {w: i for i, w in enumerate(vocab)}
+    docs_ids = [[vmap[w] for w in d if w in vmap] for d in docs]
+    rust = np.array(_topica.inspect_semantic_coherence(beta.tolist(), docs_ids, 10))
+    np.testing.assert_allclose(py, rust, atol=1e-12, rtol=0)
+    assert py.shape == (4,)
+
+
+def test_semantic_coherence_reads_corpus_vocabulary():
+    docs = [["a", "b", "c"], ["a", "a", "b"], ["b", "c", "c"], ["a", "c"]] * 8
+    corpus = topica.Corpus.from_documents(docs, min_doc_freq=1)
+    rng = np.random.default_rng(0)
+    beta = rng.gamma(0.4, size=(3, corpus.num_words))
+    beta /= beta.sum(axis=1, keepdims=True)
+    # Passing the Corpus supplies both the documents and the vocabulary.
+    from_corpus = topica.semantic_coherence(beta, corpus, n=5)
+    from_lists = topica.semantic_coherence(beta, corpus.documents(),
+                                           corpus.vocabulary, n=5)
+    np.testing.assert_allclose(from_corpus, from_lists, atol=1e-12)
+
+
 def test_lift_without_counts_ranks_like_marginal_lift():
     # No word_counts: P(w) is estimated from the column marginal, so lift is
     # log(beta) - log(marginal) — the same ranking as the historical beta/marginal

--- a/tests/test_stm.py
+++ b/tests/test_stm.py
@@ -520,9 +520,11 @@ class TestSearchK:
         for row in search_k_results:
             assert row["coherence"] <= 0.0
 
-    def test_exclusivity_in_unit_interval(self, search_k_results):
+    def test_exclusivity_nonnegative(self, search_k_results):
+        # stm's exclusivity is a FREX summary over the top words (roughly [0, n]),
+        # not a [0, 1] mean.
         for row in search_k_results:
-            assert 0.0 <= row["exclusivity"] <= 1.0
+            assert row["exclusivity"] >= 0.0 and np.isfinite(row["exclusivity"])
 
     def test_with_held_out_has_perplexity(self):
         rng = np.random.default_rng(77)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -34,7 +34,9 @@ class TestExclusivity:
         m, _, _ = _two_topic_model()
         ex = topica.exclusivity(m, n=5)
         assert ex.shape == (2,)
-        assert np.all(ex >= 0.0) and np.all(ex <= 1.0)
+        # stm's exclusivity is a FREX summary over the top-n words (roughly [0, n]),
+        # not a [0, 1] mean — assert non-negative and finite.
+        assert np.all(ex >= 0.0) and np.all(np.isfinite(ex))
 
     def test_disjoint_vocab_is_highly_exclusive(self):
         # The two planted vocabularies don't overlap, so each topic's top words


### PR DESCRIPTION
Extends #260's single-source-of-truth to the last two stm diagnostics: topica's `exclusivity` and a new `semantic_coherence` now come from topica-core's stm-faithful `inspect` (shared with faSTM and the Stata plugin), via new internal `_topica.inspect_exclusivity` / `inspect_semantic_coherence` bindings.

## What changed

- **`exclusivity` is now stm's exclusivity** — the FREX summary over each topic's top-`n` words (sum of frequency–exclusivity scores, `frexw` default 0.7), from `inspect::exclusivity`. **Scale change**: roughly `[0, n]`, not the old mean in `[0, 1]`. (You opted into this when we discussed it — replace, not add-alongside.)
  - The `best_k` model-selection frontier uses **z-scores** of coherence/exclusivity, so it's invariant to the rescale (no crash, no `[0,1]` division). The two range-asserting tests are updated to non-negative/finite.
- **New `topica.semantic_coherence(model, texts)`** — stm's `semCoh1beta` (UMass, 0.01 smoothing) over top-`n` words, from `inspect::semantic_coherence`. Accepts a `Corpus` (supplies documents *and* vocabulary) or token lists. The broader gensim-aligned suite (`c_v` / `c_npmi` / `u_mass` via `topica.coherence`) is **untouched** — those are intentionally different, validated measures.

## Validation

Parity tests assert the Python wrappers equal the core exactly. R-stm parity intact. Full suite **2802 passed**, 27 skipped. `cargo fmt`/`clippy --all-features` clean, `mkdocs --strict` clean.

## #260 status after this
FREX, lift, score, exclusivity, and semantic coherence all now flow from the one stm-faithful `topica-core::inspect` definition. The full FREX/inspect line of work is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)