### PR TITLE
release: 0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,52 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-06-21
+
+### Added
+
+- Survey weights and average marginal effects for covariate inference:
+  `estimate_effect(weights=)` runs weighted least squares (composing with
+  `cluster=` and `link=`), and `average_marginal_effects()` / `ame()` reports the
+  average change in a topic's proportion per unit of a covariate (the average
+  derivative for a continuous covariate, the average level-vs-reference contrast
+  for a factor) — cleaner than raw coefficients under splines or interactions.
+  `TopicEffect` now also exposes the full Rubin-pooled coefficient covariance
+  `.vcov`. Validated bit-for-bit against faSTM's effect layer (#258).
+- `semantic_coherence()` — stm's `semCoh1beta` semantic coherence, from the shared
+  Rust core. The broader gensim-aligned `coherence()` suite is unchanged (#260).
+- `frex()` and `label_topics()` accept `word_counts=` or `corpus=` to apply stm's
+  James-Stein FREX shrinkage and exact lift; `Corpus.word_counts` exposes the
+  per-term corpus frequencies (#260).
+- `topica-core` gains `inspect` (FREX / lift / score / exclusivity / semantic
+  coherence) and `effects` (`estimate_effect_topic`) modules plus
+  `Corpus::from_texts` — the engine shared by faSTM (R) and stmata (Stata), so the
+  stm-faithful diagnostics have one definition across languages (#259).
+
+### Changed
+
+- FREX, lift, score, exclusivity, and semantic coherence now all come from the
+  single stm-faithful implementation in `topica-core`'s `inspect`, so they cannot
+  drift between topica, faSTM, and stmata (#260). Two definitions changed as a
+  result:
+  - **`label_topics` lift** is now stm's lift, `log P(w|topic) − log P(w)`, not
+    the previous `beta / mean_k beta` ratio (which was not lift). With
+    `word_counts=`/`corpus=` it is exact; without, `P(w)` is estimated from the
+    column marginal (same ranking, correct log scale).
+  - **`exclusivity`** is now stm's FREX-summary over the top words (roughly
+    `[0, n]`), not a mean exclusivity in `[0, 1]`. The model-selection frontier
+    uses z-scores, so K selection is unaffected by the rescale.
+- Spectral initialization now weights the Arora recovery by the pooled unigram
+  frequency (stm's `wprob`), matching R `stm`'s spectral start exactly (per-topic
+  cosine 1.0 on gadarian); previously it used the gram row sums. The converged
+  STM fit is unchanged (0.996 cosine to the prior solution) (#265).
+
+### Fixed
+
+- Restore the `--features python` build: the `LoadOptions.lowercase` field added
+  to `topica-core` had left the Python binding's struct literal incomplete; this
+  also cleared two pre-existing `cargo fmt`/`clippy` lints (#262).
+
 ## [0.26.0] - 2026-06-19
 
 ### Fixed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.26.0
-date-released: 2026-06-18
+version: 0.27.0
+date-released: 2026-06-21
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.26.0"
+version = "0.27.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.26.0"
+version = "0.27.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.26.0"
+version = "0.27.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.27.0** — the faSTM-backport + stm-faithful-diagnostics release.

## Highlights

**Added**
- `estimate_effect(weights=)` (weighted least squares), `average_marginal_effects()` / `ame()`, `TopicEffect.vcov` — faSTM's covariate-effect toolkit, parity-validated (#258).
- `semantic_coherence()` (stm's `semCoh1beta`); `frex`/`label_topics` gain `word_counts=`/`corpus=` (stm James-Stein shrinkage + exact lift); `Corpus.word_counts` (#260).
- `topica-core` `inspect` + `effects` modules and `Corpus::from_texts` — the engine shared by faSTM (R) and stmata (Stata) (#259).

**Changed (output-affecting — see CHANGELOG)**
- FREX/lift/score/exclusivity/semantic coherence now share one stm-faithful `topica-core` definition. `lift` is now stm's log-lift (was `beta/mean_k beta`); `exclusivity` is now stm's FREX-summary (scale ~`[0,n]`, not `[0,1]`; frontier uses z-scores so K selection is unaffected) (#260).
- Spectral init matches stm's unigram `wprob` (cosine 1.0 to stm's start; converged STM unchanged at 0.996) (#265).

**Fixed**
- Restored the `--features python` build + lint (#262).

## Why a release
New public API plus output-affecting changes warrant a minor bump and a CHANGELOG entry. Concretely, faSTM and stmata pin `topica-core` by git tag, so a new `v0.27.0` tag is what lets them consume the shared `inspect`/`effects` engine and the spectral fix.

## Mechanics
Bumps `Cargo.toml`, `Cargo.lock`, `pyproject.toml`, `CITATION.cff` (date 2026-06-21), and adds the `CHANGELOG.md` entry. Version-consistency test passes; `topica.__version__ == "0.27.0"`. On squash-merge, tag `v0.27.0` to trigger the CI PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)