### PR TITLE
test(#271): make AVITM gold no-torch guards order-independent

### DIFF
--- a/tests/test_combinedtm_gold.py
+++ b/tests/test_combinedtm_gold.py
@@ -14,10 +14,13 @@ embeddings are frozen in the committed gold, so no torch is imported at test tim
 non-vacuous checks.
 """
 
+import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
-PARITY = Path(__file__).resolve().parents[1] / "parity"
+ROOT = Path(__file__).resolve().parents[1]
+PARITY = ROOT / "parity"
 sys.path.insert(0, str(PARITY))
 
 import harness  # noqa: E402
@@ -45,10 +48,34 @@ def test_combinedtm_gold_shape():
 
 
 def test_combinedtm_no_torch_at_test_time():
-    """The committed gold must validate with no deep-learning framework present."""
-    assert "torch" not in sys.modules, (
-        "torch was imported at test time; the gold must validate offline"
+    """The committed gold must validate with NO deep-learning framework.
+
+    Proven in a fresh subprocess that hard-blocks torch via an import finder, then
+    runs the full offline ``combinedtm_gold.run()``. A subprocess (not a bare
+    ``sys.modules`` check) is used because a sibling test in the same pytest session
+    may have already imported torch; the point is that the GOLD PATH needs none."""
+    script = textwrap.dedent(
+        f"""
+        import sys
+        BLOCKED = {{"torch"}}
+        class _Blocker:
+            def find_spec(self, name, path=None, target=None):
+                if name.split(".")[0] in BLOCKED:
+                    raise ImportError(f"blocked {{name}} for offline gold test")
+                return None
+        sys.meta_path.insert(0, _Blocker())
+        sys.path.insert(0, {str(PARITY)!r})
+        import combinedtm_gold
+        r = combinedtm_gold.run(verbose=False)
+        assert r["passes"], r
+        assert not (BLOCKED & set(sys.modules)), sorted(BLOCKED & set(sys.modules))
+        print("OK")
+        """
     )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, cwd=str(ROOT)
+    )
+    assert "OK" in proc.stdout, f"offline gold path imported a blocked module:\n{proc.stderr}"
 
 
 def test_combinedtm_gold_is_non_vacuous():

--- a/tests/test_infoctm_gold.py
+++ b/tests/test_infoctm_gold.py
@@ -16,10 +16,13 @@ explicitly below). The topica refit (A=300 / B=270 docs, K=5, 200 iters) is fast
 non-vacuous checks.
 """
 
+import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
-PARITY = Path(__file__).resolve().parents[1] / "parity"
+ROOT = Path(__file__).resolve().parents[1]
+PARITY = ROOT / "parity"
 sys.path.insert(0, str(PARITY))
 
 import harness  # noqa: E402
@@ -45,10 +48,34 @@ def test_infoctm_gold_shape():
 
 
 def test_infoctm_no_torch_at_test_time():
-    """The committed gold must validate with no deep-learning framework present."""
-    assert "torch" not in sys.modules, (
-        "torch was imported at test time; the gold must validate offline"
+    """The committed gold must validate with NO deep-learning framework.
+
+    Proven in a fresh subprocess that hard-blocks torch via an import finder, then
+    runs the full offline ``infoctm_gold.run()``. A subprocess (not a bare
+    ``sys.modules`` check) is used because a sibling test in the same pytest session
+    may have already imported torch; the point is that the GOLD PATH needs none."""
+    script = textwrap.dedent(
+        f"""
+        import sys
+        BLOCKED = {{"torch"}}
+        class _Blocker:
+            def find_spec(self, name, path=None, target=None):
+                if name.split(".")[0] in BLOCKED:
+                    raise ImportError(f"blocked {{name}} for offline gold test")
+                return None
+        sys.meta_path.insert(0, _Blocker())
+        sys.path.insert(0, {str(PARITY)!r})
+        import infoctm_gold
+        r = infoctm_gold.run(verbose=False)
+        assert r["passes"], r
+        assert not (BLOCKED & set(sys.modules)), sorted(BLOCKED & set(sys.modules))
+        print("OK")
+        """
     )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, cwd=str(ROOT)
+    )
+    assert "OK" in proc.stdout, f"offline gold path imported a blocked module:\n{proc.stderr}"
 
 
 def test_infoctm_gold_is_non_vacuous():

--- a/tests/test_prodlda_gold.py
+++ b/tests/test_prodlda_gold.py
@@ -17,12 +17,15 @@ V~1.1k, 120 epochs) takes ~15s, so the heavy refit assertion is marked
 non-vacuous checks run by default.
 """
 
+import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
 import pytest
 
-PARITY = Path(__file__).resolve().parents[1] / "parity"
+ROOT = Path(__file__).resolve().parents[1]
+PARITY = ROOT / "parity"
 sys.path.insert(0, str(PARITY))
 
 import harness  # noqa: E402
@@ -50,10 +53,34 @@ def test_prodlda_gold_shape():
 
 
 def test_prodlda_no_torch_at_test_time():
-    """The committed gold must validate with no deep-learning framework present."""
-    assert "torch" not in sys.modules, (
-        "torch was imported at test time; the gold must validate offline"
+    """The committed gold must validate with NO deep-learning framework.
+
+    Proven in a fresh subprocess that hard-blocks torch via an import finder, then
+    runs the full offline ``prodlda_gold.run()``. A subprocess (not a bare
+    ``sys.modules`` check) is used because a sibling test in the same pytest session
+    may have already imported torch; the point is that the GOLD PATH needs none."""
+    script = textwrap.dedent(
+        f"""
+        import sys
+        BLOCKED = {{"torch"}}
+        class _Blocker:
+            def find_spec(self, name, path=None, target=None):
+                if name.split(".")[0] in BLOCKED:
+                    raise ImportError(f"blocked {{name}} for offline gold test")
+                return None
+        sys.meta_path.insert(0, _Blocker())
+        sys.path.insert(0, {str(PARITY)!r})
+        import prodlda_gold
+        r = prodlda_gold.run(verbose=False)
+        assert r["passes"], r
+        assert not (BLOCKED & set(sys.modules)), sorted(BLOCKED & set(sys.modules))
+        print("OK")
+        """
     )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, cwd=str(ROOT)
+    )
+    assert "OK" in proc.stdout, f"offline gold path imported a blocked module:\n{proc.stderr}"
 
 
 def test_prodlda_gold_is_non_vacuous():

--- a/tests/test_zeroshottm_gold.py
+++ b/tests/test_zeroshottm_gold.py
@@ -15,10 +15,13 @@ embeddings are frozen in the committed gold, so no torch is imported at test tim
 non-vacuous checks.
 """
 
