### PR TITLE
Coefficient SEs and predictive intervals for SupervisedLDA (#314)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -881,6 +881,22 @@ Topics shaped to predict a per-document real-valued response (Blei & McAuliffe).
 `coefficients` give each topic's pull on the outcome, and `predict` scores new
 documents.
 
+Both come with uncertainty. `coefficient_se` is the standard error of each
+regression coefficient, from the OLS covariance `σ²M⁻¹` of the same normal
+equations the fit solves (`|coef| > ~2·SE` is the significance cue), so you can
+say which topics reliably move the outcome. `predict(docs, return_std=True)`
+returns `(mean, std)`, where `std` is the posterior-predictive standard
+deviation — the document's topic uncertainty propagated through the regression
+plus the residual `σ²` — so a prediction comes with an honest interval
+(`mean ± 1.96·std`) rather than a bare point.
+
+```python
+m = topica.SupervisedLDA(num_topics=20, seed=1)
+m.fit(docs, y)
+z = m.coefficients / m.coefficient_se        # which topics matter
+mean, std = m.predict(new_docs, return_std=True)
+```
+
 ## LabeledLDA
 
 Supervised: each label is a topic, and a document's tokens are restricted to its

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1448,10 +1448,22 @@ class SupervisedLDA:
         ...
 
     def predict(
-        self, data: Corpus | Sequence[Sequence[str]], *, var_iters: int = 20
-    ) -> numpy.typing.NDArray[numpy.float64]:
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        var_iters: int = 20,
+        return_std: bool = False,
+    ) -> (
+        numpy.typing.NDArray[numpy.float64]
+        | tuple[numpy.typing.NDArray[numpy.float64], numpy.typing.NDArray[numpy.float64]]
+    ):
         """Predict y-hat for new documents. Out-of-vocabulary words are ignored.
-        Returns a 1-D array of length = number of documents."""
+
+        With return_std=False (default) returns a 1-D array of predictions. With
+        return_std=True returns (mean, std), where std is the posterior-predictive
+        standard deviation — the document's topic uncertainty propagated through the
+        regression plus the residual variance sigma^2. A 95% interval is
+        mean +/- 1.96 * std."""
         ...
 
     @property
@@ -1475,6 +1487,14 @@ class SupervisedLDA:
     def coefficients(self) -> numpy.typing.NDArray[numpy.float64]:
         """Regression coefficients eta, shape (num_topics,) — how each topic
         moves the response per unit of topic frequency."""
+        ...
+    @property
+    def coefficient_se(self) -> numpy.typing.NDArray[numpy.float64] | None:
+        """Standard error of each regression coefficient eta, shape (num_topics,),
+        from the OLS covariance sigma^2 * M^-1 where M = sum_d E[zbar zbar^T] is the
+        normal-equations matrix the fit solves for eta. Aligned to coefficients;
+        |eta| > ~2*SE is the usual significance cue. None for models saved before
+        this was added."""
         ...
     @property
     def sigma2(self) -> float:

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -408,6 +408,9 @@ struct SldaState {
     log_likelihood_history: Vec<(usize, f64)>,
     #[serde(default)]
     converged: bool,
+    // K×K normal-equations matrix for coefficient SEs; absent in old saves.
+    #[serde(default)]
+    m_mat: Option<Vec<f64>>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct PtState {
@@ -10429,7 +10432,8 @@ pub struct SupervisedLDA {
     topic_names: Vec<String>,
     sigma2: f64,
     eta: Option<Array1<f64>>,
-    beta: Option<Array2<f64>>,  // K × V
+    m_mat: Option<Vec<f64>>, // K×K normal-equations matrix, for coefficient SEs
+    beta: Option<Array2<f64>>, // K × V
     theta: Option<Array2<f64>>, // D × K
     log_beta: Option<Vec<Vec<f64>>>,
     corpus: Option<corpus::Corpus>,
@@ -10478,6 +10482,7 @@ impl SupervisedLDA {
             topic_names: Vec::new(),
             sigma2: 0.0,
             eta: None,
+            m_mat: None,
             beta: None,
             theta: None,
             log_beta: None,
@@ -10620,6 +10625,7 @@ impl SupervisedLDA {
         self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         self.sigma2 = model.sigma2;
         self.eta = Some(Array1::from(model.eta.clone()));
+        self.m_mat = Some(model.m_mat.clone());
         self.beta = Some(beta);
         self.theta = Some(theta);
         self.log_beta = Some(model.log_beta.clone());
@@ -10631,16 +10637,22 @@ impl SupervisedLDA {
     }
 
     /// Predict the response ŷ for new documents (`list[list[str]]` or a
-    /// :class:`Corpus`). Out-of-vocabulary words are ignored. Returns a 1-D array
-    /// of length = number of documents.
+    /// :class:`Corpus`). Out-of-vocabulary words are ignored.
+    ///
+    /// With `return_std=False` (default) returns a 1-D array of predictions. With
+    /// `return_std=True` returns `(mean, std)`, where `std` is the posterior-
+    /// predictive standard deviation: the document's topic uncertainty propagated
+    /// through the regression, `ηᵀ Cov(z̄) η`, plus the residual variance σ². A
+    /// 95% predictive interval is `mean ± 1.96 * std`.
     /// `var_iters` is the number of variational E-step iterations per new document.
-    #[pyo3(signature = (data, *, var_iters=20))]
+    #[pyo3(signature = (data, *, var_iters=20, return_std=false))]
     fn predict<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'_, PyAny>,
         var_iters: usize,
-    ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        return_std: bool,
+    ) -> PyResult<Bound<'py, PyAny>> {
         self.require_fitted()?;
         let vocab = &self.corpus.as_ref().unwrap().id_to_word;
         let word_id: std::collections::HashMap<&str, u32> = vocab
@@ -10674,19 +10686,35 @@ impl SupervisedLDA {
             eta: self.eta.as_ref().unwrap().to_vec(),
             sigma2: self.sigma2,
             gamma: Vec::new(),
+            m_mat: Vec::new(),
         };
 
+        let ids_of = |doc: &[String]| -> Vec<u32> {
+            doc.iter()
+                .filter_map(|w| word_id.get(w.as_str()).copied())
+                .collect()
+        };
+        if return_std {
+            // Posterior-predictive mean and SD (topic uncertainty + residual σ²).
+            let mut means = Vec::with_capacity(docs.len());
+            let mut stds = Vec::with_capacity(docs.len());
+            for doc in &docs {
+                let (m, var) = slda::predict_one_var(&model, &ids_of(doc), var_iters);
+                means.push(m);
+                stds.push(var.max(0.0).sqrt());
+            }
+            let out: Py<PyAny> = (
+                Array1::from(means).to_pyarray_bound(py),
+                Array1::from(stds).to_pyarray_bound(py),
+            )
+                .into_py(py);
+            return Ok(out.into_bound(py));
+        }
         let preds: Vec<f64> = docs
             .iter()
-            .map(|doc| {
-                let ids: Vec<u32> = doc
-                    .iter()
-                    .filter_map(|w| word_id.get(w.as_str()).copied())
-                    .collect();
-                slda::predict_one(&model, &ids, var_iters)
-            })
+            .map(|doc| slda::predict_one(&model, &ids_of(doc), var_iters))
             .collect();
-        Ok(Array1::from(preds).to_pyarray_bound(py))
+        Ok(Array1::from(preds).to_pyarray_bound(py).into_any())
     }
 
     /// Topic-word matrix β, shape ``(num_topics, num_words)``.
@@ -10737,6 +10765,19 @@ impl SupervisedLDA {
     fn coefficients<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         Ok(self.eta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+
+    /// Standard error of each regression coefficient η, shape ``(num_topics,)``,
+    /// from the OLS-style covariance σ²M⁻¹ where M = Σ_d E[z̄ z̄ᵀ] is the
+    /// normal-equations matrix the fit solves for η. Aligned to ``coefficients``;
+    /// |η| > ~2·SE is the usual significance cue. ``None`` for models saved before
+    /// this was added.
+    #[getter]
+    fn coefficient_se<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyArray1<f64>>>> {
+        self.require_fitted()?;
+        Ok(self.m_mat.as_ref().map(|m| {
+            Array1::from(slda::coefficient_se(m, self.sigma2, self.num_topics)).to_pyarray_bound(py)
+        }))
     }
 
     /// The fitted response variance σ².
@@ -10908,6 +10949,7 @@ impl SupervisedLDA {
                 topic_names: self.topic_names.clone(),
                 log_likelihood_history: self.log_likelihood_history.clone(),
                 converged: self.converged,
+                m_mat: self.m_mat.clone(),
             },
         )
     }
@@ -10929,6 +10971,7 @@ impl SupervisedLDA {
             topic_names,
             sigma2: s.sigma2,
             eta: arr1_back(s.eta),
+            m_mat: s.m_mat,
             beta: arr2_back(s.beta)?,
             theta: arr2_back(s.theta)?,
             log_beta: s.log_beta,

--- a/src/slda.rs
+++ b/src/slda.rs
@@ -30,6 +30,9 @@ pub struct SldaModel {
     pub eta: Vec<f64>,           // K regression coefficients
     pub sigma2: f64,             // response variance
     pub gamma: Vec<Vec<f64>>,    // D × K variational Dirichlet (training docs)
+    /// `M = Σ_d E[z̄_d z̄_dᵀ]` (K×K, row-major, ridge-stabilized) — the
+    /// normal-equations matrix the η estimate solves, retained for coefficient SEs.
+    pub m_mat: Vec<f64>,
 }
 
 impl SldaModel {
@@ -150,11 +153,23 @@ fn infer_doc(
 
 /// Predict the response for a new document (ŷ = ηᵀ z̄, z̄ = Σφ / N).
 pub fn predict_one(model: &SldaModel, doc: &[u32], var_iters: usize) -> f64 {
+    predict_one_var(model, doc, var_iters).0
+}
+
+/// Predict the response and its posterior-predictive variance for a new document.
+///
+/// Returns `(ŷ, var)` with `ŷ = ηᵀ z̄` and
+/// `var = ηᵀ Cov(z̄) η + σ²`, where the variational posterior over the topic
+/// frequency `z̄ = (1/N) Σ_n z_n` (each token `z_n ~ Categorical(φ_n)`) has
+/// `Cov(z̄) = (1/N²) Σ_n [diag(φ_n) − φ_n φ_nᵀ]`. The first term is the topic
+/// uncertainty for this document, the second the irreducible response noise. An
+/// empty document carries no topic information, so only the residual `σ²` remains.
+pub fn predict_one_var(model: &SldaModel, doc: &[u32], var_iters: usize) -> (f64, f64) {
     let bag = to_bag(doc);
     if bag.is_empty() {
-        return 0.0;
+        return (0.0, model.sigma2);
     }
-    let (_, _, sum_phi) = infer_doc(
+    let (_, phi, sum_phi) = infer_doc(
         &bag,
         &model.log_beta,
         &model.eta,
@@ -163,10 +178,40 @@ pub fn predict_one(model: &SldaModel, doc: &[u32], var_iters: usize) -> f64 {
         None,
         var_iters,
     );
+    let k = model.num_topics;
     let n: f64 = bag.iter().map(|&(_, c)| c).sum();
-    (0..model.num_topics)
-        .map(|k| model.eta[k] * sum_phi[k] / n)
-        .sum()
+    let mean: f64 = (0..k).map(|kk| model.eta[kk] * sum_phi[kk] / n).sum();
+    // ηᵀ Cov(z̄) η = (1/N²)[ Σ_k η_k² sum_phi_k − Σ_w c_w (ηᵀ φ_w)² ].
+    let diag_term: f64 = (0..k)
+        .map(|kk| model.eta[kk] * model.eta[kk] * sum_phi[kk])
+        .sum();
+    let mut quad_term = 0.0f64;
+    for (i, &(_, c)) in bag.iter().enumerate() {
+        let eta_dot_phi: f64 = (0..k).map(|kk| model.eta[kk] * phi[i][kk]).sum();
+        quad_term += c * eta_dot_phi * eta_dot_phi;
+    }
+    let topic_var = ((diag_term - quad_term) / (n * n)).max(0.0);
+    (mean, topic_var + model.sigma2)
+}
+
+/// Standard errors of the regression coefficients `η`, from the OLS-style
+/// covariance `σ² M⁻¹` where `M = Σ_d E[z̄ z̄ᵀ]` is the (ridge-stabilized)
+/// normal-equations matrix that produced `η`. Returns length `num_topics`
+/// (`NaN` where `M` is not invertible).
+pub fn coefficient_se(m_mat: &[f64], sigma2: f64, num_topics: usize) -> Vec<f64> {
+    match spd_inverse(m_mat, num_topics) {
+        Some(minv) => (0..num_topics)
+            .map(|a| {
+                let v = sigma2 * minv[a * num_topics + a];
+                if v > 0.0 {
+                    v.sqrt()
+                } else {
+                    f64::NAN
+                }
+            })
+            .collect(),
+        None => vec![f64::NAN; num_topics],
+    }
 }
 
 /// Per-EM-iteration objective: the Gaussian log-likelihood of the response
@@ -239,6 +284,7 @@ pub fn fit_slda<R: Rng>(
 
     let mut bound_history: Vec<(usize, f64)> = Vec::new();
     let mut converged = false;
+    let mut last_m = vec![0.0f64; k * k]; // final M = Σ_d E[z̄ z̄ᵀ], for coefficient SEs
 
     for em_iter in 1..=em_iters {
         let mut beta_ss = vec![vec![1e-6; v]; k]; // K × V, with smoothing
@@ -306,6 +352,7 @@ pub fn fit_slda<R: Rng>(
         for a in 0..k {
             m_mat[a * k + a] += 1e-6;
         }
+        last_m.copy_from_slice(&m_mat); // retain the (ridge-stabilized) M for SEs
         if let Some(minv) = spd_inverse(&m_mat, k) {
             for a in 0..k {
                 eta[a] = (0..k).map(|c| minv[a * k + c] * b_vec[c]).sum();
@@ -338,6 +385,7 @@ pub fn fit_slda<R: Rng>(
             eta,
             sigma2,
             gamma,
+            m_mat: last_m,
         },
         bound_history,
         converged,
@@ -462,6 +510,43 @@ mod tests {
         let preds: Vec<f64> = docs.iter().map(|d| predict_one(&model, d, 20)).collect();
         let corr = pearson(&preds, &y);
         assert!(corr > 0.7, "prediction correlation too low: {}", corr);
+    }
+
+    #[test]
+    fn coefficient_se_and_predictive_variance() {
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let (docs, y, v) = supervised_corpus(&mut rng);
+        let (model, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 25, 15, 0.0, 0, &mut rng);
+
+        // Coefficient SEs: finite, positive, and the strong predictive topic's
+        // coefficient is many SEs from zero on this well-separated corpus.
+        let se = coefficient_se(&model.m_mat, model.sigma2, 2);
+        assert_eq!(se.len(), 2);
+        assert!(
+            se.iter().all(|s| s.is_finite() && *s > 0.0),
+            "bad SE: {se:?}"
+        );
+        let hi = if model.eta[0].abs() >= model.eta[1].abs() {
+            0
+        } else {
+            1
+        };
+        assert!(
+            model.eta[hi].abs() / se[hi] > 2.0,
+            "predictive coefficient should be significant: eta={:?} se={se:?}",
+            model.eta
+        );
+
+        // Predictive variance is at least the residual σ² and finite; the mean
+        // matches predict_one.
+        for d in docs.iter().take(20) {
+            let (m, var) = predict_one_var(&model, d, 20);
+            assert!(var.is_finite() && var >= model.sigma2 - 1e-9, "var={var}");
+            assert!((m - predict_one(&model, d, 20)).abs() < 1e-9);
+        }
+        // An empty document falls back to the residual variance.
+        let (_, var0) = predict_one_var(&model, &[], 20);
+        assert!((var0 - model.sigma2).abs() < 1e-12);
     }
 
     #[test]

--- a/tests/test_slda.py
+++ b/tests/test_slda.py
@@ -71,6 +71,35 @@ class TestSupervision:
         assert np.corrcoef(pred, yh)[0, 1] > 0.6
 
 
+class TestUncertainty:
+    def test_coefficient_se_shape_and_significance(self, fitted):
+        m, _, _ = fitted
+        se = m.coefficient_se
+        assert se is not None
+        assert se.shape == m.coefficients.shape == (2,)
+        assert np.all(np.isfinite(se)) and np.all(se > 0.0)
+        # On this well-separated corpus both coefficients are far from zero.
+        z = m.coefficients / se
+        assert np.all(np.abs(z) > 2.0)
+
+    def test_predict_return_std(self, fitted):
+        m, docs, _ = fitted
+        mean, std = m.predict(docs[:10], return_std=True)
+        point = m.predict(docs[:10])
+        assert mean.shape == std.shape == (10,)
+        np.testing.assert_allclose(mean, point)
+        # Predictive SD is at least the residual SD (topic uncertainty adds to it).
+        assert np.all(std >= np.sqrt(m.sigma2) - 1e-9)
+        assert np.all(np.isfinite(std))
+
+    def test_coefficient_se_survives_save_load(self, fitted, tmp_path):
+        m, _, _ = fitted
+        path = tmp_path / "slda.topica"
+        m.save(str(path))
+        m2 = SupervisedLDA.load(str(path))
+        np.testing.assert_array_equal(m.coefficient_se, m2.coefficient_se)
+
+
 class TestOutputs:
     def test_shapes(self, fitted):
         m, docs, _ = fitted


### PR DESCRIPTION
Closes #314. **Final item in the standard-errors roadmap (#309).**

Gives sLDA's two outputs honest uncertainty — both **analytic**, falling out of quantities the fit already computes (no bootstrap).

## What's added
- **`coefficient_se`** `(num_topics,)` — standard error of each regression coefficient η, from the OLS covariance `σ²M⁻¹` where `M = Σ_d E[z̄z̄ᵀ]` is the (ridge-stabilized) normal-equations matrix the M-step already solves for η. `M` was computed every EM iteration and discarded; it's now retained. `|η| > ~2·SE` is the significance cue.
- **`predict(data, return_std=True)`** → `(mean, std)` — the posterior-predictive SD, `std = sqrt(ηᵀ Cov(z̄) η + σ²)`. The topic-uncertainty term reuses the same per-document φ covariance `Cov(z̄) = (1/N²)Σ_n[diag(φ_n) − φ_nφ_nᵀ]` that appears in `M`'s assembly; `σ²` is the residual noise. An empty doc falls back to the residual variance. `predict()` without the flag is unchanged.

```python
m.fit(docs, y)
z = m.coefficients / m.coefficient_se          # which topics reliably move y
mean, std = m.predict(new_docs, return_std=True)   # mean ± 1.96·std
```

## Design notes
- `m_mat` is persisted via a `#[serde(default)]` trailing field (same precedent as DMR/sLDA's `theta_draws`); old saves load with `coefficient_se = None`.
- Both quantities are exact given the variational posterior — `σ²M⁻¹` is the coefficient covariance of the η normal equations, and the predictive variance is the closed-form variance of `ηᵀz̄` under the mean-field φ posterior plus residual `σ²`.

## Tests / gates
- Rust: SEs finite/positive and significant on a separated corpus; predictive variance ≥ σ²; empty-doc fallback; mean matches `predict_one`.
- Python: coefficient_se shape/significance, `predict(return_std=True)` (mean matches point, std ≥ √σ²), save/load round-trip.
- `cargo test --lib` (154) ✓ · `pytest` (3115 passed, 30 skipped) ✓ · `cargo fmt --check` ✓ · `cargo clippy` ✓ · `mkdocs build --strict` ✓

With this, every user-facing point estimate in topica that has a meaningful uncertainty now reports one. 🎯

🤖 Generated with [Claude Code](https://claude.com/claude-code)