### PR TITLE
feat(analysis): contrastive_topics — topic-conditional Fighting Words

### DIFF
--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -115,3 +115,5 @@ Model-neutral summaries that work on any fitted model.
 ::: topica.topics_over_time
 
 ::: topica.topics_per_class
+
+::: topica.contrastive_topics

--- a/docs/guides/keywords.md
+++ b/docs/guides/keywords.md
@@ -73,3 +73,26 @@ about equally by both sides (`usage_diff` near zero) but splits hard on
 `vocab_shift`: liberals write `iraq / surge / bush`, conservatives `israel /
 hamas / taliban`. Reporting both columns keeps that distinction visible. It works
 on any model exposing `doc_topic` and `vocabulary` (LDA, STM, DMR, CTM, keyATM).
+
+### Relationship to STM's content model
+
+This does not replace a [content-covariate STM](covariates.md). R stm splits the
+same question into two tools: `estimateEffect` for prevalence (which topics a
+group uses more) and a `content = ~group` model with `sageLabels()` /
+`plot(type="perspectives")` for wording (how a group words a topic). topica ports
+both faithfully — `estimate_effect` and STM's `content=` plus `word_contrast`.
+`contrastive_topics` is a third, lighter option that sits between them:
+
+- It is **post-hoc and model-neutral**: no content covariate is specified at fit
+  time and nothing is re-estimated, so it runs on any already-fitted model (plain
+  LDA, CTM, keyATM, or a prevalence-only STM) and you can re-slice the same fit by
+  different groupings for free.
+- It reports **both signals at once** (`usage_diff` and `vocab_shift`), which is
+  what surfaces the equal-usage-but-divergent-wording case that prevalence alone
+  misses.
+- It is **descriptive**: the per-word score is a Fighting Words z, not the content
+  model's regularized sparse deviations, and `usage_diff` is a point estimate with
+  no confidence interval. For shrinkage across the corpus use STM's
+  `word_contrast`; for uncertainty on prevalence differences use
+  `estimate_effect`. Reach for `contrastive_topics` to decide *whether* a content
+  model is worth fitting, and for the quick look that works on any model.

--- a/docs/guides/keywords.md
+++ b/docs/guides/keywords.md
@@ -42,3 +42,34 @@ topica.fighting_words(conservative, liberal, prior=0.01, informative=True)
 This pairs naturally with [SAGE / content STM](covariates.md), which find
 group-distinguishing wording *within a fitted topic model*, where Fighting Words
 works directly on two raw corpora with no model at all.
+
+## Contrastive topics
+
+Plain Fighting Words pools the whole corpus into two bags of words. Once you have
+a fitted model, you can hold each topic fixed and ask how the two groups word it
+differently. `topica.contrastive_topics` weights every document's word counts by
+its responsibility for a topic, splits those weighted counts by group, and runs
+the same z-score per topic:
+
+```python
+rows = topica.contrastive_topics(model, corpus, groups)  # groups: one label per doc
+for r in rows[:3]:                                        # most contrastive first
+    print(f"topic {r['topic']} {r['name']}  used more by {r['leans']}")
+    print("  ", r['a_label'], "words:", [w for w, _ in r['a_words'][:6]])
+    print("  ", r['b_label'], "words:", [w for w, _ in r['b_words'][:6]])
+```
+
+`corpus` is the same documents, in the same order, that produced
+`model.doc_topic`. Each row carries two complementary signals, because a topic
+both groups use equally can still split sharply on *how* they word it:
+
+- `usage_diff` — mean `doc_topic` for group A minus group B: which topics one side
+  simply talks about more. Rows are sorted by its magnitude.
+- `vocab_shift` — the RMS within-topic z over the words it keeps: how much the two
+  groups diverge in wording the topic.
+
+On the poliblog corpus (liberal vs conservative blogs) the iraq/war topic is used
+about equally by both sides (`usage_diff` near zero) but splits hard on
+`vocab_shift`: liberals write `iraq / surge / bush`, conservatives `israel /
+hamas / taliban`. Reporting both columns keeps that distinction visible. It works
+on any model exposing `doc_topic` and `vocabulary` (LDA, STM, DMR, CTM, keyATM).

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -221,6 +221,7 @@ from .analysis import (  # noqa: E402  (model-neutral fitted-model analysis surf
     representative_docs,
     topics_over_time,
     topics_per_class,
+    contrastive_topics,
     stop_reason,
     plot_report,
 )