+import subprocess
 import sys
+import textwrap
 from pathlib import Path
 
-PARITY = Path(__file__).resolve().parents[1] / "parity"
+ROOT = Path(__file__).resolve().parents[1]
+PARITY = ROOT / "parity"
 sys.path.insert(0, str(PARITY))
 
 import harness  # noqa: E402
@@ -46,10 +49,34 @@ def test_zeroshottm_gold_shape():
 
 
 def test_zeroshottm_no_torch_at_test_time():
-    """The committed gold must validate with no deep-learning framework present."""
-    assert "torch" not in sys.modules, (
-        "torch was imported at test time; the gold must validate offline"
+    """The committed gold must validate with NO deep-learning framework.
+
+    Proven in a fresh subprocess that hard-blocks torch via an import finder, then
+    runs the full offline ``zeroshot_gold.run()``. A subprocess (not a bare
+    ``sys.modules`` check) is used because a sibling test in the same pytest session
+    may have already imported torch; the point is that the GOLD PATH needs none."""
+    script = textwrap.dedent(
+        f"""
+        import sys
+        BLOCKED = {{"torch"}}
+        class _Blocker:
+            def find_spec(self, name, path=None, target=None):
+                if name.split(".")[0] in BLOCKED:
+                    raise ImportError(f"blocked {{name}} for offline gold test")
+                return None
+        sys.meta_path.insert(0, _Blocker())
+        sys.path.insert(0, {str(PARITY)!r})
+        import zeroshot_gold
+        r = zeroshot_gold.run(verbose=False)
+        assert r["passes"], r
+        assert not (BLOCKED & set(sys.modules)), sorted(BLOCKED & set(sys.modules))
+        print("OK")
+        """
     )
+    proc = subprocess.run(
+        [sys.executable, "-c", script], capture_output=True, text=True, cwd=str(ROOT)
+    )
+    assert "OK" in proc.stdout, f"offline gold path imported a blocked module:\n{proc.stderr}"
 
 
 def test_zeroshottm_gold_is_non_vacuous():


### PR DESCRIPTION
Small robustness fix flagged during Wave 2.

The four AVITM-family gold tests (ProdLDA, CombinedTM, ZeroShotTM, InfoCTM) asserted `"torch" not in sys.modules` to prove the gold validates offline. That guard is **order-dependent** — it trips whenever an earlier test in the same session imported torch (which happens once torch is installed and a live parity test or sibling gold runs first). It passed CI only because torch isn't installed there; locally with torch present, a full-suite run failed (the failing pair even shifted as test order changed).

Fix: replace each with the robust subprocess check the FASTopic gold already uses — a fresh subprocess hard-blocks torch via a `meta_path` import finder, runs the full offline `<model>_gold.run()`, and asserts it passes with torch never imported. Proves the gold *path* needs no torch regardless of the parent session.

Full local suite (torch installed) now green: **2940 passed, 28 skipped, 0 failed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)