### PR TITLE
chore: move Longleaf benchmark materials under paper

### DIFF
--- a/paper/README.md
+++ b/paper/README.md
@@ -49,7 +49,7 @@ MALLET from <https://github.com/mimno/Mallet/releases> (set `MALLET_HOME` to the
 unpacked dir and add `$MALLET_HOME/bin` to `PATH`). §5 parity and §7 are
 machine-independent; **§6 timings are hardware-dependent** — for a documented,
 repeatable §6 on UNC's Longleaf HPC (with a turnkey env-setup + SLURM script and
-the gotchas we hit), see [`longleaf/README.md`](../longleaf/README.md).
+the gotchas we hit), see [`longleaf/README.md`](longleaf/README.md).
 
 ## Building
 

--- a/paper/longleaf/README.md
+++ b/paper/longleaf/README.md
@@ -10,11 +10,11 @@ laptop via `paper/reproduce.py --no-benchmarks` and are not repeated here.)
 ## Quick start
 ```bash
 # on a Longleaf login node:
-bash longleaf/setup_env.sh           # one-time: clone, build, install deps (~20 min)
-sbatch longleaf/bench.sl             # §6 ×3 for variance; writes $WORK/bench_rep*.md
+bash paper/longleaf/setup_env.sh     # one-time: clone, build, install deps (~20 min)
+sbatch paper/longleaf/bench.sl       # §6 ×3 for variance; writes $WORK/bench_rep*.md
 ```
 Setup defaults to checking out `main` (it must include the temp-dir portability
-fix; `v0.23.1` predates it). Pass a ref to override: `bash longleaf/setup_env.sh v0.24.0`.
+fix; `v0.23.1` predates it). Pass a ref to override: `bash paper/longleaf/setup_env.sh v0.24.0`.
 
 ### The to-convergence STM headline (poliblog5k + Congress)
 

--- a/paper/longleaf/bench.sl
+++ b/paper/longleaf/bench.sl
@@ -12,7 +12,7 @@
 # Section 6 (machine-dependent) benchmarks on a documented node, repeated for
 # variance. Section 5 parity + Section 7 are machine-INDEPENDENT and run on the
 # laptop (paper/reproduce.py --no-benchmarks). Requires the env from
-# longleaf/setup_env.sh (topica built + R stm/keyATM + matplotlib).
+# paper/longleaf/setup_env.sh (topica built + R stm/keyATM + matplotlib).
 #
 # Smoke-test before batch (lesson: never batch an untested script):
 #   srun -p general --cpus-per-task=8 --mem=32g -t 0:30:00 --pty bash

--- a/paper/longleaf/setup_env.sh
+++ b/paper/longleaf/setup_env.sh
@@ -68,4 +68,4 @@ echo "mallet: $WORK/mallet/bin/mallet"
 
 # 7. Smoke-test (catches build/import/data issues before any batch job).
 python -c "import topica,numpy,pandas,sklearn,gensim,tomotopy,matplotlib; print('topica', topica.__version__, '- env OK')"
-echo "Setup done. Activate: conda activate $ENV_PREFIX ; then: sbatch longleaf/bench.sl"
+echo "Setup done. Activate: conda activate $ENV_PREFIX ; then: sbatch paper/longleaf/bench.sl"


### PR DESCRIPTION
Moves the UNC Longleaf benchmark scripts and instructions from the repository root into paper/longleaf/, and updates the paper README and internal paths. This is an organizational-only change; it does not affect the library or benchmark contents.