### PR TITLE
fix(keyatm): stop covariate model collapsing theta onto one topic (#270)

### DIFF
--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -1575,10 +1575,55 @@ impl ThetaDrawOpts {
     }
 }
 
+/// Bound on the standardized regression coefficients `λ`, matching R keyATM's
+/// `slice_max`/`slice_min` of ±5. Without it (and without standardized
+/// covariates) a high-dimensional design lets one topic's `λ` run away over the
+/// sweeps, so `α = exp(x · λ)` blows up and θ collapses onto a single topic
+/// (issue #270).
+const LAMBDA_BOUND: f64 = 5.0;
+
+/// R keyATM's covariate standardization (issue #270): z-score each non-intercept
+/// column to mean 0, sd 1. Column 0 (the prepended intercept) is left untouched.
+/// Constant columns (sd ≈ 0) are centered to 0 and given sd 1 (a null direction
+/// the N(0,1) prior regularizes). Returns the standardized matrix and the per-
+/// column means/sds (index 0 = intercept: mean 0, sd 1) so `λ` can be mapped back
+/// to the original covariate scale after fitting.
+fn standardize_features(
+    features: &[Vec<f64>],
+    num_features: usize,
+) -> (Vec<Vec<f64>>, Vec<f64>, Vec<f64>) {
+    let n = features.len();
+    let mut mean = vec![0.0f64; num_features];
+    let mut sd = vec![1.0f64; num_features];
+    if n == 0 {
+        return (features.to_vec(), mean, sd);
+    }
+    // Column 0 is the intercept (all 1.0); skip it.
+    for f in 1..num_features {
+        let m: f64 = features.iter().map(|r| r[f]).sum::<f64>() / n as f64;
+        let var: f64 = features.iter().map(|r| (r[f] - m).powi(2)).sum::<f64>() / n as f64;
+        let s = var.sqrt();
+        mean[f] = m;
+        sd[f] = if s > 1e-9 { s } else { 1.0 };
+    }
+    let std: Vec<Vec<f64>> = features
+        .iter()
+        .map(|r| {
+            (0..num_features)
+                .map(|f| if f == 0 { r[0] } else { (r[f] - mean[f]) / sd[f] })
+                .collect()
+        })
+        .collect();
+    (std, mean, sd)
+}
+
 /// Fit a keyATM **Covariate** model. The document-topic prior is a
 /// Dirichlet-Multinomial regression on document features,
 /// `α_{d,k} = exp(x_d · λ_k)` (Mimno & McCallum 2008), matching the keyATM R
-/// package's covariate model. `λ` is re-estimated by L-BFGS every
+/// package's covariate model. Following R keyATM, the covariates are standardized
+/// and `λ` is bounded to ±5 (see [`LAMBDA_BOUND`] and [`standardize_features`])
+/// to keep `α` from blowing up; `λ` is re-estimated by L-BFGS (MAP under an
+/// N(0,1) prior) every
 /// `opt_interval` sweeps once past `burn_in`; the keyword (z, s) sampler is
 /// otherwise identical to the base model.
 #[allow(clippy::too_many_arguments)]
@@ -1628,18 +1673,25 @@ pub fn fit_keyatm_cov<R: Rng>(
         );
     }
 
+    // Standardize covariates (issue #270): we fit λ in the standardized space,
+    // bounded to ±LAMBDA_BOUND, then map λ back to the original scale for storage.
+    let (features_std, feat_mean, feat_sd) = standardize_features(features, num_features);
+
     // α is replaced by the covariate prior; pass a nominal 1.0 for the struct.
     let (mut model, mut assignments, ki) = init_state(
         docs, num_types, num_topics, keywords, 1.0, beta, beta_key, gamma1, gamma2, weights, rng,
     );
 
     let mut lambda = vec![vec![0.0f64; num_features]; num_topics];
-    let mut doc_alpha = crate::dmr::compute_doc_alpha(&lambda, features, offset);
+    let mut doc_alpha = crate::dmr::compute_doc_alpha(&lambda, &features_std, offset);
     let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
     // So the log-likelihood trace uses the covariate doc-topic prior: doc_topic()
