### PR TITLE
feat(scaling): topica.polarization — model-agnostic ideal-point polarization diagnostic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- `topica.polarization(positions, labels)` — a model-agnostic ideal-point diagnostic:
+  the distance between named camps' centroids on any model's `author_positions` (1-D,
+  or Euclidean for a multi-dimensional fit), so polarization can be traced over time
+  (the Rheault & Cochrane 2020 party-distance metric). `normalize=True` gives an
+  effect-size form comparable across corpora. Joins `bimodality` /
+  `split_half_reliability` / `position_intervals` in `topica.scaling`.
 - `PartyEmbeddings` (#303) — **party embeddings** (Rheault & Cochrane 2020), the
   corpus-trained word-embedding member of the `ideal-point` family. A PV-DM
   (distributed-memory paragraph-vector) model trained by negative sampling with

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -806,9 +806,11 @@ Two notes on use. `nearest_words` returns the raw cosine ranking of words to a p
 
 ## Validating an ideal-point axis without an external scale
 
-The ideal-point family ([`Wordfish`](#wordfish), [`IdealPointLDA`](#idealpointlda), [`IdealPointTM`](#idealpointtm), [`SentenceIdealTM`](#sentenceidealtm)) returns author positions, but how do you know the discovered axis is a real, partisan dimension rather than an artifact, *without* a validated external score like DW-NOMINATE? topica ships two intrinsic diagnostics that answer this from the model and the text alone.
+The ideal-point family ([`Wordfish`](#wordfish), [`IdealPointLDA`](#idealpointlda), [`IdealPointTM`](#idealpointtm), [`SentenceIdealTM`](#sentenceidealtm), [`PartyEmbeddings`](#partyembeddings)) returns author positions, but how do you know the discovered axis is a real, partisan dimension rather than an artifact, *without* a validated external score like DW-NOMINATE? topica ships intrinsic diagnostics that answer this from the model and the text alone.
 
 `topica.bimodality(positions)` is the bimodality coefficient of the positions: above ~0.555 the authors split into two camps (a polarized, two-pole structure) rather than one blob. It is computed from `author_positions` alone.
+
+`topica.polarization(positions, labels)` measures how far two known camps sit apart on the axis: the distance between the camps' centroids, with `labels` assigning each author to a camp (e.g. their party). It works on any model's `author_positions` (1-D, or Euclidean distance for a multi-dimensional fit), so calling it once per time period traces polarization over time, the way Rheault and Cochrane (2020) use the distance between party embeddings. Pass `normalize=True` for an effect-size form (divided by the pooled within-camp spread) that is comparable across corpora and model scales. Where `bimodality` asks whether *some* two-camp structure exists without labels, `polarization` measures the separation of camps you can name.
 
 `topica.split_half_reliability(fit, group)` refits the scale on two disjoint halves of each author's documents and correlates the two position vectors. A high value means the axis is a stable, reproducible trait of the text, not an artifact of one fit. You supply a one-line `fit` closure, so it is model-agnostic:
 
@@ -823,6 +825,7 @@ def fit(idx):                        # fit on a subset of unit (document) indice
 
 m = topica.IdealPointLDA(20, seed=1); m.fit(docs, group=author)
 topica.bimodality(m.author_positions)        # > 0.555 => two camps (polarized)
+topica.polarization(m.author_positions, party_of_author)  # gap between named camps
 topica.split_half_reliability(fit, author)   # how much real signal the axis carries
 ```
 

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -267,7 +267,7 @@ from .stopwords import ENGLISH_STOPWORDS, stopwords, stopword_languages  # noqa:
 from .phrases import learn_phrases, apply_phrases, add_ngrams, Phrases  # noqa: E402
 from .frames import from_dataframe, align, prep_documents, plot_removed  # noqa: E402
 from .formulas import design_matrix  # noqa: E402
-from .scaling import bimodality, split_half_reliability, position_intervals  # noqa: E402  (intrinsic ideal-point diagnostics)
+from .scaling import bimodality, polarization, split_half_reliability, position_intervals  # noqa: E402  (intrinsic ideal-point diagnostics)
 from . import datasets  # noqa: E402  (bundled + fetch-on-demand example datasets)
 
 __all__ = [
@@ -405,6 +405,7 @@ __all__ = [
     "plot_removed",
     "design_matrix",
     "bimodality",
+    "polarization",
     "split_half_reliability",
     "position_intervals",
     "summary",

--- a/python/topica/scaling.py
+++ b/python/topica/scaling.py
@@ -5,6 +5,7 @@ These answer "how partisan / how real is the discovered axis?" from the model an
 text alone, with no external scale (no DW-NOMINATE, no party labels):
 
 - :func:`bimodality` — is the position distribution two-camped (polarized) vs one blob?
+- :func:`polarization` — how far apart are two (or more) known camps on the axis?
 - :func:`split_half_reliability` — refit the scale on two disjoint halves of each
   author's documents and correlate; this is how reproducible (hence real) the axis is.
 
@@ -19,7 +20,7 @@ from collections import namedtuple
 
 import numpy as np
 
-__all__ = ["bimodality", "split_half_reliability", "position_intervals"]
+__all__ = ["bimodality", "polarization", "split_half_reliability", "position_intervals"]
 
 #: One author's position estimate with a bootstrap standard error and CI.
 PositionInterval = namedtuple("PositionInterval", "estimate se lo hi")
@@ -47,6 +48,79 @@ def bimodality(positions) -> float:
     kurt = np.mean(c ** 4) / m2 ** 2 - 3.0  # excess kurtosis
     denom = kurt + 3.0 * (n - 1) ** 2 / ((n - 2) * (n - 3))
     return float((skew ** 2 + 1.0) / denom)
+
+
+def polarization(positions, labels, *, normalize: bool = False) -> float:
+    """Between-camp polarization on a latent scale: the distance between the camps'
+    centroids.
+
+    The standard text-scaling polarization measure (Rheault and Cochrane 2020 use
+    the Euclidean distance between party embeddings; Wordfish-style scalers use the
+    gap between party means). It is model-agnostic: pass any fitted ideal-point
+    model's ``author_positions`` and a label per row assigning each author to a camp
+    (e.g. their party). Call it once per time slice / congress to trace polarization
+    over time.
+
+    Parameters
+    ----------
+    positions : array-like, shape ``(n,)`` or ``(n, d)``
+        The latent positions, e.g. ``model.author_positions`` (1-D uses the first
+        column; multi-D uses Euclidean distance in the full position space).
+    labels : sequence, length n
+        The camp of each position (e.g. party label of each author).
+    normalize : bool
+        When ``False`` (default), return the raw centroid distance, comparable
+        across time within one model's scale. When ``True``, divide by the pooled
+        within-camp standard deviation (an effect-size form, like Cohen's d on the
+        axis), comparable across corpora and model scales.
+
+    Returns
+    -------
+    float
+        For two camps, the distance between their centroids. For more than two, the
+        mean distance over all camp pairs. ``normalize=True`` divides by the pooled
+        within-camp spread.
+
+    Raises
+    ------
+    ValueError
+        If fewer than two distinct camps are present.
+    """
+    x = np.asarray(positions, dtype=float)
+    if x.ndim == 1:
+        x = x.reshape(-1, 1)
+    labels = list(labels)
+    if len(labels) != x.shape[0]:
+        raise ValueError(
+            f"labels length ({len(labels)}) must match positions rows ({x.shape[0]})"
+        )
+    camps: dict = {}
+    for i, lab in enumerate(labels):
+        camps.setdefault(lab, []).append(i)
+    if len(camps) < 2:
+        raise ValueError("polarization needs at least 2 distinct camps in labels")
+
+    keys = list(camps)
+    centroids = {k: x[camps[k]].mean(axis=0) for k in keys}
+    dists = [
+        float(np.linalg.norm(centroids[a] - centroids[b]))
+        for i, a in enumerate(keys)
+        for b in keys[i + 1:]
+    ]
+    dist = float(np.mean(dists))
+    if not normalize:
+        return dist
+
+    # pooled within-camp standard deviation (root mean squared distance of each
+    # point to its own camp centroid), the denominator of the effect-size form
+    ss, n = 0.0, 0
+    for k in keys:
+        c = centroids[k]
+        for i in camps[k]:
+            ss += float(np.sum((x[i] - c) ** 2))
+            n += 1
+    pooled_sd = (ss / n) ** 0.5 if n > 0 else 0.0
+    return dist / pooled_sd if pooled_sd > 0 else float("inf")
 
 
 def _positions_dict(labels, positions) -> dict:

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -21,6 +21,52 @@ def test_bimodality_needs_enough_points():
         topica.bimodality([0.1, 0.2, 0.3])
 
 
+def test_polarization_centroid_distance():
+    pos = np.array([-1.0, -0.9, -1.1, 1.0, 0.9, 1.1])
+    lab = ["L", "L", "L", "R", "R", "R"]
+    # raw = distance between camp means (centroids at -1 and +1)
+    assert topica.polarization(pos, lab) == pytest.approx(2.0, abs=1e-9)
+    # accepts an (n, 1) column (e.g. author_positions)
+    assert topica.polarization(pos.reshape(-1, 1), lab) == pytest.approx(2.0, abs=1e-9)
+    # rises as the camps move apart
+    near = topica.polarization([-0.2, -0.2, 0.2, 0.2], ["L", "L", "R", "R"])
+    far = topica.polarization([-2.0, -2.0, 2.0, 2.0], ["L", "L", "R", "R"])
+    assert far > near
+
+
+def test_polarization_multidim_is_euclidean():
+    pos = np.array([[-1.0, 0.0], [-1.0, 0.0], [2.0, 4.0], [2.0, 4.0]])
+    lab = ["L", "L", "R", "R"]
+    assert topica.polarization(pos, lab) == pytest.approx(5.0, abs=1e-9)  # 3-4-5
+
+
+def test_polarization_normalize_is_scale_free():
+    # Doubling the axis scale doubles the raw distance but leaves the normalized
+    # (effect-size) form unchanged.
+    pos = np.array([-1.0, -0.8, 0.8, 1.0])
+    lab = ["L", "L", "R", "R"]
+    raw1 = topica.polarization(pos, lab)
+    raw2 = topica.polarization(pos * 2, lab)
+    assert raw2 == pytest.approx(2 * raw1)
+    assert topica.polarization(pos, lab, normalize=True) == pytest.approx(
+        topica.polarization(pos * 2, lab, normalize=True)
+    )
+
+
+def test_polarization_more_than_two_camps():
+    pos = np.array([-2.0, -2.0, 0.0, 0.0, 2.0, 2.0])
+    lab = ["A", "A", "B", "B", "C", "C"]
+    # mean of pairwise centroid distances: |A-B|=2, |A-C|=4, |B-C|=2 -> 8/3
+    assert topica.polarization(pos, lab) == pytest.approx(8.0 / 3.0, abs=1e-9)
+
+
+def test_polarization_errors():
+    with pytest.raises(ValueError):
+        topica.polarization([0.1, 0.2, 0.3], ["L", "R"])  # length mismatch
+    with pytest.raises(ValueError):
+        topica.polarization([0.1, 0.2], ["L", "L"])  # one camp
+
+
 def test_split_half_reliability_mechanics():
     # A toy "fit" with a fixed per-author trait plus tiny per-call noise: reliability
     # should be near 1. Exercises the splitting/correlation without a heavy model.


### PR DESCRIPTION
Follow-up #2 from the Party Embeddings work (the cross-pollination pass).

## What

Adds `topica.polarization(positions, labels, *, normalize=False)` to `topica.scaling`, next to `bimodality` / `split_half_reliability` / `position_intervals`.

It measures **how far two (or more) named camps sit apart on a latent scale**: the distance between the camps' centroids, where `labels` assign each author to a camp (e.g. their party). Works on **any** ideal-point model's `author_positions` — 1-D, or Euclidean distance for a multi-dimensional fit — so calling it once per time period traces polarization over time, the way Rheault & Cochrane (2020) use the distance between party embeddings. It generalizes `PartyEmbeddings.distance` (two named parties) to the whole field.

- `normalize=True` divides by the pooled within-camp spread → an effect-size form comparable across corpora and model scales.
- For >2 camps, returns the mean pairwise centroid distance.
- Complements `bimodality`: that asks whether *some* two-camp structure exists without labels; this measures the separation of camps you can name.

## Why

The first of the two follow-ups we agreed on. It's the near-free, model-agnostic win: every ideal-point model exposes `author_positions`, so this is a pure-Python helper that serves the whole family.

## Validation

Pure-Python; `tests/test_scaling.py` covers centroid distance, the multi-D Euclidean case, scale-free `normalize`, the >2-camp mean-pairwise case, `(n,1)` columns, and the error paths. Documented in the ideal-point validation section of the models guide.

Gates: `pytest tests/test_scaling.py` + naming conventions pass; `mkdocs build --strict` clean. (No Rust change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)