@@ -340,6 +341,7 @@ __all__ = [
     "representative_docs",
     "topics_over_time",
     "topics_per_class",
+    "contrastive_topics",
     "stop_reason",
     "plot_report",
     "fighting_words",

--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -352,6 +352,22 @@ def topics_per_class(model: Any, groups: Sequence[object], *, ci: float = 0.95) 
     ...
 
 
+def contrastive_topics(
+    model: Any,
+    texts: Sequence[Sequence[str]],
+    groups: Sequence[object],
+    *,
+    prior: float = 0.01,
+    informative: bool = False,
+    min_count: int = 5,
+    n_words: int = 10,
+    group_order: tuple[object, object] | None = None,
+) -> list:
+    """Topic-conditional Fighting Words: per topic, which words separate two
+    groups and how much each topic divides them (usage_diff / vocab_shift)."""
+    ...
+
+
 def plot_report(
     model: Any,
     *,
@@ -452,6 +468,7 @@ __all__ = [
     "representative_docs",
     "topics_over_time",
     "topics_per_class",
+    "contrastive_topics",
     "plot_report",
     "llm_topic_labels",
     "llm_backend",

--- a/python/topica/analysis.py
+++ b/python/topica/analysis.py
@@ -29,6 +29,7 @@ import numpy as np
 
 from . import validation as _diagnostics
 from . import effects as _effects
+from .keywords import _zeta as _fw_zeta
 
 
 # A custom-label registry keyed by ``id(model)``. PyO3 extension classes may not
@@ -259,6 +260,137 @@ def topics_per_class(model, groups, *, ci=0.95):
     return _effects.by_strata(model.doc_topic, groups, ci=ci)
 
 
+def contrastive_topics(model, texts, groups, *, prior=0.01, informative=False,
+                       min_count=5, n_words=10, group_order=None):
+    """Which topics most separate two groups, and the words that shift inside each.
+
+    This is the topic-conditional extension of :func:`topica.fighting_words`. A
+    plain Fighting Words contrast pools the whole corpus into two bags of words;
+    here we hold the topic fixed and ask, *within* topic ``t``, how the two groups
+    word it differently. Each document's word counts are weighted by its
+    responsibility for the topic (``model.doc_topic[d, t]``), the weighted counts
+    are split by group, and the Monroe-Colaresi-Quinn z-score is computed per
+    topic. We report two complementary signals, since a topic both groups use
+    equally can still split sharply on *how* they word it:
+
+    - ``usage_diff`` — mean ``doc_topic`` for group A minus group B: which topics
+      one side simply talks about more.
+    - ``vocab_shift`` — the root-mean-square topic-conditional z over the words it
+      keeps: how much the two groups diverge in their wording of the topic.
+
+    Works on any fitted model that exposes ``doc_topic`` and ``vocabulary`` (LDA,
+    STM, DMR, CTM, keyATM, ...). ``texts`` must be the same documents, in the same
+    order, that produced ``model.doc_topic``.
+
+    Parameters
+    ----------
+    model : a fitted topica model with ``doc_topic`` (D x K) and ``vocabulary``.
+    texts : sequence of token lists (``list[list[str]]``), one per document,
+        aligned row-for-row with ``model.doc_topic``.
+    groups : sequence of one label per document. Must take exactly two distinct
+        values (a binary contrast).
+    prior : float, default 0.01
+        Dirichlet pseudocount passed to the z-score; see :func:`fighting_words`.
+    informative : bool, default False
+        Use Monroe et al.'s informative (frequency-scaled) prior.
+    min_count : int, default 5
+        Within a topic, ignore words whose responsibility-weighted count across
+        both groups is below this. Keeps the per-topic word lists and
+        ``vocab_shift`` from being dominated by near-zero-mass words.
+    n_words : int, default 10
+        How many distinctive words to return per side, per topic.
+    group_order : (a, b), optional
+        Fix which group is A (positive z, positive ``usage_diff``). Defaults to
+        the two labels sorted, so the result is deterministic.
+
+    Returns
+    -------
+    list[dict], one row per topic sorted by descending ``abs(usage_diff)``. Each
+    row has ``topic`` (id), ``name`` (effective label), ``a_label``/``b_label``
+    (the two groups), ``usage_diff``, ``leans`` (the label that uses the topic
+    more), ``vocab_shift``, and ``a_words``/``b_words`` (lists of ``(word, z)``,
+    each side's most distinctive within-topic words).
+    """
+    theta = _doc_topic(model)
+    n_docs, k = theta.shape
+    if len(texts) != n_docs:
+        raise ValueError(
+            f"texts has {len(texts)} documents but the model's doc_topic has "
+            f"{n_docs} rows; pass the same corpus, in the same order, that was fit."
+        )
+    groups = list(groups)
+    if len(groups) != n_docs:
+        raise ValueError(
+            f"groups has {len(groups)} labels but the model's doc_topic has "
+            f"{n_docs} rows."
+        )
+
+    levels = sorted(set(groups)) if group_order is None else list(group_order)
+    if len(levels) != 2 or len(set(levels)) != 2:
+        raise ValueError(
+            "contrastive_topics needs exactly two distinct groups; got "
+            f"{sorted(set(groups))}. For more levels, contrast a pair at a time."
+        )
+    a_label, b_label = levels
+    in_a = np.array([g == a_label for g in groups])
+    in_b = np.array([g == b_label for g in groups])
+    if not in_a.any() or not in_b.any():
+        raise ValueError(
+            f"both groups must have documents; '{a_label}' has {int(in_a.sum())}, "
+            f"'{b_label}' has {int(in_b.sum())}."
+        )
+
+    vocab = list(model.vocabulary)
+    vindex = {w: i for i, w in enumerate(vocab)}
+    n_vocab = len(vocab)
+
+    # Responsibility-weighted word counts per group, accumulated into K x V
+    # without ever materializing a dense D x V matrix: each document adds the
+    # outer product of its topic responsibilities and its (sparse) token counts.
+    y_a = np.zeros((k, n_vocab), dtype=np.float64)
+    y_b = np.zeros((k, n_vocab), dtype=np.float64)
+    for d, doc in enumerate(texts):
+        local = {}
+        for tok in doc:
+            j = vindex.get(tok)
+            if j is not None:
+                local[j] = local.get(j, 0.0) + 1.0
+        if not local:
+            continue
+        idx = np.fromiter(local.keys(), dtype=np.intp, count=len(local))
+        cnt = np.fromiter(local.values(), dtype=np.float64, count=len(local))
+        target = y_a if in_a[d] else (y_b if in_b[d] else None)
+        if target is not None:
+            target[:, idx] += np.outer(theta[d], cnt)
+
+    usage_diff = theta[in_a].mean(axis=0) - theta[in_b].mean(axis=0)
+    names = topic_labels(model)
+
+    rows = []
+    for t in range(k):
+        zeta = _fw_zeta(y_a[t], y_b[t], prior=prior, informative=informative)
+        keep = (y_a[t] + y_b[t]) >= float(min_count)
+        z = np.where(keep, zeta, 0.0)
+        order = np.argsort(z)
+        a_words = [(vocab[i], float(z[i])) for i in order[::-1][:n_words] if z[i] > 0]
+        b_words = [(vocab[i], float(z[i])) for i in order[:n_words] if z[i] < 0]
+        shift = float(np.sqrt(np.mean(zeta[keep] ** 2))) if keep.any() else 0.0
+        rows.append({
+            "topic": t,
+            "name": names[t] if t < len(names) else f"topic_{t}",
+            "a_label": a_label,
+            "b_label": b_label,
+            "usage_diff": float(usage_diff[t]),
+            "leans": a_label if usage_diff[t] > 0 else b_label,
+            "vocab_shift": shift,
+            "a_words": a_words,
+            "b_words": b_words,
+        })
+
+    rows.sort(key=lambda r: abs(r["usage_diff"]), reverse=True)
+    return rows
+
+
 def _short(label, words, width=42):
     """A compact 'label: word word word' caption, truncated to `width`."""
     ws = " ".join(w for w, _ in words) if words and isinstance(words[0], tuple) else " ".join(map(str, words))
@@ -458,5 +590,6 @@ __all__ = [
     "representative_docs",
     "topics_over_time",
     "topics_per_class",
+    "contrastive_topics",
     "plot_report",
 ]

--- a/python/topica/keywords.py
+++ b/python/topica/keywords.py
@@ -25,6 +25,30 @@ def _counts(corpus, vocab_index):
     return c
 
 
+def _zeta(y_a, y_b, *, prior=0.01, informative=False):
+    """The Monroe-Colaresi-Quinn weighted log-odds z-score for two word-count
+    vectors over a shared vocabulary.
+
+    ``y_a`` and ``y_b`` may be fractional (e.g. responsibility-weighted counts),
+    which is what makes the same estimator reusable for the topic-conditional
+    contrast in :func:`topica.contrastive_topics`. Returns the per-word ``ζ``;
+    positive marks an A-distinctive word, negative a B-distinctive one. The math
+    is Monroe et al. eq. 16-22 and must stay identical to the body of
+    :func:`fighting_words`.
+    """
+    y_a = np.asarray(y_a, dtype=np.float64)
+    y_b = np.asarray(y_b, dtype=np.float64)
+    combined = y_a + y_b
+    alpha = prior * combined if informative else np.full(len(combined), float(prior))
+    a0 = alpha.sum()
+    n_a, n_b = y_a.sum(), y_b.sum()
+    odds_a = (y_a + alpha) / (n_a + a0 - y_a - alpha)
+    odds_b = (y_b + alpha) / (n_b + a0 - y_b - alpha)
+    delta = np.log(odds_a) - np.log(odds_b)
+    var = 1.0 / (y_a + alpha) + 1.0 / (y_b + alpha)
+    return delta / np.sqrt(var)
+
+
 def fighting_words(corpus_a, corpus_b, *, prior=0.01, informative=False, min_count=1):
     """Monroe-Colaresi-Quinn *Fighting Words* — words that distinguish corpus A
     from corpus B, with their statistical significance.
@@ -67,16 +91,7 @@ def fighting_words(corpus_a, corpus_b, *, prior=0.01, informative=False, min_cou
 
     # Compute the statistic over the FULL vocabulary so the corpus totals n_·
     # and prior mass α₀ stay correct; `min_count` only filters what is returned.
-    alpha = prior * combined if informative else np.full(len(vocab), float(prior))
-    a0 = alpha.sum()
-    n_a, n_b = y_a.sum(), y_b.sum()
-
-    # Log-odds within each corpus, then their difference (Monroe et al. eq. 16-22).
-    odds_a = (y_a + alpha) / (n_a + a0 - y_a - alpha)
-    odds_b = (y_b + alpha) / (n_b + a0 - y_b - alpha)
-    delta = np.log(odds_a) - np.log(odds_b)
-    var = 1.0 / (y_a + alpha) + 1.0 / (y_b + alpha)
-    zeta = delta / np.sqrt(var)
+    zeta = _zeta(y_a, y_b, prior=prior, informative=informative)
 
     keep = combined >= float(min_count)
     order = np.argsort(zeta)[::-1]

--- a/tests/test_contrastive_topics.py
+++ b/tests/test_contrastive_topics.py
@@ -1,0 +1,157 @@
+"""Tests for topica.contrastive_topics — the topic-conditional Fighting Words
+contrast that ranks which topics most separate two groups and surfaces the
+within-topic words that shift between them.
+"""
+
+import math
+
+import numpy as np
+import pytest
+
+import topica
+
+
+def _two_group_corpus(seed=0):
+    """A corpus with two topics, each worded differently by two groups.
+
+    Both groups use both topics about equally (so ``usage_diff`` is near zero),
+    but within each topic group A and group B use disjoint flavor words. This is
+    the case the within-topic ``vocab_shift`` is meant to catch.
+    """
+    rng = np.random.default_rng(seed)
+
+    def doc(shared, flavor):
+        return list(rng.choice(shared, 8)) + list(rng.choice(flavor, 4))
+
+    texts, groups = [], []
+    for _ in range(150):
+        texts.append(doc(["tax", "budget", "economy"], ["growth", "jobs"]))
+        groups.append("A")
+        texts.append(doc(["tax", "budget", "economy"], ["inequality", "fairness"]))
+        groups.append("B")
+        texts.append(doc(["troops", "war", "policy"], ["surge", "strength"]))
+        groups.append("A")
+        texts.append(doc(["troops", "war", "policy"], ["withdraw", "peace"]))
+        groups.append("B")
+    return texts, groups
+
+
+def _fit(texts, k=2, seed=0, iters=300):
+    m = topica.LDA(num_topics=k, seed=seed)
+    m.fit(texts, iters=iters)
+    return m
+
+
+class TestContrastiveTopics:
+    def test_recovers_within_topic_word_split(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        rows = topica.contrastive_topics(model, texts, groups, min_count=2, n_words=6)
+
+        assert len(rows) == model.num_topics
+        a_flavor = {"growth", "jobs", "surge", "strength"}
+        b_flavor = {"inequality", "fairness", "withdraw", "peace"}
+        # Every topic should put the A-flavor words on side A and B on side B.
+        for r in rows:
+            a_words = {w for w, _ in r["a_words"]}
+            b_words = {w for w, _ in r["b_words"]}
+            assert a_words & a_flavor, r
+            assert b_words & b_flavor, r
+            # No flavor word lands on the wrong side.
+            assert not (a_words & b_flavor)
+            assert not (b_words & a_flavor)
+
+    def test_signed_z_scores(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        rows = topica.contrastive_topics(model, texts, groups, min_count=2)
+        for r in rows:
+            assert all(z > 0 for _, z in r["a_words"])
+            assert all(z < 0 for _, z in r["b_words"])
+
+    def test_vocab_shift_positive_when_groups_diverge(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        rows = topica.contrastive_topics(model, texts, groups, min_count=2)
+        assert all(r["vocab_shift"] > 0 for r in rows)
+
+    def test_group_order_flips_sign(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        ab = {r["topic"]: r for r in topica.contrastive_topics(
+            model, texts, groups, group_order=("A", "B"), min_count=2)}
+        ba = {r["topic"]: r for r in topica.contrastive_topics(
+            model, texts, groups, group_order=("B", "A"), min_count=2)}
+        for t, r in ab.items():
+            assert r["a_label"] == "A" and r["b_label"] == "B"
+            assert math.isclose(r["usage_diff"], -ba[t]["usage_diff"], abs_tol=1e-9)
+            # A's distinctive words become B's distinctive words when flipped.
+            assert {w for w, _ in r["a_words"]} == {w for w, _ in ba[t]["b_words"]}
+
+    def test_default_order_is_sorted_labels(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        rows = topica.contrastive_topics(model, texts, groups, min_count=2)
+        assert rows[0]["a_label"] == "A" and rows[0]["b_label"] == "B"
+
+    def test_sorted_by_absolute_usage_diff(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts, k=4)
+        rows = topica.contrastive_topics(model, texts, groups, min_count=2)
+        mags = [abs(r["usage_diff"]) for r in rows]
+        assert mags == sorted(mags, reverse=True)
+
+    def test_usage_diff_picks_up_prevalence_gap(self):
+        # Group A only ever produces the war topic; B only the econ topic.
+        rng = np.random.default_rng(1)
+        texts, groups = [], []
+        for _ in range(120):
+            texts.append(list(rng.choice(["troops", "war", "policy", "surge"], 10)))
+            groups.append("A")
+            texts.append(list(rng.choice(["tax", "budget", "economy", "jobs"], 10)))
+            groups.append("B")
+        model = _fit(texts, k=2)
+        rows = topica.contrastive_topics(model, texts, groups, min_count=2)
+        # The most contrastive topic should have a large, non-trivial usage gap.
+        assert abs(rows[0]["usage_diff"]) > 0.3
+        leans = {r["leans"] for r in rows}
+        assert leans == {"A", "B"}
+
+    def test_works_on_dmr_covariate_model(self):
+        # Any model exposing doc_topic + vocabulary should work, not just LDA.
+        texts, groups = _two_group_corpus()
+        x = np.array([[1.0] if g == "A" else [0.0] for g in groups])
+        model = topica.DMR(num_topics=2, seed=0)
+        model.fit(texts, x, iters=300)
+        rows = topica.contrastive_topics(model, texts, groups, min_count=2)
+        assert len(rows) == 2
+        assert all("a_words" in r and "b_words" in r for r in rows)
+
+
+class TestContrastiveTopicsValidation:
+    def test_rejects_wrong_text_count(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        with pytest.raises(ValueError, match="documents"):
+            topica.contrastive_topics(model, texts[:-1], groups, min_count=2)
+
+    def test_rejects_wrong_group_count(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        with pytest.raises(ValueError, match="labels"):
+            topica.contrastive_topics(model, texts, groups[:-1], min_count=2)
+
+    def test_rejects_non_binary_groups(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        three = list(groups)
+        three[0] = "C"
+        with pytest.raises(ValueError, match="two distinct groups"):
+            topica.contrastive_topics(model, texts, three, min_count=2)
+
+    def test_rejects_empty_group(self):
+        texts, groups = _two_group_corpus()
+        model = _fit(texts)
+        with pytest.raises(ValueError, match="both groups"):
+            topica.contrastive_topics(
+                model, texts, groups, group_order=("A", "Z"), min_count=2)


### PR DESCRIPTION
## What

Adds `topica.contrastive_topics(model, texts, groups)`: for each topic, **which words separate two groups** and **how strongly each topic divides them**. It is the topic-conditional extension of `fighting_words` — instead of pooling the whole corpus into two bags of words, it holds each topic fixed, weights every document's word counts by its responsibility for that topic (`doc_topic[d, t]`), splits the weighted counts by group, and runs the same Monroe-Colaresi-Quinn z-score per topic.

This came out of a four-idea exploration sprint; it was the clear winner (the other three — spectral K-selection, NMF warm-start, stability-plateau stopping — were partial/negative).

## Two complementary signals per topic

- **`usage_diff`** — mean `doc_topic` gap between groups: *which topics one side talks about more*. Rows are sorted by its magnitude.
- **`vocab_shift`** — RMS within-topic z over kept words: *how differently the two groups word the topic*.

They are non-redundant: a topic both sides use equally can still split sharply on wording. On poliblog, the iraq/war topic has near-zero `usage_diff` but the **highest** `vocab_shift` — liberals write `iraq / surge / bush`, conservatives `israel / hamas / taliban`:

```
t 3 usage_diff=+0.019 shift=1.09
     Conservative: ['israel', 'isra', 'hama', 'nuclear', 'russian']
     Liberal:      ['iraq', 'mccain', 'bush', 'presid', 'iraqi']
```

## Design

- **Model-neutral**: any fitted model exposing `doc_topic` + `vocabulary` (LDA, STM, DMR, CTM, keyATM). Returns a list of self-describing dict rows (`topic`, `name`, `a_label`/`b_label`, `usage_diff`, `leans`, `vocab_shift`, `a_words`/`b_words`).
- **Memory-safe**: accumulates responsibility-weighted counts into two `K x V` matrices via per-document outer products — never materializes a dense `D x V`.
- **No new math**: the Monroe z-score is factored out of `fighting_words` into `keywords._zeta` and reused, leaving `fighting_words` bit-identical (verified by the existing `TestFightingWords` suite).
- **Freeze-compatible**: pure-Python reporting function, no new model, no Rust, no API churn.

## Tests / docs

- `tests/test_contrastive_topics.py` — 12 cases: within-topic word split, signed z-scores, `vocab_shift` > 0, sign control via `group_order`, sort order, prevalence pickup, runs on a DMR covariate model, and four validation errors.
- API reference (`docs/api/diagnostics.md`), guide section (`docs/guides/keywords.md`), and `.pyi` stub.
- `mkdocs build --strict` clean; meta-tests (naming conventions, doc coverage, AGENTS sync) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)