-    // takes the (lambda, features) path only when both are set on the model.
+    // takes the (lambda, features) path only when both are set on the model. While
+    // fitting we keep the standardized features and standardized-space λ on the
+    // model so the trace is self-consistent; both are converted to the original
+    // scale at the end.
     if ll_interval > 0 {
-        model.features = Some(features.to_vec());
+        model.features = Some(features_std.clone());
         model.prior_offset = offset.map(|o| o.to_vec());
     }
     let mut nkw_t = build_nkw_t(&model.nkw, num_types, num_topics);
@@ -1658,7 +1710,7 @@ pub fn fit_keyatm_cov<R: Rng>(
         if opt_interval > 0 && it + 1 > burn_in && (it + 1 - burn_in).is_multiple_of(opt_interval) {
             crate::dmr::optimize_lambda(
                 &mut lambda,
-                features,
+                &features_std,
                 &model.ndk,
                 num_topics,
                 num_features,
@@ -1666,11 +1718,20 @@ pub fn fit_keyatm_cov<R: Rng>(
                 lbfgs_iters,
                 offset,
             );
-            doc_alpha = crate::dmr::compute_doc_alpha(&lambda, features, offset);
+            // Bound λ to ±LAMBDA_BOUND in the standardized space (R keyATM's
+            // slice bounds), so a runaway coefficient cannot blow up α (#270).
+            for lk in lambda.iter_mut() {
+                for v in lk.iter_mut() {
+                    *v = v.clamp(-LAMBDA_BOUND, LAMBDA_BOUND);
+                }
+            }
+            doc_alpha = crate::dmr::compute_doc_alpha(&lambda, &features_std, offset);
         }
         draws.maybe_collect(&mut theta_draw_buf, it + 1, &model.ndk, &doc_alpha);
         if record_ll(it + 1, ll_interval, iters) {
+            // During the trace, λ and features are both in the standardized space.
             model.lambda = Some(lambda.clone());
+            model.features = Some(features_std.clone());
             model.prior_offset = offset.map(|o| o.to_vec());
             model
                 .log_likelihood_history
@@ -1683,7 +1744,24 @@ pub fn fit_keyatm_cov<R: Rng>(
         }
     }
 
-    model.lambda = Some(lambda);
+    // Map λ from the standardized space back to the original covariate scale, so
+    // that exp(features · λ_orig) == exp(features_std · λ_std): for f ≥ 1,
+    // λ_orig[f] = λ_std[f] / sd_f, with the intercept absorbing the mean shift.
+    // `feature_effects` and held-out `transform` then operate on raw covariates.
+    let lambda_orig: Vec<Vec<f64>> = lambda
+        .iter()
+        .map(|lk| {
+            let mut row = lk.clone();
+            let mut shift = 0.0;
+            for f in 1..num_features {
+                row[f] = lk[f] / feat_sd[f];
+                shift += lk[f] * feat_mean[f] / feat_sd[f];
+            }
+            row[0] = lk[0] - shift;
+            row
+        })
+        .collect();
+    model.lambda = Some(lambda_orig);
     model.features = Some(features.to_vec());
     model.prior_offset = offset.map(|o| o.to_vec());
     model.theta_draws = theta_draw_buf;
@@ -2217,6 +2295,60 @@ mod tests {
     use super::*;
     use rand_chacha::rand_core::SeedableRng;
     use rand_chacha::ChaCha8Rng;
+
+    /// Covariate standardization (#270): non-intercept columns come out mean ~0,
+    /// sd ~1, the intercept is untouched, and mapping λ from standardized back to
+    /// the original scale reproduces the same α = exp(features · λ) for every doc.
+    #[test]
+    fn standardize_and_lambda_mapback_roundtrip() {
+        // features: [intercept, a continuous col, a 0/1 dummy col]
+        let features = vec![
+            vec![1.0, 2.0, 0.0],
+            vec![1.0, 4.0, 1.0],
+            vec![1.0, 6.0, 0.0],
+            vec![1.0, 8.0, 1.0],
+        ];
+        let nf = 3;
+        let (fstd, mean, sd) = standardize_features(&features, nf);
+        // Intercept untouched.
+        assert!(fstd.iter().all(|r| (r[0] - 1.0).abs() < 1e-12));
+        assert!((mean[0]).abs() < 1e-12 && (sd[0] - 1.0).abs() < 1e-12);
+        // Non-intercept columns standardized to mean ~0, sd ~1.
+        for f in 1..nf {
+            let m: f64 = fstd.iter().map(|r| r[f]).sum::<f64>() / 4.0;
+            let v: f64 = fstd.iter().map(|r| (r[f] - m).powi(2)).sum::<f64>() / 4.0;
+            assert!(m.abs() < 1e-9, "col {f} mean {m}");
+            assert!((v.sqrt() - 1.0).abs() < 1e-9, "col {f} sd {}", v.sqrt());
+        }
+        // A λ in standardized space, mapped back to the original scale, must give
+        // the same linear predictor (hence the same α) on the raw features.
+        let lambda_std = vec![vec![0.5, -1.2, 0.8], vec![-0.3, 2.0, -1.5]];
+        let lambda_orig: Vec<Vec<f64>> = lambda_std
+            .iter()
+            .map(|lk| {
+                let mut row = lk.clone();
+                let mut shift = 0.0;
+                for f in 1..nf {
+                    row[f] = lk[f] / sd[f];
+                    shift += lk[f] * mean[f] / sd[f];
+                }
+                row[0] = lk[0] - shift;
+                row
+            })
+            .collect();
+        let a_std = crate::dmr::compute_doc_alpha(&lambda_std, &fstd, None);
+        let a_orig = crate::dmr::compute_doc_alpha(&lambda_orig, &features, None);
+        for d in 0..features.len() {
+            for k in 0..lambda_std.len() {
+                assert!(
+                    (a_std[d][k] - a_orig[d][k]).abs() < 1e-9,
+                    "doc {d} topic {k}: {} vs {}",
+                    a_std[d][k],
+                    a_orig[d][k]
+                );
+            }
+        }
+    }
 
     /// Build a small keyword-annotated corpus and verify that keyword topics
     /// are pulled toward their designated keyword blocks.

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -1610,7 +1610,13 @@ fn standardize_features(
         .iter()
         .map(|r| {
             (0..num_features)
-                .map(|f| if f == 0 { r[0] } else { (r[f] - mean[f]) / sd[f] })
+                .map(|f| {
+                    if f == 0 {
+                        r[0]
+                    } else {
+                        (r[f] - mean[f]) / sd[f]
+                    }
+                })
                 .collect()
         })
         .collect();

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -16906,8 +16906,12 @@ impl KeyATM {
     /// the **covariate** keyATM: the document-topic prior becomes a
     /// Dirichlet-multinomial regression, ``α_{d,k} = exp(x_d · λ_k)`` (an
     /// intercept is prepended). `feature_names` (length F) labels the columns;
-    /// the learned `λ` is exposed as `feature_effects`. With no `covariates`,
-    /// this is the base symmetric-α keyATM.
+    /// the learned `λ` is exposed as `feature_effects` (on the original covariate
+    /// scale). With no `covariates`, this is the base symmetric-α keyATM.
+    /// Following R keyATM, the covariates are standardized internally and `λ` is
+    /// bounded (±5 in standardized space) under the N(0,1) prior, which keeps a
+    /// high-dimensional design (e.g. many one-hot levels) from driving `α` to a
+    /// degenerate fit on one topic (issue #270).
     ///
     /// Pass `times` (one value per document) for the **dynamic** keyATM: a
     /// Chib (1998) change-point HMM lets topic prevalence shift over time across

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,6 +10,13 @@ def pytest_configure(config: pytest.Config) -> None:
         "parity: slow CLI-parity check; builds the release binaries and "
         "compares binding output against the `train` CLI byte-for-byte.",
     )
+    config.addinivalue_line(
+        "markers",
+        "slow: realistic-scale / high-iteration check (issue #271). Some bugs "
+        "(e.g. #270's covariate-keyATM collapse) only appear at scale, so these "
+        "fit tens of thousands of documents and are opt-in: run with "
+        "`-m slow`; the default suite deselects them.",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_binding_doc_coverage.py
+++ b/tests/test_binding_doc_coverage.py
@@ -1,0 +1,79 @@
+"""Documentation-coverage lint for the PyO3 bindings (issues #267, #271).
+
+Every parameter in a ``#[pyo3(signature = (...))]`` (constructors and methods
+alike) must be named in the preceding ``///`` doc-comment, so the runtime
+``help()`` text and the mkdocstrings API site never silently drift behind the
+signatures again. This is the tested-artifact guard #271 item 7 asks for: it
+turns "a parameter has no documented meaning" from an invisible gap into a test
+failure. Constructors are covered here precisely because the *runtime* can't see
+them (PyO3 exposes ``__init__`` as ``*args, **kwargs``).
+"""
+
+import re
+from pathlib import Path
+
+MOD_RS = Path(__file__).resolve().parent.parent / "src" / "python" / "mod.rs"
+
+# Receiver / framework params that never need documenting.
+SKIP = {"self", "py", "data", "_py"}
+
+
+def _undocumented_params():
+    src = MOD_RS.read_text(encoding="utf-8").splitlines()
+    n = len(src)
+    findings = []
+    i = 0
+    while i < n:
+        if "#[pyo3(signature" not in src[i]:
+            i += 1
+            continue
+        # Gather the (possibly multi-line) signature attribute.
+        j = i
+        sig_lines = [src[i]]
+        while ")]" not in src[j]:
+            j += 1
+            sig_lines.append(src[j])
+        sig_text = " ".join(sig_lines)
+        m = re.search(r"signature\s*=\s*\((.*)\)\s*\)\]", sig_text, re.S)
+        params = []
+        if m:
+            for tok in m.group(1).split(","):
+                tok = tok.strip()
+                if not tok or tok.startswith("*"):
+                    continue
+                name = tok.split("=")[0].strip().lstrip("*").strip()
+                if name and name not in SKIP:
+                    params.append(name)
+        # Walk back over attribute / blank lines to the doc-comment block.
+        k = i - 1
+        while k >= 0 and (src[k].strip().startswith("#[") or src[k].strip() == ""):
+            k -= 1
+        doc = []
+        while k >= 0 and src[k].strip().startswith("///"):
+            doc.append(src[k].strip()[3:])
+            k -= 1
+        doc_text = "\n".join(reversed(doc))
+        fn = "?"
+        for look in range(j, min(j + 6, n)):
+            fm = re.search(r"fn\s+(\w+)", src[look])
+            if fm:
+                fn = fm.group(1)
+                break
+        missing = [p for p in params
+                   if not re.search(rf"(?<![\w]){re.escape(p)}(?![\w])", doc_text)]
+        if missing:
+            findings.append((i + 1, fn, missing))
+        i = j + 1
+    return findings
+
+
+def test_every_binding_param_is_documented():
+    assert MOD_RS.exists(), f"bindings not found at {MOD_RS}"
+    findings = _undocumented_params()
+    if findings:
+        lines = [f"  src/python/mod.rs:{ln}  {fn}(): {', '.join(ps)}"
+                 for ln, fn, ps in findings]
+        raise AssertionError(
+            "Undocumented binding parameters (add them to the `///` docstring):\n"
+            + "\n".join(lines)
+        )

--- a/tests/test_keyatm_covariate.py
+++ b/tests/test_keyatm_covariate.py
@@ -73,3 +73,84 @@ def test_covariate_row_count_validated():
     m = topica.KeyATM(SEEDS, num_topics=2, seed=1)
     with pytest.raises(ValueError):
         m.fit(docs, covariates=party[:-1].reshape(-1, 1), iters=10)
+
+
+# ---------------------------------------------------------------------------
+# Issue #270 regression: a high-dimensional covariate design (many one-hot
+# levels, e.g. ~C(year)) must not drive the covariate prior to a degenerate
+# theta on a single topic. The guards (covariate standardization + lambda
+# bounded to +/-5 under the N(0,1) prior, matching R keyATM) prevent the
+# runaway. See also issue #271 (hardening the suite with validity invariants).
+# ---------------------------------------------------------------------------
+
+def _effective_topics(theta):
+    """exp(H(mean theta)): how many topics carry real mass (1.0 == collapsed)."""
+    mean_t = np.asarray(theta).mean(axis=0)
+    mean_t = mean_t / mean_t.sum()
+    return float(np.exp(-(mean_t * np.log(mean_t + 1e-12)).sum()))
+
+
+def _onehot_corpus(n, k, levels, vocab=120, topic_alpha=0.5, seed=0):
+    """Overlapping-topic corpus with a high-dim one-hot covariate, each level
+    favouring one topic (a planted, recoverable covariate effect)."""
+    rng = np.random.default_rng(seed)
+    topics = rng.dirichlet(np.full(vocab, topic_alpha), size=k)
+    level_pref = np.array([g % k for g in range(levels)])
+    docs, lev = [], rng.integers(0, levels, size=n)
+    for d in range(n):
+        base = np.full(k, 0.3)
+        base[level_pref[lev[d]]] += 2.0
+        theta = rng.dirichlet(base)
+        toks = [f"w{int(rng.choice(vocab, p=topics[rng.choice(k, p=theta)]))}"
+                for _ in range(rng.integers(35, 55))]
+        docs.append(toks)
+    keywords = {f"kt{j}": [f"w{int(w)}" for w in np.argsort(topics[j])[::-1][:5]]
+                for j in range(min(4, k))}
+    X = np.zeros((n, levels))
+    X[np.arange(n), lev] = 1.0
+    return docs, X, keywords, level_pref
+
+
+def test_high_dim_covariate_fit_is_healthy_and_recovers_effect():
+    """#270/#271: covariate keyATM on a 15-level one-hot design stays healthy
+    (no collapse), keyword_rate leaves its 0.5 init, lambda is finite, and the
+    planted level->topic effect is recovered directionally."""
+    k, levels = 8, 15
+    docs, X, keywords, level_pref = _onehot_corpus(3000, k, levels, seed=1)
+    m = topica.KeyATM(keywords, num_topics=k, seed=1, num_threads=2)
+    m.fit(docs, covariates=X, iters=400)
+
+    theta = m.doc_topic
+    # Invariants (the #271 high-leverage assertions): not degenerate.
+    mean_mass = np.asarray(theta).mean(axis=0)
+    mean_mass = mean_mass / mean_mass.sum()
+    assert mean_mass.max() < 0.6, f"one topic dominates: {mean_mass.max():.3f}"
+    assert _effective_topics(theta) > k * 0.5, "theta collapsed (too few effective topics)"
+
+    fe = np.asarray(m.feature_effects)
+    assert np.isfinite(fe).all(), "feature_effects not finite"
+
+    kr = np.asarray(m.keyword_rate)[:4]  # keyword topics
+    assert np.all((kr > 0.0) & (kr < 1.0)), f"keyword_rate out of (0,1): {kr}"
+    assert np.any(np.abs(kr - 0.5) > 1e-3), "keyword_rate stuck at 0.5 init"
+
+    # Directional recovery: a level's planted topic gets a higher coefficient on
+    # that level's column than the average topic does.
+    planted = np.array([fe[level_pref[g], g + 1] for g in range(levels)])
+    assert planted.mean() > fe[:, 1:].mean(), "planted covariate effect not recovered"
+
+
+@pytest.mark.slow
+def test_covariate_collapse_regression_at_scale():
+    """#270: at scale (the regime that exposed the bug) the covariate fit must
+    not collapse onto one topic. Opt-in (slow); set TOPICA_SLOW_TESTS=1."""
+    import os
+
+    if not os.environ.get("TOPICA_SLOW_TESTS"):
+        pytest.skip("slow scale test; set TOPICA_SLOW_TESTS=1 to run")
+    k, levels = 31, 30
+    docs, X, keywords, _ = _onehot_corpus(50000, k, levels, topic_alpha=0.7, seed=2)
+    m = topica.KeyATM(keywords, num_topics=k, seed=1, num_threads=8)
+    m.fit(docs, covariates=X, iters=500)
+    eff = _effective_topics(m.doc_topic)
+    assert eff > k * 0.4, f"covariate theta collapsed at scale: eff#topics={eff:.1f}/{k}"


### PR DESCRIPTION
Fixes #270. Partial #271 (minimal regression set + doc-coverage lint). Doc part of #267 follow-up.

## The bug

Covariate keyATM (`fit(covariates=...)`) silently collapsed θ onto a **single topic** at scale (high-dimensional `~C(year)` design, many sweeps, large N), while the base model on the same data stayed healthy. No exception, `converged=False`, normal return — a degenerate fit that downstream code happily consumed.

Reproduced (synthetic, overlapping topics + a 30-level one-hot covariate), 80k docs / 500 sweeps:

| | eff#topics `exp(H(meanθ))` | max mean topic mass | max\|λ\| |
|---|---|---|---|
| before | **1.1 / 31** | **0.990** | **9.83** |
| after | **27.6 / 31** | 0.083 | bounded |

## Root cause (diffed against R keyATM)

The covariate prior is `α_{d,k} = exp(x_d · λ_k)`. R keyATM guards it three ways; topica had only one:

| guard | R keyATM (`keyATM_cov.cpp` / `utils.R`) | topica before |
|---|---|---|
| N(0,1) prior on λ | yes | yes ✓ |
| covariate standardization | z-score (mean 0, sd 1) | **none** ✗ |
| λ bounds | hard ±5 (slice shrink/expand) | **none** ✗ |

Without standardization the full one-hot design is collinear with the prepended intercept; without bounds the fixed prior is overwhelmed as N grows and the per-sweep MAP-λ ↔ Gibbs feedback runs λ away, so `exp(x·λ)` explodes and θ collapses.

## Fix

Keep topica's fast L-BFGS MAP for λ (the slice sampler is O(docs·topics·covariates·sweeps) — too slow at the scale this bug bites), but add R's two missing guards to the **covariate path only** (DMR's optimizer and its MALLET/tomotopy parity are untouched):

- standardize covariate columns to mean 0 / sd 1 (intercept left as 1), fit λ in that space, and **map λ back to the original scale** so `feature_effects` and held-out `transform` stay on raw covariates;
- **clamp λ to ±5** in standardized space each optimize step.

This also closes a real keyATM↔R parity gap on the covariate model (which had no R-comparison test — part of why it slipped through).

## Tests (issue #271, minimal set)

- **Rust:** `standardize_features` + λ map-back round-trip (α identity on raw vs standardized).
- **Python (fast):** high-dim one-hot covariate fit stays healthy (no degenerate θ, `keyword_rate` leaves its 0.5 init, λ finite) and recovers the planted level→topic effect.
- **Python (slow, opt-in `TOPICA_SLOW_TESTS=1`):** 50k-scale regression in the divergent regime.
- **Doc-coverage lint:** every `#[pyo3(signature)]` param must be named in its `///` docstring (closes the #267 class; #271 item 7), constructors included.

## Verification

- `cargo test --lib`: 134 passed
- `pytest -k "keyatm or dmr or doc_coverage or gdmr"`: 367 passed, 1 slow skipped
- `mkdocs build --strict`: clean
- 80k repro: collapse (eff 1.1) → healthy (eff 27.6); base model unchanged

## Deferred (noted, not in this PR)

- Runtime degenerate-θ warning + "honest `converged`" (the silent-failure defensiveness in #270) — behavior additions; small follow-up.
- Full slice-sampler port / broader #271 hardening (grid + metamorphic + differential-vs-R) — tracked in #271; MCMC diagnostics in #269.

🤖 Generated with [Claude Code](https://claude.com/claude-code)