### PR TITLE
Standard errors for DMR / GDMR feature effects (#311)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -342,14 +342,24 @@ model.fit(corpus)
 
 Dirichlet-Multinomial Regression: each document's topic prior depends on its
 metadata, `α_d = exp(Xγ)`. The learned `feature_effects` show how covariates
-shift topic propensity.
+shift topic propensity, and `feature_effect_se` reports the standard error of
+each, so you can tell a real effect from noise.
 
 ```python
 import numpy as np
 X, names = topica.one_hot(party)
 model = topica.DMR(num_topics=20, seed=1)
 model.fit(docs, X, feature_names=names)
+z = model.feature_effects / model.feature_effect_se   # |z| > ~2 ⇒ notable
 ```
+
+`feature_effect_se` is the standard error of each weight λ from the observed
+information of the penalized Dirichlet-multinomial likelihood at the fit — the
+curvature of the very objective L-BFGS maximizes to estimate the effects, so it
+is exact (no bootstrap) and computed once at fit time. The topics couple through
+the Dirichlet normalizer, so the full cross-topic Hessian is inverted rather than
+a per-topic approximation. `GDMR` exposes the same getter, rescaled to its
+Legendre basis.
 
 Like `LDA`, `DMR` accepts the alternate inference backends via `sampler=`:
 `"warp"` (WarpLDA with a per-document-α doc phase) for fine-grained, large-`K`

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -308,6 +308,15 @@ class DMR:
         ...
 
     @property
+    def feature_effect_se(self) -> numpy.typing.NDArray[numpy.float64] | None:
+        """Standard error of each feature weight lambda, shape (num_topics,
+        num_features), from the observed information of the penalized
+        Dirichlet-multinomial likelihood at the fit. Aligned to feature_effects; an
+        effect more than ~2 SEs from zero is the usual significance cue. None for
+        models saved before this was added."""
+        ...
+
+    @property
     def feature_names(self) -> list[str]:
         """Feature names aligned with feature_effects columns ('intercept' first)."""
         ...

--- a/python/topica/gdmr.py
+++ b/python/topica/gdmr.py
@@ -667,6 +667,21 @@ class GDMR:
         return self._get_true_feature_effects()
 
     @property
+    def feature_effect_se(self) -> np.ndarray | None:
+        """Standard error of :attr:`feature_effects`, shape ``(num_topics,
+        num_basis)``, from the underlying DMR's observed-information SE rescaled by
+        the same per-column factor that undoes the basis standardization. Aligned to
+        ``feature_effects``; ``None`` for models saved before this was added.
+        """
+        self._require_fitted()
+        dmr_se = self._dmr.feature_effect_se
+        if dmr_se is None:
+            return None
+        # The basis rescaling is a per-column linear map, so the SE scales by the
+        # same (non-negative) factor as the effect itself.
+        return dmr_se * np.abs(self._recover_scales)[np.newaxis, :]
+
+    @property
     def degrees(self) -> list[int]:
         """Maximum Legendre degree per metadata dimension (read-only)."""
         return list(self._degrees)

--- a/src/dmr.rs
+++ b/src/dmr.rs
@@ -204,6 +204,112 @@ pub fn dmr_objective_and_gradient(
     (value, grad)
 }
 
+/// Standard errors of the DMR feature weights `lambda`, from the observed
+/// information of the penalized Dirichlet-multinomial log-likelihood at the fit.
+///
+/// `lambda` is fit by maximizing the penalized likelihood (see
+/// [`dmr_objective_and_gradient`]), so its asymptotic covariance is the inverse of
+/// the negative Hessian of that objective. The topics couple through the Dirichlet
+/// normalizer `α_{d,·}`, so the Hessian is not block-diagonal across topics; per
+/// document `d` it is
+/// ```text
+///   ∂²L_d/∂λ_{t,f}∂λ_{u,g} = x_{d,f} x_{d,g} ( c_d a_t a_u + [t=u] a_t b_t )
+/// ```
+/// with `a_t = α_{d,t}`, `c_d = ψ'(α_{d,·}) − ψ'(α_{d,·}+N_d)`,
+/// `g_t = ψ(α_·) − ψ(α_·+N_d) + ψ(a_t+n_t) − ψ(a_t)`, and
+/// `b_t = a_t(ψ'(a_t+n_t) − ψ'(a_t)) + g_t`. The observed information is
+/// `J = (1/σ²)I − Σ_d H_d` (a `(T·F)×(T·F)` SPD matrix); the SE of `λ_{t,f}` is
+/// `sqrt(diag(J^{-1}))`. Returns `[num_topics][num_features]`, aligned to `lambda`.
+pub fn dmr_lambda_se(
+    lambda: &[Vec<f64>],
+    features: &[Vec<f64>],
+    doc_topic_counts: &[Vec<f64>],
+    num_topics: usize,
+    num_features: usize,
+    prior_variance: f64,
+    offset: Option<&[Vec<f64>]>,
+) -> Vec<Vec<f64>> {
+    use crate::linalg::{make_diagonally_dominant, spd_inverse};
+    use crate::optimize::trigamma;
+
+    let t = num_topics;
+    let f = num_features;
+    let p = t * f;
+    // Observed information J, assembled as (1/σ²)I − Σ_d H_d (row-major p x p).
+    let mut info = vec![0.0f64; p * p];
+    let mut a = vec![0.0f64; t];
+    let mut b = vec![0.0f64; t];
+
+    for (d, x) in features.iter().enumerate() {
+        let mut alpha_sum = 0.0f64;
+        for tt in 0..t {
+            let dot: f64 = lambda[tt].iter().zip(x).map(|(l, xi)| l * xi).sum();
+            let off = offset.map_or(0.0, |o| o[d][tt]);
+            a[tt] = (dot + off).exp();
+            alpha_sum += a[tt];
+        }
+        let counts = &doc_topic_counts[d];
+        let n_d: f64 = counts.iter().sum();
+        let c_d = trigamma(alpha_sum) - trigamma(alpha_sum + n_d);
+        let dg_asum = digamma(alpha_sum);
+        let dg_asum_n = digamma(alpha_sum + n_d);
+        for tt in 0..t {
+            let at = a[tt];
+            let n = counts[tt];
+            let g_t = dg_asum - dg_asum_n + digamma(at + n) - digamma(at);
+            b[tt] = at * (trigamma(at + n) - trigamma(at)) + g_t;
+        }
+        // Add −H_d = −x_f x_g ( c_d a_t a_u + [t=u] a_t b_t ) into J.
+        for tt in 0..t {
+            for uu in 0..t {
+                let mut coef = -c_d * a[tt] * a[uu];
+                if tt == uu {
+                    coef -= a[tt] * b[tt];
+                }
+                if coef == 0.0 {
+                    continue;
+                }
+                for ff in 0..f {
+                    let xf = x[ff];
+                    if xf == 0.0 {
+                        continue;
+                    }
+                    let row = (tt * f + ff) * p + uu * f;
+                    for gg in 0..f {
+                        info[row + gg] += coef * xf * x[gg];
+                    }
+                }
+            }
+        }
+    }
+    // Gaussian prior contributes (1/σ²) to the diagonal.
+    let inv_var = 1.0 / prior_variance;
+    for i in 0..p {
+        info[i * p + i] += inv_var;
+    }
+
+    let cov = spd_inverse(&info, p).unwrap_or_else(|| {
+        let mut s = info.clone();
+        make_diagonally_dominant(&mut s, p);
+        spd_inverse(&s, p).unwrap_or_else(|| vec![f64::NAN; p * p])
+    });
+    (0..t)
+        .map(|tt| {
+            (0..f)
+                .map(|ff| {
+                    let idx = tt * f + ff;
+                    let v = cov[idx * p + idx];
+                    if v > 0.0 {
+                        v.sqrt()
+                    } else {
+                        f64::NAN
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
 use crate::variational::lbfgs_minimize;
 
 /// Optimize `lambda` in place to maximize the penalized DMR likelihood for the
@@ -324,6 +430,113 @@ mod tests {
                     grad[t][f],
                     numeric
                 );
+            }
+        }
+    }
+
+    // The observed-information matrix used for SEs must equal the negative Hessian
+    // of the objective: finite-difference the analytic gradient w.r.t. each lambda
+    // entry and compare to -(J - prior) reconstructed from dmr_lambda_se's assembly.
+    // We check the full Hessian via the gradient's central difference.
+    #[test]
+    fn lambda_se_hessian_matches_finite_difference() {
+        use crate::linalg::spd_inverse;
+        let (t, f) = (3usize, 2usize);
+        let lambda = vec![vec![0.1, -0.2], vec![-0.3, 0.4], vec![0.05, 0.15]];
+        let features = vec![
+            vec![1.0, 0.5],
+            vec![1.0, -1.0],
+            vec![1.0, 2.0],
+            vec![1.0, 0.0],
+            vec![1.0, 1.3],
+        ];
+        let counts = vec![
+            vec![3.0f64, 1.0, 0.0],
+            vec![0.0f64, 2.0, 2.0],
+            vec![1.0f64, 1.0, 5.0],
+            vec![2.0f64, 0.0, 1.0],
+            vec![1.0f64, 3.0, 2.0],
+        ];
+        let sigma2 = 10.0;
+        let p = t * f;
+
+        // Analytic observed information J from the same assembly the SE uses.
+        // Rebuild J by inverting the SE-derived covariance is circular, so instead
+        // FD the gradient: H[i,j] = d g_i / d lambda_j, and J = -H + (1/sigma2)I.
+        let grad_flat = |lam: &[Vec<f64>]| -> Vec<f64> {
+            let (_, g) = dmr_objective_and_gradient(lam, &features, &counts, t, f, sigma2, None);
+            let mut out = vec![0.0; p];
+            for tt in 0..t {
+                for ff in 0..f {
+                    out[tt * f + ff] = g[tt][ff];
+                }
+            }
+            out
+        };
+        let eps = 1e-6;
+        let mut j_fd = vec![0.0f64; p * p];
+        for j in 0..p {
+            let (tj, fj) = (j / f, j % f);
+            let mut lp = lambda.clone();
+            let mut lm = lambda.clone();
+            lp[tj][fj] += eps;
+            lm[tj][fj] -= eps;
+            let gp = grad_flat(&lp);
+            let gm = grad_flat(&lm);
+            for i in 0..p {
+                // J = -H = -(dg/dlambda)
+                j_fd[i * p + j] = -(gp[i] - gm[i]) / (2.0 * eps);
+            }
+        }
+        let se_fd: Vec<f64> = {
+            let cov = spd_inverse(&j_fd, p).expect("FD info not invertible");
+            (0..p).map(|i| cov[i * p + i].sqrt()).collect()
+        };
+        let se = dmr_lambda_se(&lambda, &features, &counts, t, f, sigma2, None);
+        for tt in 0..t {
+            for ff in 0..f {
+                let analytic = se[tt][ff];
+                let numeric = se_fd[tt * f + ff];
+                assert!(
+                    (analytic - numeric).abs() < 1e-4 * (1.0 + numeric.abs()),
+                    "se[{tt}][{ff}]: analytic {analytic} vs FD {numeric}"
+                );
+            }
+        }
+    }
+
+    // More documents at the same design shrinks the standard errors.
+    #[test]
+    fn lambda_se_shrinks_with_more_data() {
+        let (t, f) = (2usize, 2usize);
+        let lambda = vec![vec![0.0, 0.6], vec![0.0, -0.6]];
+        let mk = |reps: usize| -> (Vec<Vec<f64>>, Vec<Vec<f64>>) {
+            let mut features = Vec::new();
+            let mut counts = Vec::new();
+            for i in 0..reps {
+                let cov = if i % 2 == 0 { 1.0 } else { -1.0 };
+                features.push(vec![1.0, cov]);
+                counts.push(if cov > 0.0 {
+                    vec![2.0f64, 8.0]
+                } else {
+                    vec![8.0f64, 2.0]
+                });
+            }
+            (features, counts)
+        };
+        let (fs, cs) = mk(40);
+        let (fl, cl) = mk(400);
+        let se_small = dmr_lambda_se(&lambda, &fs, &cs, t, f, 100.0, None);
+        let se_large = dmr_lambda_se(&lambda, &fl, &cl, t, f, 100.0, None);
+        for tt in 0..t {
+            for ff in 0..f {
+                assert!(
+                    se_large[tt][ff] < se_small[tt][ff],
+                    "se[{tt}][{ff}] should shrink: {} -> {}",
+                    se_small[tt][ff],
+                    se_large[tt][ff]
+                );
+                assert!(se_large[tt][ff].is_finite() && se_large[tt][ff] > 0.0);
             }
         }
     }

--- a/src/optimize.rs
+++ b/src/optimize.rs
@@ -16,6 +16,24 @@ pub fn digamma(mut x: f64) -> f64 {
     result + x.ln() - 0.5 * inv - inv2 * (1.0 / 12.0 - inv2 * (1.0 / 120.0 - inv2 / 252.0))
 }
 
+/// Trigamma function ψ'(x) via recurrence + asymptotic expansion (the derivative
+/// of [`digamma`]). Used for observed-information / standard-error computations.
+pub fn trigamma(mut x: f64) -> f64 {
+    let mut result = 0.0;
+    // Recurrence: ψ'(x) = ψ'(x+1) + 1/x²  →  shift x into the asymptotic region.
+    while x < 6.0 {
+        result += 1.0 / (x * x);
+        x += 1.0;
+    }
+    // Asymptotic: 1/x + 1/(2x²) + 1/(6x³) - 1/(30x⁵) + 1/(42x⁷) - 1/(30x⁹).
+    let inv = 1.0 / x;
+    let inv2 = inv * inv;
+    result
+        + inv
+        + 0.5 * inv2
+        + inv * inv2 * (1.0 / 6.0 - inv2 * (1.0 / 30.0 - inv2 * (1.0 / 42.0 - inv2 / 30.0)))
+}
+
 /// One Minka fixed-point step for a symmetric Dirichlet concentration parameter.
 ///
 /// Both alpha (document-topic) and beta (topic-word) optimisation use this

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -162,6 +162,9 @@ struct DmrState {
     // Thinned MCMC theta draws (num_draws, num_docs, num_topics), f32.
     #[serde(default)]
     theta_draws: Option<Arr3f32>,
+    // SE of the feature weights (num_topics, num_features); absent in old saves.
+    #[serde(default)]
+    feature_effect_se: Option<Arr2>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct LabeledState {
@@ -3320,6 +3323,7 @@ pub struct DMR {
     // keep_theta_draws=False. Feeds composition_theta's cross-sweep uncertainty.
     theta_draws: Option<Array3<f32>>,
     feature_effects: Option<Array2<f64>>, // (num_topics, num_features)
+    feature_effect_se: Option<Array2<f64>>, // (num_topics, num_features), SE of λ
     feature_names: Vec<String>,
     corpus: Option<corpus::Corpus>,
     log_likelihood_history: Vec<(usize, f64)>,
@@ -3398,6 +3402,7 @@ impl DMR {
             theta: None,
             theta_draws: None,
             feature_effects: None,
+            feature_effect_se: None,
             feature_names: Vec::new(),
             corpus: None,
             log_likelihood_history: Vec::new(),
@@ -3557,6 +3562,7 @@ impl DMR {
             acc_theta,
             theta_draw_buf,
             feat_eff,
+            feat_eff_se,
             ll_history,
             converged_flag,
             model,
@@ -3589,12 +3595,22 @@ impl DMR {
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
                 cv.phi_into(&mut acc_phi);
                 cv.theta_into(&mut acc_theta);
+                let se = dmr::dmr_lambda_se(
+                    &lambda,
+                    &feats,
+                    cv.doc_topic_expected(),
+                    k,
+                    nf,
+                    prior_variance,
+                    None,
+                );
                 let model = cv.to_topic_model(&corpus);
                 (
                     acc_phi,
                     acc_theta,
                     Vec::new(),
                     lambda,
+                    se,
                     Vec::new(),
                     false,
                     model,
@@ -3700,12 +3716,22 @@ impl DMR {
                         *v /= n;
                     }
                 }
+                let se = dmr::dmr_lambda_se(
+                    &lambda,
+                    &feats,
+                    &doc_topic_counts(ws.doc_topics(), k),
+                    k,
+                    nf,
+                    prior_variance,
+                    None,
+                );
                 let model = ws.to_topic_model();
                 (
                     acc_phi,
                     acc_theta,
                     theta_draw_buf,
                     lambda,
+                    se,
                     Vec::new(),
                     false,
                     model,
@@ -3850,11 +3876,21 @@ impl DMR {
                     }
                 }
 
+                let se = dmr::dmr_lambda_se(
+                    &lambda,
+                    &feats,
+                    &doc_topic_counts(&model.doc_topics, k),
+                    k,
+                    nf,
+                    prior_variance,
+                    None,
+                );
                 (
                     acc_phi,
                     acc_theta,
                     theta_draw_buf,
                     lambda,
+                    se,
                     ll_history,
                     converged_flag,
                     model,
@@ -3882,12 +3918,19 @@ impl DMR {
                 fe[[t, f]] = val;
             }
         }
+        let mut fe_se = Array2::<f64>::zeros((k, nf));
+        for (t, row) in feat_eff_se.iter().enumerate() {
+            for (f, &val) in row.iter().enumerate() {
+                fe_se[[t, f]] = val;
+            }
+        }
 
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         self.phi = Some(phi);
         self.theta = Some(theta);
         self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
         self.feature_effects = Some(fe);
+        self.feature_effect_se = Some(fe_se);
         self.feature_names = names;
         self.log_likelihood_history = ll_history;
         self.converged = converged_flag;
@@ -3950,6 +3993,24 @@ impl DMR {
     fn feature_effects<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.feature_effects.as_ref().unwrap().to_pyarray_bound(py))
+    }
+
+    /// Standard error of each feature weight λ, shape ``(num_topics, num_features)``,
+    /// from the observed information of the penalized Dirichlet-multinomial
+    /// likelihood at the fit — the curvature of the same objective L-BFGS maximizes
+    /// to estimate :attr:`feature_effects`. Aligned to ``feature_effects``; an
+    /// effect more than ~2 SEs from zero is the usual significance cue. ``None`` for
+    /// models saved before this was added.
+    #[getter]
+    fn feature_effect_se<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Option<Bound<'py, PyArray2<f64>>>> {
+        self.require_fitted()?;
+        Ok(self
+            .feature_effect_se
+            .as_ref()
+            .map(|a| a.to_pyarray_bound(py)))
     }
 
     /// Feature names aligned with the columns of :attr:`feature_effects`
@@ -4201,6 +4262,7 @@ impl DMR {
                 log_likelihood_history: self.log_likelihood_history.clone(),
                 converged: self.converged,
                 theta_draws: arr3f32_opt(&self.theta_draws),
+                feature_effect_se: arr2_opt(&self.feature_effect_se),
             },
         )
     }
@@ -4229,6 +4291,7 @@ impl DMR {
             phi: arr2_back(s.phi)?,
             theta: arr2_back(s.theta)?,
             feature_effects: arr2_back(s.feature_effects)?,
+            feature_effect_se: arr2_back(s.feature_effect_se)?,
             feature_names: s.feature_names,
             corpus: s.corpus,
             theta_draws: arr3f32_back(s.theta_draws)?,

--- a/tests/test_dmr.py
+++ b/tests/test_dmr.py
@@ -194,6 +194,12 @@ class TestDMRShapesAndProperties:
         # (num_topics, num_features) = (2, 2) [intercept + is_A]
         assert fitted_model.feature_effects.shape == (2, 2)
 
+    def test_feature_effect_se_shape_and_finite(self, fitted_model):
+        se = fitted_model.feature_effect_se
+        assert se is not None
+        assert se.shape == fitted_model.feature_effects.shape == (2, 2)
+        assert np.all(np.isfinite(se)) and np.all(se > 0.0)
+
     def test_feature_names_intercept_first(self, fitted_model):
         assert fitted_model.feature_names[0] == "intercept"
         assert fitted_model.feature_names == ["intercept", "is_A"]
@@ -247,6 +253,13 @@ class TestDMRCovariateRecovery:
             f"Covariate recovery failed: effect_diff={effect_diff:.4f} "
             f"(A_topic={A_topic}, feature_effects=\n{recovery_model.feature_effects})"
         )
+
+    def test_strong_effect_is_significant(self, recovery_model):
+        """The planted is_A effect is large, so it should sit many SEs from zero."""
+        A_topic = _identify_A_topic(recovery_model)
+        eff = recovery_model.feature_effects[A_topic, 1]
+        se = recovery_model.feature_effect_se[A_topic, 1]
+        assert abs(eff) / se > 2.0, f"z={eff / se:.2f} for a planted effect"
 
     def test_a_topic_has_positive_is_A_effect(self, recovery_model):
         """The A-topic (space words) should have a positive is_A feature effect."""

--- a/tests/test_gdmr.py
+++ b/tests/test_gdmr.py
@@ -241,6 +241,12 @@ class TestGDMRShapesAndInvariants:
         expected_num_basis = 3  # prod(d+1 for d in [2]) = 3
         assert fitted.feature_effects.shape == (K, expected_num_basis)
 
+    def test_feature_effect_se_shape_and_finite(self, fitted):
+        se = fitted.feature_effect_se
+        assert se is not None
+        assert se.shape == fitted.feature_effects.shape
+        assert np.all(np.isfinite(se)) and np.all(se > 0.0)
+
     def test_alpha_shape(self, fitted):
         K = fitted.num_topics
         assert fitted.alpha.shape == (K,)


### PR DESCRIPTION
Closes #311 (DMR/GDMR portion). The covariate-keyATM half is split to #316. Part of the standard-errors roadmap (#309).

Adds an analytic standard error next to every DMR feature weight λ, from the **observed information of the same penalized Dirichlet-multinomial objective** that L-BFGS already maximizes to fit the effects — so it's exact and bootstrap-free, following the roadmap's "analytic where the model affords it" rule.

## What's added
- **`dmr::dmr_lambda_se`** — assembles the `(T·F)×(T·F)` observed information `J = (1/σ²)I − Σ_d H_d`, inverts it, and takes `sqrt(diag)`. Topics couple through the Dirichlet normalizer `α_{d,·}`, so the **full cross-topic Hessian** is used rather than a per-topic block approximation. Per-doc structure: `H_d[(t,f),(u,g)] = x_f x_g (c_d a_t a_u + [t=u] a_t b_t)`.
- **`optimize::trigamma`** (ψ′), matching the existing `digamma`.
- **`DMR.feature_effect_se`** `(num_topics, num_features)` — computed at fit time on all three sampler paths (`sparse` / `warp` / `cvb0`), where the design matrix and final counts are in hand. `z = feature_effects / feature_effect_se`; `|z| > ~2` is the significance cue.
- **`GDMR.feature_effect_se`** — the DMR SE rescaled by the same per-column factor that undoes the Legendre-basis standardization.

## Design notes
- **Save format unchanged in spirit.** `feature_effect_se` is persisted via a `#[serde(default)]` trailing field, exactly the precedent set by `theta_draws`/`converged` on `DmrState`; old saves load with `feature_effect_se = None`.
- DMR doesn't store the design matrix `X`, so the SE is computed at fit (like `feature_effects` itself) rather than lazily.
- The SE conditions on the fitted topic assignments, the standard plug-in; it shrinks with more documents.

## Why keyATM is split (#316)
keyATM's covariate λ uses the same objective but is fit in **z-scored, ±5-bounded** space and isn't retained as a trace, so it needs a standardization Jacobian (or a new λ trace) to report correctly — separate, careful work.

## Tests / gates
- Rust: FD-check of the SE-implied observed information against the analytic gradient; SEs shrink with more data.
- Python: shape/finiteness for DMR and GDMR; a planted strong covariate effect lands >2 SEs from zero.
- `cargo test --lib` (153) ✓ · `pytest` (3105 passed, 30 skipped) ✓ · `cargo fmt --check` ✓ · `cargo clippy` ✓ · `mkdocs build --strict` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)