### PR TITLE
release: 0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-06-25
+
+### Added
+
+- Three experimental **ideal-point comparison companions** to `IdealPointTM`, spanning
+  the representation x structure grid (so the contribution of topics vs embeddings can be
+  measured head to head):
+  - `Wordfish` (#293) — Slapin & Proksch (2008) Poisson scaling: a one-dimensional
+    unsupervised ideal point from word frequencies alone, no topics. Deterministic;
+    validated bit-for-scale against R `quanteda.textmodels::textmodel_wordfish` (r = 1.00).
+  - `IdealPointLDA` (#294) — the count-based twin of `IdealPointTM`: the same
+    position-displaced topic-word model parameterized directly over the vocabulary (no
+    embeddings). "Wordfish with topics."
+  - `SentenceIdealTM` (#295) — a continuous ideal-point model over sentence/document
+    embeddings: topics are Gaussian clusters whose centroids are displaced by a latent
+    author position. Closed-form EM.
+  - `examples/ideal_point_comparison.py` fits all four on one corpus and reports recovery
+    and pairwise agreement.
+  All gated behind `topica.enable_experimental()`.
+
 ## [0.29.0] - 2026-06-25
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.29.0
+version: 0.30.0
 date-released: 2026-06-22
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.29.0"
+version = "0.30.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.29.0"
+version = "0.30.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.29.0"
+version = "0.30.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Ships the three experimental ideal-point comparison companions to `IdealPointTM` that landed since 0.29.0:

- `Wordfish` (#293) — Poisson scaling, validated r=1.00 vs R quanteda
- `IdealPointLDA` (#294) — count-based twin of IdealPointTM
- `SentenceIdealTM` (#295) — continuous ideal points over sentence embeddings
- `examples/ideal_point_comparison.py`

All gated experimental. Version bump 0.29.0 → 0.30.0 (Cargo.toml / pyproject.toml / CITATION.cff) + CHANGELOG. No functional code changes; tag will publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKDCie4FsKHA6Vxpbjjs2B