### PR TITLE
release: 0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-06-26
+
+### Added
+
+- `TBIP` (#299) — **Text-Based Ideal Points** (Vafa, Naidu & Blei 2020), experimental: a
+  Poisson factorization in which an author's latent ideal point rescales a neutral
+  topic-word intensity by a per-word ideological factor, fit by the paper's mean-field
+  variational inference (reparameterized SVI, Adam). The official implementation is
+  TensorFlow 1.14, so topica reimplements the published model and inference in the Rust core
+  (hand-coded reverse-mode gradients, FD-checked); the VI minibatch is rayon-parallel with a
+  fixed-chunk deterministic reduction. Validated by synthetic planted-position recovery and
+  against a PyTorch reference. Joins the ideal-point family; gated behind
+  `topica.enable_experimental()`. Save tag 35.
+- Standard errors for ideal-point positions (#298): `topica.position_intervals(fit, group)`
+  returns model-agnostic bootstrap standard errors and confidence intervals for any of the
+  ideal-point models; `Wordfish.position_se` adds an analytic asymptotic standard error,
+  validated equal to R `quanteda`'s `se.theta` (|r| = 1.00).
+- Intrinsic ideal-point diagnostics (#297): `topica.bimodality` (a bimodality coefficient
+  for the positions) and `topica.split_half_reliability` (refit on disjoint document halves
+  and correlate), so an unsupervised scale can be certified without an external reference.
+
 ## [0.30.0] - 2026-06-25
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.30.0
-date-released: 2026-06-22
+version: 0.31.0
+date-released: 2026-06-26
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than two

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.30.0"
+version = "0.31.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.30.0"
+version = "0.31.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.31.0**, bundling the three experimental features merged since 0.30.0:

- **TBIP** — Text-Based Ideal Points (Vafa, Naidu & Blei 2020), experimental (#299)
- **Standard errors** for ideal-point positions — `position_intervals` (bootstrap, all models) + `Wordfish.position_se` (analytic, = R `quanteda` `se.theta`) (#298)
- **Intrinsic diagnostics** — `bimodality` + `split_half_reliability` to certify a scale without an external reference (#297)

Bumps `Cargo.toml`, `pyproject.toml`, `CITATION.cff` to 0.31.0 (version-consistency test passes) and adds the `CHANGELOG.md` entry. Tagging `v0.31.0` after merge triggers the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AKDCie4FsKHA6Vxpbjjs2B