### PR TITLE
feat: single-chain MCMC diagnostics for the Gibbs models (topica.mcmc)

### DIFF
--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -97,6 +97,23 @@ and in the `topica.validation` module.
 
 ::: topica.cross_ensemble
 
+## MCMC convergence (`topica.mcmc`)
+
+Single-chain autocorrelation and effective sample size for the collapsed-Gibbs
+models, computed from the retained log-likelihood trace and `theta_draws`. See
+the [convergence section](../guides/diagnostics.md#has-the-chain-plateaued-or-mixed)
+of the diagnostics guide.
+
+::: topica.mcmc_diagnostics
+
+::: topica.McmcDiagnostics
+
+::: topica.effective_sample_size
+
+::: topica.integrated_autocorr_time
+
+::: topica.autocorrelation
+
 ## Held-out likelihood
 
 Build a within-corpus word-heldout set — the analogue of R `stm`'s

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -346,6 +346,47 @@ they satisfy the contract without early-stop support. HDP and GSDMM record a
 their topic and cluster counts, so a log-likelihood plateau is not a convergence
 signal.
 
+### Has the chain plateaued, or mixed?
+
+For the collapsed-Gibbs samplers, `convergence_tol` watches the log-likelihood
+trace, and a flat trace means the sampler found a mode — not that the chain has
+*mixed*. A plateaued log-likelihood and a poorly-mixed chain look identical from
+the objective alone. `topica.mcmc` reports the MCMC-native diagnostics a Bayesian
+workflow expects, computed from traces the model already keeps: the
+log-likelihood history and the thinned `theta_draws`.
+
+```python
+model = topica.LDA(num_topics=20, seed=1)
+model.fit(docs, iters=2000, num_theta_draws=200)   # more retained draws -> finer ESS
+
+d = topica.mcmc_diagnostics(model)
+print(d.summary())
+# MCMC diagnostics for LDA (inference=gibbs)
+#   retained draws          : 200
+#   log-likelihood tau      : 3.10
+#   log-likelihood ESS      : 6.5
+#   theta ESS (min/median)  : 41.2 / 118.7 (of 200 draws)
+
+d.theta_ess          # (num_docs, num_topics) effective sample size per element
+d.loglik_autocorr    # autocorrelation of the log-likelihood trace
+```
+
+A low `theta ESS` relative to `retained draws` means the chain is autocorrelated
+— the draws carry less information than their count suggests, so run more sweeps
+or thin further. The `theta_draws` are already thinned, so raise
+`num_theta_draws` on `fit` for a finer estimate.
+
+The underlying estimators are also exposed directly for any trace you hold —
+`topica.autocorrelation`, `topica.integrated_autocorr_time` (Geyer's
+initial-positive-sequence `tau`), and `topica.effective_sample_size` (`N / tau`,
+for one chain or columnwise over a `(draws, params)` matrix).
+
+Multi-chain R-hat (Gelman-Rubin), which needs several seeds run and compared, is
+not yet exposed ([issue #269](https://github.com/nealcaren/topica/issues/269));
+these single-chain diagnostics are the cheap first cut. The variational models
+(STM, CTM, …) converge a bound and have no MCMC chain — `mcmc_diagnostics` warns
+if you point it at one.
+
 ## Visualization
 
 ```python

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -191,6 +191,14 @@ from .coherence import (  # noqa: E402
 # intrusion, select_k, backend, PROMPTS) -- it is an llm-bounded family, kept
 # distinct from the bit-exact diagnostics above. See topica/llm.py.
 from . import llm  # noqa: E402
+from . import mcmc  # noqa: E402  (single-chain MCMC diagnostics for the Gibbs models)
+from .mcmc import (  # noqa: E402
+    mcmc_diagnostics,
+    effective_sample_size,
+    autocorrelation,
+    integrated_autocorr_time,
+    McmcDiagnostics,
+)
 from .registry import list_models, ModelInfo, REGISTRY  # noqa: E402  model taxonomy / discovery
 
 from .validation import (  # noqa: E402  general, model-agnostic post-hoc analyses
@@ -421,6 +429,12 @@ __all__ = [
     "position_intervals",
     "summary",
     "diagnostics",
+    "mcmc",
+    "mcmc_diagnostics",
+    "effective_sample_size",
+    "autocorrelation",
+    "integrated_autocorr_time",
+    "McmcDiagnostics",
     "perplexity",
     "make_heldout",
     "eval_heldout",

--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -33,6 +33,14 @@ from ._topica import (
 from . import stm as stm
 from . import keyatm as keyatm
 from . import effects as effects
+from . import mcmc as mcmc
+from .mcmc import (
+    mcmc_diagnostics as mcmc_diagnostics,
+    effective_sample_size as effective_sample_size,
+    autocorrelation as autocorrelation,
+    integrated_autocorr_time as integrated_autocorr_time,
+    McmcDiagnostics as McmcDiagnostics,
+)
 from .effects import (
     estimate_effect as estimate_effect,
     average_marginal_effects as average_marginal_effects,

--- a/python/topica/mcmc.py
+++ b/python/topica/mcmc.py
@@ -1,0 +1,277 @@
+"""MCMC-native convergence diagnostics for the collapsed-Gibbs models.
+
+For the Gibbs samplers (``LDA``, ``KeyATM``, ``DMR``, ``SAGE``, ``PA``,
+``SeededLDA``, ``LabeledLDA``, ...), the ``convergence_tol`` early-stop is a
+pragmatic heuristic on the log-likelihood trace, *not* a measure of MCMC
+convergence: a flat log-likelihood says the chain found a mode, not that it has
+mixed. This module adds the chain diagnostics a Bayesian workflow expects,
+computed from traces the models already retain -- the log-likelihood history and
+the thinned ``theta_draws``.
+
+- :func:`autocorrelation` -- the autocorrelation function of a 1-D trace.
+- :func:`integrated_autocorr_time` -- the integrated autocorrelation time
+  ``tau`` (Geyer 1992 initial-positive-sequence estimator).
+- :func:`effective_sample_size` -- ``ESS = N / tau`` for one chain or, columnwise,
+  for a ``(draws, params)`` matrix.
+- :func:`mcmc_diagnostics` -- read the log-likelihood trace and ``theta_draws``
+  off a fitted Gibbs model and summarize both.
+
+Single-chain autocorrelation and ESS are the cheap diagnostics that land here.
+Multi-chain R-hat (Gelman-Rubin) needs a multi-chain runner and is tracked
+separately (issue #269).
+
+.. note::
+   ``theta_draws`` are *thinned* MCMC draws (``num_theta_draws`` samples spaced
+   ``sample_interval`` sweeps apart), so their ESS measures the effective size of
+   the retained draws. Raise ``num_theta_draws`` on ``fit`` for a finer estimate.
+"""
+
+from __future__ import annotations
+
+import warnings
+from dataclasses import dataclass
+
+import numpy as np
+
+from .registry import REGISTRY
+
+
+def _autocovariance(x: np.ndarray) -> np.ndarray:
+    """Biased autocovariance of a 1-D series at lags 0..N-1, via FFT."""
+    x = np.asarray(x, dtype=float).ravel()
+    n = x.size
+    x = x - x.mean()
+    # zero-pad to at least 2N-1 and up to a power of two for a fast transform
+    size = 1 << (2 * n - 1).bit_length()
+    freq = np.fft.rfft(x, n=size)
+    acov = np.fft.irfft(freq * np.conjugate(freq), n=size)[:n]
+    return acov / n
+
+
+def autocorrelation(x, max_lag: int | None = None) -> np.ndarray:
+    """Autocorrelation function of a 1-D trace at lags ``0..max_lag``.
+
+    Parameters
+    ----------
+    x : 1-D sequence
+        The trace (e.g. a log-likelihood history or a single scalar chain).
+    max_lag : int, optional
+        Highest lag to return. Defaults to ``len(x) - 1``. Lag 0 is always 1.
+
+    Returns
+    -------
+    numpy.ndarray
+        ``rho[0..max_lag]`` with ``rho[0] == 1``. A constant trace (zero
+        variance) returns all zeros except ``rho[0]``.
+    """
+    x = np.asarray(x, dtype=float).ravel()
+    n = x.size
+    if n < 2:
+        return np.ones(1)
+    acov = _autocovariance(x)
+    var = acov[0]
+    lag = n - 1 if max_lag is None else min(max_lag, n - 1)
+    if var <= 0:
+        rho = np.zeros(lag + 1)
+        rho[0] = 1.0
+        return rho
+    return acov[: lag + 1] / var
+
+
+def integrated_autocorr_time(x) -> float:
+    """Integrated autocorrelation time ``tau = 1 + 2 * sum_{t>=1} rho_t``.
+
+    Uses Geyer's (1992) initial-positive-sequence estimator: the pair sums
+    ``Gamma_m = rho_{2m} + rho_{2m+1}`` are summed until the first non-positive
+    pair, which truncates the noisy tail of the empirical autocorrelation.
+    Floored at 1 (an independent chain), so ``ESS`` never exceeds ``N``.
+
+    A degenerate (constant) chain returns ``inf`` -- there is no information to
+    resample from, so its effective sample size is zero.
+    """
+    x = np.asarray(x, dtype=float).ravel()
+    n = x.size
+    if n < 2:
+        return 1.0
+    acov = _autocovariance(x)
+    var = acov[0]
+    if var <= 0:
+        return float("inf")
+    rho = acov / var
+    gamma_sum = 0.0
+    for m in range(0, (n - 1) // 2 + 1):
+        i, j = 2 * m, 2 * m + 1
+        pair = rho[i] + (rho[j] if j < n else 0.0)
+        if pair <= 0:
+            break
+        gamma_sum += pair
+    tau = 2.0 * gamma_sum - 1.0
+    return max(tau, 1.0)
+
+
+def effective_sample_size(chain):
+    """Effective sample size ``ESS = N / tau`` of a chain.
+
+    Parameters
+    ----------
+    chain : 1-D or 2-D array
+        A single scalar chain of length ``N``, or an ``(N, params)`` matrix of
+        ``params`` independent chains sharing the ``N`` draws (e.g.
+        ``theta_draws`` flattened over docs and topics).
+
+    Returns
+    -------
+    float or numpy.ndarray
+        A scalar for a 1-D chain, or a ``(params,)`` array of per-column ESS for
+        a 2-D chain. A degenerate (constant) column yields ``0.0``.
+    """
+    chain = np.asarray(chain, dtype=float)
+    if chain.ndim == 1:
+        return chain.shape[0] / integrated_autocorr_time(chain)
+    if chain.ndim == 2:
+        n = chain.shape[0]
+        out = np.empty(chain.shape[1])
+        for j in range(chain.shape[1]):
+            out[j] = n / integrated_autocorr_time(chain[:, j])
+        return out
+    raise ValueError(f"chain must be 1-D or 2-D, got {chain.ndim}-D")
+
+
+@dataclass
+class McmcDiagnostics:
+    """Single-chain MCMC diagnostics for a fitted Gibbs model.
+
+    Attributes
+    ----------
+    model : str
+        The model class name.
+    inference : str or None
+        The model's inference engine from the registry (``"gibbs"`` for the
+        samplers these diagnostics are meant for).
+    n_draws : int
+        Number of retained ``theta_draws``.
+    loglik_autocorr : numpy.ndarray or None
+        Autocorrelation of the log-likelihood trace, or ``None`` when the model
+        recorded no trace (e.g. the WarpLDA / CVB0 sampler paths).
+    loglik_tau : float or None
+        Integrated autocorrelation time of the log-likelihood trace.
+    loglik_ess : float or None
+        Effective sample size of the log-likelihood trace (``len(trace) / tau``).
+    theta_ess : numpy.ndarray
+        Per-element effective sample size of ``theta_draws``, shaped
+        ``(num_docs, num_topics)``.
+    """
+
+    model: str
+    inference: str | None
+    n_draws: int
+    loglik_autocorr: np.ndarray | None
+    loglik_tau: float | None
+    loglik_ess: float | None
+    theta_ess: np.ndarray
+
+    @property
+    def theta_ess_min(self) -> float:
+        return float(np.min(self.theta_ess))
+
+    @property
+    def theta_ess_median(self) -> float:
+        return float(np.median(self.theta_ess))
+
+    @property
+    def theta_ess_mean(self) -> float:
+        return float(np.mean(self.theta_ess))
+
+    def summary(self) -> str:
+        """A short human-readable table of the diagnostics."""
+        lines = [
+            f"MCMC diagnostics for {self.model} (inference={self.inference})",
+            f"  retained draws          : {self.n_draws}",
+        ]
+        if self.loglik_tau is not None:
+            lines.append(f"  log-likelihood tau      : {self.loglik_tau:.2f}")
+            ess = "n/a" if self.loglik_ess is None else f"{self.loglik_ess:.1f}"
+            lines.append(f"  log-likelihood ESS      : {ess}")
+        else:
+            lines.append("  log-likelihood trace    : none recorded")
+        lines.append(
+            f"  theta ESS (min/median)  : {self.theta_ess_min:.1f} / "
+            f"{self.theta_ess_median:.1f} (of {self.n_draws} draws)"
+        )
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return self.summary()
+
+
+def mcmc_diagnostics(model, *, warn: bool = True) -> McmcDiagnostics:
+    """Single-chain MCMC diagnostics from a fitted Gibbs model's retained traces.
+
+    Reads the model's log-likelihood history and thinned ``theta_draws`` and
+    reports the autocorrelation and effective sample size of each -- the honest
+    "has the chain mixed?" companion to the ``convergence_tol`` plateau check.
+
+    Parameters
+    ----------
+    model : a fitted topica model
+        Must expose ``theta_draws`` (fit with ``keep_theta_draws=True``, the
+        default). The log-likelihood diagnostics also need a non-empty
+        ``log_likelihood_history`` / ``fit_history``.
+    warn : bool, default True
+        Warn when the model is not a Gibbs sampler. The variational models
+        (STM, CTM, ...) converge a bound and have no MCMC chain; these
+        diagnostics do not apply to them.
+
+    Returns
+    -------
+    McmcDiagnostics
+
+    Raises
+    ------
+    ValueError
+        If the model retained no ``theta_draws``.
+    """
+    name = type(model).__name__
+    info = REGISTRY.get(name)
+    inference = info.inference if info is not None else None
+    if warn and inference is not None and inference != "gibbs":
+        warnings.warn(
+            f"{name} uses {inference!r} inference, not Gibbs sampling; MCMC "
+            "chain diagnostics (autocorrelation / ESS) do not apply to it. Its "
+            "convergence is measured by the variational bound.",
+            stacklevel=2,
+        )
+
+    draws = getattr(model, "theta_draws", None)
+    if draws is None:
+        raise ValueError(
+            f"{name} retained no theta_draws; refit with keep_theta_draws=True "
+            "to compute MCMC diagnostics."
+        )
+    draws = np.asarray(draws, dtype=float)  # (num_draws, num_docs, num_topics)
+    n_draws, n_docs, n_topics = draws.shape
+    flat = draws.reshape(n_draws, n_docs * n_topics)
+    theta_ess = effective_sample_size(flat).reshape(n_docs, n_topics)
+
+    ll_hist = getattr(model, "log_likelihood_history", None)
+    if not ll_hist:
+        ll_hist = getattr(model, "fit_history", None)
+    ll_acf = None
+    ll_tau = None
+    ll_ess = None
+    if ll_hist:
+        ll_vals = np.array([float(v) for _, v in ll_hist], dtype=float)
+        if ll_vals.size >= 2:
+            ll_acf = autocorrelation(ll_vals)
+            ll_tau = integrated_autocorr_time(ll_vals)
+            ll_ess = None if np.isinf(ll_tau) else ll_vals.size / ll_tau
+
+    return McmcDiagnostics(
+        model=name,
+        inference=inference,
+        n_draws=n_draws,
+        loglik_autocorr=ll_acf,
+        loglik_tau=ll_tau,
+        loglik_ess=ll_ess,
+        theta_ess=theta_ess,
+    )

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -1,0 +1,150 @@
+"""Single-chain MCMC diagnostics (topica.mcmc).
+
+The estimators are validated against their defining properties: an i.i.d. chain
+has an integrated autocorrelation time near 1 (ESS ~ N), an AR(1) chain recovers
+its theoretical tau = (1+phi)/(1-phi), and a constant chain carries no
+information (tau = inf, ESS = 0). The model-facing wrapper is checked against a
+real fitted Gibbs model and against the guards for the non-Gibbs / no-draws
+cases.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import topica
+from topica import LDA
+
+
+def test_autocorrelation_of_iid_is_flat():
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal(4000)
+    acf = topica.autocorrelation(x, max_lag=10)
+    assert acf[0] == pytest.approx(1.0)
+    # lag>=1 autocorrelation of white noise is ~0 (1/sqrt(N) noise band)
+    assert np.all(np.abs(acf[1:]) < 0.1)
+
+
+def test_autocorrelation_recovers_ar1_coefficient():
+    rng = np.random.default_rng(1)
+    phi = 0.8
+    x = np.empty(20000)
+    x[0] = 0.0
+    for i in range(1, x.size):
+        x[i] = phi * x[i - 1] + rng.standard_normal()
+    acf = topica.autocorrelation(x, max_lag=3)
+    assert acf[1] == pytest.approx(phi, abs=0.03)
+    assert acf[2] == pytest.approx(phi**2, abs=0.05)
+
+
+def test_iac_time_iid_near_one():
+    rng = np.random.default_rng(2)
+    x = rng.standard_normal(5000)
+    tau = topica.integrated_autocorr_time(x)
+    assert 0.8 < tau < 1.3
+
+
+def test_iac_time_ar1_matches_theory():
+    rng = np.random.default_rng(3)
+    phi = 0.8
+    x = np.empty(50000)
+    x[0] = 0.0
+    for i in range(1, x.size):
+        x[i] = phi * x[i - 1] + rng.standard_normal()
+    tau = topica.integrated_autocorr_time(x)
+    theory = (1 + phi) / (1 - phi)  # = 9
+    assert tau == pytest.approx(theory, rel=0.15)
+
+
+def test_ess_iid_close_to_n():
+    rng = np.random.default_rng(4)
+    x = rng.standard_normal(3000)
+    assert topica.effective_sample_size(x) == pytest.approx(3000, rel=0.15)
+
+
+def test_ess_never_exceeds_n():
+    # tau is floored at 1, so ESS <= N for any positively-correlated chain
+    rng = np.random.default_rng(5)
+    phi = 0.9
+    x = np.empty(8000)
+    x[0] = 0.0
+    for i in range(1, x.size):
+        x[i] = phi * x[i - 1] + rng.standard_normal()
+    assert topica.effective_sample_size(x) <= x.size
+
+
+def test_constant_chain_has_zero_ess():
+    const = np.ones(200)
+    assert np.isinf(topica.integrated_autocorr_time(const))
+    assert topica.effective_sample_size(const) == 0.0
+
+
+def test_ess_2d_is_columnwise():
+    rng = np.random.default_rng(6)
+    x = rng.standard_normal((2000, 4))
+    ess = topica.effective_sample_size(x)
+    assert ess.shape == (4,)
+    assert np.all(ess == pytest.approx(2000, rel=0.2))
+
+
+def test_autocorrelation_short_and_constant_inputs():
+    assert topica.autocorrelation([1.0]).tolist() == [1.0]
+    acf = topica.autocorrelation(np.ones(10), max_lag=3)
+    assert acf[0] == 1.0
+    assert np.all(acf[1:] == 0.0)
+
+
+@pytest.fixture(scope="module")
+def fitted_lda():
+    docs = [
+        ["apple", "banana", "apple", "fruit"],
+        ["dog", "cat", "pet", "dog"],
+        ["apple", "fruit", "banana", "juice"],
+        ["cat", "pet", "kitten", "dog"],
+    ] * 20
+    corpus = topica.Corpus.from_documents(docs)
+    model = LDA(num_topics=3, seed=0)
+    model.fit(corpus, iters=300, num_theta_draws=60)
+    return model
+
+
+def test_mcmc_diagnostics_on_fitted_model(fitted_lda):
+    d = topica.mcmc_diagnostics(fitted_lda)
+    assert d.model == "LDA"
+    assert d.inference == "gibbs"
+    assert d.n_draws == 60
+    assert d.theta_ess.shape == (80, 3)
+    # ESS is bounded by the number of retained draws
+    assert d.theta_ess_min > 0
+    assert d.theta_ess.max() <= d.n_draws + 1e-6
+    assert d.loglik_tau is not None and d.loglik_tau >= 1.0
+    assert d.loglik_ess is not None
+    assert "LDA" in d.summary()
+
+
+def test_mcmc_diagnostics_requires_theta_draws():
+    docs = [["a", "b", "c"], ["d", "e", "f"]] * 20
+    corpus = topica.Corpus.from_documents(docs)
+    model = LDA(num_topics=2, seed=0)
+    model.fit(corpus, iters=40, keep_theta_draws=False)
+    with pytest.raises(ValueError, match="theta_draws"):
+        topica.mcmc_diagnostics(model)
+
+
+def test_mcmc_diagnostics_warns_for_variational_model():
+    docs = [["a", "b", "c"], ["d", "e", "f"]] * 20
+    corpus = topica.Corpus.from_documents(docs)
+    model = topica.CTM(num_topics=2, seed=0)
+    model.fit(corpus, iters=15)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        with pytest.raises(ValueError):
+            topica.mcmc_diagnostics(model)
+    assert any("not Gibbs" in str(w.message) for w in caught)
+
+
+def test_mcmc_diagnostics_warn_false_is_silent(fitted_lda):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning would fail the test
+        topica.mcmc_diagnostics(fitted_lda, warn=False)


### PR DESCRIPTION
Cheap first slice of #269 — the single-chain MCMC convergence diagnostics a Bayesian workflow expects for the collapsed-Gibbs samplers, computed from traces the models already retain (no Rust, no binding changes, no multi-chain runner).

## What

New `topica.mcmc` module:

- `mcmc_diagnostics(model, *, warn=True)` — reads a fitted Gibbs model's `log_likelihood_history` + thinned `theta_draws` → `McmcDiagnostics` (per-doc-topic θ-ESS, log-likelihood autocorrelation/τ/ESS, `.summary()` table).
- `effective_sample_size(chain)` — `N/τ`; scalar for a 1-D chain, columnwise for a `(draws, params)` matrix.
- `integrated_autocorr_time(x)` — Geyer (1992) initial-positive-sequence τ.
- `autocorrelation(x, max_lag=)` — FFT-based ACF.

This is the honest "has the chain *mixed*?" companion to `convergence_tol`, which only watches the log-likelihood *plateau*.

## Why

Per #269: for the Gibbs models, a flat log-likelihood says the sampler found a mode, not that the chain mixed. These read the already-retained traces, so they add no fit-time cost.

## Validation

13 new tests (`tests/test_mcmc.py`), all green. Estimators recover their theoretical targets — i.i.d. τ≈1, AR(0.8) τ≈9 and ACF ρ₁≈φ, constant chain → τ=inf/ESS=0, ESS≤N. Model wrapper checked on a real LDA fit; guards verified: raises with no `theta_draws`, warns on a variational model. `mkdocs build --strict` passes; naming/coverage/conformance suites pass.

## Docs

- `guides/diagnostics.md` — a "Has the chain plateaued, or mixed?" subsection (the plateau-vs-mixing distinction #269 asked for).
- `api/diagnostics.md` — API reference for the new surface.

## Deferred (stays in #269)

Multi-chain R-hat / Gelman-Rubin needs a multi-chain runner; the docs and code both flag it as the remaining piece. No version bump (feature PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01L8cTAm21kB4hhnAVM7q1YK