### PR TITLE
release: 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.33.0] - 2026-06-28
+
 ### Changed
 
 - The experimental ideal-point family was consolidated under the `IdealPoint` stem,
@@ -68,6 +70,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   (2014); the reference package builds on gensim `Doc2Vec`, and the topica scale
   matches it at correlation 1.00 on a planted ordering
   (`parity/party_embeddings_compare.py`). Save tag 36.
+- `KeyATM.feature_effect_se` (#316) — standard errors for the covariate keyATM's
+  feature effects `λ`, mirroring `DMR.feature_effect_se` and completing the
+  standard-errors roadmap (#309). Computed from the observed information of the
+  penalized Dirichlet-multinomial in the standardized fit space (where `λ` is fit,
+  z-scored and ±5-bounded per #270), then mapped to the original covariate scale by
+  the standardization Jacobian (the intercept mixes the slopes, so it is not a
+  per-column rescale). Entries whose standardized `λ` sat at the ±5 bound are
+  returned as `NaN` (a constrained estimate has no valid asymptotic SE). Computed at
+  fit time alongside `feature_effects`; `dmr::dmr_lambda_cov` now exposes the full
+  covariance the Jacobian needs.
 
 ## [0.32.0] - 2026-06-27
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.32.0
-date-released: 2026-06-27
+version: 0.33.0
+date-released: 2026-06-28
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -940,7 +940,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.32.0"
+version = "0.33.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.32.0"
+version = "0.33.0"
 edition = "2021"
 
 [lib]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.32.0"
+version = "0.33.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.33.0** from `main`, rolling the `[Unreleased]` backlog plus the just-merged keyATM SE into one release.

## Included
- Ideal-point consolidation: `IdealPointTM` count/word2vec representations (folds in the former `IdealPointLDA`), `SentenceIdealTM` → `IdealPointSentenceTM`.
- `Wordfish.fit(control=...)` confound covariate.
- `topica.polarization(positions, labels)` diagnostic.
- `PartyEmbeddings` (#303) — party embeddings (Rheault & Cochrane 2020).
- `KeyATM.feature_effect_se` (#316) — completes the standard-errors roadmap (#309).

## Mechanics
- `Cargo.toml` + `pyproject.toml` → 0.33.0.
- CHANGELOG `[Unreleased]` → `[0.33.0] - 2026-06-28`, fresh empty `[Unreleased]` left on top, #316 entry added.

Tagging `v0.33.0` after merge triggers the PyPI publish workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)