### PR TITLE
feat(wordfish): control= confound covariate to absorb a nuisance axis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- `Wordfish.fit(control=...)` — a categorical confound covariate for Wordfish. When a
+  corpus has a dominant non-ideological axis (a chamber, government/opposition status,
+  an era, a language) the latent position is otherwise hijacked by it; `control`
+  absorbs that level-specific word usage into per-level word offsets
+  (`log rate += delta[level, word]`, baseline level held at zero), and the
+  initialization is residualized by level so `theta` does not start on the nuisance
+  axis. Exposed via `control_names` / `control_word_offsets`. With no `control` the fit
+  is exactly the historical Wordfish, bit-for-bit (quanteda parity preserved). On a
+  planted contaminated corpus, ideology recovery rises from ~0.03 to ~0.8.
 - `topica.polarization(positions, labels)` — a model-agnostic ideal-point diagnostic:
   the distance between named camps' centroids on any model's `author_positions` (1-D,
   or Euclidean for a multi-dimensional fit), so polarization can be traced over time

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -735,6 +735,20 @@ m.discriminating_words(10)  # the words at the two ends of the axis
 
 We fit by the standard Wordfish EM: alternate Newton updates of the per-word `(psi, beta)` and per-author `(alpha, theta)`, with weak Gaussian priors on `beta` and `theta` (`beta_prior_sd`, `theta_prior_sd`; pass `math.inf` for none). Identification is applied every iteration and is lossless: `theta` is standardized to mean 0 / unit variance (the scale absorbed into `beta`, the location into `psi`), `psi` is centered into `alpha`, and the sign is oriented to the anchors. There is no RNG and the reductions run in a fixed order, so the fit is bit-reproducible. We validate against `quanteda.textmodels::textmodel_wordfish`: on a corpus sampled from the model the two recover the same scale at correlation 1.00 (`parity/wordfish_r_compare.py`).
 
