### PR TITLE
feat(keyatm): analytic standard errors for covariate-keyATM feature effects (#316)

### DIFF
--- a/docs/guides/guided.md
+++ b/docs/guides/guided.md
@@ -73,10 +73,19 @@ model.fit(docs, covariates=is_dem, feature_names=["is_dem"], iters=1000)
 
 model.feature_names       # ['intercept', 'is_dem']
 model.feature_effects     # (num_topics, 2): coefficient of each covariate per topic
+model.feature_effect_se   # same shape: standard error of each coefficient
+z = model.feature_effects / model.feature_effect_se   # |z| > ~2 ⇒ notable
 ```
 
 A larger `feature_effects[k, j]` means covariate `j` raises topic `k`'s
-prevalence. For uncertainty, pair the fitted `doc_topic` with
+prevalence. `feature_effect_se` gives the standard error of each λ, so you can
+tell a real effect from noise: it is the observed information of the same
+penalized Dirichlet-multinomial that `DMR` uses, computed in the standardized fit
+space (keyATM z-scores covariates internally, issue #270) and mapped back to the
+original covariate scale, so it is exact (no bootstrap) and computed once at fit
+time. An entry is `NaN` when its standardized coefficient hit keyATM's ±5 bound,
+where the constrained estimate has no valid asymptotic standard error. For
+uncertainty on the resulting topic prevalences, pair the fitted `doc_topic` with
 [`estimate_effect`](covariates.md).
 
 ### Dynamic keyATM

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3615,6 +3615,14 @@ class KeyATM:
         the intercept. Raises if fit without covariates."""
         ...
     @property
+    def feature_effect_se(self) -> numpy.typing.NDArray[numpy.float64]:
+        """Covariate model: standard errors of feature_effects (lambda), same
+        shape and column order, on the original covariate scale (observed
+        information in the standardized fit space mapped back by the
+        standardization Jacobian, issue #316). NaN where the standardized lambda
+        hit the +/-5 bound. Raises if fit without covariates."""
+        ...
+    @property
     def feature_names(self) -> list[str]:
         """Covariate model: names for feature_effects columns ('intercept' first)."""
         ...

--- a/src/dmr.rs
+++ b/src/dmr.rs
@@ -229,6 +229,50 @@ pub fn dmr_lambda_se(
     prior_variance: f64,
     offset: Option<&[Vec<f64>]>,
 ) -> Vec<Vec<f64>> {
+    let t = num_topics;
+    let f = num_features;
+    let p = t * f;
+    let cov = dmr_lambda_cov(
+        lambda,
+        features,
+        doc_topic_counts,
+        num_topics,
+        num_features,
+        prior_variance,
+        offset,
+    );
+    (0..t)
+        .map(|tt| {
+            (0..f)
+                .map(|ff| {
+                    let idx = tt * f + ff;
+                    let v = cov[idx * p + idx];
+                    if v > 0.0 {
+                        v.sqrt()
+                    } else {
+                        f64::NAN
+                    }
+                })
+                .collect()
+        })
+        .collect()
+}
+
+/// Full asymptotic covariance of the DMR feature weights `λ`: the inverse of the
+/// observed information described in [`dmr_lambda_se`], returned as a flattened
+/// row-major `(T·F)×(T·F)` matrix (index `(t·F+f)`). [`dmr_lambda_se`] is the
+/// square root of its diagonal. The full matrix is needed when `λ` is later
+/// transformed by a non-diagonal map (e.g. keyATM's standardization Jacobian),
+/// which mixes the within-topic covariance entries.
+pub fn dmr_lambda_cov(
+    lambda: &[Vec<f64>],
+    features: &[Vec<f64>],
+    doc_topic_counts: &[Vec<f64>],
+    num_topics: usize,
+    num_features: usize,
+    prior_variance: f64,
+    offset: Option<&[Vec<f64>]>,
+) -> Vec<f64> {
     use crate::linalg::{make_diagonally_dominant, spd_inverse};
     use crate::optimize::trigamma;
 
@@ -288,26 +332,11 @@ pub fn dmr_lambda_se(
         info[i * p + i] += inv_var;
     }
 
-    let cov = spd_inverse(&info, p).unwrap_or_else(|| {
+    spd_inverse(&info, p).unwrap_or_else(|| {
         let mut s = info.clone();
         make_diagonally_dominant(&mut s, p);
         spd_inverse(&s, p).unwrap_or_else(|| vec![f64::NAN; p * p])
-    });
-    (0..t)
-        .map(|tt| {
-            (0..f)
-                .map(|ff| {
-                    let idx = tt * f + ff;
-                    let v = cov[idx * p + idx];
-                    if v > 0.0 {
-                        v.sqrt()
-                    } else {
-                        f64::NAN
-                    }
-                })
-                .collect()
-        })
-        .collect()
+    })
 }
 
 use crate::variational::lbfgs_minimize;

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -206,6 +206,15 @@ pub struct KeyAtmModel {
     /// on, and not persisted across save/load.
     #[serde(skip)]
     pub theta_draws: Vec<Vec<Vec<f32>>>,
+    /// Covariate model only: standard errors of `lambda` on the **original**
+    /// covariate scale (`[K][F]`, aligned to `lambda`), from the observed
+    /// information of the penalized Dirichlet-multinomial in the standardized fit
+    /// space mapped back by the standardization Jacobian (issue #316). Entries
+    /// whose standardized `λ` sat at the ±[`LAMBDA_BOUND`] clamp are `NaN` (the
+    /// unconstrained asymptotic SE is invalid at the bound). `None` for the base
+    /// and dynamic models. A fit-time artifact, not persisted across save/load.
+    #[serde(default)]
+    pub lambda_se: Option<Vec<Vec<f64>>>,
 }
 
 /// Fitted state of the keyATM **Dynamic** model (Eshima, Imai & Sasaki 2024,
@@ -1315,6 +1324,7 @@ fn init_state<R: Rng>(
         pi_history: Vec::new(),
         converged: false,
         theta_draws: Vec::new(),
+        lambda_se: None,
     };
     (model, assignments, ki)
 }
@@ -1623,6 +1633,91 @@ fn standardize_features(
     (std, mean, sd)
 }
 
+/// Standard errors of the covariate-keyATM `λ` on the **original** covariate
+/// scale (issue #316). `λ` is fit in the standardized space (z-scored covariates,
+/// N(0,1) prior, bounded to ±[`LAMBDA_BOUND`]); its asymptotic covariance is the
+/// inverse observed information of the penalized Dirichlet-multinomial there
+/// ([`crate::dmr::dmr_lambda_cov`]). The mapping back to the raw scale,
+/// `λ_orig = M λ_std` with (per topic)
+/// ```text
+///   λ_orig[0] = λ_std[0] − Σ_{g≥1} (mean_g/sd_g) λ_std[g],   λ_orig[f] = λ_std[f]/sd_f,
+/// ```
+/// is a non-diagonal linear map (the intercept mixes the slopes), so the raw-scale
+/// covariance of topic `k` is `Cov_orig = M Cov_std[k] Mᵀ` and the SE is
+/// `sqrt(diag)`. The map is block-diagonal across topics, so only the within-topic
+/// `F×F` blocks of the standardized covariance are needed. Entries whose
+/// standardized `λ` sits at the ±[`LAMBDA_BOUND`] clamp are returned as `NaN`: the
+/// coefficient is constrained, not at an interior optimum, so the unconstrained
+/// asymptotic SE does not apply.
+fn covariate_lambda_se(
+    lambda_std: &[Vec<f64>],
+    features_std: &[Vec<f64>],
+    doc_topic_counts: &[Vec<f64>],
+    num_topics: usize,
+    num_features: usize,
+    prior_variance: f64,
+    feat_mean: &[f64],
+    feat_sd: &[f64],
+    offset: Option<&[Vec<f64>]>,
+) -> Vec<Vec<f64>> {
+    let t = num_topics;
+    let f = num_features;
+    let p = t * f;
+    let cov_std = crate::dmr::dmr_lambda_cov(
+        lambda_std,
+        features_std,
+        doc_topic_counts,
+        t,
+        f,
+        prior_variance,
+        offset,
+    );
+    // Per-topic Jacobian M (F×F), identical across topics: row 0 maps the
+    // intercept and subtracts each standardized slope's mean shift; row g≥1
+    // rescales by 1/sd_g.
+    let mut se = vec![vec![0.0f64; f]; t];
+    // tol: treat |λ_std| within 1e-6 of the bound as clamped.
+    let bound_tol = 1e-6;
+    for k in 0..t {
+        let base = k * f;
+        // Extract the within-topic block C (F×F) from the flat covariance.
+        let cblk = |i: usize, j: usize| cov_std[(base + i) * p + (base + j)];
+        // Build M·C (F×F).
+        let mut mc = vec![vec![0.0f64; f]; f];
+        for j in 0..f {
+            // Row 0 of M: [1, -mean_1/sd_1, ..., -mean_{F-1}/sd_{F-1}].
+            let mut acc = cblk(0, j);
+            for g in 1..f {
+                acc += -(feat_mean[g] / feat_sd[g]) * cblk(g, j);
+            }
+            mc[0][j] = acc;
+            // Rows f≥1 of M: scale row f of C by 1/sd_f.
+            for ff in 1..f {
+                mc[ff][j] = cblk(ff, j) / feat_sd[ff];
+            }
+        }
+        // diag of (M·C)·Mᵀ, then sqrt; flag clamped entries as NaN.
+        for ff in 0..f {
+            let var = if ff == 0 {
+                let mut acc = mc[0][0];
+                for g in 1..f {
+                    acc += mc[0][g] * (-(feat_mean[g] / feat_sd[g]));
+                }
+                acc
+            } else {
+                mc[ff][ff] / feat_sd[ff]
+            };
+            let clamped = lambda_std[k][ff].abs() >= LAMBDA_BOUND - bound_tol;
+            se[k][ff] = if clamped || !(var > 0.0) {
+                f64::NAN
+            } else {
+                var.sqrt()
+            };
+        }
+    }
+    se
+}
+
 /// Fit a keyATM **Covariate** model. The document-topic prior is a
 /// Dirichlet-Multinomial regression on document features,
 /// `α_{d,k} = exp(x_d · λ_k)` (Mimno & McCallum 2008), matching the keyATM R
@@ -1750,6 +1845,22 @@ pub fn fit_keyatm_cov<R: Rng>(
         }
     }
 
