### PR TITLE
Bootstrap intervals for topic coherence (#313)

### DIFF
--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -15,6 +15,8 @@ and in the `topica.validation` module.
 
 ::: topica.coherence
 
+::: topica.coherence_ci
+
 ::: topica.semantic_coherence
 
 ::: topica.topic_diversity

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -175,6 +175,8 @@ from .keyatm import time_prevalence_ci  # noqa: E402  (dynamic keyATM credible b
 from . import phrases  # noqa: E402
 from .coherence import (  # noqa: E402
     coherence,
+    coherence_ci,
+    CoherenceCI,
     semantic_coherence,
     topic_diversity,
     topic_semantic_diversity,
@@ -323,6 +325,8 @@ __all__ = [
     "TopicCorrelationCI",
     "phrases",
     "coherence",
+    "coherence_ci",
+    "CoherenceCI",
     "topic_diversity",
     "topic_semantic_diversity",
     "exclusivity",

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import math
 import re
 from collections import Counter, defaultdict
+from dataclasses import dataclass
 from itertools import combinations
 
 import numpy as np
@@ -354,6 +355,97 @@ def coherence(topics, texts, *, coherence_type="c_v", topn=10, window_size=None,
     p = occ / nw
     scorer = {"c_uci": _score_uci, "c_npmi": _score_npmi, "c_v": _score_cv}[ct]
     return np.array([scorer(t, vocab, p, co, nw, epsilon) for t in tops])
+
+
+@dataclass
+class CoherenceCI:
+    """Per-topic coherence with a bootstrap standard error and interval.
+
+    ``estimate``/``se``/``ci_low``/``ci_high`` are each ``(num_topics,)`` arrays:
+    the coherence on the full reference corpus, the bootstrap standard error, and
+    the lower/upper percentile bounds.
+    """
+
+    estimate: np.ndarray
+    se: np.ndarray
+    ci_low: np.ndarray
+    ci_high: np.ndarray
+
+
+def coherence_ci(
+    topics,
+    texts,
+    *,
+    coherence_type="c_v",
+    topn=10,
+    window_size=None,
+    n_boot=200,
+    ci=0.9,
+    seed=0,
+    epsilon=1e-12,
+):
+    """Bootstrap standard errors and a credible interval for topic coherence.
+
+    Coherence is a corpus statistic with no model likelihood or posterior behind
+    it, so its uncertainty is obtained by bootstrap: hold each topic's top words
+    fixed, resample the reference documents with replacement ``n_boot`` times,
+    recompute coherence on each resample, and report the per-topic standard error
+    and percentile interval. The topics never change, so there is no refit and no
+    topic-alignment step — the interval reflects how much a topic's coherence score
+    would wobble under a different sample of the reference corpus, the honest answer
+    to "is topic A's coherence reliably higher than topic B's?".
+
+    ``estimate`` is the coherence on the full corpus (the conventional point
+    summary); because resampling documents estimates the sampling distribution of
+    that same statistic, the percentile interval is centered on it (unlike the
+    posterior-draw intervals elsewhere).
+
+    Parameters
+    ----------
+    topics : a fitted model, or a list of topics (each a list of words / ``(word,
+        prob)`` pairs). The top words are extracted once and held fixed.
+    texts : list of tokenized documents — the reference corpus to resample.
+    coherence_type, topn, window_size, epsilon : as in :func:`coherence`.
+    n_boot : number of bootstrap resamples (each recomputes co-occurrence, so this
+        is O(n_boot x corpus size); the windowed measures (``c_v`` etc.) are the
+        costliest).
+    ci : central interval mass (default 0.9 for a 90% interval).
+    seed : seed for the document resampling.
+
+    Returns
+    -------
+    CoherenceCI
+        ``(estimate, se, ci_low, ci_high)``, each ``(num_topics,)``.
+    """
+    if len(texts) == 0:
+        raise ValueError("texts is empty; pass the reference corpus as list[list[str]]")
+    # Fix the top words once; pass them as the `topics` argument on every resample
+    # so the coherence is recomputed for the same words against new corpora.
+    tops = _extract_topics(topics, topn)
+    texts = [list(d) for d in texts]
+    common = dict(coherence_type=coherence_type, topn=topn, window_size=window_size, epsilon=epsilon)
+    estimate = coherence(tops, texts, **common)
+
+    d = len(texts)
+    k = len(tops)
+    rng = np.random.default_rng(seed)
+    draws = np.empty((n_boot, k), dtype=float)
+    for b in range(n_boot):
+        picks = rng.integers(0, d, size=d)
+        boot = [texts[i] for i in picks]
+        draws[b] = coherence(tops, boot, **common)
+
+    lo_q, hi_q = (1.0 - ci) / 2.0, 1.0 - (1.0 - ci) / 2.0
+    se = np.full(k, np.nan)
+    ci_low = np.full(k, np.nan)
+    ci_high = np.full(k, np.nan)
+    for t in range(k):
+        col = draws[:, t]
+        col = col[np.isfinite(col)]
+        if col.size >= 2:
+            se[t] = col.std(ddof=1)
+            ci_low[t], ci_high[t] = np.quantile(col, [lo_q, hi_q])
+    return CoherenceCI(np.asarray(estimate, dtype=float), se, ci_low, ci_high)
 
 
 def topic_diversity(topics, topn=25):

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -46,6 +46,45 @@ class TestCoherenceRanksTopics:
         assert s.shape == (3,)
 
 
+class TestCoherenceCI:
+    def test_shape_and_estimate_matches_point(self, reference):
+        r = topica.coherence_ci(
+            [COHERENT, INCOHERENT], reference, coherence_type="c_npmi", topn=3, n_boot=100, seed=0
+        )
+        point = topica.coherence([COHERENT, INCOHERENT], reference, coherence_type="c_npmi", topn=3)
+        for arr in (r.estimate, r.se, r.ci_low, r.ci_high):
+            assert arr.shape == (2,)
+        np.testing.assert_allclose(r.estimate, point)
+
+    def test_interval_brackets_estimate_and_orders(self, reference):
+        r = topica.coherence_ci(
+            [COHERENT, INCOHERENT], reference, coherence_type="c_npmi", topn=3, n_boot=150, seed=1
+        )
+        assert np.all(r.ci_low <= r.estimate + 1e-9)
+        assert np.all(r.estimate <= r.ci_high + 1e-9)
+        assert np.all(r.ci_low <= r.ci_high)
+        assert np.all(np.isfinite(r.se)) and np.all(r.se >= 0.0)
+
+    def test_wider_ci_widens_band(self, reference):
+        wide = topica.coherence_ci(
+            [COHERENT, INCOHERENT], reference, coherence_type="c_npmi", topn=3, n_boot=150, ci=0.95, seed=2
+        )
+        narrow = topica.coherence_ci(
+            [COHERENT, INCOHERENT], reference, coherence_type="c_npmi", topn=3, n_boot=150, ci=0.5, seed=2
+        )
+        assert float(np.sum(wide.ci_high - wide.ci_low)) > float(np.sum(narrow.ci_high - narrow.ci_low))
+
+    def test_accepts_fitted_model(self, reference):
+        m = LDA(num_topics=2, seed=1)
+        m.fit(reference, iters=200)
+        r = topica.coherence_ci(m, reference, coherence_type="c_npmi", topn=3, n_boot=50, seed=0)
+        assert r.estimate.shape == (2,)
+
+    def test_empty_texts_raises(self):
+        with pytest.raises(ValueError, match="texts is empty"):
+            topica.coherence_ci([COHERENT], [], n_boot=10)
+
+
 class TestRanges:
     def test_npmi_in_unit_range(self, reference):
         s = topica.coherence([COHERENT, INCOHERENT], reference, coherence_type="c_npmi", topn=3)


### PR DESCRIPTION
Closes #313. Part of the standard-errors roadmap (#309).

Adds `topica.coherence_ci()` — per-topic bootstrap standard error and percentile interval on topic coherence. Coherence is a corpus statistic with no model likelihood or posterior behind it, so **bootstrap is the right (and only) tool** — this is the one genuine bootstrap case in the roadmap, as planned.

## How it works
- Holds each topic's top words **fixed**, resamples the reference documents with replacement `n_boot` times, and recomputes coherence on each resample via the existing model-agnostic `topica.coherence`. **No refit and no topic alignment** (the topics never change), so it's cheap and the interval cleanly reflects sampling variability of the coherence score.
- `estimate` is the full-corpus coherence. Because resampling documents estimates the sampling distribution of that *same* statistic, the percentile interval is centered on it (the textbook bootstrap CI — and unlike the posterior-draw intervals elsewhere, no attenuation subtlety).
- Returns `CoherenceCI(estimate, se, ci_low, ci_high)`, each `(num_topics,)`. Works for any `coherence_type` (`u_mass`/`c_uci`/`c_npmi`/`c_v`) and accepts a fitted model or raw word lists.

```python
r = topica.coherence_ci(model, docs, coherence_type="c_npmi", n_boot=200, ci=0.9)
# topic t's coherence is r.estimate[t] with interval [r.ci_low[t], r.ci_high[t]]
```

Pure Python, reuses `topica.coherence`; **no Rust or save-format changes**.

## Tests / gates
- Shape; `estimate == coherence()`; interval brackets the estimate and is ordered; wider `ci=` widens the band; fitted-model input; empty-texts guard.
- `pytest` (3112 passed, 30 skipped) ✓ · `mkdocs build --strict` ✓ · (no Rust changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)