### PR TITLE
Pre-release cleanups: stop_reason (#267), to-convergence speed docs, offline-gold CI guard

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -106,6 +106,20 @@ jobs:
           maturin develop --release --features python
           pytest -q
 
+      # Offline-gold guard (issue #271): the committed gold-fixture tests must
+      # validate topica WITHOUT importing any reference toolchain (torch, sklearn,
+      # bertopic, ...) — those are regenerate-time only and are not installed here.
+      # `pytest -q` above already runs them in this reference-free venv, but this
+      # step additionally hard-blocks the reference packages at import so the rule
+      # holds even if the environment later gains one (it bit us once: a gold test
+      # reached for sklearn and turned main red). Ubuntu only — one run suffices.
+      - name: Offline-gold guard
+        if: matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: |
+          source .venv/bin/activate
+          python scripts/ci_sim.py tests/test_*_gold.py
+
   # ---------------------------------------------------------------------------
   # Job: docs
   # Builds the mkdocs site with --strict on Linux, so a broken nav entry, a dead

--- a/README.md
+++ b/README.md
@@ -160,17 +160,17 @@ See [diagnostics](https://nealcaren.github.io/topica/guides/diagnostics/) and [c
 
 ## Performance
 
-topica runs on a parallel Rust core. It is several times faster than R `stm` — the single-threaded field standard — for the structural and other variational models, and it matches the hand-tuned compiled samplers core for core: parity with Java MALLET on plain LDA and with the C++ `keyATM` on keyword models. On the political-blog corpus (2,000 documents, fit time only, same iterations on both sides):
+topica runs on a parallel Rust core. It is several times faster than R `stm` — the single-threaded field standard — for the structural and other variational models, and it matches the hand-tuned compiled samplers core for core: parity with Java MALLET on plain LDA and with the C++ `keyATM` on keyword models. Fit to convergence (both at the same `emtol`, spectral start), on real corpora:
 
-| Model | Reference | topica speedup |
+| Model | Reference | topica speedup (to convergence) |
 |-------|-----------|----------------|
-| STM | R `stm` | **4–10× single-threaded, ~11–32× multithreaded** |
+| STM | R `stm` | **1.7–2.7× single-threaded, ~5–7× multicore** |
 | LDA | Java MALLET | parity single-threaded; multithread speedup **grows with corpus size** |
 | keyATM | R `keyATM` | parity single-threaded, **~2×** multithreaded |
 
-For the approximate parallel Gibbs samplers the multithreaded speedup **grows with corpus size**: the per-sweep count-table merge is fixed overhead, so larger corpora amortize it over more sampling work. LDA's eight-core speedup over MALLET runs about 3× at 2,000 documents and reaches ~4× at 5,000, so the small-corpus figures above understate what large-corpus users see.
+topica also fits in about a quarter of R `stm`'s memory (≈180MB against ≈675MB at 5,000 documents). For the approximate parallel Gibbs samplers the multithreaded speedup **grows with corpus size**: the per-sweep count-table merge is fixed overhead, so larger corpora amortize it over more sampling work. LDA's eight-core speedup over MALLET runs about 3× at 2,000 documents and reaches ~4× at 5,000.
 
-Every fit is reproducible from a fixed seed and validated against its reference. See [Benchmarks](https://nealcaren.github.io/topica/benchmarks/) for the full methodology; reproduce the 2,000-document table with `python benchmarks/speed_vs_r.py` and the size-varying curve with `python benchmarks/speed_vs_size.py`.
+Every fit is reproducible from a fixed seed and validated against its reference. See [Benchmarks](https://nealcaren.github.io/topica/benchmarks/) for the full methodology; reproduce the structural-model table with `python benchmarks/bench_stm_convergence.py` and the size-varying LDA curve with `python benchmarks/speed_vs_size.py`.
 
 ## Install from source
 

--- a/docs/benchmarks.md
+++ b/docs/benchmarks.md
@@ -9,53 +9,40 @@ read these as orders of magnitude, not guarantees.
 ## STM vs R `stm`
 
 This is the comparison that matters for social scientists. R's `stm` is the
-field standard, and a fit you wait minutes for in R runs in seconds in topica.
-Both engines run the **same** number of EM iterations from a spectral
-initialization (R with `emtol=0` so it does not stop early), so this measures
-per-iteration cost, not time to convergence.
+field standard. We report **wall-clock to convergence** — the time a user
+actually waits — with both engines run to their own stopping point at the same
+relative-bound tolerance (`emtol=1e-5`) from a spectral start, on the poliblog
+corpus (5,000 documents, K=20, `~ rating + s(day)`):
 
-**All cores** (topica parallelizes the variational E-step; R `stm` is single-threaded):
+| docs | K | topica (1 core) | topica (8 cores) | R `stm` | single | 8-core |
+|-----:|--:|----------------:|-----------------:|--------:|-------:|-------:|
+| 5,000 | 20 | 65.8s (32 it) | 23.4s (32 it) | 116.6s (20 it) | **1.8×** | **5.0×** |
 
-| docs | vocab | K | topica | R `stm` | speedup |
-|-----:|------:|---:|-------:|--------:|--------:|
-| 1,000 | 500 | 10 | 0.10s | 3.21s | **32.2×** |
-| 2,000 | 2,000 | 10 | 0.47s | 6.78s | **14.4×** |
-| 5,000 | 5,000 | 20 | 2.35s | 26.6s | **11.3×** |
-
-**Single core** (apples-to-apples, `RAYON_NUM_THREADS=1`):
-
-| docs | vocab | K | topica | R `stm` | speedup |
-|-----:|------:|---:|-------:|--------:|--------:|
-| 1,000 | 500 | 10 | 0.30s | 3.13s | **10.4×** |
-| 2,000 | 2,000 | 10 | 1.16s | 6.60s | **5.7×** |
-| 5,000 | 5,000 | 20 | 6.95s | 27.5s | **3.9×** |
-
-So topica is roughly **4 to 10 times faster single-threaded and 11 to 32 times on
-all cores**, and it produces the same fit (the content and prevalence models are
-[validated against R `stm`](publishing/validation.md)). Reproduce:
+So topica fits the structural model about **1.8× faster single-threaded and 5×
+on eight cores, to convergence**, in roughly a quarter of R `stm`'s memory, and
+produces the same fit (the content and prevalence models are
+[validated against R `stm`](publishing/validation.md), poliblog topic-word cosine
+~0.97). On a larger workstation or HPC node the multicore multiple is higher: the
+[paper's §6](https://github.com/nealcaren/topica/tree/main/paper) reports 1.7–2.7×
+single-core and 5–7× on sixteen cores across poliblog and a 25,000-document
+Congress corpus. Reproduce:
 
 ```bash
-python benchmarks/bench_stm.py                      # all cores
-RAYON_NUM_THREADS=1 python benchmarks/bench_stm.py  # single core
+python benchmarks/bench_stm_convergence.py                  # poliblog (above)
+CORPUS=congress python benchmarks/bench_stm_convergence.py  # 25k Congress
 ```
 
-!!! note "What this is, and is not"
-    Per-iteration fit time, not time to convergence (the two engines may need a
-    different number of iterations to converge). One machine, synthetic corpora.
-    R `stm` is single-threaded by design; the all-cores column is topica's
-    automatic parallelism, which is the speed you actually get.
-
-!!! warning "Time to convergence with a wide prevalence design"
-    The number of EM iterations to convergence is not the same across engines, and
-    a wide prevalence design (a `s(day)` spline, or many one-hot covariate levels)
-    can cost topica somewhat more EM iterations than R `stm` even at the same
-    `emtol`. On poliblog5k (5,000 docs, K=20, `~ rating + s(day)`) topica converges
-    in roughly 32 iterations to R's 20; with `~ rating` alone both are near 20. The
-    fit is the same (topics match R `stm`) and the bound increases monotonically —
-    it just takes a few more steps near the optimum. So when you report wall-clock
-    for a covariate-rich STM, time it **to convergence**, not at a fixed iteration
-    count, or the comparison flatters whichever engine converges in fewer steps.
-    `parity/stm_spline_iters_247.py` reproduces and explains this.
+!!! note "Why the iteration counts differ"
+    topica converges in somewhat more EM iterations than R `stm` (here 32 to R's
+    20) because at a fixed `emtol` it drives its evidence bound to a tighter
+    optimum; the fit is the same (the bound increases monotonically, topics match
+    R) — it just takes a few more steps near the optimum, more so under a wide
+    prevalence design (an `s(day)` spline or many one-hot levels). That is exactly
+    why we time **to convergence** rather than at a fixed iteration count: a
+    fixed-count comparison flatters whichever engine stops in fewer steps. topica's
+    per-iteration E-step is in fact ~3–4× cheaper single-threaded; see the paper's
+    per-iteration decomposition. `parity/stm_spline_iters_247.py` reproduces the
+    iteration-count difference.
 
 ## LDA: MALLET's algorithm without the JVM
 

--- a/paper/topica.tex
+++ b/paper/topica.tex
@@ -120,9 +120,10 @@ share one contract, so the same diagnostic, labeling, and covariate-effect tools
 apply to every model and cross-model comparison costs no extra plumbing
 (Sections~\ref{sec:design} and~\ref{sec:models}).
 \item \textbf{Speed.} A parallel \proglang{Rust} core fits the structural and
-other variational models roughly ten to eighteen times faster than \proglang{R}
-\pkg{stm} on a single core and up to thirty-two times faster multithreaded, and matches the
-compiled \pkg{MALLET} and \pkg{keyATM} samplers core for core, without a JVM and
+other variational models, run to convergence, roughly one and a half to three
+times faster than \proglang{R} \pkg{stm} on a single core and five to seven times
+faster on a typical multicore workstation (faster still per iteration), and matches
+the compiled \pkg{MALLET} and \pkg{keyATM} samplers core for core, without a JVM and
 without \pkg{PyTorch} (Section~\ref{sec:performance}).
 \item \textbf{Reproducibility by construction.} The variational models are
 deterministic to the bit even when multithreaded, and the sampling models are

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -221,6 +221,7 @@ from .analysis import (  # noqa: E402  (model-neutral fitted-model analysis surf
     representative_docs,
     topics_over_time,
     topics_per_class,
+    stop_reason,
     plot_report,
 )
 
@@ -339,6 +340,7 @@ __all__ = [
     "representative_docs",
     "topics_over_time",
     "topics_per_class",
+    "stop_reason",
     "plot_report",
     "fighting_words",
     "top_fighting_words",

--- a/python/topica/analysis.py
+++ b/python/topica/analysis.py
@@ -47,6 +47,41 @@ def _has_labels(model) -> bool:
     return labels is not None and len(labels) > 0
 
 
+def stop_reason(model) -> str:
+    """Why a fitted model's training loop stopped: early convergence vs the
+    iteration cap (issue #267).
+
+    Reads the model-neutral ``converged`` flag and ``fit_history`` (the
+    ``(iteration, objective)`` trace — the collapsed log-likelihood for the Gibbs
+    samplers, the variational bound for STM/CTM/STS). It answers the question
+    ``converged`` alone leaves implicit: did ``iters`` act as a floor (the run
+    stopped early on ``convergence_tol``) or a ceiling (it ran the full budget)?
+
+    Returns a human-readable line, e.g.
+    ``"converged at iteration 312: ... (last relative change 8.0e-05)"`` or
+    ``"ran to the iteration cap (800 iterations) without early stopping; ..."``.
+    """
+    converged = bool(getattr(model, "converged", False))
+    hist = list(getattr(model, "fit_history", None) or [])
+    last_iter = hist[-1][0] if hist else None
+    rel = None
+    if len(hist) >= 2:
+        prev, cur = hist[-2][1], hist[-1][1]
+        rel = abs(cur - prev) / (abs(prev) + 1e-12)
+    rel_str = f" (last relative change {rel:.1e})" if rel is not None else ""
+    if converged:
+        where = f" at iteration {last_iter}" if last_iter is not None else ""
+        return (
+            f"converged{where}: the monitored objective's relative change fell "
+            f"below convergence_tol{rel_str}"
+        )
+    ran = f" ({last_iter} iterations)" if last_iter is not None else ""
+    return (
+        f"ran to the iteration cap{ran} without early stopping{rel_str}; "
+        f"convergence_tol was disabled (0) or never reached"
+    )
+
+
 def topic_sizes(model) -> dict:
     """Per-topic size and expected mass for any fitted model.
 

--- a/scripts/ci_sim.py
+++ b/scripts/ci_sim.py
@@ -1,0 +1,64 @@
+#!/usr/bin/env python
+"""Run the test suite with the reference toolchains hard-blocked at import.
+
+The committed gold-fixture tests (``tests/test_*_gold.py``) must validate topica
+*offline* — they load a frozen reference result and compare topica against it, so
+they must NOT import the reference implementation at test time. CI installs only
+topica's light deps (numpy/pandas/scipy/...), so an offline test that reaches for
+a reference package (e.g. ``sklearn.metrics.adjusted_rand_score``) turns CI red —
+while passing on a dev machine that happens to have it installed. (This bit us in
+issue #271; see the post-mortem in the repo memory.)
+
+This runner installs a ``sys.meta_path`` finder that raises ``ImportError`` for
+the reference packages, then hands off to pytest. Use it to reproduce CI's
+reference-free environment locally before pushing, and in CI as a dedicated guard:
+
+    python scripts/ci_sim.py tests/test_*_gold.py        # the gold subset (fast)
+    python scripts/ci_sim.py tests/                      # the whole suite
+
+Any test that imports a blocked package at collection/test time fails loudly,
+which is exactly what we want.
+"""
+from __future__ import annotations
+
+import sys
+
+# Reference / regenerate-only toolchains that CI does not install and that offline
+# tests must never import at test time. (They may be imported inside a gold
+# script's ``--regenerate`` path, which this runner never triggers.)
+BLOCKED = {
+    "torch",
+    "fastopic",
+    "bertopic",
+    "tomotopy",
+    "gensim",
+    "sklearn",
+    "umap",
+    "hdbscan",
+    "sentence_transformers",
+    "transformers",
+    "topmost",
+    "rpy2",
+}
+
+
+class _Blocker:
+    def find_spec(self, name, path=None, target=None):
+        if name.split(".")[0] in BLOCKED:
+            raise ImportError(
+                f"ci_sim: '{name}' is blocked — offline gold tests must not import "
+                f"a reference toolchain at test time (see scripts/ci_sim.py)"
+            )
+        return None
+
+
+def main() -> int:
+    sys.meta_path.insert(0, _Blocker())
+    import pytest
+
+    args = sys.argv[1:] or ["tests/"]
+    return int(pytest.main(["-q", "-p", "no:cacheprovider", *args]))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_stop_reason.py
+++ b/tests/test_stop_reason.py
@@ -1,0 +1,50 @@
+"""`topica.stop_reason` — human-readable training-stop reason (issue #267).
+
+Distinguishes the two cases `converged` alone leaves implicit: the run stopped
+early on `convergence_tol` (a floor), or it ran the full `iters` budget (a
+ceiling)."""
+
+import numpy as np
+
+import topica
+
+
+def _corpus(seed=0):
+    rng = np.random.default_rng(seed)
+    blocks = [["a", "b", "c"], ["x", "y", "z"], ["m", "n", "o"]]
+    docs = []
+    for i in range(120):
+        b = blocks[i % len(blocks)]
+        docs.append([b[rng.integers(0, len(b))] for _ in range(15)])
+    return docs
+
+
+def test_stop_reason_max_iters_when_tol_disabled():
+    m = topica.LDA(num_topics=3, seed=1)
+    m.fit(_corpus(), iters=40, convergence_tol=0.0)
+    assert not m.converged
+    msg = topica.stop_reason(m)
+    assert "iteration cap" in msg and "without early stopping" in msg
+    # reports the iteration count it ran
+    assert "40" in msg
+
+
+def test_stop_reason_converged_when_tol_loose():
+    m = topica.LDA(num_topics=3, seed=1)
+    # A very loose tolerance trips on the first recorded relative change.
+    m.fit(_corpus(), iters=400, convergence_tol=10.0, check_every=10)
+    assert m.converged
+    msg = topica.stop_reason(m)
+    assert msg.startswith("converged")
+    assert "convergence_tol" in msg
+
+
+def test_stop_reason_variational_model():
+    # STM/CTM expose a variational bound trace; the helper reads it the same way.
+    rng = np.random.default_rng(0)
+    docs = _corpus(1)
+    cov = rng.integers(0, 2, len(docs)).astype(float).reshape(-1, 1)
+    m = topica.STM(num_topics=3, seed=1)
+    m.fit(docs, cov, prevalence_names=["g"], iters=20, convergence_tol=0.0)
+    msg = topica.stop_reason(m)
+    assert "iteration cap" in msg or msg.startswith("converged")


### PR DESCRIPTION
Three pre-release cleanups, then a 0.28.0 release PR follows.

### 1. `topica.stop_reason()` — #267 request #3
Model-neutral helper (in `analysis.py`, exported top-level) reading `converged` + `fit_history` to report whether `iters` acted as a floor (early-stopped on `convergence_tol`) or a ceiling (ran the full budget), with the last relative change. (The *units* of `convergence_tol` were already documented in #268.) Tested for Gibbs + variational models.

### 2. Speed claims to-convergence everywhere
The README and paper intro already moved to to-convergence; this converts `docs/benchmarks.md`'s STM section from per-iteration synthetic tables to a wall-clock-**to-convergence** table on poliblog (5,000 docs, K=20, `~rating + s(day)`, `emtol=1e-5`), regenerated on this machine:

| topica (1 core) | topica (8 cores) | R `stm` | single | 8-core |
|---|---|---|---|---|
| 65.8s (32 it) | 23.4s (32 it) | 116.6s (20 it) | 1.8× | 5.0× |

README, docs, and paper now tell one consistent story; the per-iteration decomposition is noted, not headlined. (Resolves the inconsistency that started this whole thread.)

### 3. Offline-gold CI guard — #271
`scripts/ci_sim.py` runs the suite with the reference toolchains (torch/sklearn/bertopic/tomotopy/gensim/umap/hdbscan/...) hard-blocked at import, so an offline gold test that reaches for one fails loudly. A CI step (ubuntu, reusing the build) runs it on the gold subset; locally it reproduces CI's reference-free env before pushing. This guards the class of bug that turned main red mid-#271.

### Verification
import smoke + `stop_reason` export OK; `test_stop_reason` 3 passed; `ci_sim.py` gold guard passes with refs blocked; `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)