+    // Standard errors of λ (issue #316): computed in the standardized fit space
+    // at the final counts, then mapped to the original scale by the same
+    // standardization Jacobian used for λ below. Done before the λ mapback so the
+    // bound check sees the standardized coefficients that were actually clamped.
+    let lambda_se = covariate_lambda_se(
+        &lambda,
+        &features_std,
+        &model.ndk,
+        num_topics,
+        num_features,
+        prior_variance,
+        &feat_mean,
+        &feat_sd,
+        offset,
+    );
+
     // Map λ from the standardized space back to the original covariate scale, so
     // that exp(features · λ_orig) == exp(features_std · λ_std): for f ≥ 1,
     // λ_orig[f] = λ_std[f] / sd_f, with the intercept absorbing the mean shift.
@@ -1770,6 +1881,7 @@ pub fn fit_keyatm_cov<R: Rng>(
     model.lambda = Some(lambda_orig);
     model.features = Some(features.to_vec());
     model.prior_offset = offset.map(|o| o.to_vec());
+    model.lambda_se = Some(lambda_se);
     model.theta_draws = theta_draw_buf;
     model
 }
@@ -2354,6 +2466,105 @@ mod tests {
                 );
             }
         }
+    }
+
+    // The covariate λ SE (#316) maps the standardized-space covariance to the
+    // original scale by the standardization Jacobian. Check the helper against a
+    // brute-force full-matrix transform (M ⊗-block applied to the whole p×p
+    // covariance), and that a clamped coefficient is flagged NaN.
+    #[test]
+    fn covariate_lambda_se_matches_full_jacobian_transform() {
+        let (t, f) = (3usize, 3usize);
+        let features = vec![
+            vec![1.0, 2.0, 0.0],
+            vec![1.0, 4.0, 1.0],
+            vec![1.0, 6.0, 0.0],
+            vec![1.0, 8.0, 1.0],
+            vec![1.0, 5.0, 1.0],
+            vec![1.0, 3.0, 0.0],
+        ];
+        let nf = f;
+        let (fstd, mean, sd) = standardize_features(&features, nf);
+        let lambda_std = vec![
+            vec![0.5, -1.2, 0.8],
+            vec![-0.3, 2.0, -1.5],
+            vec![0.1, 0.4, -0.6],
+        ];
+        let counts = vec![
+            vec![3.0f64, 1.0, 0.0],
+            vec![0.0f64, 2.0, 2.0],
+            vec![1.0f64, 1.0, 5.0],
+            vec![2.0f64, 0.0, 1.0],
+            vec![1.0f64, 3.0, 2.0],
+            vec![4.0f64, 1.0, 1.0],
+        ];
+        let sigma2 = 1.0;
+
+        // Reference: full p×p covariance in std space, transformed by the full
+        // block-diagonal Jacobian J (each topic block = M), SE = sqrt(diag).
+        let p = t * f;
+        let cov = crate::dmr::dmr_lambda_cov(&lambda_std, &fstd, &counts, t, f, sigma2, None);
+        // M (F×F): row 0 = [1, -mean_g/sd_g...]; row g≥1 = e_g / sd_g.
+        let mut m = vec![vec![0.0f64; f]; f];
+        m[0][0] = 1.0;
+        for g in 1..f {
+            m[0][g] = -mean[g] / sd[g];
+            m[g][g] = 1.0 / sd[g];
+        }
+        // Full J (p×p) block-diagonal with M on each topic block.
+        let mut jac = vec![0.0f64; p * p];
+        for k in 0..t {
+            for i in 0..f {
+                for j in 0..f {
+                    jac[(k * f + i) * p + (k * f + j)] = m[i][j];
+                }
+            }
+        }
+        // cov_orig = J cov Jᵀ; reference SE = sqrt(diag).
+        let mut jc = vec![0.0f64; p * p];
+        for i in 0..p {
+            for j in 0..p {
+                let mut s = 0.0;
+                for l in 0..p {
+                    s += jac[i * p + l] * cov[l * p + j];
+                }
+                jc[i * p + j] = s;
+            }
+        }
+        let mut ref_se = vec![vec![0.0f64; f]; t];
+        for k in 0..t {
+            for ff in 0..f {
+                let i = k * f + ff;
+                let mut var = 0.0;
+                for l in 0..p {
+                    var += jc[i * p + l] * jac[i * p + l];
+                }
+                ref_se[k][ff] = var.sqrt();
+            }
+        }
+
+        let se = covariate_lambda_se(
+            &lambda_std, &fstd, &counts, t, f, sigma2, &mean, &sd, None,
+        );
+        for k in 0..t {
+            for ff in 0..f {
+                assert!(
+                    (se[k][ff] - ref_se[k][ff]).abs() < 1e-9,
+                    "se[{k}][{ff}]: helper {} vs full-transform {}",
+                    se[k][ff],
+                    ref_se[k][ff]
+                );
+            }
+        }
+
+        // A coefficient at the ±LAMBDA_BOUND clamp is flagged NaN.
+        let mut clamped = lambda_std.clone();
+        clamped[1][2] = LAMBDA_BOUND;
+        let se_c = covariate_lambda_se(
+            &clamped, &fstd, &counts, t, f, sigma2, &mean, &sd, None,
+        );
+        assert!(se_c[1][2].is_nan(), "clamped λ must give NaN SE");
+        assert!(se_c[0][0].is_finite(), "unclamped entries stay finite");
     }
 
     /// Build a small keyword-annotated corpus and verify that keyword topics

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -1708,10 +1708,11 @@ fn covariate_lambda_se(
                 mc[ff][ff] / feat_sd[ff]
             };
             let clamped = lambda_std[k][ff].abs() >= LAMBDA_BOUND - bound_tol;
