### PR TITLE
fix(sentence-ideal): deterministic fit across thread counts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Fixed
+
+- `SentenceIdealTM` is now deterministic from a fixed `seed` regardless of thread
+  count. Two parallel `f64` reductions (the E-step log-likelihood and the M-step
+  variance) summed in rayon work-stealing order, which is not associative, so two
+  same-seed fits could differ by ULPs and diverge (the log-likelihood drives the EM
+  early-stop). Both now collect in index order and sum sequentially, matching
+  topica's determinism guarantee. Surfaced as an intermittent macOS CI failure of
+  `test_sentence_ideal.py::test_determinism`.
+
 ### Added
 
 - `topica.polarization(positions, labels)` — a model-agnostic ideal-point diagnostic:

--- a/src/sentence_ideal.rs
+++ b/src/sentence_ideal.rs
@@ -159,7 +159,11 @@ pub fn fit_sentence_ideal<R: Rng>(
         // E-step: responsibilities r_{i,k} ∝ pi_k N(e_i | mu_k + x_a V_k, sigma2 I).
         let inv2s = 1.0 / (2.0 * sigma2);
         let log_pi: Vec<f64> = pi.iter().map(|&p| p.max(1e-300).ln()).collect();
-        let ll: f64 = emb
+        // Per-document log-likelihood, collected in document order then summed
+        // sequentially so the total is independent of rayon's work-stealing order
+        // (a parallel `.sum()` of f64 is not associative and would break the
+        // fixed-seed determinism guarantee).
+        let ll_parts: Vec<f64> = emb
             .par_iter()
             .zip(resp.par_iter_mut())
             .zip(group.par_iter())
@@ -189,7 +193,8 @@ pub fn fit_sentence_ideal<R: Rng>(
                 }
                 max + z.ln()
             })
-            .sum();
+            .collect();
+        let ll: f64 = ll_parts.iter().sum();
         ll_history.push(ll);
 
         // M-step: mixture weights.
@@ -313,8 +318,9 @@ pub fn fit_sentence_ideal<R: Rng>(
             }
         }
 
-        // M-step: spherical variance from the mean squared residual.
-        let ss: f64 = (0..n)
+        // M-step: spherical variance from the mean squared residual. Collected in
+        // index order then summed sequentially (fixed-order, see the E-step note).
+        let ss_parts: Vec<f64> = (0..n)
             .into_par_iter()
             .map(|i| {
                 let a = group[i];
@@ -334,7 +340,8 @@ pub fn fit_sentence_ideal<R: Rng>(
                 }
                 s
             })
-            .sum();
+            .collect();
+        let ss: f64 = ss_parts.iter().sum();
         sigma2 = (ss / (n.max(1) * dim.max(1)) as f64).max(1e-8);
 
         // Identification: standardize positions (lossless into mu/V), orient sign.


### PR DESCRIPTION
## Problem

`test_sentence_ideal.py::test_determinism` intermittently failed on **macos-latest** (passed Ubuntu/Windows) — two same-seed `SentenceIdealTM` fits produced different `author_positions`.

## Cause

Two parallel `f64` reductions summed in rayon **work-stealing order**, which is not associative:
- the E-step per-document log-likelihood (`ll`), and
- the M-step spherical variance (`ss` → `sigma2`).

Two same-seed fits could differ by ULPs, and because `ll` drives the EM early-stop (`em_tol`), the runs then diverged into different iteration counts and positions. The flake was scheduling-dependent, so it surfaced on one runner.

## Fix

Both sites keep the parallel per-item work but **collect in index order and sum sequentially** (fixed-order), matching topica's determinism guarantee ("parallel reductions must combine in a fixed order"). No change to the math or results otherwise.

## Verification

- After the fix: **0/15** nondeterministic across `RAYON_NUM_THREADS` ∈ {1, 4, 8} on a planted corpus.
- `cargo test --lib sentence_ideal`, `pytest tests/test_sentence_ideal.py` (6 passed), `cargo fmt --check`, `cargo clippy -- -D warnings` all pass.

Independent of the in-flight Wordfish `control=` PR (#306), which this unblocks (that PR's macOS CI was red on this same flake).

🤖 Generated with [Claude Code](https://claude.com/claude-code)