### PR TITLE
Spectral init: weight recovery by stm's unigram-frequency wprob

### DIFF
--- a/parity/spectral_recover_stm.py
+++ b/parity/spectral_recover_stm.py
@@ -17,6 +17,13 @@ its exponentiated gradient diverged at a fixed eta=50.) #240 note: an end-to-end
 gap observed downstream comes from feeding a *differently prepared* corpus, not
 from the spectral algorithm — given identical prepped input, topica matches stm.
 
+The reference uses stm's ACTUAL word weighting in recovery — the pooled unigram
+frequency ``colSums(mat)/sum(mat)`` that ``stm.init`` passes to ``recoverL2`` —
+which topica now matches (previously topica weighted by the gram row sums; #260
+follow-up). recoverL2 is still called with ``recoverEG=FALSE`` for the converged
+QP optimum, since stm's default ``recoverEG=TRUE`` is a non-converging
+exponentiated-gradient approximation, not the recovery target.
+
 Skips cleanly if Rscript or the stm/Matrix packages are unavailable.
 """
 import json
@@ -47,7 +54,10 @@ for(i in seq_along(docs)){m<-docs[[i]];rows<-c(rows,rep(i,ncol(m)));cols<-c(cols
 mat <- sparseMatrix(i=rows,j=cols,x=vals,dims=c(length(docs),V))
 Q <- stm:::gram(mat); Qsums <- rowSums(Q); Qbar <- Q/Qsums
 anchors <- stm:::fastAnchor(Qbar, K, verbose=FALSE)
-beta <- stm:::recoverL2(Qbar, anchors, Qsums/sum(Qsums), verbose=FALSE, recoverEG=FALSE)$A
+# wprob = stm's ACTUAL word weighting: the pooled unigram frequency that
+# stm.init passes to recoverL2 (colSums(mat)/sum(mat)), not the gram row sums.
+wprob <- as.numeric(Matrix::colSums(mat)/sum(mat))
+beta <- stm:::recoverL2(Qbar, anchors, wprob, verbose=FALSE, recoverEG=FALSE)$A
 writeLines(vocab, file.path(outdir, "vocab.txt"))
 write.table(beta, file.path(outdir, "beta.csv"), sep=",", row.names=FALSE, col.names=FALSE)
 cat("OK\n")

--- a/topica-core/src/spectral.rs
+++ b/topica-core/src/spectral.rs
@@ -32,11 +32,22 @@ const PROJ_DIM: usize = 1024;
 const PROJ_SEED: u64 = 0x5EED_C0FFEE;
 
 /// Build the row-normalized co-occurrence matrix `Q̄` (V×V) and the word
-/// marginals `p`. Returns `None` if the corpus is too small/degenerate.
+/// probabilities `wprob`. `wprob` is the pooled unigram frequency
+/// (`colSums(mat)/sum(mat)`, over all documents), matching Arora et al. and R
+/// `stm`'s `wprob` — the word weighting the recovery uses. Returns `None` if the
+/// corpus is too small/degenerate.
 fn cooccurrence(docs: &[Vec<u32>], v: usize) -> Option<(Vec<Vec<f64>>, Vec<f64>)> {
     let mut q = vec![vec![0.0f64; v]; v];
+    let mut total_count = vec![0.0f64; v];
+    let mut total_tokens = 0.0f64;
     let mut used_docs = 0usize;
     for doc in docs {
+        // Unigram counts over ALL documents (stm computes wprob from the full
+        // term-document matrix, before the gram step drops length-<2 docs).
+        for &w in doc {
+            total_count[w as usize] += 1.0;
+            total_tokens += 1.0;
+        }
         let n = doc.len();
         if n < 2 {
             continue;
@@ -55,16 +66,10 @@ fn cooccurrence(docs: &[Vec<u32>], v: usize) -> Option<(Vec<Vec<f64>>, Vec<f64>)
             }
         }
     }
-    if used_docs == 0 {
+    if used_docs == 0 || total_tokens == 0.0 {
         return None;
     }
-    for row in &mut q {
-        for x in row.iter_mut() {
-            *x /= used_docs as f64;
-        }
-    }
-    let p: Vec<f64> = q.iter().map(|r| r.iter().sum()).collect();
-    // Row-normalize → Q̄.
+    // Row-normalize → Q̄ (the per-document scaling cancels here, so no /used_docs).
     let mut qbar = q;
     for row in qbar.iter_mut() {
         let s: f64 = row.iter().sum();
@@ -74,7 +79,8 @@ fn cooccurrence(docs: &[Vec<u32>], v: usize) -> Option<(Vec<Vec<f64>>, Vec<f64>)
             }
         }
     }
-    Some((qbar, p))
+    let wprob: Vec<f64> = total_count.iter().map(|&c| c / total_tokens).collect();
+    Some((qbar, wprob))
 }
 
 fn dot(a: &[f64], b: &[f64]) -> f64 {
@@ -266,9 +272,15 @@ fn cooccurrence_projected(
         .collect();
 
     let mut qp = vec![vec![0.0f64; m]; v];
-    let mut p = vec![0.0f64; v];
+    let mut rowsum = vec![0.0f64; v]; // co-occurrence row marginal (for Q̄ normalization)
+    let mut total_count = vec![0.0f64; v]; // unigram counts over all docs (for wprob)
+    let mut total_tokens = 0.0f64;
     let mut used_docs = 0usize;
     for doc in docs {
+        for &w in doc {
+            total_count[w as usize] += 1.0;
+            total_tokens += 1.0;
+        }
         let n = doc.len();
         if n < 2 {
             continue;
@@ -292,33 +304,26 @@ fn cooccurrence_projected(
             for j in 0..m {
                 qp[w][j] += coef * (s[j] - r[w][j]);
             }
-            p[w] += c / nf; // row marginal (matches the exact path's p)
+            rowsum[w] += c / nf; // matches the dense path's pre-normalization row sum
         }
     }
-    if used_docs == 0 {
+    if used_docs == 0 || total_tokens == 0.0 {
         return None;
     }
-    let inv = 1.0 / used_docs as f64;
-    for row in &mut qp {
-        for x in row.iter_mut() {
-            *x *= inv;
-        }
-    }
-    for x in &mut p {
-        *x *= inv;
-    }
-    // Q̄·R = (Q·R) row-normalized by the marginal p (projection is linear, so
-    // proj(q[w]/p[w]) = (q[w]·R)/p[w]).
+    // Q̄·R = (Q·R) row-normalized by the row marginal (projection is linear, so
+    // proj(q[w]/rowsum[w]) = (q[w]·R)/rowsum[w]). The per-document scaling cancels.
     let mut qbar = qp;
     for (w, row) in qbar.iter_mut().enumerate() {
-        if p[w] > 0.0 {
-            let pw = p[w];
+        if rowsum[w] > 0.0 {
+            let rw = rowsum[w];
             for x in row.iter_mut() {
-                *x /= pw;
+                *x /= rw;
             }
         }
     }
-    Some((qbar, p))
+    // wprob = pooled unigram frequency (Arora / stm wprob), as in the dense path.
+    let wprob: Vec<f64> = total_count.iter().map(|&c| c / total_tokens).collect();
+    Some((qbar, wprob))
 }
 
 /// Deterministic anchor-word initialization of the K×V topic-word matrix.


### PR DESCRIPTION
Closes the one genuine fidelity gap between topica's spectral initialization and R `stm`'s (from the spectral-init audit).

## The gap

topica's spectral recovery weighted words by the **gram row sums** (`rowSums(Q)`, which works out to the mean within-document frequency). R `stm`'s `stm.init` weights the recovery by the **pooled unigram frequency** `colSums(mat)/sum(mat)` — the Arora et al. `p_w`. These differ whenever document lengths vary, so topica's spectral start drifted slightly from stm's actual default. Everything else (gram construction, anchor selection, the converged exp-gradient recovery) already matched.

## The fix

Compute `wprob` as the pooled unigram frequency (over all documents, before the gram step drops length-<2 docs) in both the dense and random-projected paths, and keep the true co-occurrence row sums **only** for the Q̄ row-normalization, where they belong. The two roles were conflated in one vector before.

## Validation

`parity/spectral_recover_stm.py` previously compared against `Qsums/sum(Qsums)` (the gram row sums) as stm's `wprob` — which happened to match topica's old behavior, so the "cosine 1.0" was self-consistent but **not** stm's real weighting. The reference now uses stm's actual `wprob = colSums(mat)/sum(mat)` (still `recoverEG=FALSE`, the converged QP optimum). With this fix topica matches at:

```
per-topic (same-order) cosine = 1.0000
matched (Hungarian)    cosine = 1.0000   (gadarian, K=5)
```

Full suite 2802 passed; `cargo fmt`/`clippy --all-features` clean. The spectral init is deterministic so this is a small, one-time shift to the default start of the variational models (STM/CTM), now bit-faithful to stm.

Note: faSTM pins `topica-core` by tag, so it's unaffected until it bumps; when it does, its `spectral_recover_parity.R` reference should move to `colSums/sum` too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)