-            se[k][ff] = if clamped || !(var > 0.0) {
-                f64::NAN
-            } else {
+            // A clamped coefficient, or a non-positive/NaN variance, has no valid SE.
+            se[k][ff] = if !clamped && var > 0.0 {
                 var.sqrt()
+            } else {
+                f64::NAN
             };
         }
     }
@@ -2543,9 +2544,7 @@ mod tests {
             }
         }
 
-        let se = covariate_lambda_se(
-            &lambda_std, &fstd, &counts, t, f, sigma2, &mean, &sd, None,
-        );
+        let se = covariate_lambda_se(&lambda_std, &fstd, &counts, t, f, sigma2, &mean, &sd, None);
         for k in 0..t {
             for ff in 0..f {
                 assert!(
@@ -2560,9 +2559,7 @@ mod tests {
         // A coefficient at the ±LAMBDA_BOUND clamp is flagged NaN.
         let mut clamped = lambda_std.clone();
         clamped[1][2] = LAMBDA_BOUND;
-        let se_c = covariate_lambda_se(
-            &clamped, &fstd, &counts, t, f, sigma2, &mean, &sd, None,
-        );
+        let se_c = covariate_lambda_se(&clamped, &fstd, &counts, t, f, sigma2, &mean, &sd, None);
         assert!(se_c[1][2].is_nan(), "clamped λ must give NaN SE");
         assert!(se_c[0][0].is_finite(), "unclamped entries stay finite");
     }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -16820,6 +16820,9 @@ pub struct KeyATM {
     corpus: Option<corpus::Corpus>,
     // Covariate model only: learned λ (K × F+1, intercept first) and column names.
     feature_effects: Option<Array2<f64>>,
+    // Covariate model only: SE of λ on the original covariate scale (K × F+1),
+    // aligned to feature_effects; NaN where the standardized λ hit the ±5 clamp.
+    feature_effect_se: Option<Array2<f64>>,
     feature_names: Vec<String>,
     // Dynamic model only: the HMM state of each time segment (length T), the
     // smoothed prevalence per segment (T × K), the segment labels, and the
@@ -16943,6 +16946,7 @@ impl KeyATM {
             theta: None,
             corpus: None,
             feature_effects: None,
+            feature_effect_se: None,
             feature_names: Vec::new(),
             time_state: Vec::new(),
             time_prevalence: None,
@@ -17001,6 +17005,7 @@ impl KeyATM {
             theta: None,
             corpus: None,
             feature_effects: None,
+            feature_effect_se: None,
             feature_names: Vec::new(),
             time_state: Vec::new(),
             time_prevalence: None,
@@ -17479,6 +17484,7 @@ impl KeyATM {
         self.alpha_vec = model.alpha_vec.clone();
         if let Some(lam) = &model.lambda {
             self.feature_effects = Some(vecs_to_arr2(lam));
+            self.feature_effect_se = model.lambda_se.as_ref().map(|se| vecs_to_arr2(se));
             self.feature_names = cov_names;
         }
         let mut names = self.key_names.clone();
@@ -17497,6 +17503,23 @@ impl KeyATM {
     fn feature_effects<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         self.feature_effects
+            .as_ref()
+            .map(|e| e.to_pyarray_bound(py))
+            .ok_or_else(|| PyRuntimeError::new_err("model was fit without covariates"))
+    }
+
+    /// Covariate model: standard errors of `feature_effects` (λ), same shape
+    /// ``(num_topics, F+1)`` and column order, on the original covariate scale.
+    /// From the observed information of the penalized Dirichlet-multinomial in the
+    /// standardized fit space, mapped back by the standardization Jacobian
+    /// (issue #316). A coefficient is notable when ``|feature_effects| /
+    /// feature_effect_se`` exceeds ~2. Entries are ``NaN`` where the standardized
+    /// λ hit the ±5 bound (the constrained estimate has no valid asymptotic SE).
+    /// Raises if the model was fit without covariates.
+    #[getter]
+    fn feature_effect_se<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        self.feature_effect_se
             .as_ref()
             .map(|e| e.to_pyarray_bound(py))
             .ok_or_else(|| PyRuntimeError::new_err("model was fit without covariates"))
@@ -17773,6 +17796,7 @@ impl KeyATM {
             theta: arr2_back(s.theta)?,
             corpus: s.corpus,
             feature_effects: None,
+            feature_effect_se: None,
             feature_names: Vec::new(),
             time_state: Vec::new(),
             time_prevalence: None,

--- a/tests/test_keyatm_covariate.py
+++ b/tests/test_keyatm_covariate.py
@@ -45,6 +45,30 @@ def test_recovers_covariate_effect_on_prevalence(cov_model):
     assert m.feature_effects[si, 1] - m.feature_effects[ei, 1] > 1.0
 
 
+def test_feature_effect_se_shape_and_finite(cov_model):
+    m, _, _ = cov_model
+    se = m.feature_effect_se
+    assert se.shape == m.feature_effects.shape == (2, 2)
+    # No clamped coefficients in this well-identified design, so all finite & > 0.
+    assert np.all(np.isfinite(se)) and np.all(se > 0.0)
+
+
+def test_strong_effect_is_significant(cov_model):
+    """The planted party->social effect is large, so it sits many SEs from zero."""
+    m, _, _ = cov_model
+    si = m.topic_names.index("social")
+    z = m.feature_effects[si, 1] / m.feature_effect_se[si, 1]
+    assert abs(z) > 2.0, f"z={z:.2f} for a planted effect"
+
+
+def test_feature_effect_se_base_model_raises():
+    docs, _ = _corpus()
+    m = topica.KeyATM(SEEDS, num_topics=2, seed=1)
+    m.fit(docs, iters=200)
+    with pytest.raises(RuntimeError):
+        _ = m.feature_effect_se
+
+
 def test_theta_tracks_covariate(cov_model):
     m, _, party = cov_model
     th = m.doc_topic


### PR DESCRIPTION
Closes #316. Final item of the standard-errors roadmap (#309).

## What
Adds `feature_effect_se` to the covariate `KeyATM`, mirroring `DMR.feature_effect_se`.

## Why it isn't a drop-in of the DMR SE
keyATM fits λ in z-scored, ±5-bounded space (#270). So:
- The observed-information covariance is computed in the **standardized fit space** (`dmr::dmr_lambda_cov`, the FD-validated path, now split out to return the full p×p covariance) and mapped to the original covariate scale by the **standardization Jacobian** — which mixes the intercept with the slopes, so the full within-topic covariance block is needed, not just the diagonal.
- Entries whose standardized λ sat at the ±5 clamp are returned as **NaN** (the constrained estimate has no valid asymptotic SE).

Computed once at fit time, in-memory alongside `feature_effects` (the covariate λ itself is likewise not persisted in `KeyAtmState`), so **no save-format change**.

## Validation
- New Rust test checks `covariate_lambda_se` against a brute-force full-matrix `J·Cov·Jᵀ` transform and the NaN bound-flagging.
- Underlying `dmr_lambda_cov` is the existing finite-difference-validated Hessian.
- Python tests: SE shape/finiteness, planted-effect z-score, base-model raises.

## Surface
`KeyATM.feature_effect_se` getter, type stub, and guided-topics doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)