### PR TITLE
release: 0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,48 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-06-22
+
+### Added
+
+- `topica.stop_reason(model)` — a model-neutral report of why a fit's training
+  loop stopped: early convergence on `convergence_tol` (a floor) versus the
+  iteration cap (a ceiling), with the last relative change. Answers the question
+  `converged` alone leaves implicit (#267).
+- Statistical-validity test coverage for every model (#271): universal invariant
+  and metamorphic checks (no degenerate/collapsed θ, an effective-topics floor,
+  finite parameters, "more iterations must not collapse the fit") with a coverage
+  manifest that fails if a new model ships without them. This is the layer that
+  catches the class of bug #270 was.
+- Committed gold-fixture parity for 30 models, validating topica **offline** in CI
+  (no reference toolchain installed): cross-implementation against the reference
+  where one exists — R `stm` (STM/CTM/STS), R `keyATM`, Java MALLET (LDA/DMR/
+  LabeledLDA), tomotopy (GDMR), gensim (DTM), scikit-learn (NMF/LSA), the AVITM
+  PyTorch reference (ProdLDA/CombinedTM/ZeroShotTM/InfoCTM), BERTopic, and
+  FASTopic — and against a frozen planted self-consistency baseline where no
+  reference implementation exists (SAGE, HDP, PA, HLDA, ETM, DETM, ECTM,
+  SupervisedLDA, SeededLDA, GSDMM, PT, EmbeddingLDA). Each fixture ships a JSON
+  provenance log and a non-vacuous control. A shared `parity/harness.py` and a
+  `scripts/ci_sim.py` offline-gold guard support it.
+
+### Fixed
+
+- Covariate keyATM (`fit(covariates=...)`) no longer silently collapses the
+  document-topic matrix onto a single topic on a high-dimensional design at scale.
+  Following R `keyATM`, the covariates are now standardized and the regression
+  coefficients bounded under the N(0,1) prior, which keeps `α = exp(x·λ)` from
+  running away; validated against R `keyATM`'s covariate model (#270).
+
+### Documentation
+
+- Every public binding parameter is now documented, with a doc-coverage lint
+  (constructors included) so the runtime `help()` text and the API site can no
+  longer drift behind the signatures (#268). `convergence_tol`'s units and scale
+  are documented across the model `fit` methods (#267).
+- Speed is reported **to convergence** — the time a user actually waits — across
+  the README, the paper, and `docs/benchmarks.md`, replacing the earlier
+  per-iteration framing (the per-iteration decomposition is noted, not headlined).
+
 ## [0.27.0] - 2026-06-21
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.27.0
-date-released: 2026-06-21
+version: 0.28.0
+date-released: 2026-06-22
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.27.0"
+version = "0.28.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.27.0"
+version = "0.28.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.27.0"
+version = "0.28.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.28.0** (from 0.27.0). Bumps `Cargo.toml` + `pyproject.toml` and adds the CHANGELOG entry. Merge + tag `v0.28.0` to publish to PyPI (the `v*` tag is what triggers the release workflow).

## Highlights

**Added**
- `topica.stop_reason(model)` — why training stopped (early convergence vs the iteration cap), with the last relative change (#267).
- Statistical-validity test coverage for **every** model (#271): universal invariant + metamorphic checks with a coverage manifest — the layer that catches the #270 class of bug.
- Committed **gold-fixture parity for 30 models**, validating topica offline in CI: cross-implementation vs R stm/keyATM, MALLET, tomotopy, gensim, scikit-learn, the AVITM reference, BERTopic, FASTopic — and planted self-consistency where no reference exists. Shared `parity/harness.py` + a `scripts/ci_sim.py` offline-gold guard.

**Fixed**
- Covariate keyATM no longer collapses θ onto one topic on high-dimensional designs at scale — added R keyATM's covariate standardization + λ bounds (#270).

**Documentation**
- Every public binding parameter documented + a doc-coverage lint (#268).
- Speed reported **to convergence** across README/paper/benchmarks (replacing per-iteration framing).

## What landed this cycle
#268 (docstrings) · #270/#273 (covariate fix) · #274 (Wave 0 invariants) · #275–#282, #285 (gold roster) · #283 (torch-guard) · #284 (CI-correctness) · #286 (stop_reason + speed docs + CI guard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)