### PR TITLE
fix(embeddings): L2-normalize PCA scores before clustering (#342)

### DIFF
--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -418,7 +418,11 @@ For statistically-selected phrases instead of every bigram, use
 - `n_components` is the dimensionality the embeddings are reduced to before
   clustering. The default reducer is a randomized PCA: fast, deterministic, and
   dependency-free, but it separates less sharply than UMAP and on closely spaced
-  themes can merge clusters a UMAP run would split.
+  themes can merge clusters a UMAP run would split. The reduced coordinates are
+  L2-normalized onto the unit sphere before clustering, so the Euclidean clusterer
+  measures cosine distance — the geometry sentence embeddings are trained for.
+  Without this the few highest-variance PCA directions dominate the metric and the
+  clusterer under-splits real embeddings into a couple of broad topics.
 - `reducer="umap"` switches to a faithful UMAP reducer (with `n_neighbors`), which
   separates real document embeddings much better than a linear projection and, on
   closely spaced themes, splits clusters PCA would merge. It ships in the wheel, so

--- a/src/bertopic.rs
+++ b/src/bertopic.rs
@@ -155,11 +155,22 @@ pub fn fit_bertopic(
 
     // (1) reduce, (2) cluster. HDBSCAN (default) leaves `-1` noise; KMeans /
     // agglomerative assign every document instead.
-    let reduced: Vec<Vec<f64>> = if emb_dim > n_components && n_components > 0 {
+    let did_reduce = emb_dim > n_components && n_components > 0;
+    let mut reduced: Vec<Vec<f64>> = if did_reduce {
         reduce::reduce(doc_embeddings, n_components, use_umap, n_neighbors, seed)
     } else {
         doc_embeddings.to_vec()
     };
+    // L2-normalize the PCA scores onto the unit sphere before Euclidean
+    // clustering so the metric tracks cosine, the geometry sentence embeddings
+    // are trained for; otherwise a few high-variance PCA directions dominate and
+    // HDBSCAN under-splits real embeddings. UMAP output is already
+    // cosine-structured, so skip it there. `use_umap` falls back to PCA when the
+    // `umap` feature is not compiled, so gate on what actually ran.
+    let did_pca = did_reduce && !(use_umap && reduce::umap_available());
+    if did_pca {
+        reduce::l2_normalize_rows(&mut reduced);
+    }
     let mut labels = cluster::cluster_points(
         &reduced,
         clusterer,
@@ -418,6 +429,88 @@ mod tests {
             );
         }
         (docs, emb, vocab_size)
+    }
+
+    // Clusters that differ by *direction* (each along its own axis) but carry a
+    // wide random *radial* magnitude, the geometry L2-normalization is meant to
+    // fix (issue #342). On the raw PCA scores the radial spread dominates the
+    // Euclidean metric, so a density clusterer mis-splits the rays (here it
+    // fragments them); normalizing onto the sphere collapses each ray to its
+    // direction and recovers the true clusters. The real sentence-embedding
+    // failure is the same cause with the opposite symptom (under-splitting a
+    // dense core), but a small deterministic synthetic reproduces the fragmenting
+    // form; either way raw clustering is wrong and normalization corrects it.
+    fn radial_rays(
+        n_clusters: usize,
+        per: usize,
+        seed: u64,
+    ) -> (Vec<Vec<u32>>, Vec<Vec<f64>>, usize) {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let dim = 16;
+        let block = 5;
+        let vocab_size = n_clusters * block;
+        let mut docs = Vec::new();
+        let mut emb = Vec::new();
+        for d in 0..(n_clusters * per) {
+            let c = d % n_clusters;
+            let toks: Vec<u32> = (0..8)
+                .map(|_| (c * block + rng.gen_range(0..block)) as u32)
+                .collect();
+            docs.push(toks);
+            // Direction = axis c; magnitude spread wide so the radial variance
+            // dominates the raw Euclidean metric.
+            let mag = 1.0 + rng.gen::<f64>() * 11.0;
+            let row: Vec<f64> = (0..dim)
+                .map(|t| {
+                    let dir = if t == c { mag } else { 0.0 };
+                    dir + (rng.gen::<f64>() - 0.5) * 0.3
+                })
+                .collect();
+            emb.push(row);
+        }
+        (docs, emb, vocab_size)
+    }
+
+    #[test]
+    fn l2_normalization_recovers_rays_that_raw_pca_misclusters() {
+        let (docs, emb, vocab) = radial_rays(4, 60, 7);
+        // Raw PCA scores: radial spread dominates the Euclidean metric, so
+        // HDBSCAN gets the cluster count wrong.
+        let raw = crate::reduce::pca(&emb, 5, 7);
+        let raw_k = topic_count(&crate::cluster::cluster_points(
+            &raw, "hdbscan", None, 15, 5, 7,
+        ));
+        assert_ne!(raw_k, 4, "raw PCA clustering should mis-count the 4 rays");
+        // L2-normalized: each point maps to its ray direction, cleanly separable
+        // into exactly the 4 true clusters.
+        let mut normed = crate::reduce::pca(&emb, 5, 7);
+        crate::reduce::l2_normalize_rows(&mut normed);
+        let norm_k = topic_count(&crate::cluster::cluster_points(
+            &normed, "hdbscan", None, 15, 5, 7,
+        ));
+        assert_eq!(
+            norm_k, 4,
+            "normalized clustering should recover exactly 4 rays, got {norm_k}"
+        );
+        // The shipped pipeline normalizes on the PCA path, so fit_bertopic itself
+        // recovers block-pure topics (each topic's top words from one planted block).
+        let m = fit_bertopic(
+            &docs, &emb, vocab, 5, false, 15, 15, 5, None, 4, 1, false, false, "hdbscan", None, 7,
+        );
+        assert_eq!(
+            m.num_topics, 4,
+            "fit_bertopic recovered {} topics",
+            m.num_topics
+        );
+        for t in 0..m.num_topics {
+            let blocks: std::collections::HashSet<usize> =
+                m.top_words(4, t).into_iter().map(|(w, _)| w / 5).collect();
+            assert_eq!(
+                blocks.len(),
+                1,
+                "topic {t} mixes planted blocks: {blocks:?}"
+            );
+        }
     }
 
     #[test]

--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -252,6 +252,28 @@ pub fn project(
     }
 }
 
+/// L2-normalize each row in place, projecting the points onto the unit sphere.
+///
+/// The embedding heads cluster reduced coordinates with a Euclidean density
+/// clusterer, but sentence embeddings are trained for cosine similarity. On raw
+/// PCA scores a few high-variance directions dominate the Euclidean metric and
+/// HDBSCAN under-splits into a couple of broad clusters; normalizing onto the
+/// sphere makes squared Euclidean distance a monotone function of cosine
+/// distance (`||a-b||^2 = 2(1 - cos)` for unit vectors), so the clusterer sees
+/// the metric the encoder was trained for. A zero-norm row (all-zero
+/// coordinates) is left untouched rather than divided by zero.
+pub fn l2_normalize_rows(rows: &mut [Vec<f64>]) {
+    for row in rows.iter_mut() {
+        let norm: f64 = row.iter().map(|&v| v * v).sum::<f64>().sqrt();
+        if norm > 0.0 {
+            let inv = 1.0 / norm;
+            for v in row.iter_mut() {
+                *v *= inv;
+            }
+        }
+    }
+}
+
 /// Project `data` (`n_rows × n_features`, each row a sample) onto its top
 /// `n_components` principal components and return the scores (`n_rows ×
 /// n_components`).
@@ -713,6 +735,24 @@ mod tests {
         let s = pca(&small, 3, 0);
         assert_eq!(s.len(), 1);
         assert_eq!(s[0].len(), 3);
+    }
+
+    #[test]
+    fn l2_normalize_rows_projects_onto_sphere() {
+        let mut rows = vec![
+            vec![3.0, 4.0],       // norm 5 -> (0.6, 0.8)
+            vec![0.0, 0.0],       // zero row stays put (no divide by zero)
+            vec![-2.0, 0.0, 0.0], // norm 2 -> (-1, 0, 0)
+        ];
+        l2_normalize_rows(&mut rows);
+        assert!((rows[0][0] - 0.6).abs() < 1e-12 && (rows[0][1] - 0.8).abs() < 1e-12);
+        assert_eq!(rows[1], vec![0.0, 0.0]);
+        assert!((rows[2][0] + 1.0).abs() < 1e-12);
+        // Every non-zero row now has unit norm.
+        for row in [&rows[0], &rows[2]] {
+            let n: f64 = row.iter().map(|&v| v * v).sum::<f64>().sqrt();
+            assert!((n - 1.0).abs() < 1e-12, "row norm {n}");
+        }
     }
 
     #[test]

--- a/src/top2vec.rs
+++ b/src/top2vec.rs
@@ -185,11 +185,20 @@ pub fn fit_top2vec(
     };
 
     // (1) Reduce, unless the embeddings are already at or below the target dim.
-    let reduced: Vec<Vec<f64>> = if emb_dim > n_components && n_components > 0 {
+    let did_reduce = emb_dim > n_components && n_components > 0;
+    let mut reduced: Vec<Vec<f64>> = if did_reduce {
         reduce::reduce(doc_embeddings, n_components, use_umap, n_neighbors, seed)
     } else {
         doc_embeddings.to_vec()
     };
+    // L2-normalize the PCA scores onto the unit sphere before Euclidean
+    // clustering so the metric tracks cosine (see `fit_bertopic`); UMAP output is
+    // already cosine-structured, and `use_umap` silently falls back to PCA when
+    // the `umap` feature is absent, so gate on what actually ran.
+    let did_pca = did_reduce && !(use_umap && reduce::umap_available());
+    if did_pca {
+        reduce::l2_normalize_rows(&mut reduced);
+    }
 
     // (2) Cluster the reduced points. HDBSCAN (the default) leaves sparse points
     // as `-1` noise; KMeans / agglomerative assign every document instead.


### PR DESCRIPTION
Closes #342.

## Problem

`BERTopic` and `Top2Vec` reduce document embeddings with randomized PCA and then run Euclidean HDBSCAN directly on the raw scores. Because `reduce::pca` scales scores by singular value, a few high-variance directions dominate the Euclidean metric, so on real sentence embeddings the clusterer under-splits into a couple of broad topics and discards most of the encoder's signal. The effect scales with embedding dimensionality, so the default pipeline does not even preserve the ranking between encoders (per the issue, a frontier encoder can score *below* LDA with the current default).

## Fix

L2-normalize each reduced row onto the unit sphere before clustering, so squared Euclidean distance tracks cosine (`||a-b||² = 2(1-cos)` for unit vectors) — the geometry sentence embeddings are trained for, and what the UMAP path already produces.

- New shared `reduce::l2_normalize_rows` helper (zero-norm rows left untouched).
- Applied in both `fit_bertopic` and `fit_top2vec`, gated on whether PCA actually ran: `did_reduce && !(use_umap && reduce::umap_available())`. This matters because `use_umap` silently falls back to PCA when the `umap` feature is not compiled.
- Topic vectors (Top2Vec centroids) and c-TF-IDF are computed from the original inputs, so only the cluster labels change.

## Tests

- `reduce::l2_normalize_rows` unit test (unit norms, zero-row guard).
- A `bertopic` regression on radial-nuisance embeddings that raw PCA clustering mis-counts and normalized clustering recovers exactly (with block-pure topics).
- No-op on the existing well-separated planted-cluster tests (all still pass).

Honest note: the deterministic regression fixture reproduces the *cause* (a dominant radial direction defeating the Euclidean metric) but surfaces as over-fragmentation rather than the under-splitting seen on real 20NG embeddings — same mechanism, opposite symptom. Reproducing clean under-splitting needs a real encoder; the raw-vs-normalized contrast is captured deterministically in the Rust test.

## Verification

- `cargo test --lib --features embeddings` — 192 passed.
- Embedding pytest suites — 44 passed; Top2Vec/parity/neural — 68 passed, 3 skipped (incl. `test_top2vec_matches_bertopic`).
- `mkdocs build --strict` — clean.
- End-to-end: rebuilt wheel, `BERTopic` on separable angular structure recovers all 6 planted topics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qMBhchZpttn6n3xtvnc5H