### PR TITLE
release: 0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-06-27
+
 ### Changed
 
 - New `ideal-point` model group ("Ideal point"), and `Wordfish` and `TBIP` graduate

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.31.0
-date-released: 2026-06-26
+version: 0.32.0
+date-released: 2026-06-27
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.31.0"
+version = "0.32.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.31.0"
+version = "0.32.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.31.0"
+version = "0.32.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Release 0.32.0.

Ships the **Wordfish/TBIP promotion out of the experimental tier** (merged in #301): both are now validated, non-experimental members of the new `ideal-point` model group and no longer require `topica.enable_experimental()`. `IdealPointTM`/`IdealPointLDA`/`SentenceIdealTM` stay experimental.

- Bump `Cargo.toml`, `pyproject.toml`, `CITATION.cff` → 0.32.0
- Date the CHANGELOG `0.32.0` section (2026-06-27)

On merge, tag `v0.32.0` to trigger the PyPI publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)