### PR TITLE
test(#271): universal validity invariants for every model (Wave 0)

### DIFF
--- a/tests/invariants.py
+++ b/tests/invariants.py
@@ -1,0 +1,284 @@
+"""Reference-free statistical-validity invariants for every topica model
+(issue #271, "Wave 0").
+
+The historical test suite checked *mechanics* — a fit ran, the shapes were
+right, rows summed to one. None of that catches a *degenerate* fit. Issue #270
+is the canonical example: a covariate keyATM collapsed every document's topic
+proportions onto a single topic, yet every shape/sum test still passed because a
+one-hot row is a perfectly valid simplex.
+
+This module supplies the validity checks the suite was missing. They are
+universal (no reference implementation, no gold fixture) and they are written so
+that a *degenerate* fit FAILS:
+
+- ``effective_topics`` measures how many topics actually carry mass.
+- ``assert_healthy_theta`` rejects a θ where one topic hoovers up the mass or
+  where the effective topic count has collapsed.
+- the metamorphic helpers (``assert_more_iters_not_worse``,
+  ``assert_seed_reproducible``) check relations *between* fits rather than a
+  single fit in isolation, which is where #270 actually showed up (more
+  iterations made the collapse worse, not better).
+
+A self-test (:func:`_degenerate_theta_must_raise`, exercised as a real test in
+``tests/test_model_invariants.py``) proves the assertions are not vacuous: a
+deliberately collapsed θ must raise.
+"""
+from __future__ import annotations
+
+import numpy as np
+
+__all__ = [
+    "effective_topics",
+    "assert_finite",
+    "assert_simplex",
+    "assert_healthy_theta",
+    "assert_more_iters_not_worse",
+    "assert_seed_reproducible",
+    "_degenerate_theta_must_raise",
+]
+
+
+def effective_topics(theta) -> float:
+    """The effective number of topics carrying mass: ``exp(H(mean_d theta_d))``.
+
+    ``theta`` is a ``(D, K)`` document-topic matrix. We average over documents to
+    get the corpus-level topic distribution, then return the exponential of its
+    Shannon entropy (the "perplexity" of the topic distribution). A perfectly
+    flat distribution over ``K`` topics gives ``K``; a distribution collapsed
+    onto one topic gives ``1``. This is the single number that #270 would have
+    tripped on (it collapsed to ~1).
+    """
+    theta = np.asarray(theta, dtype=float)
+    mean_t = theta.mean(axis=0)
+    total = mean_t.sum()
+    if total <= 0:
+        raise AssertionError("mean theta has non-positive mass; cannot be a topic distribution")
+    mean_t = mean_t / total
+    # entropy with a tiny floor so log(0) is well-behaved for empty topics
+    h = -(mean_t * np.log(mean_t + 1e-12)).sum()
+    return float(np.exp(h))
+
+
+def assert_finite(*arrays, model: str = "") -> None:
+    """Assert every supplied array is all-finite (no NaN, no Inf)."""
+    tag = f"[{model}] " if model else ""
+    for i, a in enumerate(arrays):
+        if a is None:
+            continue
+        arr = np.asarray(a, dtype=float)
+        if not np.isfinite(arr).all():
+            n_bad = int((~np.isfinite(arr)).sum())
+            raise AssertionError(
+                f"{tag}array #{i} has {n_bad} non-finite value(s) "
+                f"(NaN or Inf) out of {arr.size}"
+            )
+
+
+def assert_simplex(matrix, axis: int = 1, *, atol: float = 1e-5, model: str = "") -> None:
+    """Assert the rows (``axis=1``) or columns (``axis=0``) form valid simplices:
+    non-negative and summing to one."""
+    tag = f"[{model}] " if model else ""
+    m = np.asarray(matrix, dtype=float)
+    if (m < -atol).any():
+        raise AssertionError(f"{tag}simplex has a negative entry (min={m.min():.3e})")
+    sums = m.sum(axis=axis)
+    if not np.allclose(sums, 1.0, atol=atol):
+        worst = float(np.abs(sums - 1.0).max())
+        raise AssertionError(
+            f"{tag}simplex rows do not sum to 1 along axis {axis} "
+            f"(max |sum - 1| = {worst:.3e})"
+        )
+
+
+def assert_healthy_theta(
+    theta,
+    n_topics: int,
+    *,
+    max_mass: float = 0.8,
+    min_eff_frac: float = 0.25,
+    model: str = "",
+) -> None:
+    """Assert a document-topic matrix ``theta`` describes a *healthy*, non-degenerate
+    fit. Three conditions, each of which #270's collapse would have violated:
+
+    1. Every row is a valid simplex (non-negative, sums to ~1).
+    2. No single topic holds more than ``max_mass`` of the corpus-mean mass.
+       (A collapse parks ~all the mass on one topic.)
+    3. The effective topic count exceeds ``min_eff_frac * n_topics``.
+       (A collapse drives effective_topics toward 1.)
+
+    Raises ``AssertionError`` naming the model and the offending number.
+    """
+    tag = f"[{model}] " if model else ""
+    theta = np.asarray(theta, dtype=float)
+
+    # 1) valid simplex per document
+    assert_finite(theta, model=model)
+    assert_simplex(theta, axis=1, model=model)
+
+    # 2) no single topic dominates the mean mass
+    mean_mass = theta.mean(axis=0)
+    mean_mass = mean_mass / mean_mass.sum()
+    top_mass = float(mean_mass.max())
+    if top_mass > max_mass:
+        raise AssertionError(
+            f"{tag}theta collapsed: one topic holds {top_mass:.3f} of the mean "
+            f"mass (> max_mass={max_mass}); fit is degenerate"
+        )
+
+    # 3) enough effective topics
+    eff = effective_topics(theta)
+    floor = min_eff_frac * n_topics
+    if eff <= floor:
+        raise AssertionError(
+            f"{tag}theta collapsed: effective_topics={eff:.2f} <= "
+            f"{floor:.2f} (= {min_eff_frac} * {n_topics}); fit carries too few topics"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Metamorphic helpers — relations between fits, not a single fit in isolation.
+# ---------------------------------------------------------------------------
+
+def assert_more_iters_not_worse(
+    fit_fn,
+    *,
+    low: int = 25,
+    high: int = 150,
+    retain_frac: float = 0.6,
+    n_topics: int | None = None,
+    model: str = "",
+) -> None:
+    """Fit at ``low`` and ``high`` iterations and require the longer fit not be
+    MORE degenerate than the shorter one.
+
+    ``fit_fn(iters) -> theta`` returns the document-topic matrix for that
+    iteration count. A longer fit may legitimately *sharpen* (a Gibbs/EM model
+    concentrates mass as it settles, so effective_topics drifts down somewhat),
+    so we allow a sharpening but reject a *collapse*: the high-iters effective
+    topic count must retain at least ``retain_frac`` of the low-iters value. This
+    is the #270 failure mode -- training longer drove the covariate prior to dump
+    everything on one topic, taking effective_topics from ~K down to ~1 (a
+    retention far below ``retain_frac``).
+    """
+    tag = f"[{model}] " if model else ""
+    theta_low = np.asarray(fit_fn(low), dtype=float)
+    theta_high = np.asarray(fit_fn(high), dtype=float)
+    assert_finite(theta_low, theta_high, model=model)
+
+    eff_low = effective_topics(theta_low)
+    eff_high = effective_topics(theta_high)
+
+    # The high-iters fit may sharpen but must not collapse: keep a fraction of the
+    # low-iters effective topic count.
+    if eff_high < retain_frac * eff_low:
+        raise AssertionError(
+            f"{tag}more iterations made the fit MORE degenerate: "
+            f"effective_topics fell from {eff_low:.2f} (@{low} iters) to "
+            f"{eff_high:.2f} (@{high} iters), below {retain_frac:.0%} retention; "
+            f"collapse-on-training (cf. #270)"
+        )
+
+    # And it must not be outright collapsed onto a single topic.
+    k = n_topics if n_topics is not None else theta_high.shape[1]
+    if eff_high <= 1.0 + 1e-6 and k > 1:
+        raise AssertionError(
+            f"{tag}high-iters fit collapsed onto one topic "
+            f"(effective_topics={eff_high:.2f})"
+        )
+
+
+def assert_seed_reproducible(fit_fn, *, atol: float = 1e-6, model: str = "") -> None:
+    """Two fits with the same seed/threads must give ~identical θ.
+
+    ``fit_fn() -> theta``. For seed-reproducible / bit-exact models this is a
+    cheap guard that the seeding actually plumbs through. Allclose (not exact) so
+    a model with benign floating-point reordering still passes.
+    """
+    tag = f"[{model}] " if model else ""
+    a = np.asarray(fit_fn(), dtype=float)
+    b = np.asarray(fit_fn(), dtype=float)
+    if a.shape != b.shape:
+        raise AssertionError(f"{tag}same-seed fits differ in shape: {a.shape} vs {b.shape}")
+    if not np.allclose(a, b, atol=atol):
+        worst = float(np.abs(a - b).max())
+        raise AssertionError(
+            f"{tag}same-seed fits are not reproducible (max |Δθ| = {worst:.3e})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Non-vacuity self-test: a deliberately degenerate theta MUST raise. This is the
+# proof that the invariant has teeth (run as test_invariants_catch_degenerate_theta).
+# ---------------------------------------------------------------------------
+
+def _degenerate_theta_must_raise() -> None:
+    """A θ with all mass on one topic must be rejected by every health check.
+
+    If any of these does NOT raise, the invariant is vacuous and the whole wave
+    is worthless — so this self-test is the load-bearing one.
+    """
+    K = 5
+    D = 40
+
+    # Fully collapsed: every document is one-hot on topic 0.
+    collapsed = np.zeros((D, K))
+    collapsed[:, 0] = 1.0
+
+    # effective_topics of a collapse is ~1.
+    eff = effective_topics(collapsed)
+    assert eff < 1.01, f"effective_topics failed to detect collapse: {eff}"
+
+    raised = False
+    try:
+        assert_healthy_theta(collapsed, K, model="self-test")
+    except AssertionError:
+        raised = True
+    assert raised, "assert_healthy_theta accepted a fully collapsed theta (VACUOUS!)"
+
+    # A near-collapse (95% on one topic, the rest spread thin) must also fail the
+    # max_mass guard.
+    near = np.full((D, K), 0.05 / (K - 1))
+    near[:, 0] = 0.95
+    raised = False
+    try:
+        assert_healthy_theta(near, K, model="self-test")
+    except AssertionError:
+        raised = True
+    assert raised, "assert_healthy_theta accepted a 95%-on-one-topic theta (VACUOUS!)"
+
+    # A NaN theta must be rejected by assert_finite / assert_healthy_theta.
+    nan_theta = np.full((D, K), 1.0 / K)
+    nan_theta[0, 0] = np.nan
+    raised = False
+    try:
+        assert_healthy_theta(nan_theta, K, model="self-test")
+    except AssertionError:
+        raised = True
+    assert raised, "assert_healthy_theta accepted a theta with a NaN (VACUOUS!)"
+
+    # Sanity in the other direction: a healthy (flat) theta must PASS, otherwise
+    # the check is so strict it rejects everything.
+    healthy = np.full((D, K), 1.0 / K)
+    assert_healthy_theta(healthy, K, model="self-test")  # must not raise
+
+    # The metamorphic helper must catch a collapse-on-training: low-iters is
+    # healthy (flat), high-iters is collapsed onto one topic.
+    def _collapsing(iters):
+        return collapsed if iters >= 100 else healthy
+
+    raised = False
+    try:
+        assert_more_iters_not_worse(_collapsing, low=25, high=150, model="self-test")
+    except AssertionError:
+        raised = True
+    assert raised, "assert_more_iters_not_worse accepted a collapse-on-training (VACUOUS!)"
+
+    # ...but a benign sharpening (flat -> moderately concentrated) must PASS.
+    sharper = np.full((D, K), 0.5 / (K - 1))
+    sharper[:, 0] = 0.5
+
+    def _sharpening(iters):
+        return sharper if iters >= 100 else healthy
+
+    assert_more_iters_not_worse(_sharpening, low=25, high=150, model="self-test")

--- a/tests/test_model_coverage_manifest.py
+++ b/tests/test_model_coverage_manifest.py
@@ -1,0 +1,66 @@
+"""Coverage gate (issue #271, "Wave 0").
+
+Every model in ``topica.list_models()`` must have *some* form of validity
+coverage. A model is covered if it is one of:
+
+  (a) present in ``FIT_ADAPTERS`` (the registry-driven invariant suite fits it),
+  (b) shipped with a committed gold fixture ``parity/<lower>_gold.npz``, or
+  (c) listed in the explicit, documented ``INVARIANT_EXEMPT`` set.
+
+So a newly added model with no validity coverage FAILS this test, and the only
+way to pass is to add an adapter, a gold fixture, or a documented exemption with
+a reason. This is the structural guard that the suite cannot silently fall behind
+the model roster.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import topica
+from test_model_invariants import FIT_ADAPTERS
+
+# Models that cannot be exercised by a reference-free fit and are deliberately
+# left uncovered, each with a documented reason.
+INVARIANT_EXEMPT = {
+    "TopicGPT": "needs an LLM / external API",
+}
+
+_PARITY_DIR = Path(__file__).resolve().parents[1] / "parity"
+
+
+def _has_gold_fixture(name: str) -> bool:
+    return (_PARITY_DIR / f"{name.lower()}_gold.npz").exists()
+
+
+def test_every_model_has_validity_coverage():
+    offenders = []
+    for info in topica.list_models():
+        name = info.name
+        covered = (
+            name in FIT_ADAPTERS
+            or _has_gold_fixture(name)
+            or name in INVARIANT_EXEMPT
+        )
+        if not covered:
+            offenders.append(name)
+
+    assert not offenders, (
+        "models with no validity coverage (add a FIT_ADAPTER, a "
+        f"parity/<lower>_gold.npz, or an INVARIANT_EXEMPT entry): {offenders}"
+    )
+
+
+def test_no_stale_adapters_or_exemptions():
+    """Adapters and exemptions must name real, registered models (no drift)."""
+    registered = {m.name for m in topica.list_models()}
+    stale_adapters = sorted(set(FIT_ADAPTERS) - registered)
+    stale_exempt = sorted(set(INVARIANT_EXEMPT) - registered)
+    assert not stale_adapters, f"FIT_ADAPTERS names not in registry: {stale_adapters}"
+    assert not stale_exempt, f"INVARIANT_EXEMPT names not in registry: {stale_exempt}"
+
+
+def test_exempt_models_have_reasons():
+    for name, reason in INVARIANT_EXEMPT.items():
+        assert isinstance(reason, str) and reason.strip(), (
+            f"INVARIANT_EXEMPT[{name!r}] must give a non-empty reason"
+        )

--- a/tests/test_model_invariants.py
+++ b/tests/test_model_invariants.py
@@ -1,0 +1,555 @@
+"""Registry-driven validity-invariant suite (issue #271, "Wave 0").
+
+For EVERY model in ``topica.list_models()`` we build a small planted/synthetic
+corpus tailored to that model's input contract (its ``ModelInfo.brings``), fit it
+with small K and modest iterations under a fixed seed, and assert the fit is
+statistically VALID — not merely well-shaped. The validity checks live in
+``tests/invariants.py``; the headline one is ``assert_healthy_theta``, which a
+degenerate fit (issue #270's covariate-keyATM collapse) FAILS.
+
+A single ``FIT_ADAPTERS`` dict maps model name -> a fit function returning
+``(theta, topic_word_or_None, n_topics)``. The coverage gate
+(``tests/test_model_coverage_manifest.py``) imports this dict so a newly added
+model with no adapter fails CI.
+
+Where it is cheap (the stochastic count-based models), we also run the
+metamorphic ``assert_more_iters_not_worse`` check, which is what actually catches
+collapse-on-training.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import topica
+from invariants import (
+    assert_finite,
+    assert_healthy_theta,
+    assert_more_iters_not_worse,
+    assert_simplex,
+    effective_topics,
+    _degenerate_theta_must_raise,
+)
+
+
+# ---------------------------------------------------------------------------
+# The non-vacuity self-test (required by #271): a collapsed theta MUST raise.
+# ---------------------------------------------------------------------------
+
+def test_invariants_catch_degenerate_theta():
+    """Proof the invariant has teeth: a deliberately degenerate theta is rejected.
+
+    If this passes, ``assert_healthy_theta`` genuinely detects collapse; if the
+    body of ``_degenerate_theta_must_raise`` ever stops raising, this test fails
+    loudly rather than the suite silently going vacuous.
+    """
+    _degenerate_theta_must_raise()
+
+
+# ---------------------------------------------------------------------------
+# Planted-block corpus builders (shared across adapters)
+# ---------------------------------------------------------------------------
+
+def _planted_blocks(k=4, block=8, n=300, length=14, seed=0):
+    """K disjoint word-blocks; each document draws all its tokens from one block,
+    cycling through the blocks so the corpus-level topic distribution is roughly
+    flat (a healthy fit spreads mass across K topics). Returns (docs, vocab)."""
+    rng = np.random.default_rng(seed)
+    vocab = [f"b{b}w{i}" for b in range(k) for i in range(block)]
+    docs = []
+    for d in range(n):
+        b = d % k
+        docs.append([f"b{b}w{int(rng.integers(block))}" for _ in range(length)])
+    return docs, vocab
+
+
+def _planted_embeddings(k=4, block=8, seed=0):
+    """Word embeddings for the planted-block vocabulary: each word points along
+    its block's axis. Returns (vocab, word_emb)."""
+    rng = np.random.default_rng(seed)
+    vocab = [f"b{b}w{i}" for b in range(k) for i in range(block)]
+    e = k + 2
+    word_emb = rng.normal(0, 0.2, (k * block, e))
+    for w in range(k * block):
+        word_emb[w, w // block] += 3.0
+    return vocab, word_emb
+
+
+def _doc_embeddings(docs, k=4, block=8, seed=0):
+    """One embedding per document, one-hot (plus noise) along the document's block.
+    The block of a planted doc is recoverable from its first token's name."""
+    rng = np.random.default_rng(seed)
+    e = k + 2
+    out = np.zeros((len(docs), e))
+    for d, doc in enumerate(docs):
+        b = int(doc[0].split("w")[0][1:])  # "b3w5" -> 3
+        out[d, b] += 3.0
+        out[d] += rng.normal(0, 0.2, e)
+    return out
+
+
+def _block_keywords(vocab, k=4, block=8, per=4):
+    """A keyword/seed dict over the planted blocks: ``{topic: [first words]}``."""
+    return {f"t{b}": [f"b{b}w{i}" for i in range(per)] for b in range(k)}
+
+
+# ---------------------------------------------------------------------------
+# Per-model fit adapters. Each returns (theta, topic_word_or_None, n_topics).
+# Kept small so the whole file runs in a couple of minutes.
+# ---------------------------------------------------------------------------
+
+K = 4  # default planted-block count for the suite
+
+
+def _theta_from_doc_paths(model):
+    """HLDA has no doc_topic; build a per-document distribution over tree nodes by
+    spreading each document's mass uniformly over the nodes on its path. A healthy
+    tree puts documents on several distinct paths; a collapsed one puts them all
+    on the same node, which the effective-topics check then flags."""
+    n_nodes = model.num_nodes
+    paths = model.doc_paths
+    theta = np.zeros((len(paths), n_nodes))
+    for d, path in enumerate(paths):
+        for node in path:
+            theta[d, node] += 1.0 / len(path)
+    return theta, n_nodes
+
+
+# ---- General-purpose --------------------------------------------------------
+
+def _fit_lda(iters=200):
+    docs, _ = _planted_blocks(seed=0)
+    m = topica.LDA(num_topics=K, seed=1)
+    m.fit(docs, iters=iters, num_samples=2, sample_interval=5)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_ctm(iters=60):
+    docs, _ = _planted_blocks(seed=0)
+    m = topica.CTM(num_topics=K, seed=1)
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_prodlda(iters=150):
+    docs, _ = _planted_blocks(seed=0)
+    m = topica.ProdLDA(num_topics=K, batch_size=64, lr=0.01, dropout=0.0, seed=1)
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_hdp(iters=150):
+    docs, _ = _planted_blocks(k=K, seed=0)
+    m = topica.HDP(seed=1, alpha=1.0, gamma=1.0)
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, m.num_topics
+
+
+def _fit_nmf(iters=None):
+    docs, _ = _planted_blocks(seed=0)
+    m = topica.NMF(K, seed=1)
+    m.fit(docs)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_lsa(iters=None):
+    # LSA's doc_topic is signed SVD coordinates, not a simplex. Map to a topic
+    # distribution by absolute loading per document so the health check is
+    # meaningful (a collapse would still pile abs-loading onto one component).
+    docs, _ = _planted_blocks(seed=0)
+    m = topica.LSA(K, seed=1)
+    m.fit(docs)
+    dt = np.abs(np.asarray(m.doc_topic))
+    dt = dt / dt.sum(axis=1, keepdims=True)
+    tw = np.abs(np.asarray(m.topic_word))
+    tw = tw / tw.sum(axis=1, keepdims=True)
+    return dt, tw, K
+
+
+# ---- Covariates & structure -------------------------------------------------
+
+def _covariate_corpus(seed=0):
+    """Planted blocks plus a one-hot covariate that favours one block per level,
+    matching the DMR/STM/SAGE recovery fixtures' spirit."""
+    docs, vocab = _planted_blocks(k=K, seed=seed)
+    # level == block of each doc (recoverable, planted covariate effect)
+    levels = [int(doc[0].split("w")[0][1:]) for doc in docs]
+    X = np.zeros((len(docs), K))
+    X[np.arange(len(docs)), levels] = 1.0
+    return docs, vocab, X, levels
+
+
+def _fit_stm(iters=60):
+    docs, _, X, _ = _covariate_corpus()
+    m = topica.STM(num_topics=K, seed=1)
+    m.fit(docs, prevalence=X, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_sts(iters=40):
+    docs, _, X, levels = _covariate_corpus()
+    sent_seed = [float(l % 3) for l in levels]  # 3-level sentiment seed
+    m = topica.STS(num_topics=K, seed=1)
+    m.fit(docs, sentiment_seed=sent_seed, prevalence=X, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_sage(iters=200):
+    docs, _, _, levels = _covariate_corpus()
+    groups = [f"g{l % 2}" for l in levels]  # 2 content groups
+    m = topica.SAGE(num_topics=K, seed=1, optimize_interval=25, burn_in=50)
+    m.fit(docs, groups, iters=iters, num_samples=2, sample_interval=10)
+    # topic_word is (K, G, V); collapse to the marginal for the finite/simplex check
+    return m.doc_topic, np.asarray(m.topic_word_marginal), K
+
+
+def _fit_ectm(iters=60):
+    # ECTM is experimental and gated.
+    was = topica.experimental_enabled()
+    topica.enable_experimental(True)
+    try:
+        docs, _, _, levels = _covariate_corpus()
+        groups = [f"g{l % 2}" for l in levels]
+        times = [2000 + (i % 3) for i in range(len(docs))]
+        m = topica.ECTM(num_topics=K, seed=1, init="spectral")
+        m.fit(docs, times=times, content=groups, iters=iters,
+              period_smooth=5.0, interaction_shrink=2.0)
+        return m.doc_topic, m.topic_word, K
+    finally:
+        topica.enable_experimental(was)
+
+
+def _fit_dmr(iters=300):
+    docs, _, X, _ = _covariate_corpus()
+    m = topica.DMR(num_topics=K, seed=1, optimize_interval=25, burn_in=50)
+    m.fit(docs, X, iters=iters, num_samples=2, sample_interval=10)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_gdmr(iters=300):
+    # GDMR wants a continuous covariate; use the block index scaled to [0,1].
+    docs, vocab = _planted_blocks(k=K, seed=0)
+    levels = np.array([int(doc[0].split("w")[0][1:]) for doc in docs], dtype=float)
+    meta = (levels / (K - 1))[:, None]
+    m = topica.GDMR(num_topics=K, degrees=[3], seed=1, optimize_interval=25, burn_in=50)
+    m.fit(docs, meta, iters=iters, num_samples=2, sample_interval=10)
+    return m.doc_topic, m.topic_word, K
+
+
+# ---- Guided & supervised ----------------------------------------------------
+
+def _fit_keyatm(iters=400):
+    docs, vocab = _planted_blocks(k=K, seed=0)
+    seeds = _block_keywords(vocab, k=K)
+    m = topica.KeyATM(seeds, num_topics=K, seed=1)
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_seededlda(iters=400):
+    docs, vocab = _planted_blocks(k=K, seed=0)
+    seeds = _block_keywords(vocab, k=K)
+    m = topica.SeededLDA(seeds, seed=1)  # 4 seeded topics
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, m.num_topics
+
+
+def _fit_labeledlda(iters=300):
+    docs, vocab = _planted_blocks(k=K, seed=0)
+    labels = [[f"t{int(doc[0].split('w')[0][1:])}"] for doc in docs]
+    m = topica.LabeledLDA(alpha=0.1, seed=1)
+    m.fit(docs, labels, iters=iters, num_samples=2, sample_interval=10)
+    return m.doc_topic, m.topic_word, m.num_topics
+
+
+def _supervised_corpus(n=200, seed=0):
+    """Mixed two-block docs with a response driven by block-0 prevalence."""
+    rng = np.random.default_rng(seed)
+    T0 = [f"a{i}" for i in range(6)]
+    T1 = [f"g{i}" for i in range(6)]
+    docs, y = [], []
+    for _ in range(n):
+        p = rng.random()
+        doc = [(T0 if rng.random() < p else T1)[rng.integers(6)] for _ in range(20)]
+        docs.append(doc)
+        y.append(2 * p - 1 + (rng.random() - 0.5) * 0.2)
+    return docs, np.array(y)
+
+
+def _fit_supervisedlda(iters=25):
+    docs, y = _supervised_corpus()
+    m = topica.SupervisedLDA(num_topics=2, seed=7)
+    m.fit(docs, y, iters=iters, var_iters=15)
+    return m.doc_topic, m.topic_word, 2
+
+
+# ---- Short text -------------------------------------------------------------
+
+def _short_corpus(seed=0, n=300):
+    """Short (3-token) docs over K disjoint blocks."""
+    rng = np.random.default_rng(seed)
+    blocks = [[f"b{b}w{i}" for i in range(4)] for b in range(K)]
+    docs = []
+    for d in range(n):
+        blk = blocks[d % K]
+        docs.append([blk[int(rng.integers(4))] for _ in range(3)])
+    return docs
+
+
+def _fit_gsdmm(iters=60):
+    docs = _short_corpus()
+    m = topica.GSDMM(num_topics=15, seed=1)
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, m.num_topics
+
+
+def _fit_pt(iters=300):
+    docs = _short_corpus()
+    m = topica.PT(num_topics=K, num_pseudo=10, seed=1)
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+# ---- Dynamic & hierarchical -------------------------------------------------
+
+def _fit_dtm(iters=20):
+    # DTM exposes no doc_topic (it models topic-word drift, not per-doc theta).
+    # Build a fit-derived per-document topic distribution by scoring each document
+    # under the slice-0 topic-word distributions (a soft assignment from the
+    # learned topics). A collapse -- all K topics on the same words -- then shows
+    # up as one dominant column / low effective_topics, exactly as intended.
+    docs, vocab = _planted_blocks(k=K, n=300, seed=0)
+    times = [i % 3 for i in range(len(docs))]
+    m = topica.DTM(num_topics=K, chain_variance=0.5, seed=1)
+    m.fit(docs, times, iters=iters)
+    tw = np.asarray(m.topic_word(0))  # (K, V) slice-0 word distributions
+    vocab_idx = {w: i for i, w in enumerate(m.vocabulary)}
+    logtw = np.log(tw + 1e-12)
+    theta = np.zeros((len(docs), K))
+    for d, doc in enumerate(docs):
+        ids = [vocab_idx[w] for w in doc if w in vocab_idx]
+        scores = logtw[:, ids].sum(axis=1)  # log p(doc | topic k)
+        scores -= scores.max()
+        p = np.exp(scores)
+        theta[d] = p / p.sum()
+    return theta, tw, K
+
+
+def _fit_detm(iters=40):
+    docs, vocab = _planted_blocks(k=K, block=6, n=240, length=20, seed=0)
+    _, word_emb = _planted_embeddings(k=K, block=6, seed=0)
+    times = np.array([i % 4 for i in range(len(docs))])
+    m = topica.DETM(K, delta=0.005, hidden_size=32, lr=0.02, seed=42)
+    m.fit(docs, word_emb, vocab, times=times, iters=iters)
+    return np.asarray(m.doc_topic), np.asarray(m.topic_word), K
+
+
+def _fit_hlda(iters=300):
+    # HLDA has no doc_topic / num_topics; synthesize a per-doc node distribution
+    # from the learned tree paths.
+    shared = ["the", "of", "and"]
+    blocks = [[f"b{b}w{i}" for i in range(4)] for b in range(K)]
+    docs = []
+    for d in range(300):
+        docs.append(shared + [blocks[d % K][i] for i in range(4)])
+    m = topica.HLDA(depth=2, seed=1)
+    m.fit(docs, iters=iters)
+    theta, n_nodes = _theta_from_doc_paths(m)
+    return theta, m.topic_word, n_nodes
+
+
+def _fit_pa(iters=300):
+    rng = np.random.default_rng(0)
+    blocks = [[f"b{g}w{i}" for i in range(5)] for g in range(4)]
+    docs = []
+    for _ in range(160):
+        pair = (blocks[0], blocks[1]) if rng.random() < 0.5 else (blocks[2], blocks[3])
+        doc = []
+        for blk in pair:
+            doc += [blk[int(rng.integers(5))] for _ in range(6)]
+        docs.append(doc)
+    m = topica.PA(num_super=2, num_sub=4, seed=1)
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, m.num_sub
+
+
+# ---- Embedding-based --------------------------------------------------------
+
+def _fit_bertopic(iters=None):
+    docs, vocab = _planted_blocks(k=K, block=8, n=300, seed=0)
+    doc_emb = _doc_embeddings(docs, k=K, block=8, seed=0)
+    m = topica.BERTopic(min_cluster_size=15, seed=1)
+    m.fit(docs, doc_emb)
+    if m.num_topics == 0:
+        pytest.skip("BERTopic found no clusters at this min_cluster_size")
+    return m.doc_topic, m.topic_word, m.num_topics
+
+
+def _fit_top2vec(iters=None):
+    docs, vocab = _planted_blocks(k=K, block=8, n=300, seed=0)
+    doc_emb = _doc_embeddings(docs, k=K, block=8, seed=0)
+    m = topica.Top2Vec(min_cluster_size=15, seed=1)
+    m.fit(docs, doc_emb)
+    if m.num_topics == 0:
+        pytest.skip("Top2Vec found no clusters at this min_cluster_size")
+    return m.doc_topic, m.topic_word, m.num_topics
+
+
+def _fit_etm(iters=80):
+    docs, vocab = _planted_blocks(k=K, block=8, n=240, length=12, seed=0)
+    _, word_emb = _planted_embeddings(k=K, block=8, seed=0)
+    m = topica.ETM(num_topics=K, seed=1)
+    m.fit(docs, word_emb, vocab, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_fastopic(iters=200):
+    docs, vocab = _planted_blocks(k=K, block=6, n=200, length=10, seed=0)
+    doc_emb = _doc_embeddings(docs, k=K, block=6, seed=0)
+    m = topica.FASTopic(num_topics=K, lr=0.05, seed=1)
+    m.fit(docs, doc_emb, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_embeddinglda(iters=300):
+    docs, vocab = _planted_blocks(k=K, block=8, n=300, seed=0)
+    _, word_emb = _planted_embeddings(k=K, block=8, seed=0)
+    m = topica.EmbeddingLDA(num_topics=K, embeddings=word_emb, vocabulary=vocab,
+                            top_m=5, seed=1)
+    m.fit(docs, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_contextual(cls, iters=120):
+    docs, vocab = _planted_blocks(k=K, block=8, n=200, length=15, seed=0)
+    doc_emb = _doc_embeddings(docs, k=K, block=8, seed=0)
+    m = cls(num_topics=K, batch_size=60, lr=0.01, dropout=0.0, seed=1)
+    m.fit(docs, doc_emb, iters=iters)
+    return m.doc_topic, m.topic_word, K
+
+
+def _fit_combinedtm(iters=120):
+    return _fit_contextual(topica.CombinedTM, iters=iters)
+
+
+def _fit_zeroshottm(iters=120):
+    return _fit_contextual(topica.ZeroShotTM, iters=iters)
+
+
+def _fit_infoctm(iters=120):
+    rng = np.random.default_rng(0)
+    blocks = K
+    per, length = 4, 12
+
+    def corpus(prefix, n):
+        return [[f"{prefix}{d % blocks}_{int(rng.integers(per))}" for _ in range(length)]
+                for d in range(n)]
+
+    a, b = corpus("a", 160), corpus("b", 152)
+    dictionary = [(f"a{blk}_{i}", f"b{blk}_{j}")
+                  for blk in range(blocks) for i in range(per) for j in range(per)]
+    m = topica.InfoCTM(num_topics=K, seed=1, hidden_size=32, lr=0.01,
+                       languages=("en", "zh"))
+    m.fit(a, b, dictionary=dictionary, iters=iters, batch_size=40)
+    # validate both languages; return language A for the headline check.
+    assert_simplex(m.topic_word(lang="zh"), axis=1, model="InfoCTM(zh)")
+    return m.doc_topic(lang="en"), m.topic_word(lang="en"), K
+
+
+FIT_ADAPTERS = {
+    "LDA": _fit_lda,
+    "CTM": _fit_ctm,
+    "ProdLDA": _fit_prodlda,
+    "HDP": _fit_hdp,
+    "NMF": _fit_nmf,
+    "LSA": _fit_lsa,
+    "STM": _fit_stm,
+    "STS": _fit_sts,
+    "SAGE": _fit_sage,
+    "ECTM": _fit_ectm,
+    "DMR": _fit_dmr,
+    "GDMR": _fit_gdmr,
+    "KeyATM": _fit_keyatm,
+    "SeededLDA": _fit_seededlda,
+    "LabeledLDA": _fit_labeledlda,
+    "SupervisedLDA": _fit_supervisedlda,
+    "GSDMM": _fit_gsdmm,
+    "PT": _fit_pt,
+    "DTM": _fit_dtm,
+    "DETM": _fit_detm,
+    "HLDA": _fit_hlda,
+    "PA": _fit_pa,
+    "BERTopic": _fit_bertopic,
+    "Top2Vec": _fit_top2vec,
+    "ETM": _fit_etm,
+    "FASTopic": _fit_fastopic,
+    "EmbeddingLDA": _fit_embeddinglda,
+    "CombinedTM": _fit_combinedtm,
+    "ZeroShotTM": _fit_zeroshottm,
+    "InfoCTM": _fit_infoctm,
+}
+
+# Models that need an external LLM/API and so cannot be fit here.
+SKIP_MODELS = {"TopicGPT": "needs an LLM / external API"}
+
+# Models for which the cheap metamorphic "more iters not worse" check is run.
+# These are the stochastic count-based / Gibbs models where it is fast and where
+# collapse-on-training (the #270 failure) is the relevant risk. Neural/OT/SVD
+# models and the auto-K / non-simplex models are excluded (slow or ill-posed for
+# this particular relation).
+METAMORPHIC_MODELS = {
+    "LDA": _fit_lda,
+    "DMR": _fit_dmr,
+    "KeyATM": _fit_keyatm,
+    "SeededLDA": _fit_seededlda,
+    "PT": _fit_pt,
+    "SAGE": _fit_sage,
+}
+
+
+def _theta_only(fit_fn):
+    """Wrap a (theta, tw, k) adapter into an iters -> theta function."""
+    def inner(iters):
+        return fit_fn(iters)[0]
+    return inner
+
+
+# ---------------------------------------------------------------------------
+# The parametrized validity suite.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "name",
+    [m.name for m in topica.list_models()],
+    ids=[m.name for m in topica.list_models()],
+)
+def test_model_theta_is_healthy(name):
+    """Every model produces a non-degenerate, valid theta on a planted corpus."""
+    if name in SKIP_MODELS:
+        pytest.skip(SKIP_MODELS[name])
+    adapter = FIT_ADAPTERS.get(name)
+    assert adapter is not None, f"no FIT_ADAPTER for registered model {name!r}"
+
+    theta, topic_word, n_topics = adapter()
+    theta = np.asarray(theta, dtype=float)
+
+    # Validity invariants (the #271 high-leverage assertions).
+    assert n_topics >= 1, f"[{name}] degenerate n_topics={n_topics}"
+    assert_finite(theta, model=name)
+    if topic_word is not None:
+        assert_finite(topic_word, model=name)
+        assert_simplex(topic_word, axis=1, model=name)
+
+    if n_topics == 1:
+        # An auto-K model that found a single topic on this corpus still must be
+        # finite/valid, but the multi-topic health check is not meaningful.
+        assert_simplex(theta, axis=1, model=name)
+    else:
+        assert_healthy_theta(theta, n_topics, model=name)
+
+
+@pytest.mark.parametrize("name", sorted(METAMORPHIC_MODELS), ids=sorted(METAMORPHIC_MODELS))
+def test_more_iters_not_worse(name):
+    """Training longer must not make the fit MORE degenerate (catches #270)."""
+    fit_fn = METAMORPHIC_MODELS[name]
+    assert_more_iters_not_worse(_theta_only(fit_fn), low=25, high=150, model=name)


### PR DESCRIPTION
Wave 0 of #271. Reference-free statistical-validity coverage for all 31 models — the layer that would have caught #270 (and the class of degenerate-but-well-shaped fits) before a user did.

## Why
The suite verified *mechanics* (runs, right shape, rows sum to 1) but never *validity*. A collapsed θ — every doc on one topic — is a perfectly valid simplex, so #270 passed every test. This wave asserts the fit is non-degenerate.

## What's here
- **`tests/invariants.py`** — `effective_topics = exp(H(mean θ))`; `assert_healthy_theta` (simplex + no topic over `max_mass=0.8` + `effective_topics > 0.25·K`); `assert_finite`/`assert_simplex`; metamorphic `assert_more_iters_not_worse` (the #270 mode: training longer collapsed the fit) and `assert_seed_reproducible`. A **non-vacuity self-test** proves the checks bite: collapsed / 95%-on-one / NaN θ all raise; flat and benignly-sharpened θ pass.
- **`tests/test_model_invariants.py`** — registry-driven, parametrized over `topica.list_models()`. `FIT_ADAPTERS` builds the right small planted corpus per model from its `brings` field (covariates, seeds, labels, times, embeddings, InfoCTM's cross-lingual setup) and asserts a healthy, finite θ; count-based models also run the more-iters metamorphic check.
- **`tests/test_model_coverage_manifest.py`** — coverage gate: every registered model must have a `FIT_ADAPTER`, a committed `parity/<lower>_gold.npz`, or a documented `INVARIANT_EXEMPT` entry, so coverage can't silently fall behind the roster (the test-coverage analogue of the doc-coverage lint).

## Coverage
All 31 models fit and pass except **TopicGPT** (exempt — needs an LLM). `effective_topics` lands ≈K for the count/variational models; lowest is DETM at 2.3/4 (LSTM η-amortizer on a tiny corpus — still well clear of the floor).

## Verification
- `pytest tests/test_model_invariants.py tests/test_model_coverage_manifest.py -q`: **40 passed, 1 skipped, ~4s**
- Self-test confirms a #270-style collapse (eff→~1, mass→0.99) trips both `max_mass` and the `effective_topics` floor.

## Next (not in this PR)
**Wave 1** — committed gold fixtures (run the reference once, save `<model>_gold.npz` + a metadata/log sidecar, compare in CI without the reference toolchain) generalizing the existing NMF/LSA pattern, via a shared `parity/harness.py`. Tracked under #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)