### PR TITLE
Credible intervals on STM/CTM topic correlations (#312)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -307,7 +307,11 @@ topica's STM matches R's STM.
 
 The Correlated Topic Model (logistic-normal): topics can co-occur, unlike LDA's
 Dirichlet. This is the engine STM builds on; `topic_correlation` reports the
-learned structure. Fit by parallel variational EM.
+learned structure, and `topica.topic_correlation_ci(model)` puts a credible
+interval on each cell by propagating the per-document logistic-normal posterior
+(it draws θ from `η_d ~ N(λ_d, ν_d)` and recomputes the correlation on each draw),
+so you can tell a reliably signed topic relationship from one whose interval
+straddles zero. Fit by parallel variational EM.
 
 For corpora too large to sweep in full each EM step, `fit(..., inference="svi")`
 switches to stochastic variational inference (online VB, Hoffman et al. 2013):

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -146,7 +146,7 @@ def summary(model, topn=8):
 
 from .gdmr import GDMR  # noqa: E402  (pure-Python Legendre-basis DMR wrapper)
 from . import stm  # noqa: E402  (stm imports names defined above)
-from .stm import align_corpus, spline, interaction  # noqa: E402  (general covariate-design helpers)
+from .stm import align_corpus, spline, interaction, topic_correlation_ci, TopicCorrelationCI  # noqa: E402  (general covariate-design helpers)
 from . import keyatm  # noqa: E402  (keyATM-specific workflow helpers)
 from . import ectm  # noqa: E402  (ECTM content-trajectory interpretation helpers)
 from . import effects  # noqa: E402  (model-neutral prevalence analysis)
@@ -319,6 +319,8 @@ __all__ = [
     "keyatm",
     "spline",
     "interaction",
+    "topic_correlation_ci",
+    "TopicCorrelationCI",
     "phrases",
     "coherence",
     "topic_diversity",

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -1243,6 +1243,92 @@ def posterior_theta_samples(model, nsims=25, seed=0):
     return theta.transpose(1, 0, 2).copy()               # (nsims, D, K)
 
 
+@dataclass
+class TopicCorrelationCI:
+    """A topic-correlation matrix with a credible interval per cell.
+
+    ``estimate``/``se``/``ci_low``/``ci_high`` are each ``(num_topics,
+    num_topics)`` arrays: the point estimate (the model's ``topic_correlation``),
+    the posterior standard deviation, and the lower/upper credible bounds.
+    """
+
+    estimate: np.ndarray
+    se: np.ndarray
+    ci_low: np.ndarray
+    ci_high: np.ndarray
+
+
+def _theta_correlation(theta):
+    """Across-document correlation of a doc-topic matrix ``theta`` (D, K) -> (K, K),
+    matching the core ``topic_correlation`` (biased covariance, unit diagonal, zero
+    where a topic has no variance)."""
+    cov = np.cov(np.asarray(theta, dtype=np.float64), rowvar=False, bias=True)
+    cov = np.atleast_2d(cov)
+    d = np.sqrt(np.clip(np.diag(cov), 0.0, None))
+    den = np.outer(d, d)
+    with np.errstate(invalid="ignore", divide="ignore"):
+        cor = np.where(den > 0.0, cov / den, 0.0)
+    np.fill_diagonal(cor, 1.0)
+    return cor
+
+
+def topic_correlation_ci(model, *, nsims=200, ci=0.9, seed=0):
+    """Credible interval on an STM/CTM topic-correlation matrix.
+
+    ``model.topic_correlation`` is the across-document correlation of the
+    *posterior-mean* doc-topic matrix. This propagates the model's logistic-normal
+    posterior into that statistic: it draws ``nsims`` doc-topic matrices from the
+    per-document posterior ``η_d ~ N(λ_d, ν_d)`` (via
+    :func:`posterior_theta_samples`), recomputes the correlation on each draw, and
+    reports the per-cell posterior mean, SD, and percentile interval. A cell whose
+    interval straddles zero is not a reliably signed topic relationship.
+
+    The returned ``estimate`` is the posterior *mean* of the across-draw
+    correlations, so the interval is centered on it. This is deliberately distinct
+    from ``model.topic_correlation``: the latter correlates the posterior means and
+    so ignores within-document posterior variance, which makes it more extreme than
+    the uncertainty-aware draw-based estimate here (adding per-document posterior
+    noise attenuates an across-document correlation). Use ``estimate`` with its
+    interval when you need honest uncertainty; ``model.topic_correlation`` remains
+    the conventional point summary.
+
+    Reuses the same posterior draws as method-of-composition effect estimation, so
+    it adds no new model state. Only logistic-normal models (STM/CTM/STS, which
+    carry ``eta_mean``/``eta_cov``) are supported.
+
+    Parameters
+    ----------
+    model : STM or CTM
+        A fitted logistic-normal topic model.
+    nsims : int
+        Number of posterior draws.
+    ci : float
+        Central interval mass (default 0.9 for a 90% interval).
+    seed : int
+        Seed for the posterior draws.
+
+    Returns
+    -------
+    TopicCorrelationCI
+        ``(estimate, se, ci_low, ci_high)``, each ``(num_topics, num_topics)``.
+    """
+    cls = type(model)
+    if not (hasattr(cls, "eta_mean") and hasattr(cls, "eta_cov")):
+        raise TypeError(
+            "topic_correlation_ci requires a logistic-normal model (STM/CTM/STS) "
+            "with eta_mean/eta_cov; this model exposes neither"
+        )
+    draws = posterior_theta_samples(model, nsims=nsims, seed=seed)  # (nsims, D, K)
+    cors = np.stack([_theta_correlation(draws[s]) for s in range(draws.shape[0])])
+    estimate = cors.mean(axis=0)
+    np.fill_diagonal(estimate, 1.0)
+    lo_q, hi_q = (1.0 - ci) / 2.0, 1.0 - (1.0 - ci) / 2.0
+    ci_low = np.quantile(cors, lo_q, axis=0)
+    ci_high = np.quantile(cors, hi_q, axis=0)
+    se = cors.std(axis=0, ddof=1) if cors.shape[0] > 1 else np.zeros_like(estimate)
+    return TopicCorrelationCI(estimate, se, ci_low, ci_high)
+
+
 def spline(x, df=4, knots=None):
     """Restricted (natural) cubic-spline basis for a covariate — the building
     block for nonlinear prevalence terms like R ``stm``'s ``~ s(day)``.

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -176,6 +176,38 @@ def test_composition_top_words_is_rejected():
         topica.standard_errors(m, corpus, of="top_words", method="composition")
 
 
+def test_topic_correlation_ci_well_shaped_and_coherent():
+    # CTM/STM topic-correlation credible interval from the logistic-normal posterior:
+    # K x K, symmetric, unit diagonal, ci_low <= estimate <= ci_high in every cell,
+    # and the estimate is the posterior mean of the draw correlations.
+    _, corpus, _ = _planted()
+    m = topica.CTM(num_topics=3, seed=1)
+    m.fit(corpus, iters=40)
+    res = topica.topic_correlation_ci(m, nsims=150, ci=0.9, seed=0)
+    K = m.num_topics
+    for arr in (res.estimate, res.se, res.ci_low, res.ci_high):
+        assert arr.shape == (K, K)
+    assert np.allclose(res.estimate, res.estimate.T)
+    assert np.allclose(np.diag(res.estimate), 1.0)
+    assert np.all(res.ci_low <= res.estimate + 1e-9)
+    assert np.all(res.estimate <= res.ci_high + 1e-9)
+    assert np.all(res.ci_low <= res.ci_high + 1e-9)
+    assert np.all(np.isfinite(res.se))
+    # Wider interval mass gives a wider band.
+    narrow = topica.topic_correlation_ci(m, nsims=150, ci=0.5, seed=0)
+    span90 = float(np.sum(res.ci_high - res.ci_low))
+    span50 = float(np.sum(narrow.ci_high - narrow.ci_low))
+    assert span90 > span50
+
+
+def test_topic_correlation_ci_rejects_non_logistic_normal():
+    _, corpus, _ = _planted()
+    m = topica.LDA(2, seed=1)
+    m.fit(corpus, iters=50)
+    with pytest.raises(TypeError, match="logistic-normal"):
+        topica.topic_correlation_ci(m)
+
+
 def test_bootstrap_prevalence_matches_composition_on_clean_data():
     m, corpus, _ = _planted()
     comp = topica.standard_errors(m, corpus, of="prevalence", nsims=40)


### PR DESCRIPTION
Closes #312. Part of the standard-errors roadmap (#309).

Adds `topica.topic_correlation_ci(model)` — a per-cell credible interval on the topic-correlation matrix, by **propagating the model's logistic-normal posterior** rather than bootstrapping. Reuses the exact draw machinery that method-of-composition effect estimation already uses, so it adds **no new model state and no Rust/save changes**.

## How it works
- Draws `nsims` doc-topic matrices from the per-document posterior `η_d ~ N(λ_d, ν_d)` via `posterior_theta_samples`, recomputes the across-document correlation on each draw, and reports the per-cell posterior **mean, SD, and percentile interval** as a `TopicCorrelationCI` dataclass (`estimate`, `se`, `ci_low`, `ci_high`), each `K×K`.
- Only logistic-normal models (STM/CTM/STS, which carry `eta_mean`/`eta_cov`) are supported; others raise `TypeError`.

```python
res = topica.topic_correlation_ci(model, nsims=200, ci=0.9)
res.estimate, res.ci_low, res.ci_high   # K×K each; cells straddling 0 aren't reliably signed
```

## A subtlety worth flagging
The returned `estimate` is the **posterior mean of the draw correlations**, so the interval is centered on it. This is deliberately distinct from `model.topic_correlation`, which correlates the *posterior-mean* θ and so ignores within-document posterior variance. Adding per-document posterior noise attenuates an across-document correlation, so `model.topic_correlation` is systematically *more extreme* than the uncertainty-aware estimate here — and would fall outside the band if used as the center. Centering on the draw mean keeps the interval coherent; the docstring explains the relationship and when to use which.

## Tests / gates
- Shape / symmetry / unit-diagonal; `ci_low <= estimate <= ci_high` in every cell; wider `ci=` widens the band; non-logistic-normal models rejected.
- `pytest` (3107 passed, 30 skipped) ✓ · `mkdocs build --strict` ✓ · (no Rust changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)