### PR TITLE
Analytic position standard errors for the ideal-point family (#310)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -606,12 +606,26 @@ m.fit(docs,                                   # counts: no embeddings needed
       group=speaker_id,                       # documents sharing a speaker share a position
       anchors={"Sanders": -1.0, "Cruz": 1.0}) # orient the sign of the axis
 m.author_positions          # (num_authors, num_dims): the estimated ideal points
+m.position_se               # (num_authors, num_dims): standard error of each position
 m.topic_discrimination      # (num_topics,): which topics carry the cleavage
 m.position_shift(topic=k)   # the words that move within topic k from one end to the other
 
 # or factor through word embeddings (ETM-style), passing the aligned vocabulary:
 m.fit(docs, word_embeddings=rho, vocabulary=vocab, group=speaker_id)
 ```
+
+**Uncertainty on the positions.** `position_se` is the standard error of each
+author's ideal point, from the observed information of the penalized position
+objective at the fit — the multinomial-content analog of Wordfish's Hessian-based
+`se.theta`. It conditions on the fitted topic content and shrinks with the number of
+tokens an author contributes, so a prolific author is placed more precisely than a
+quiet one. The same getter is on `IdealPointSentenceTM` (the exact Laplace SE of its
+linear-Gaussian position step) and on `TBIP` (the variational posterior SD); `Wordfish`
+has had `position_se` all along. To carry that uncertainty into a polarization estimate,
+`topica.polarization_ci` propagates the per-author SEs by simulation and returns a
+confidence interval on the camp gap — a band that straddles zero means the camps are
+not reliably apart. (`PartyEmbeddings`, whose positions are a PCA of doc2vec tag
+vectors, has no analytic SE; use `topica.position_intervals` to bootstrap one.)
 
 We fit by variational EM on ETM's core: the E-step is the logistic-normal Laplace step with the author's position-displaced `beta`, and the M-step updates the topic embeddings, the loadings, and the positions in turn. Positions are initialized from the leading principal components of the author-word matrix, as Wordfish does, which keeps the fit off the trivial zero-loading fixed point. Identification is exact and loss-free: each iteration standardizes the positions to mean zero and unit variance and absorbs the rescaling into the embeddings and loadings, then orients the sign to the anchors. On data simulated from the model the positions recover the planted trait at a correlation above 0.98 and `position_shift` reads off the discriminating axis.
 

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -266,7 +266,7 @@ from .stopwords import ENGLISH_STOPWORDS, stopwords, stopword_languages  # noqa:
 from .phrases import learn_phrases, apply_phrases, add_ngrams, Phrases  # noqa: E402
 from .frames import from_dataframe, align, prep_documents, plot_removed  # noqa: E402
 from .formulas import design_matrix  # noqa: E402
-from .scaling import bimodality, polarization, split_half_reliability, position_intervals  # noqa: E402  (intrinsic ideal-point diagnostics)
+from .scaling import bimodality, polarization, polarization_ci, split_half_reliability, position_intervals  # noqa: E402  (intrinsic ideal-point diagnostics)
 from . import datasets  # noqa: E402  (bundled + fetch-on-demand example datasets)
 
 __all__ = [
@@ -404,6 +404,7 @@ __all__ = [
     "design_matrix",
     "bimodality",
     "polarization",
+    "polarization_ci",
     "split_half_reliability",
     "position_intervals",
     "summary",

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3746,6 +3746,14 @@ class IdealPointTM:
         """The latent ideal points (num_authors, num_dims)."""
         ...
     @property
+    def position_se(self) -> numpy.typing.NDArray[numpy.float64]:
+        """Asymptotic standard error of each author position (num_authors,
+        num_dims), from the observed information of the penalized position objective
+        at the fit. The multinomial-content analog of Wordfish's Hessian-based
+        `se.theta`: it conditions on the fitted topic content and shrinks with the
+        number of tokens an author contributes. Aligned to author_positions."""
+        ...
+    @property
     def author_names(self) -> list[str]: ...
     @property
     def topic_discrimination(self) -> numpy.typing.NDArray[numpy.float64]:
@@ -3907,6 +3915,13 @@ class IdealPointSentenceTM:
     @property
     def author_positions(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
+    def position_se(self) -> numpy.typing.NDArray[numpy.float64]:
+        """Standard error of each author position (num_authors, num_dims). The
+        position is a linear-Gaussian least squares given the topic responsibilities,
+        so this is the exact Laplace posterior SE; it shrinks with the number of the
+        author's observations. Aligned to author_positions."""
+        ...
+    @property
     def author_names(self) -> list[str]: ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
@@ -3975,6 +3990,13 @@ class TBIP:
     def num_authors(self) -> int: ...
     @property
     def ideal_points(self) -> numpy.typing.NDArray[numpy.float64]: ...
+    @property
+    def position_se(self) -> numpy.typing.NDArray[numpy.float64]:
+        """Standard error of each author ideal point (num_authors,): the standard
+        deviation of the Gaussian variational posterior q(x_s), estimated jointly
+        with the mean. As with any mean-field VI this can understate the true
+        posterior spread. Aligned to ideal_points / author_names."""
+        ...
     @property
     def author_names(self) -> list[str]: ...
     @property

--- a/python/topica/scaling.py
+++ b/python/topica/scaling.py
@@ -20,10 +20,20 @@ from collections import namedtuple
 
 import numpy as np
 
-__all__ = ["bimodality", "polarization", "split_half_reliability", "position_intervals"]
+__all__ = [
+    "bimodality",
+    "polarization",
+    "polarization_ci",
+    "split_half_reliability",
+    "position_intervals",
+]
 
 #: One author's position estimate with a bootstrap standard error and CI.
 PositionInterval = namedtuple("PositionInterval", "estimate se lo hi")
+
+#: A polarization estimate with a standard error and confidence interval, from
+#: propagating per-author position standard errors.
+PolarizationCI = namedtuple("PolarizationCI", "estimate se lo hi")
 
 
 def bimodality(positions) -> float:
@@ -121,6 +131,79 @@ def polarization(positions, labels, *, normalize: bool = False) -> float:
             n += 1
     pooled_sd = (ss / n) ** 0.5 if n > 0 else 0.0
     return dist / pooled_sd if pooled_sd > 0 else float("inf")
+
+
+def polarization_ci(
+    positions,
+    labels,
+    position_se,
+    *,
+    normalize: bool = False,
+    n_sim: int = 1000,
+    ci: float = 0.95,
+    seed: int = 0,
+) -> "PolarizationCI":
+    """Confidence interval on :func:`polarization`, propagating per-author position
+    uncertainty.
+
+    The polarization statistic is a nonlinear function of the author positions, so
+    its uncertainty is obtained by Monte Carlo: draw each author's position from
+    ``N(estimate, se**2)`` (independently per dimension), recompute the polarization
+    on each draw, and report the point estimate together with the simulation
+    standard error and a percentile interval. This makes the centroid-distance
+    measure honest about how much of the gap is signal versus noise in the placement
+    -- a wide interval that straddles zero means the camps are not reliably apart.
+
+    It is the analytic-SE companion to :func:`position_intervals` (which gets the
+    same uncertainty by bootstrap when no SE is available). Pass any ideal-point
+    model's ``position_se``: ``IdealPointTM``, ``IdealPointSentenceTM``, ``TBIP``
+    (variational posterior SD), or ``Wordfish`` (Hessian SE). ``PartyEmbeddings``
+    has no analytic SE -- use :func:`position_intervals` for it.
+
+    Parameters
+    ----------
+    positions : array-like, shape ``(n,)`` or ``(n, d)``
+        The latent positions, e.g. ``model.author_positions``.
+    labels : sequence, length n
+        The camp of each position (e.g. party label of each author).
+    position_se : array-like, broadcastable to ``positions``
+        The standard error of each position, e.g. ``model.position_se``.
+    normalize : bool
+        Passed through to :func:`polarization` on every draw (raw centroid distance
+        vs the pooled-within-camp effect-size form).
+    n_sim : int
+        Number of Monte Carlo draws.
+    ci : float
+        Central interval mass (default 0.95 for a 95% interval).
+    seed : int
+        Seed for the simulation noise.
+
+    Returns
+    -------
+    PolarizationCI
+        ``(estimate, se, lo, hi)``: the point estimate at the given positions, the
+        standard deviation across draws, and the percentile interval bounds.
+    """
+    x = np.asarray(positions, dtype=float)
+    if x.ndim == 1:
+        x = x.reshape(-1, 1)
+    se = np.asarray(position_se, dtype=float)
+    if se.ndim == 1:
+        se = se.reshape(-1, 1)
+    se = np.broadcast_to(se, x.shape)
+
+    estimate = polarization(x, labels, normalize=normalize)
+    rng = np.random.default_rng(seed)
+    draws = np.empty(n_sim, dtype=float)
+    for s in range(n_sim):
+        xs = x + rng.standard_normal(x.shape) * se
+        draws[s] = polarization(xs, labels, normalize=normalize)
+    finite = draws[np.isfinite(draws)]
+    lo_q, hi_q = (1.0 - ci) / 2.0, 1.0 - (1.0 - ci) / 2.0
+    if finite.size == 0:
+        return PolarizationCI(float(estimate), float("nan"), float("nan"), float("nan"))
+    lo, hi = np.quantile(finite, [lo_q, hi_q])
+    return PolarizationCI(float(estimate), float(finite.std(ddof=1)), float(lo), float(hi))
 
 
 def _positions_dict(labels, positions) -> dict:

--- a/src/idealpoint.rs
+++ b/src/idealpoint.rs
@@ -193,6 +193,111 @@ impl IdealPointModel {
             })
             .collect()
     }
+
+    /// Asymptotic standard error of each author position, `(A x d)`, from the
+    /// observed information of the penalized position objective at the fit. `ntot`
+    /// is the per-author expected topic-token count `n_{a,k}` (the E-step soft
+    /// counts), `x_prior_variance` the Gaussian prior on the positions. The
+    /// discrimination logits are `disc_{k,j,v} = rho_v . W_{k,j}`. See
+    /// [`position_ses`] for the derivation.
+    pub fn position_se(&self, ntot: &[Vec<f64>], x_prior_variance: f64) -> Vec<Vec<f64>> {
+        position_ses(
+            self.num_authors,
+            self.num_dims,
+            ntot,
+            &self.disc,
+            &|a, k| self.position_topic_beta(k, &self.x[a]),
+            x_prior_variance,
+        )
+    }
+}
+
+/// Observed-information standard errors for author positions, shared by both
+/// IdealPointTM cores (the embedded `disc` is `rho.W`, the count `disc` is `W`).
+///
+/// For author `a` the position objective is a sum over topics of multinomial
+/// log-likelihoods in `x_a` plus a Gaussian prior:
+/// `Q(x_a) = sum_k [ S_{a,k}.eta_{a,k}(x_a) - n_{a,k} logZ_{a,k}(x_a) ] - ||x_a||^2 / 2v`.
+/// The data term is linear in `x_a`, so the curvature is carried entirely by the
+/// `-n_{a,k} logZ` terms, giving the `d x d` observed information
+/// `J_a[j,l] = sum_k n_{a,k} Cov_{beta_{a,k}}(disc_{k,j}, disc_{k,l}) + I[j=l]/v`,
+/// where the covariance is over the topic's word distribution `beta_{a,k}` at the
+/// author's position. The position SE is `sqrt(diag(J_a^{-1}))`. This conditions on
+/// the fitted topic content (`alpha`/`W`), exactly as Wordfish's `se.theta`
+/// conditions on its word parameters; an author with no tokens falls back to the
+/// prior SD `sqrt(v)`. Sequential over authors, so it is thread-count independent.
+pub fn position_ses(
+    num_authors: usize,
+    num_dims: usize,
+    ntot: &[Vec<f64>],
+    disc: &[Vec<Vec<f64>>],
+    beta: &dyn Fn(usize, usize) -> Vec<f64>,
+    x_prior_variance: f64,
+) -> Vec<Vec<f64>> {
+    let k = disc.len();
+    let d = num_dims;
+    let inv_v = 1.0 / x_prior_variance;
+    (0..num_authors)
+        .map(|a| {
+            let mut info = vec![0.0f64; d * d];
+            for kk in 0..k {
+                let n = ntot[a][kk];
+                if n <= 0.0 {
+                    continue;
+                }
+                let b = beta(a, kk);
+                let disc_k = &disc[kk];
+                // Weighted means mean_j = sum_v beta_v disc_{k,j,v}.
+                let mut mean = vec![0.0f64; d];
+                for (j, dj) in disc_k.iter().enumerate().take(d) {
+                    mean[j] = b.iter().zip(dj).map(|(&bv, &g)| bv * g).sum();
+                }
+                // n * Cov_beta(disc_j, disc_l) into the (symmetric) information.
+                for j in 0..d {
+                    let dj = &disc_k[j];
+                    for l in j..d {
+                        let dl = &disc_k[l];
+                        let m2: f64 = b
+                            .iter()
+                            .zip(dj)
+                            .zip(dl)
+                            .map(|((&bv, &gj), &gl)| bv * gj * gl)
+                            .sum();
+                        let c = n * (m2 - mean[j] * mean[l]);
+                        info[j * d + l] += c;
+                        if l != j {
+                            info[l * d + j] += c;
+                        }
+                    }
+                }
+            }
+            for j in 0..d {
+                info[j * d + j] += inv_v;
+            }
+            if d == 1 {
+                return vec![if info[0] > 0.0 {
+                    info[0].sqrt().recip()
+                } else {
+                    f64::NAN
+                }];
+            }
+            let cov = spd_inverse(&info, d).unwrap_or_else(|| {
+                let mut s = info.clone();
+                make_diagonally_dominant(&mut s, d);
+                spd_inverse(&s, d).unwrap()
+            });
+            (0..d)
+                .map(|j| {
+                    let var = cov[j * d + j];
+                    if var > 0.0 {
+                        var.sqrt()
+                    } else {
+                        f64::NAN
+                    }
+                })
+                .collect()
+        })
+        .collect()
 }
 
 /// Fit IdealPointTM by variational EM. `group[d] in 0..num_authors` maps each
@@ -1061,6 +1166,85 @@ mod tests {
         let x_hat: Vec<f64> = (0..a_n).map(|a| m.x[a][0]).collect();
         let r = pearson(&x_hat, &x_true).abs();
         assert!(r > 0.8, "grid-path position correlation too low: {r}");
+    }
+
+    // Position SEs are finite and positive, and an author with more tokens has a
+    // smaller SE than an otherwise-identical author with fewer tokens. ntot is the
+    // per-author expected topic-token count, reconstructed here the same way the
+    // binding does (doc length x doc-topic proportions).
+    #[test]
+    fn position_se_finite_and_shrinks_with_data() {
+        let mut rng = ChaCha8Rng::seed_from_u64(11);
+        let (k, e, dd) = (2usize, 5usize, 1usize);
+        let vsz = 30usize;
+        let a_n = 16usize;
+        let rho: Vec<Vec<f64>> = (0..vsz)
+            .map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect())
+            .collect();
+        let alpha_true: Vec<Vec<f64>> = (0..k)
+            .map(|_| (0..e).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect())
+            .collect();
+        let mut w_true = vec![vec![vec![0.0f64; e]; dd]; k];
+        for ee in 0..e {
+            w_true[0][0][ee] = (rng.gen::<f64>() * 2.0 - 1.0) * 2.5;
+        }
+        let x_true: Vec<f64> = (0..a_n).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect();
+        let (base, disc) = build_cache(&rho, &alpha_true, &w_true);
+        // Author 0 gets many documents; author 1 gets few. The rest get a moderate
+        // count. Same generative position scale across authors.
+        let mut docs: Vec<Vec<u32>> = Vec::new();
+        let mut group: Vec<usize> = Vec::new();
+        for a in 0..a_n {
+            let beta_a: Vec<Vec<f64>> = (0..k)
+                .map(|t| topic_beta(&base[t], &disc[t], &[x_true[a]]))
+                .collect();
+            let ndocs = if a == 0 {
+                40
+            } else if a == 1 {
+                3
+            } else {
+                10
+            };
+            for _ in 0..ndocs {
+                let mut doc = Vec::new();
+                for _ in 0..40 {
+                    let t = rng.gen_range(0..k);
+                    doc.push(sample_cat(&beta_a[t], &mut rng) as u32);
+                }
+                docs.push(doc);
+                group.push(a);
+            }
+        }
+        let anchors = vec![(0usize, x_true[0])];
+        let m = fit_idealpoint(
+            &docs, &group, a_n, k, vsz, dd, &rho, &anchors, 40, 1e-6, 0.0, 1e6, 10.0, 1.0, 15,
+            &mut rng,
+        );
+        // Reconstruct ntot[a][k] = sum_{d in a} L_d theta_{d,k}, as the binding does.
+        let theta = m.doc_topics();
+        let mut ntot = vec![vec![0.0f64; k]; a_n];
+        for (d, theta_d) in theta.iter().enumerate() {
+            let a = group[d];
+            let len = docs[d].len() as f64;
+            for (kk, &t) in theta_d.iter().enumerate() {
+                ntot[a][kk] += len * t;
+            }
+        }
+        let se = m.position_se(&ntot, 1.0);
+        assert_eq!(se.len(), a_n);
+        for row in &se {
+            assert_eq!(row.len(), dd);
+            assert!(row[0].is_finite() && row[0] > 0.0, "bad SE: {row:?}");
+            // The prior alone caps the SE at sqrt(x_prior_variance) = 1.
+            assert!(row[0] <= 1.0 + 1e-9, "SE exceeds prior SD: {}", row[0]);
+        }
+        // The data-rich author (0) is more precisely placed than the data-poor one (1).
+        assert!(
+            se[0][0] < se[1][0],
+            "data-rich author should have smaller SE: {} vs {}",
+            se[0][0],
+            se[1][0]
+        );
     }
 
     #[test]

--- a/src/idealpoint_lda.rs
+++ b/src/idealpoint_lda.rs
@@ -109,6 +109,21 @@ impl IdealPointLdaModel {
             })
             .collect()
     }
+
+    /// Asymptotic standard error of each author position, `(A x d)`. Same observed-
+    /// information derivation as the embedded core; here the discrimination logits
+    /// are the per-word loadings `W_{k,j,v}` directly. See
+    /// [`crate::idealpoint::position_ses`].
+    pub fn position_se(&self, ntot: &[Vec<f64>], x_prior_variance: f64) -> Vec<Vec<f64>> {
+        crate::idealpoint::position_ses(
+            self.num_authors,
+            self.num_dims,
+            ntot,
+            &self.w,
+            &|a, k| self.position_topic_beta(k, &self.x[a]),
+            x_prior_variance,
+        )
+    }
 }
 
 /// Fit the count representation by variational EM. `group[d]` maps document `d` to its author.

--- a/src/python/idealpoint.rs
+++ b/src/python/idealpoint.rs
@@ -54,6 +54,18 @@ impl IpInner {
             IpInner::Count(m) => &m.x,
         }
     }
+    fn group(&self) -> &Vec<usize> {
+        match self {
+            IpInner::Embedded(m) => &m.group,
+            IpInner::Count(m) => &m.group,
+        }
+    }
+    fn position_se(&self, ntot: &[Vec<f64>], x_prior_variance: f64) -> Vec<Vec<f64>> {
+        match self {
+            IpInner::Embedded(m) => m.position_se(ntot, x_prior_variance),
+            IpInner::Count(m) => m.position_se(ntot, x_prior_variance),
+        }
+    }
     fn topic_discrimination(&self) -> Vec<f64> {
         match self {
             IpInner::Embedded(m) => m.topic_discrimination(),
@@ -200,6 +212,31 @@ impl IdealPointTM {
         self.model
             .as_ref()
             .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+    }
+
+    /// Per-author expected topic-token counts `n_{a,k}` (`A x K`), reconstructed
+    /// from the stored corpus and document topic proportions:
+    /// `n_{a,k} = sum_{d in a} L_d theta_{d,k}`, where `L_d` is the doc's in-vocab
+    /// length. This is the data weight each author's position SE conditions on, and
+    /// it is recoverable from saved state, so the SE is available after `load`.
+    fn author_topic_counts(&self) -> PyResult<Vec<Vec<f64>>> {
+        let m = self.fitted_model()?;
+        let theta = m.doc_topics();
+        let group = m.group();
+        let a_n = m.num_authors();
+        let corpus = self
+            .corpus
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))?;
+        let mut ntot = vec![vec![0.0f64; self.num_topics]; a_n];
+        for (d, theta_d) in theta.iter().enumerate() {
+            let a = group[d];
+            let len = corpus.docs[d].len() as f64;
+            for (kk, &t) in theta_d.iter().enumerate() {
+                ntot[a][kk] += len * t;
+            }
+        }
+        Ok(ntot)
     }
 
     /// Shared front matter for both fit paths: resolve docs, author grouping, and
@@ -428,6 +465,20 @@ impl IdealPointTM {
     #[getter]
     fn author_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         Ok(vecs_to_arr2(self.fitted_model()?.x()).to_pyarray_bound(py))
+    }
+    /// Asymptotic standard error of each author position (num_authors, num_dims),
+    /// from the observed information of the penalized position objective at the fit.
+    /// Conditions on the fitted topic content (alpha/W), the multinomial-content
+    /// analog of Wordfish's Hessian-based `se.theta`; an author's SE shrinks with
+    /// the number of tokens they contribute. Aligned to `author_positions` /
+    /// `author_names`.
+    #[getter]
+    fn position_se<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let ntot = self.author_topic_counts()?;
+        let se = self
+            .fitted_model()?
+            .position_se(&ntot, self.x_prior_variance);
+        Ok(vecs_to_arr2(&se).to_pyarray_bound(py))
     }
     /// The author labels, in the row order of `author_positions`.
     #[getter]

--- a/src/python/sentence_ideal.rs
+++ b/src/python/sentence_ideal.rs
@@ -220,6 +220,15 @@ impl IdealPointSentenceTM {
     fn author_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         Ok(vecs_to_arr2(&self.fitted_model()?.x).to_pyarray_bound(py))
     }
+    /// Standard error of each author position (num_authors, num_dims). The position
+    /// is a linear-Gaussian least squares given the topic responsibilities, so this
+    /// is the exact Laplace posterior SE, sqrt(diag(H_a^-1)); it shrinks with the
+    /// number of the author's observations. Aligned to `author_positions`.
+    #[getter]
+    fn position_se<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        let se = self.fitted_model()?.position_se(self.x_prior_variance);
+        Ok(vecs_to_arr2(&se).to_pyarray_bound(py))
+    }
     #[getter]
     fn author_names(&self) -> PyResult<Vec<String>> {
         self.fitted_model()?;

--- a/src/python/tbip.rs
+++ b/src/python/tbip.rs
@@ -282,6 +282,14 @@ impl TBIP {
     fn ideal_points<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         Ok(Array1::from(self.fitted_model()?.ideal_points()).to_pyarray_bound(py))
     }
+    /// Standard error of each author ideal point (num_authors,): the standard
+    /// deviation of the Gaussian variational posterior q(x_s) estimated jointly with
+    /// the mean. As with any mean-field VI this can understate the true posterior
+    /// spread. Aligned to `ideal_points` / `author_names`.
+    #[getter]
+    fn position_se<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        Ok(Array1::from(self.fitted_model()?.position_se()).to_pyarray_bound(py))
+    }
     #[getter]
     fn author_names(&self) -> PyResult<Vec<String>> {
         self.fitted_model()?;

--- a/src/sentence_ideal.rs
+++ b/src/sentence_ideal.rs
@@ -67,6 +67,85 @@ impl SentenceIdealModel {
             })
             .collect()
     }
+
+    /// Asymptotic standard error of each author position `(A x d)`. The position is
+    /// a linear-Gaussian weighted least squares (E-step responsibilities held
+    /// fixed), so the negative-log-posterior Hessian is exact and constant in `x`:
+    /// `H_a = (sum_k N_{a,k} G_k) / sigma^2 + I / x_prior_variance`, with
+    /// `N_{a,k} = sum_{i in a} r_{i,k}` the expected number of the author's
+    /// observations in topic `k` and `G_k[j,l] = V_{k,j}.V_{k,l}`. The SE is
+    /// `sqrt(diag(H_a^{-1}))` -- the closed-form analog of Wordfish's `se.theta`,
+    /// exact here because the model is Gaussian in `x` given the responsibilities.
+    pub fn position_se(&self, x_prior_variance: f64) -> Vec<Vec<f64>> {
+        let dd = self.num_dims;
+        let inv_xvar = 1.0 / x_prior_variance;
+        let inv_s2 = 1.0 / self.sigma2.max(1e-300);
+        // Per-topic G_k[j,l] = V_{k,j} . V_{k,l} (d x d), constant across authors.
+        let g_topic: Vec<Vec<f64>> = self
+            .v
+            .iter()
+            .map(|vk| {
+                let mut g = vec![0.0f64; dd * dd];
+                for j in 0..dd {
+                    for l in j..dd {
+                        let dot: f64 = vk[j].iter().zip(&vk[l]).map(|(&a, &b)| a * b).sum();
+                        g[j * dd + l] = dot;
+                        g[l * dd + j] = dot;
+                    }
+                }
+                g
+            })
+            .collect();
+        // N_{a,k} = sum_{i in a} resp[i][k].
+        let mut nak = vec![vec![0.0f64; self.num_topics]; self.num_authors];
+        for (i, ri) in self.resp.iter().enumerate() {
+            let a = self.group[i];
+            for (kk, &r) in ri.iter().enumerate() {
+                nak[a][kk] += r;
+            }
+        }
+        (0..self.num_authors)
+            .map(|a| {
+                let mut h = vec![0.0f64; dd * dd];
+                for kk in 0..self.num_topics {
+                    let n = nak[a][kk];
+                    if n <= 0.0 {
+                        continue;
+                    }
+                    for idx in 0..dd * dd {
+                        h[idx] += n * inv_s2 * g_topic[kk][idx];
+                    }
+                }
+                for j in 0..dd {
+                    h[j * dd + j] += inv_xvar;
+                }
+                if dd == 1 {
+                    return vec![if h[0] > 0.0 {
+                        h[0].sqrt().recip()
+                    } else {
+                        f64::NAN
+                    }];
+                }
+                let cov = spd_inverse(&h, dd).unwrap_or_else(|| {
+                    let mut id = vec![0.0f64; dd * dd];
+                    for j in 0..dd {
+                        id[j * dd + j] = f64::NAN;
+                    }
+                    id
+                });
+                (0..dd)
+                    .map(|j| {
+                        let var = cov[j * dd + j];
+                        if var > 0.0 {
+                            var.sqrt()
+                        } else {
+                            f64::NAN
+                        }
+                    })
+                    .collect()
+            })
+            .collect()
+    }
 }
 
 /// Displaced mean `mu_k + sum_j x_{a,j} V_{k,j}` (length D).
@@ -582,6 +661,73 @@ mod tests {
         assert!(
             disc[hi] > disc[lo],
             "discrimination should differ: {disc:?}"
+        );
+
+        // Position SEs are finite, positive, capped by the prior SD (=1), and the
+        // exact Laplace covariance, so they are reproducible across calls.
+        let se = m.position_se(1.0);
+        assert_eq!(se.len(), a_n);
+        for row in &se {
+            assert_eq!(row.len(), dd);
+            assert!(row[0].is_finite() && row[0] > 0.0, "bad SE: {row:?}");
+            assert!(row[0] <= 1.0 + 1e-9, "SE exceeds prior SD: {}", row[0]);
+        }
+    }
+
+    // An author with many observations is placed more precisely than one with few.
+    #[test]
+    fn sentence_position_se_shrinks_with_data() {
+        let mut rng = ChaCha8Rng::seed_from_u64(9);
+        let (k, dim, dd) = (2usize, 6usize, 1usize);
+        let a_n = 12usize;
+        let mut mu_true = vec![vec![0.0f64; dim]; k];
+        mu_true[0][0] = 3.0;
+        mu_true[1][1] = 3.0;
+        let mut v_true = vec![vec![vec![0.0f64; dim]; dd]; k];
+        v_true[0][0][2] = 2.0;
+        v_true[0][0][3] = -2.0;
+        let x_true: Vec<f64> = (0..a_n).map(|_| rng.gen::<f64>() * 2.0 - 1.0).collect();
+        let sigma = 0.5;
+        let mut emb: Vec<Vec<f64>> = Vec::new();
+        let mut group: Vec<usize> = Vec::new();
+        for a in 0..a_n {
+            // author 0 data-rich, author 1 data-poor, the rest moderate
+            let nobs = if a == 0 {
+                120
+            } else if a == 1 {
+                6
+            } else {
+                25
+            };
+            for _ in 0..nobs {
+                let t = rng.gen_range(0..k);
+                let mean = topic_mean(&mu_true[t], &v_true[t], &[x_true[a]]);
+                let e: Vec<f64> = mean
+                    .iter()
+                    .map(|&m| m + (rng.gen::<f64>() - 0.5) * 2.0 * sigma * 1.732)
+                    .collect();
+                emb.push(e);
+                group.push(a);
+            }
+        }
+        let m = fit_sentence_ideal(
+            &emb,
+            &group,
+            a_n,
+            k,
+            dd,
+            &[(0, x_true[0])],
+            60,
+            1e-7,
+            1.0,
+            &mut rng,
+        );
+        let se = m.position_se(1.0);
+        assert!(
+            se[0][0] < se[1][0],
+            "data-rich author should have smaller SE: {} vs {}",
+            se[0][0],
+            se[1][0]
         );
     }
 }

--- a/src/tbip.rs
+++ b/src/tbip.rs
@@ -135,6 +135,19 @@ impl TbipModel {
         self.params.mu_x.clone()
     }
 
+    /// Standard error of each author ideal point (length A): the standard deviation
+    /// of the Gaussian variational posterior `q(x_s) = N(mu_x, sig_x^2)`,
+    /// `sig_x = softplus(rs_x) + SQRT_FLOOR`. This is the model's own (mean-field)
+    /// posterior uncertainty on the position, estimated jointly with the mean; like
+    /// any mean-field VI it can understate the true posterior spread.
+    pub fn position_se(&self) -> Vec<f64> {
+        self.params
+            .rs_x
+            .iter()
+            .map(|&rs| softplus(rs) + SQRT_FLOOR)
+            .collect()
+    }
+
     /// Neutral topic-word matrix from `exp(mu_beta)`, row-normalized for display
     /// (K x V simplices).
     pub fn topic_word(&self) -> Vec<Vec<f64>> {
@@ -1089,6 +1102,37 @@ mod tests {
         let r = pearson(&xhat, &x_true).abs();
         println!("synthetic recovery Pearson r = {r:.4}");
         assert!(r > 0.9, "ideal-point recovery too low: r={r:.4}");
+    }
+
+    // The position SE is the variational posterior SD: positive, finite, and equal
+    // to softplus(rs_x) + SQRT_FLOOR for every author.
+    #[test]
+    fn position_se_is_variational_posterior_sd() {
+        let mut rng = ChaCha8Rng::seed_from_u64(2);
+        let (k, block) = (2usize, 6usize);
+        let v = k * block;
+        let docs: Vec<Vec<u32>> = (0..30)
+            .map(|d| {
+                let bk = d % k;
+                (0..10)
+                    .map(|_| (bk * block + (rng.gen::<f64>() * block as f64) as usize) as u32)
+                    .collect()
+            })
+            .collect();
+        let group: Vec<usize> = (0..docs.len()).map(|d| d % 6).collect();
+        let cfg = TbipConfig {
+            iters: 40,
+            batch_size: docs.len(),
+            ..Default::default()
+        };
+        let m = fit_tbip(&docs, &group, 6, k, v, &cfg, &mut rng);
+        let se = m.position_se();
+        assert_eq!(se.len(), 6);
+        for (s, &sd) in se.iter().enumerate() {
+            assert!(sd.is_finite() && sd > 0.0, "bad SE: {sd}");
+            let expect = softplus(m.params.rs_x[s]) + SQRT_FLOOR;
+            assert!((sd - expect).abs() < 1e-12, "{sd} vs {expect}");
+        }
     }
 
     #[test]

--- a/tests/test_idealpoint.py
+++ b/tests/test_idealpoint.py
@@ -98,6 +98,46 @@ def test_fitted_surface_is_well_shaped():
     assert len(m.top_words(5)) == K
 
 
+@pytest.mark.parametrize("representation", ["word2vec", "counts"])
+def test_position_se_is_well_shaped_and_shrinks_with_data(representation):
+    # Observed-information SE on the latent positions: aligned to author_positions,
+    # finite and positive, capped by the prior SD (sqrt(x_prior_variance)=1), and
+    # smaller for authors who contribute more tokens. Holds for both representations.
+    docs, vocab, emb, group, _ = _planted(seed=4)
+    # Give author_0 many extra documents so it is the data-rich author.
+    extra = [docs[i] for i in range(len(group)) if group[i] == "author_0"]
+    docs = docs + extra * 6
+    group = group + ["author_0"] * (len(extra) * 6)
+
+    m = topica.IdealPointTM(K, num_dims=1, seed=1)
+    kw = dict(word_embeddings=emb, vocabulary=vocab) if representation == "word2vec" else {}
+    m.fit(docs, group=group, iters=25, **kw)
+    assert m.representation == representation
+
+    se = m.position_se
+    assert se.shape == m.author_positions.shape == (m.num_authors, 1)
+    assert np.all(np.isfinite(se)) and np.all(se > 0.0)
+    assert np.all(se <= 1.0 + 1e-9)  # prior SD caps the SE
+
+    names = list(m.author_names)
+    rich = names.index("author_0")
+    others = [i for i in range(len(names)) if i != rich]
+    assert se[rich, 0] < np.median(se[others, 0])
+
+
+def test_position_se_survives_save_load():
+    # The SE is reconstructed from saved state (corpus + doc-topic proportions), so
+    # it is identical after a round trip even though it is not itself persisted.
+    docs, vocab, emb, group, _ = _planted(seed=5)
+    m = topica.IdealPointTM(K, num_dims=1, seed=1)
+    m.fit(docs, word_embeddings=emb, vocabulary=vocab, group=group, iters=20)
+    with tempfile.TemporaryDirectory() as d:
+        path = os.path.join(d, "m.topica")
+        m.save(path)
+        m2 = topica.IdealPointTM.load(path)
+    assert np.array_equal(m.position_se, m2.position_se)
+
+
 def test_recovers_positions():
     # The headline ideal-point claim: latent positions recover the planted author
     # trait. (Which topic absorbs the contrast is not asserted here -- on this

--- a/tests/test_scaling.py
+++ b/tests/test_scaling.py
@@ -60,6 +60,48 @@ def test_polarization_more_than_two_camps():
     assert topica.polarization(pos, lab) == pytest.approx(8.0 / 3.0, abs=1e-9)
 
 
+def test_polarization_ci_propagates_position_se():
+    # The point estimate matches polarization(); tight SEs give a narrow interval
+    # bracketing the estimate, large SEs widen it toward (and past) zero.
+    pos = np.array([-1.0, -0.9, -1.1, 1.0, 0.9, 1.1])
+    lab = ["L", "L", "L", "R", "R", "R"]
+    point = topica.polarization(pos, lab)
+
+    tight = topica.polarization_ci(pos, lab, np.full(6, 0.02), n_sim=2000, seed=0)
+    assert tight.estimate == pytest.approx(point, abs=1e-9)
+    assert tight.lo <= point <= tight.hi
+    assert tight.se > 0.0
+
+    wide = topica.polarization_ci(pos, lab, np.full(6, 1.0), n_sim=2000, seed=0)
+    assert wide.se > tight.se
+    assert wide.hi - wide.lo > tight.hi - tight.lo
+
+
+def test_polarization_ci_matches_model_surface():
+    # End to end: an ideal-point model's position_se feeds polarization_ci directly.
+    topica.enable_experimental(True)
+    rng = np.random.default_rng(0)
+    docs, group, lab = [], [], []
+    for camp in (0, 1):
+        for a in range(5):
+            p = np.ones(20)
+            p[:10] += 4 if camp == 0 else 0
+            p[10:] += 0 if camp == 0 else 4
+            p /= p.sum()
+            for _ in range(8):
+                docs.append(list(rng.choice([f"w{i}" for i in range(20)], size=25, p=p)))
+                group.append(f"{camp}_{a}")
+    m = topica.IdealPointTM(3, num_dims=1, seed=1)
+    m.fit(docs, group=group)
+    camp_of = {n: n.split("_")[0] for n in m.author_names}
+    labels = [camp_of[n] for n in m.author_names]
+    res = topica.polarization_ci(m.author_positions, labels, m.position_se, n_sim=500, seed=0)
+    assert res.estimate == pytest.approx(
+        topica.polarization(m.author_positions, labels), abs=1e-9
+    )
+    assert res.lo <= res.estimate <= res.hi
+
+
 def test_polarization_errors():
     with pytest.raises(ValueError):
         topica.polarization([0.1, 0.2, 0.3], ["L", "R"])  # length mismatch

--- a/tests/test_sentence_ideal.py
+++ b/tests/test_sentence_ideal.py
@@ -73,6 +73,39 @@ def test_shapes_and_topics():
     assert c.shape == (emb.shape[1],)
 
 
+def test_position_se_is_well_shaped_and_shrinks_with_data():
+    # The position SE is the exact Laplace posterior SE of the linear-Gaussian
+    # position system: aligned to author_positions, finite/positive, capped by the
+    # prior SD (sqrt(x_prior_variance)=1), and smaller for authors with more
+    # observations. Author a0 is made data-rich by replicating its observations.
+    emb, group, _ = _planted(seed=6)
+    emb = np.asarray(emb)
+    a0 = [i for i, g in enumerate(group) if g == "a0"]
+    emb = np.concatenate([emb] + [emb[a0]] * 6, axis=0)
+    group = list(group) + ["a0"] * (len(a0) * 6)
+
+    m = topica.IdealPointSentenceTM(num_topics=2, num_dims=1, seed=1)
+    m.fit(emb, group=group, iters=50)
+    se = m.position_se
+    assert se.shape == m.author_positions.shape == (m.num_authors, 1)
+    assert np.all(np.isfinite(se)) and np.all(se > 0.0)
+    assert np.all(se <= 1.0 + 1e-9)
+    names = list(m.author_names)
+    rich = names.index("a0")
+    others = [i for i in range(len(names)) if i != rich]
+    assert se[rich, 0] < np.median(se[others, 0])
+
+
+def test_position_se_survives_save_load(tmp_path):
+    emb, group, _ = _planted(seed=7)
+    m = topica.IdealPointSentenceTM(num_topics=2, num_dims=1, seed=1)
+    m.fit(emb, group=group, iters=40)
+    path = tmp_path / "s.topica"
+    m.save(str(path))
+    m2 = topica.IdealPointSentenceTM.load(str(path))
+    assert np.array_equal(m.position_se, m2.position_se)
+
+
 def test_anchors_orient_sign():
     emb, group, _ = _planted(seed=3)
     m = topica.IdealPointSentenceTM(num_topics=2, seed=1)

--- a/tests/test_tbip.py
+++ b/tests/test_tbip.py
@@ -59,6 +59,17 @@ def test_shapes_and_getters():
     assert m.iters_run == 200
 
 
+def test_position_se_is_variational_posterior_sd():
+    # The ideal-point SE is the SD of the Gaussian variational posterior q(x_s):
+    # aligned to ideal_points, finite and strictly positive.
+    docs, group, _ = _planted(seed=2)
+    m = topica.TBIP(num_topics=3, seed=0, iters=200, batch_size=64)
+    m.fit(docs, group=group)
+    se = m.position_se
+    assert se.shape == m.ideal_points.shape == (12,)
+    assert np.all(np.isfinite(se)) and np.all(se > 0.0)
+
+
 def test_recovers_positions():
     docs, group, x_true = _planted(seed=2, n_authors=15, docs_per=8)
     m = topica.TBIP(num_topics=3, seed=0, iters=1500, batch_size=len(docs))


### PR DESCRIPTION
Closes #310. First item in the standard-errors roadmap (#309).

Adds `position_se` to every ideal-point model where an analytic/posterior SE is principled, following the roadmap's rule that **bootstrap is the fallback** — used only where there is no likelihood or posterior.

## What's added

| Model | `position_se` route | Notes |
|---|---|---|
| `IdealPointTM` (count + word2vec cores) | Observed information of the penalized position objective | `J_a = Σ_k n_{a,k} Cov_β(disc_k) + I/x_prior_var`, `SE = sqrt(diag(J_a⁻¹))` — the multinomial-content analog of Wordfish's `se.theta` |
| `IdealPointSentenceTM` | Exact Laplace SE of the linear-Gaussian position step | `H_a = (Σ_k N_{a,k} VᵀV)/σ² + I/x_prior_var` |
| `TBIP` | Gaussian variational posterior SD | `softplus(rs_x) + floor`, the model's own uncertainty |
| `PartyEmbeddings` | *(none)* | Positions are a PCA of doc2vec tag vectors — no analytic SE; documented to use `topica.position_intervals` (bootstrap) |
| `Wordfish` | already had `position_se` | unchanged |

Plus **`topica.polarization_ci`**: propagates per-author position SEs by simulation to a confidence interval on the camp-gap polarization statistic (a band straddling zero means the camps aren't reliably apart). The analytic-SE companion to `position_intervals`.

## Design notes

- **No save-format change.** `IdealPointTM`'s SE needs per-author expected topic counts `n_{a,k}`; rather than persist a new field (which would break the bincode tag-31/33 saves #308 deliberately kept readable), it reconstructs them from the saved corpus + doc-topic proportions. SE is therefore identical across save/load, including for models saved before this PR.
- Each SE conditions on the fitted topic content, exactly as Wordfish conditions on its word parameters; an author's SE shrinks with the tokens/observations they contribute, and is capped by the prior SD when they have no data.
- SE computation is sequential over authors, so it is thread-count independent.

## Tests / gates

- Rust unit tests per core: finite/positive, capped by the prior SD, shrinks with data; TBIP SE equals the variational posterior SD.
- Python tests: each model's getter shape + alignment, save/load round-trip, and `polarization_ci` propagation (tight SEs → narrow interval, large SEs → wide).
- `cargo test --lib` (151) ✓ · `pytest` (3102 passed, 30 skipped) ✓ · `cargo fmt --check` ✓ · `cargo clippy` ✓ · `mkdocs build --strict` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)