### PR TITLE
fix: red main CI — Top2Vec gold must not require scikit-learn

### DIFF
--- a/parity/harness.py
+++ b/parity/harness.py
@@ -255,6 +255,36 @@ def doc_topic_correlation(theta_a: np.ndarray, theta_b: np.ndarray) -> float:
     return float(np.mean(cors)) if cors else float("nan")
 
 
+def adjusted_rand_index(labels_true, labels_pred) -> float:
+    """Adjusted Rand index between two label assignments, numpy-only.
+
+    A vendored equivalent of ``sklearn.metrics.adjusted_rand_score`` so the
+    clustering gold tests (Top2Vec/BERTopic) stay reference-toolchain-free at test
+    time — CI installs numpy/scipy but not scikit-learn (which is only a *reference*
+    here, used at regenerate time)."""
+    a = np.asarray(labels_true)
+    b = np.asarray(labels_pred)
+    _, a_idx = np.unique(a, return_inverse=True)
+    _, b_idx = np.unique(b, return_inverse=True)
+    n = a.shape[0]
+    cont = np.zeros((a_idx.max() + 1, b_idx.max() + 1), dtype=np.int64)
+    np.add.at(cont, (a_idx, b_idx), 1)
+
+    def _comb2(x):
+        x = np.asarray(x, dtype=np.float64)
+        return (x * (x - 1.0) / 2.0).sum()
+
+    sum_comb = _comb2(cont.ravel())
+    sum_comb_a = _comb2(cont.sum(axis=1))
+    sum_comb_b = _comb2(cont.sum(axis=0))
+    comb_n = n * (n - 1.0) / 2.0
+    expected = sum_comb_a * sum_comb_b / comb_n if comb_n else 0.0
+    max_index = 0.5 * (sum_comb_a + sum_comb_b)
+    if max_index == expected:
+        return 1.0
+    return float((sum_comb - expected) / (max_index - expected))
+
+
 # --------------------------------------------------------------------------- #
 # Gold fixture I/O
 # --------------------------------------------------------------------------- #

--- a/parity/top2vec_gold.py
+++ b/parity/top2vec_gold.py
@@ -67,9 +67,9 @@ PURITY_MIN = 0.9
 
 
 def _ari(a, b) -> float:
-    from sklearn.metrics import adjusted_rand_score
-
-    return float(adjusted_rand_score(a, b))
+    # numpy-only ARI (harness) so the offline gold test needs no scikit-learn,
+    # which CI does not install (sklearn is only a regenerate-time reference).
+    return harness.adjusted_rand_index(a, b)
 
 
 def _topica_fit(docs, doc_emb, word_emb, vocab):

--- a/tests/test_top2vec_gold.py
+++ b/tests/test_top2vec_gold.py
@@ -93,18 +93,18 @@ def test_top2vec_gold_is_non_vacuous():
     Jaccard: a permuted label vector keeps the same cluster sizes but destroys the
     doc->cluster correspondence, so its ARI against the truth must drop near zero."""
     import numpy as np
-    from sklearn.metrics import adjusted_rand_score
 
     arrays, meta = harness.load_gold("top2vec")
     truth = arrays["truth"].astype(np.int64)
     bt_labels = arrays["bertopic_labels"].astype(np.int64)
 
     # The frozen BERTopic labels recover the truth (sanity on the gold itself).
-    assert adjusted_rand_score(truth, bt_labels) >= meta["truth_ari_min"]
+    # Uses the harness's numpy-only ARI so the test needs no scikit-learn (CI).
+    assert harness.adjusted_rand_index(truth, bt_labels) >= meta["truth_ari_min"]
 
     rng = np.random.default_rng(0)
     shuffled = rng.permutation(bt_labels)
-    jumbled_ari = adjusted_rand_score(truth, shuffled)
+    jumbled_ari = harness.adjusted_rand_index(truth, shuffled)
     bar = max(meta["truth_ari_min"], meta["bertopic_truth_ari"] - meta["ari_margin"])
     assert jumbled_ari < bar, (
         f"shuffled-partition ARI {jumbled_ari:.3f} should be far below the bar "


### PR DESCRIPTION
**Fixes red main CI** (failing on macOS/Ubuntu/Windows since #281).

## Root cause
The Top2Vec gold (#281) computed its clustering ARI via `sklearn.metrics.adjusted_rand_score` **at test time**. CI installs only `numpy pandas formulaic matplotlib scipy plotly polars` — **no scikit-learn** (sklearn is a *regenerate-time* reference here, exactly as it is for NMF/LSA, whose offline tests are numpy-only). So `test_top2vec_gold.py` raised `ImportError` on every OS once it hit main. It slipped through review because the dev machine has sklearn installed (pulled in by bertopic), so the local suite was green.

## Fix
- Vendor a numpy-only `harness.adjusted_rand_index`, **verified bit-equal to `sklearn.adjusted_rand_score`** across random and degenerate cases.
- Use it in `parity/top2vec_gold.py::_ari` and in the test's non-vacuous check.
- The gold test is now truly reference-toolchain-free, like the rest of the suite.

## Verification
Reproduced CI locally with a `meta_path` import finder that blocks the packages CI lacks (torch / fastopic / bertopic / tomotopy / gensim / sklearn / umap / hdbscan): **full suite 2934 passed, 30 skipped, 0 failed**. (That same harness is how I confirmed the breakage and the fix.)

## Note
This is the lesson the whole gold effort is built on — offline tests must not import the reference toolchain. Worth considering a CI-sim job (block reference packages) so this can't regress; happy to add it if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)