+### Controlling for a confound
+
+Text scaling fails in a specific, well-documented way: when a corpus has a dominant axis of variation that is *not* the one you want (a chamber, a government/opposition split, an era, a language), the single latent position latches onto it and the ideological signal is lost. Wordfish accepts a `control` covariate to absorb exactly that. Pass a categorical label per document (constant within each author); each non-baseline level gets a per-word log-rate offset `delta[level, word]`, so systematic level-specific word usage is explained away instead of contaminating `theta`. The model becomes `log rate = alpha_i + psi_j + beta_j * theta_i + delta[level_i, j]`.
+
+```python
+m = topica.Wordfish()
+m.fit(docs, group=author, control=chamber,        # absorb the chamber's word usage
+      anchors={"Sanders": -1.0, "Cruz": 1.0})
+m.control_names           # the level labels (row 0 is the held-out baseline)
+m.control_word_offsets    # (num_levels, vocab): the absorbed per-level word effects
+```
+
+On a corpus where a control-aligned nuisance axis dominates, plain Wordfish recovers the ideological scale at essentially zero correlation while `control=` restores it (in our planted test, `|r|` with the true scale rises from ~0.03 to ~0.8). The initialization is residualized by level too, so `theta` does not start on the nuisance axis. With no `control` the fit is exactly the historical Wordfish, bit-for-bit.
+
 As a scaling model Wordfish has no topics, so it cannot tell you what is being talked about or how language differs within a topic. When you want the scale and the topics together, reach for [`IdealPointTM`](#idealpointtm) (word embeddings). On clean messaging text the two are comparable on the scale itself; IdealPointTM adds the per-topic framing Wordfish structurally cannot produce.
 
 ## SentenceIdealTM

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3808,12 +3808,15 @@ class Wordfish:
         data: Corpus | Sequence[Sequence[str]],
         *,
         group: Sequence[str] | None = None,
+        control: Sequence[str] | None = None,
         anchors: dict[str, float] | None = None,
         iters: int | None = None,
         convergence_tol: float | None = None,
     ) -> None:
         """group pools documents sharing a label into one unit with one position;
-        anchors orients the sign of the axis."""
+        control is an optional categorical confound (constant within each author)
+        whose level-specific word usage is absorbed into per-level offsets so it does
+        not contaminate the position; anchors orients the sign of the axis."""
         ...
     @property
     def num_authors(self) -> int: ...
@@ -3823,6 +3826,10 @@ class Wordfish:
     def position_se(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
     def author_names(self) -> list[str]: ...
+    @property
+    def control_names(self) -> list[str]: ...
+    @property
+    def control_word_offsets(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
     def word_discrimination(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -17,6 +17,8 @@ pub struct Wordfish {
     fitted: bool,
     author_names: Vec<String>,
     id_to_word: Vec<String>,
+    /// Control-covariate level labels (row order of `delta`); empty with no control.
+    control_names: Vec<String>,
     model: Option<WordfishModel>,
 }
 
@@ -40,6 +42,12 @@ struct WordfishState {
     ll_history: Option<Vec<f64>>,
     converged: Option<bool>,
     iters_run: Option<usize>,
+    #[serde(default)]
+    delta: Option<Vec<Vec<f64>>>,
+    #[serde(default)]
+    level: Option<Vec<usize>>,
+    #[serde(default)]
+    control_names: Vec<String>,
 }
 
 impl Wordfish {
@@ -77,6 +85,7 @@ impl Wordfish {
             fitted: false,
             author_names: Vec::new(),
             id_to_word: Vec::new(),
+            control_names: Vec::new(),
             model: None,
         })
     }
@@ -84,16 +93,21 @@ impl Wordfish {
     /// Fit on `data` (a Corpus or list of token lists). `group` is an optional list
     /// of author labels (length num_docs): documents sharing a label are pooled into
     /// one unit with one position; if omitted, each document is its own unit.
-    /// `anchors` is an optional `{author_label: value}` mapping used to orient the
-    /// sign of the axis so positions align with the supplied direction. `iters` sets
-    /// the EM iteration cap (default 100).
-    #[pyo3(signature = (data, *, group=None, anchors=None, iters=None,
+    /// `control` is an optional categorical confound (length num_docs) that must be
+    /// constant within each author: it absorbs systematic, level-specific word usage
+    /// (a chamber, a government/opposition status, an era, a language) into per-level
+    /// word offsets so it does not contaminate the latent position. `anchors` is an
+    /// optional `{author_label: value}` mapping used to orient the sign of the axis so
+    /// positions align with the supplied direction. `iters` sets the EM iteration cap
+    /// (default 100).
+    #[pyo3(signature = (data, *, group=None, control=None, anchors=None, iters=None,
                         convergence_tol=None))]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         group: Option<Vec<String>>,
+        control: Option<Vec<String>>,
         anchors: Option<HashMap<String, f64>>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
@@ -151,6 +165,43 @@ impl Wordfish {
                 "Wordfish needs at least 2 authors/documents to scale",
             ));
         }
+
+        // Resolve the control covariate into a per-author level (constant within
+        // each author; baseline level 0 is the first label in sorted order).
+        let (author_level, control_names, num_levels): (Vec<usize>, Vec<String>, usize) =
+            match &control {
+                None => (vec![0usize; num_authors], Vec::new(), 1),
+                Some(labels) => {
+                    if labels.len() != num_docs {
+                        return Err(PyValueError::new_err(format!(
+                            "control must have length num_docs ({num_docs}), got {}",
+                            labels.len()
+                        )));
+                    }
+                    let mut names: Vec<String> = labels.clone();
+                    names.sort();
+                    names.dedup();
+                    let index: HashMap<&str, usize> = names
+                        .iter()
+                        .enumerate()
+                        .map(|(i, s)| (s.as_str(), i))
+                        .collect();
+                    let mut author_level = vec![usize::MAX; num_authors];
+                    for (d, lab) in labels.iter().enumerate() {
+                        let a = group_idx[d];
+                        let lv = index[lab.as_str()];
+                        if author_level[a] == usize::MAX {
+                            author_level[a] = lv;
+                        } else if author_level[a] != lv {
+                            return Err(PyValueError::new_err(
+                                "control must be constant within each author group",
+                            ));
+                        }
+                    }
+                    let nl = names.len();
+                    (author_level, names, nl)
+                }
+            };
 
         // Build the vocabulary (corpus frequency >= min_count), deterministically
         // ordered by descending frequency then word.
@@ -227,12 +278,23 @@ impl Wordfish {
         let it = iters.unwrap_or(100);
         let (bsd, tsd) = (self.beta_prior_sd, self.theta_prior_sd);
         let model = py.allow_threads(move || {
-            wordfish::fit_wordfish(&counts, num_types, &anchor_pairs, it, tol, bsd, tsd)
+            wordfish::fit_wordfish_controlled(
+                &counts,
+                num_types,
+                &author_level,
+                num_levels,
+                &anchor_pairs,
+                it,
+                tol,
+                bsd,
+                tsd,
+            )
         });
 
         self.model = Some(model);
         self.id_to_word = id_to_word;
         self.author_names = author_names;
+        self.control_names = control_names;
         self.fitted = true;
         Ok(())
     }
@@ -320,6 +382,21 @@ impl Wordfish {
     fn iters_run(&self) -> PyResult<usize> {
         Ok(self.fitted_model()?.iters_run)
     }
+    /// The control-covariate level labels, in the row order of
+    /// `control_word_offsets`. Empty when no control covariate was supplied; the
+    /// first label is the held-out baseline level.
+    #[getter]
+    fn control_names(&self) -> PyResult<Vec<String>> {
+        self.fitted_model()?;
+        Ok(self.control_names.clone())
+    }
+    /// Per-level per-word log-rate offsets `delta` as a (num_levels, num_types)
+    /// matrix: how much more (or less) each control level uses each word, relative
+    /// to the baseline level (row 0, all zeros). The covariate's absorbed effect.
+    #[getter]
+    fn control_word_offsets<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        Ok(vecs_to_arr2(&self.fitted_model()?.delta).to_pyarray_bound(py))
+    }
 
     fn save(&self, path: &str) -> PyResult<()> {
         let m = self.model.as_ref();
@@ -345,6 +422,9 @@ impl Wordfish {
                 ll_history: m.map(|m| m.ll_history.clone()),
                 converged: m.map(|m| m.converged),
                 iters_run: m.map(|m| m.iters_run),
+                delta: m.map(|m| m.delta.clone()),
+                level: m.map(|m| m.level.clone()),
+                control_names: self.control_names.clone(),
             },
         )
     }
@@ -353,9 +433,18 @@ impl Wordfish {
     fn load(path: &str) -> PyResult<Self> {
         let s: WordfishState = read_state(path, MODEL_TAG_WORDFISH)?;
         let model = if s.fitted && s.theta.is_some() {
+            let num_authors = s.num_authors.unwrap_or(0);
+            let num_types = s.num_types.unwrap_or(0);
+            // Old saves predate the control covariate: default to a single
+            // all-zero baseline level (plain Wordfish).
+            let delta = s
+                .delta
+                .clone()
+                .unwrap_or_else(|| vec![vec![0.0; num_types]]);
+            let level = s.level.clone().unwrap_or_else(|| vec![0usize; num_authors]);
             Some(WordfishModel {
-                num_authors: s.num_authors.unwrap_or(0),
-                num_types: s.num_types.unwrap_or(0),
+                num_authors,
+                num_types,
                 theta: s.theta.unwrap_or_default(),
                 alpha: s.alpha.unwrap_or_default(),
                 psi: s.psi.unwrap_or_default(),
@@ -365,6 +454,8 @@ impl Wordfish {
                 converged: s.converged.unwrap_or(false),
                 iters_run: s.iters_run.unwrap_or(0),
                 theta_prior_sd: s.theta_prior_sd,
+                delta,
+                level,
             })
         } else {
             None
@@ -378,6 +469,7 @@ impl Wordfish {
             fitted: s.fitted,
             author_names: s.author_names,
             id_to_word: s.id_to_word,
+            control_names: s.control_names,
             model,
         })
     }

--- a/src/wordfish.rs
+++ b/src/wordfish.rs
@@ -32,6 +32,13 @@ pub struct WordfishModel {
     pub iters_run: usize,
     /// Prior sd on theta, retained so the asymptotic standard error can be computed.
     pub theta_prior_sd: f64,
+    /// Per-control-level per-word log-rate offsets `delta[c][j]` (the control
+    /// covariate). `delta[0]` is the baseline level and is held at zero. With no
+    /// control covariate this is a single all-zero row, so the model reduces exactly
+    /// to plain Wordfish.
+    pub delta: Vec<Vec<f64>>,
+    /// Each author's control level (index into `delta`); all zero with no control.
+    pub level: Vec<usize>,
 }
 
 impl WordfishModel {
@@ -53,9 +60,10 @@ impl WordfishModel {
             .map(|i| {
                 let ai = self.alpha[i];
                 let ti = self.theta[i];
+                let dl = &self.delta[self.level[i]];
                 let (mut i_aa, mut i_at, mut i_tt) = (0.0, 0.0, inv_var);
                 for j in 0..self.num_types {
-                    let mu = (ai + self.psi[j] + self.beta[j] * ti).exp();
+                    let mu = (ai + self.psi[j] + self.beta[j] * ti + dl[j]).exp();
                     i_aa += mu;
                     i_at += mu * self.beta[j];
                     i_tt += mu * self.beta[j] * self.beta[j];
@@ -74,10 +82,48 @@ impl WordfishModel {
 /// Sparse author-major counts: `counts[i]` is the list of `(word_id, count)` for
 /// author `i`. `num_types` is the vocabulary size; `anchors` is a list of
 /// `(author_index, target)` used only to orient the sign of the axis.
+///
+/// Plain Wordfish (no control covariate). Equivalent to
+/// [`fit_wordfish_controlled`] with a single control level, so the fit is
+/// bit-identical to the historical implementation.
 #[allow(clippy::too_many_arguments)]
 pub fn fit_wordfish(
     counts: &[Vec<(u32, f64)>],
     num_types: usize,
+    anchors: &[(usize, f64)],
+    iters: usize,
+    tol: f64,
+    beta_prior_sd: f64,
+    theta_prior_sd: f64,
+) -> WordfishModel {
+    let level = vec![0usize; counts.len()];
+    fit_wordfish_controlled(
+        counts,
+        num_types,
+        &level,
+        1,
+        anchors,
+        iters,
+        tol,
+        beta_prior_sd,
+        theta_prior_sd,
+    )
+}
+
+/// Wordfish with a categorical **control covariate**. `level[i]` is the control
+/// level of author `i` (an index in `0..num_levels`); level 0 is the baseline.
+/// Each non-baseline level `c` gets a per-word log-rate offset `delta[c][j]`, so
+/// the rate is `exp(alpha_i + psi_j + beta_j theta_i + delta[level_i][j])`. This
+/// absorbs systematic, level-specific word usage (a chamber, a government/opposition
+/// status, an era, a language) into `delta` instead of letting it contaminate the
+/// latent position `theta`. With `num_levels == 1` the offsets are all zero and the
+/// fit is exactly plain Wordfish.
+#[allow(clippy::too_many_arguments)]
+pub fn fit_wordfish_controlled(
+    counts: &[Vec<(u32, f64)>],
+    num_types: usize,
+    level: &[usize],
+    num_levels: usize,
     anchors: &[(usize, f64)],
     iters: usize,
     tol: f64,
@@ -112,6 +158,24 @@ pub fn fit_wordfish(
         }
     }
 
+    // Control covariate: authors grouped by level, and the level-major word totals
+    // (y_{c,j}) that drive the per-(level, word) offset step. Empty work when
+    // num_levels == 1 (the plain-Wordfish path), keeping delta all-zero.
+    let mut level_authors: Vec<Vec<usize>> = vec![Vec::new(); num_levels];
+    for (i, &c) in level.iter().enumerate() {
+        level_authors[c].push(i);
+    }
+    let mut level_word_total: Vec<Vec<f64>> = vec![vec![0.0; v]; num_levels];
+    for (i, doc) in counts.iter().enumerate() {
+        let c = level[i];
+        for &(w, cnt) in doc {
+            level_word_total[c][w as usize] += cnt;
+        }
+    }
+    // delta[c][j]: per-level per-word log-rate offset; level 0 is the held-out
+    // baseline and stays zero.
+    let mut delta: Vec<Vec<f64>> = vec![vec![0.0; v]; num_levels];
+
     // --- deterministic initialization ---------------------------------------
     // alpha_i = log author total; psi_j = log mean word rate; theta from the
     // leading principal axis of the row-normalized, column-centered log matrix.
@@ -122,7 +186,7 @@ pub fn fit_wordfish(
         .map(|&t| (t.max(1.0) / a as f64).ln())
         .collect();
     let mut beta = vec![0.0f64; v];
-    let mut theta = init_theta(counts, a, v, eps);
+    let mut theta = init_theta(counts, level, num_levels, a, v, eps);
 
     standardize_theta(&mut theta, &mut beta, &mut psi);
     center_psi(&mut psi, &mut alpha);
@@ -147,7 +211,7 @@ pub fn fit_wordfish(
                 y_theta += c * theta[i as usize];
             }
             for i in 0..a {
-                let mu = (alpha[i] + psi[j] + beta[j] * theta[i]).exp();
+                let mu = (alpha[i] + psi[j] + beta[j] * theta[i] + delta[level[i]][j]).exp();
                 g0 -= mu;
                 g1 -= mu * theta[i];
                 h00 -= mu;
@@ -172,8 +236,9 @@ pub fn fit_wordfish(
                 y_sum += c;
                 y_beta += c * beta[w as usize];
             }
+            let dl = &delta[level[i]];
             for j in 0..v {
-                let mu = (alpha[i] + psi[j] + beta[j] * theta[i]).exp();
+                let mu = (alpha[i] + psi[j] + beta[j] * theta[i] + dl[j]).exp();
                 g0 -= mu;
                 g1 -= mu * beta[j];
                 h00 -= mu;
@@ -188,12 +253,28 @@ pub fn fit_wordfish(
             theta[i] -= dt;
         }
 
+        // M-step part 3: per-(level, word) control offset delta[c][j], a 1-D Newton
+        // step over the authors in level c. Level 0 is the baseline (delta == 0), so
+        // this loop is empty for plain Wordfish (num_levels == 1).
+        for c in 1..num_levels {
+            for j in 0..v {
+                let mut mu_sum = 0.0;
+                for &i in &level_authors[c] {
+                    mu_sum += (alpha[i] + psi[j] + beta[j] * theta[i] + delta[c][j]).exp();
+                }
+                let grad = level_word_total[c][j] - mu_sum; // d loglik / d delta
+                let hess = -mu_sum - 1e-9; // observed information (negative), ridged
+                let step = (grad / hess).clamp(-5.0, 5.0);
+                delta[c][j] -= step;
+            }
+        }
+
         // Identification: standardize theta (lossless), center psi (lossless).
         standardize_theta(&mut theta, &mut beta, &mut psi);
         center_psi(&mut psi, &mut alpha);
 
         // Convergence on the Poisson log-likelihood.
-        let ll = loglik(counts, &alpha, &psi, &beta, &theta, a, v);
+        let ll = loglik(counts, &alpha, &psi, &beta, &theta, level, &delta, a, v);
         ll_history.push(ll);
         if prev_ll.is_finite() {
             let denom = prev_ll.abs().max(1.0);
@@ -220,27 +301,42 @@ pub fn fit_wordfish(
         converged,
         iters_run,
         theta_prior_sd,
+        delta,
+        level: level.to_vec(),
     }
 }
 
 /// Leading principal axis of the doubly-centered log-count matrix, via power
 /// iteration on the author x author gram (no dense V x V). Deterministic.
-fn init_theta(counts: &[Vec<(u32, f64)>], a: usize, v: usize, eps: f64) -> Vec<f64> {
+///
+/// Column centering is done **per control level**: subtracting `col_mean[level][j]`
+/// removes the control axis from the starting position, so `theta` is not initialized
+/// on a dominant, level-specific nuisance axis. With `num_levels == 1` this is the
+/// plain global column centering, bit-identical to before.
+fn init_theta(
+    counts: &[Vec<(u32, f64)>],
+    level: &[usize],
+    num_levels: usize,
+    a: usize,
+    v: usize,
+    eps: f64,
+) -> Vec<f64> {
     // Doubly-centered residual on present entries: r_ij = log1p(y_ij) minus the row
-    // mean, the column mean, plus the grand mean. Its leading author-space axis is a
-    // robust, dependency-free starting position (correspondence-analysis flavored).
+    // mean, the (level-specific) column mean, plus the grand mean. Its leading
+    // author-space axis is a robust, dependency-free starting position.
     let val = |c: f64| (c + 1.0).ln();
     let mut row_mean = vec![0.0f64; a];
-    let mut col_mean = vec![0.0f64; v];
-    let mut col_n = vec![0.0f64; v];
+    let mut col_mean = vec![vec![0.0f64; v]; num_levels];
+    let mut col_n = vec![vec![0.0f64; v]; num_levels];
     let mut grand_mean = 0.0;
     let mut nnz = 0.0;
     for (i, doc) in counts.iter().enumerate() {
-        for &(w, c) in doc {
-            let x = val(c);
+        let c = level[i];
+        for &(w, cnt) in doc {
+            let x = val(cnt);
             row_mean[i] += x;
-            col_mean[w as usize] += x;
-            col_n[w as usize] += 1.0;
+            col_mean[c][w as usize] += x;
+            col_n[c][w as usize] += 1.0;
             grand_mean += x;
             nnz += 1.0;
         }
@@ -248,21 +344,29 @@ fn init_theta(counts: &[Vec<(u32, f64)>], a: usize, v: usize, eps: f64) -> Vec<f
     for (i, rm) in row_mean.iter_mut().enumerate() {
         *rm /= counts[i].len().max(1) as f64;
     }
-    for j in 0..v {
-        if col_n[j] > 0.0 {
-            col_mean[j] /= col_n[j];
+    for c in 0..num_levels {
+        for j in 0..v {
+            if col_n[c][j] > 0.0 {
+                col_mean[c][j] /= col_n[c][j];
+            }
         }
     }
     if nnz > 0.0 {
         grand_mean /= nnz;
     }
-    // Sparse residual rows: r_i = { (j, val - row_mean_i - col_mean_j + grand_mean) }.
+    // Sparse residual rows: r_i = { (j, val - row_mean_i - col_mean[level_i][j] + grand_mean) }.
     let resid: Vec<Vec<(u32, f64)>> = counts
         .iter()
         .enumerate()
         .map(|(i, doc)| {
+            let c = level[i];
             doc.iter()
-                .map(|&(w, c)| (w, val(c) - row_mean[i] - col_mean[w as usize] + grand_mean))
+                .map(|&(w, cnt)| {
+                    (
+                        w,
+                        val(cnt) - row_mean[i] - col_mean[c][w as usize] + grand_mean,
+                    )
+                })
                 .collect()
         })
         .collect();
@@ -403,27 +507,31 @@ fn solve2(h00: f64, h01: f64, h10: f64, h11: f64, g0: f64, g1: f64) -> (f64, f64
     (clamp(d0), clamp(d1))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn loglik(
     counts: &[Vec<(u32, f64)>],
     alpha: &[f64],
     psi: &[f64],
     beta: &[f64],
     theta: &[f64],
+    level: &[usize],
+    delta: &[Vec<f64>],
     a: usize,
     v: usize,
 ) -> f64 {
-    // sum_ij [ y_ij * eta_ij - exp(eta_ij) ], eta = alpha + psi + beta*theta.
-    // The -exp term is dense; the y*eta term is sparse.
+    // sum_ij [ y_ij * eta_ij - exp(eta_ij) ], eta = alpha + psi + beta*theta +
+    // delta[level_i][j]. The -exp term is dense; the y*eta term is sparse.
     let mut ll = 0.0;
     for i in 0..a {
         let ai = alpha[i];
         let ti = theta[i];
+        let dl = &delta[level[i]];
         for j in 0..v {
-            ll -= (ai + psi[j] + beta[j] * ti).exp();
+            ll -= (ai + psi[j] + beta[j] * ti + dl[j]).exp();
         }
         for &(w, c) in &counts[i] {
             let j = w as usize;
-            ll += c * (ai + psi[j] + beta[j] * ti);
+            ll += c * (ai + psi[j] + beta[j] * ti + dl[j]);
         }
     }
     ll
@@ -515,5 +623,86 @@ mod tests {
         assert!(mean.abs() < 1e-6, "theta not centered: {mean}");
         // anchors orient the sign: low anchor negative, high anchor positive
         assert!(m.theta[0] < m.theta[a - 1], "anchors did not orient");
+    }
+
+    #[test]
+    fn control_covariate_rescues_axis_under_contamination() {
+        // A corpus with a weak ideology signal plus a DOMINANT, control-aligned
+        // nuisance axis. Without the control, theta is hijacked by the nuisance;
+        // with it, theta recovers ideology.
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let a = 50usize;
+        // vocab: 0..8 ideology-left, 8..16 ideology-right, 16..24 nuisance-level0,
+        // 24..32 nuisance-level1, 32..62 filler
+        let v = 62usize;
+        let ideo: Vec<f64> = (0..a)
+            .map(|i| (i as f64 / (a as f64 - 1.0)) * 2.0 - 1.0)
+            .collect();
+        let level: Vec<usize> = (0..a).map(|i| i % 2).collect();
+        let mut counts: Vec<Vec<(u32, f64)>> = Vec::with_capacity(a);
+        for i in 0..a {
+            let mut row = vec![0.0f64; v];
+            let pr_right = (ideo[i] + 1.0) / 2.0;
+            for _ in 0..560 {
+                let u: f64 = rng.gen();
+                let w = if u < 0.45 {
+                    // dominant nuisance, determined by the control level
+                    let base = if level[i] == 1 { 24 } else { 16 };
+                    base + (rng.gen::<usize>() % 8)
+                } else if u < 0.85 {
+                    if rng.gen::<f64>() < pr_right {
+                        8 + (rng.gen::<usize>() % 8)
+                    } else {
+                        rng.gen::<usize>() % 8
+                    }
+                } else {
+                    32 + (rng.gen::<usize>() % 30)
+                };
+                row[w] += 1.0;
+            }
+            counts.push(
+                row.iter()
+                    .enumerate()
+                    .filter(|&(_, &c)| c > 0.0)
+                    .map(|(j, &c)| (j as u32, c))
+                    .collect(),
+            );
+        }
+        let no_control = fit_wordfish(&counts, v, &[], 120, 1e-8, 3.0, 1.0);
+        let with_control = fit_wordfish_controlled(&counts, v, &level, 2, &[], 120, 1e-8, 3.0, 1.0);
+        let r_plain = pearson(&no_control.theta, &ideo).abs();
+        let r_ctrl = pearson(&with_control.theta, &ideo).abs();
+        assert!(
+            r_plain < 0.4,
+            "expected the nuisance to hijack plain Wordfish, got ideology r={r_plain}"
+        );
+        assert!(
+            r_ctrl > 0.8,
+            "control covariate should recover ideology, got r={r_ctrl}"
+        );
+    }
+
+    #[test]
+    fn single_level_control_is_plain_wordfish() {
+        // num_levels == 1 must reproduce plain Wordfish bit-for-bit.
+        let mut rng = ChaCha8Rng::seed_from_u64(3);
+        let (a, v) = (30usize, 40usize);
+        let mut counts = Vec::new();
+        for _ in 0..a {
+            let mut row = Vec::new();
+            for j in 0..v {
+                let c = poisson(&mut rng, 3.0);
+                if c > 0.0 {
+                    row.push((j as u32, c));
+                }
+            }
+            counts.push(row);
+        }
+        let plain = fit_wordfish(&counts, v, &[], 50, 1e-8, 3.0, 1.0);
+        let level = vec![0usize; a];
+        let ctrl = fit_wordfish_controlled(&counts, v, &level, 1, &[], 50, 1e-8, 3.0, 1.0);
+        assert_eq!(plain.theta, ctrl.theta);
+        assert_eq!(plain.beta, ctrl.beta);
+        assert_eq!(plain.psi, ctrl.psi);
     }
 }

--- a/tests/test_wordfish.py
+++ b/tests/test_wordfish.py
@@ -7,6 +7,7 @@ positions and word discriminations from counts sampled from its own model.
 import math
 
 import numpy as np
+import pytest
 
 import topica
 
@@ -123,3 +124,87 @@ def test_inf_prior_is_flat():
     pos = dict(zip(m.author_names, m.author_positions[:, 0]))
     recovered = np.array([pos[f"a{a}"] for a in range(40)])
     assert abs(np.corrcoef(recovered, theta)[0, 1]) > 0.85
+
+
+def _contaminated(seed=0, n_authors=50, docs_per=14, doc_len=40, p_nu=0.45, p_id=0.40):
+    """A weak ideology signal plus a DOMINANT, control-aligned nuisance axis. Plain
+    Wordfish is hijacked by the nuisance; the control covariate should absorb it and
+    recover ideology."""
+    rng = np.random.default_rng(seed)
+    ideo = np.linspace(-1.0, 1.0, n_authors)
+    ctrl = np.array([i % 2 for i in range(n_authors)])
+    iL = [f"iL{i}" for i in range(8)]; iR = [f"iR{i}" for i in range(8)]
+    nA = [f"nA{i}" for i in range(8)]; nB = [f"nB{i}" for i in range(8)]
+    fill = [f"f{i}" for i in range(30)]
+    docs, group, control = [], [], []
+    for a in range(n_authors):
+        pr_right = (ideo[a] + 1) / 2
+        for _ in range(docs_per):
+            d = []
+            for _ in range(doc_len):
+                u = rng.random()
+                if u < p_nu:
+                    d.append((nB if ctrl[a] == 1 else nA)[rng.integers(8)])
+                elif u < p_nu + p_id:
+                    d.append((iR if rng.random() < pr_right else iL)[rng.integers(8)])
+                else:
+                    d.append(fill[rng.integers(30)])
+            docs.append(d); group.append(f"a{a:02d}"); control.append(f"c{ctrl[a]}")
+    return docs, group, control, ideo
+
+
+def _ideology_recovery(m, ideo):
+    pos = m.author_positions[:, 0]
+    truth = np.array([ideo[int(n[1:])] for n in m.author_names])
+    return abs(np.corrcoef(pos, truth)[0, 1])
+
+
+def test_control_covariate_rescues_axis():
+    docs, group, control, ideo = _contaminated(seed=0)
+    plain = topica.Wordfish(min_count=1, seed=1)
+    plain.fit(docs, group=group, iters=120)
+    ctrl = topica.Wordfish(min_count=1, seed=1)
+    ctrl.fit(docs, group=group, control=control, iters=120)
+    r_plain = _ideology_recovery(plain, ideo)
+    r_ctrl = _ideology_recovery(ctrl, ideo)
+    assert r_plain < 0.4, f"nuisance should hijack plain Wordfish, got {r_plain:.3f}"
+    assert r_ctrl > 0.8, f"control should recover ideology, got {r_ctrl:.3f}"
+    # the absorbed effect is exposed
+    assert ctrl.control_names == ["c0", "c1"]
+    assert ctrl.control_word_offsets.shape == (2, len(ctrl.vocabulary))
+    # baseline level row is held at zero
+    assert np.allclose(ctrl.control_word_offsets[0], 0.0)
+
+
+def test_control_none_matches_plain():
+    # control=None must give exactly the historical Wordfish fit.
+    docs, group, _, _ = _planted(seed=2)
+    a = topica.Wordfish(seed=1); a.fit(docs, group=group, iters=60)
+    b = topica.Wordfish(seed=1); b.fit(docs, group=group, control=None, iters=60)
+    assert np.array_equal(a.author_positions, b.author_positions)
+
+
+def test_control_save_load(tmp_path):
+    docs, group, control, _ = _contaminated(seed=3)
+    m = topica.Wordfish(min_count=1, seed=1)
+    m.fit(docs, group=group, control=control, iters=40)
+    p = tmp_path / "wfc.topica"
+    m.save(str(p))
+    m2 = topica.Wordfish.load(str(p))
+    assert np.array_equal(m.author_positions, m2.author_positions)
+    assert np.array_equal(m.control_word_offsets, m2.control_word_offsets)
+    assert m.control_names == m2.control_names
+
+
+def test_control_validation():
+    docs, group, control, _ = _contaminated(seed=4)
+    m = topica.Wordfish(min_count=1, seed=1)
+    # wrong length
+    with pytest.raises(Exception):
+        m.fit(docs, group=group, control=control[:-5], iters=10)
+    # not constant within an author: flip one document's control within author a00
+    bad = list(control)
+    first = group.index("a00")
+    bad[first] = "cX" if bad[first] != "cX" else "cY"
+    with pytest.raises(Exception):
+        m.fit(docs, group=group, control=bad, iters=10)


### PR DESCRIPTION
Follow-up #1 from the Party Embeddings cross-pollination pass (the substantial one).

## What

Adds a `control=` covariate to `Wordfish.fit`. Text scaling has a well-documented failure: when a corpus has a dominant axis of variation that *isn't* the one you want (a chamber, a government/opposition split, an era, a language), the single latent position latches onto it and the ideological signal is lost. `control=` lets Wordfish absorb that nuisance.

- **Model:** `log rate = alpha_i + psi_j + beta_j*theta_i + delta[level_i, j]`, where `delta` is a per-(control-level, word) log-rate offset estimated by a 1-D Newton step, with the baseline level held at zero (reference coding). The borrowing from Rheault & Cochrane's use of control tags, here in the Poisson-scaling setting.
- **The key detail:** the `theta` initialization is residualized per level (per-(level, word) column centering in `init_theta`), so it does not *start* on the dominant nuisance axis — without that, the covariate helps only partially.
- **API:** `Wordfish.fit(docs, group=author, control=chamber, anchors=...)` — `control` is a categorical label per document, constant within each author (validated). Exposes `control_names` and `control_word_offsets` (the absorbed `(num_levels, vocab)` effect).

## Why

The first of the two follow-ups we agreed on, targeting the fragility documented across the IdealPointTM work ("genre is the master variable; Wordfish collapses when the dominant axis isn't ideology").

## Validation

A contamination-injection test at both the Rust and Python level: inject an ideology-orthogonal nuisance axis tied to a control variable and make it *dominant*. Plain Wordfish is hijacked (ideology `|r| ~ 0.03`); `control=` restores it (`|r| ~ 0.8`). Plus plain-equivalence, save/load-with-control, and input-validation tests.

**Bit-identical no-control path:** with no `control`, the fit reduces exactly to historical Wordfish (`+delta` is `+0.0`; the per-level column mean collapses to the old global mean). The quanteda parity (`parity/wordfish_r_compare.py`, planted `|r|`=0.9932, SE `|r|`=1.0000) and all existing Wordfish tests pass unchanged — verified.

## Compatibility note

The serialized Wordfish state gains `delta`/`level`/`control_names`. Saves are bincode (positional), so a **pre-0.32 Wordfish `.topica` file will not load** in this build — it fails with the format's clean header-guarded error rather than a panic, which is what that header exists for. New saves round-trip. Consistent with topica's save policy on a state-schema change; flagging since it affects anyone with an old Wordfish save.

## Gates

`cargo test --lib` (148), `pytest tests/` (3100 passed, 30 skipped), `cargo fmt --check`, `cargo clippy -- -D warnings`, `mkdocs build --strict` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)