### PR TITLE
feat(embeddings): faithful in-house UMAP reducer, drop umap-rs (#343)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,26 +18,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alga"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f823d037a7ec6ea2197046bafd4ae150e6bc36f9ca347404f46a46823fa84f2"
-dependencies = [
- "approx",
- "num-complex 0.2.4",
- "num-traits",
-]
-
-[[package]]
-name = "approx"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0e60b75072ecd4168020818c0107f2857bb6c4e64252d8d3983f6263b40a5c3"
-dependencies = [
- "num-traits",
-]
-
-[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -67,18 +47,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitflags"
-version = "2.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84d7ced0ae9557296835c32bf1b1e02b44c746701f898460fb000d7eaa84f00a"
-
-[[package]]
-name = "bumpalo"
-version = "3.20.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
-
-[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -89,18 +57,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "console"
-version = "0.16.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
-dependencies = [
- "encode_unicode",
- "libc",
- "unicode-width",
- "windows-sys",
-]
 
 [[package]]
 name = "crc32fast"
@@ -189,31 +145,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dashmap"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6361d5c062261c78a176addb82d4c821ae42bed6089de0e12603cd25de2059c"
-dependencies = [
- "cfg-if",
- "crossbeam-utils",
- "hashbrown",
- "lock_api",
- "once_cell",
- "parking_lot_core",
- "rayon",
-]
-
-[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
-
-[[package]]
-name = "encode_unicode"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "flate2"
@@ -223,30 +158,6 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
-]
-
-[[package]]
-name = "futures-core"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-task"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
-
-[[package]]
-name = "futures-util"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
-dependencies = [
- "futures-core",
- "futures-task",
- "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -273,35 +184,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "hashbrown"
-version = "0.14.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
-
-[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
-
-[[package]]
-name = "indicatif"
-version = "0.18.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25470f23803092da7d239834776d653104d551bc4d7eacaf31e6837854b8e9eb"
-dependencies = [
- "console",
- "portable-atomic",
- "unicode-width",
- "unit-prefix",
- "web-time",
-]
 
 [[package]]
 name = "indoc"
@@ -328,18 +214,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
-name = "js-sys"
-version = "0.3.99"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
-dependencies = [
- "cfg-if",
- "futures-util",
- "once_cell",
- "wasm-bindgen",
-]
-
-[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -350,15 +224,6 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
-
-[[package]]
-name = "lock_api"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
-dependencies = [
- "scopeguard",
-]
 
 [[package]]
 name = "matrixmultiply"
@@ -402,7 +267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "882ed72dce9365842bf196bdeedf5055305f11fc8c03dee7bb0194a6cad34841"
 dependencies = [
  "matrixmultiply",
- "num-complex 0.4.6",
+ "num-complex",
  "num-integer",
  "num-traits",
  "portable-atomic",
@@ -417,23 +282,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "520080814a7a6b4a6e9070823bb24b4531daac8c4627e08ba5de8c5ef2f2752d"
 dependencies = [
  "matrixmultiply",
- "num-complex 0.4.6",
+ "num-complex",
  "num-integer",
  "num-traits",
  "portable-atomic",
  "portable-atomic-util",
  "rawpointer",
- "serde",
-]
-
-[[package]]
-name = "num-complex"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
-dependencies = [
- "autocfg",
- "num-traits",
 ]
 
 [[package]]
@@ -465,16 +319,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi",
- "libc",
-]
-
-[[package]]
 name = "numpy"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,7 +326,7 @@ checksum = "edb929bc0da91a4d85ed6c0a84deaa53d411abfb387fc271124f91bf6b89f14e"
 dependencies = [
  "libc",
  "ndarray 0.16.1",
- "num-complex 0.4.6",
+ "num-complex",
  "num-integer",
  "num-traits",
  "pyo3",
@@ -502,19 +346,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7d950ca161dc355eaf28f82b11345ed76c6e1f6eb1f4f4479e0323b9e2fbd0e"
 dependencies = [
  "num-traits",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.9.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
-dependencies = [
- "cfg-if",
- "libc",
- "redox_syscall",
- "smallvec",
- "windows-link",
 ]
 
 [[package]]
@@ -543,12 +374,6 @@ dependencies = [
  "ordered-float",
  "thiserror",
 ]
-
-[[package]]
-name = "pin-project-lite"
-version = "0.2.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "portable-atomic"
@@ -766,15 +591,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "redox_syscall"
-version = "0.5.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
-dependencies = [
- "bitflags",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -822,12 +638,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
-name = "scopeguard"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
-
-[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -862,34 +672,6 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
-name = "slab"
-version = "0.4.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
-
-[[package]]
-name = "smallvec"
-version = "1.15.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "sprs"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dca58a33be2188d4edc71534f8bafa826e787cc28ca1c47f31be3423f0d6e55"
-dependencies = [
- "alga",
- "ndarray 0.17.2",
- "num-complex 0.4.6",
- "num-traits",
- "num_cpus",
- "rayon",
- "serde",
- "smallvec",
-]
 
 [[package]]
 name = "succinct"
@@ -956,7 +738,6 @@ dependencies = [
  "regex",
  "serde",
  "topica-core",
- "umap-rs",
 ]
 
 [[package]]
@@ -972,97 +753,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "tracing"
-version = "0.1.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
-dependencies = [
- "pin-project-lite",
- "tracing-attributes",
- "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "tracing-core"
-version = "0.1.36"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
-dependencies = [
- "once_cell",
-]
-
-[[package]]
-name = "typed-builder"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fef81aec2ca29576f9f6ae8755108640d0a86dd3161b2e8bca6cfa554e98f77d"
-dependencies = [
- "typed-builder-macro",
-]
-
-[[package]]
-name = "typed-builder-macro"
-version = "0.21.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ecb9ecf7799210407c14a8cfdfe0173365780968dc57973ed082211958e0b18"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "umap-rs"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edf38efe1c61db7d7d53fca13c9654a9fa902460d3501f7809dff029e977d54e"
-dependencies = [
- "dashmap",
- "indicatif",
- "itertools",
- "ndarray 0.17.2",
- "rand 0.9.4",
- "rayon",
- "serde",
- "sprs",
- "tracing",
- "typed-builder",
-]
-
-[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-width"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
 name = "unindent"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7264e107f553ccae879d21fbea1d6724ac785e8c3bfc762137959b5802826ef3"
-
-[[package]]
-name = "unit-prefix"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81e544489bf3d8ef66c953931f56617f423cd4b5494be343d9b9d3dda037b9a3"
 
 [[package]]
 name = "wasi"
@@ -1077,76 +777,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
-]
-
-[[package]]
-name = "wasm-bindgen"
-version = "0.2.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
-dependencies = [
- "cfg-if",
- "once_cell",
- "rustversion",
- "wasm-bindgen-macro",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-macro"
-version = "0.2.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
-dependencies = [
- "quote",
- "wasm-bindgen-macro-support",
-]
-
-[[package]]
-name = "wasm-bindgen-macro-support"
-version = "0.2.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
-dependencies = [
- "bumpalo",
- "proc-macro2",
- "quote",
- "syn",
- "wasm-bindgen-shared",
-]
-
-[[package]]
-name = "wasm-bindgen-shared"
-version = "0.2.122"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
-dependencies = [
- "unicode-ident",
-]
-
-[[package]]
-name = "web-time"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
-dependencies = [
- "js-sys",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "windows-link"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-sys"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,10 +63,8 @@ flate2 = { version = "1", optional = true }
 # matrix type (numpy 0.22 carries ndarray 0.16, so we bridge via raw f64 data).
 petal-clustering = { version = "0.13", optional = true }
 ndarray = { version = "0.17", optional = true }
-# Faithful UMAP reducer (wilsonzlin/umap-rs): pure Rust, BLAS-free, ndarray 0.17
-# (same version as petal-clustering). Behind the `umap` feature so the default
-# embedding build keeps the BLAS-free randomized-PCA reducer.
-umap-rs = { version = "0.4", optional = true }
+# UMAP is now implemented in-house (src/umap.rs), faithful to umap-learn and
+# fully seeded/reproducible; no external UMAP crate. Gated by the `umap` feature.
 # Barnes-Hut t-SNE (frjnn/bhtsne): pure Rust, rayon-parallel, BLAS-free. Behind
 # the `tsne` feature; the shipped wheel enables it so `viz.document_map` and
 # `topica.project` offer method="tsne". The fit is stochastic (bhtsne exposes no
@@ -88,7 +86,7 @@ embeddings = ["dep:petal-clustering", "dep:ndarray"]
 # Faithful UMAP reducer for the embedding models. PCA stays the default reducer;
 # UMAP's discovery fit is stochastic (the umap-rs optimizer's negative sampling is
 # unseeded), while the transform / prediction phase is deterministic regardless.
-umap = ["embeddings", "dep:umap-rs"]
+umap = ["embeddings"]
 # Barnes-Hut t-SNE projection (frjnn/bhtsne), exposed via `topica.project` and the
 # `viz.document_map` panel. Independent of the embedding models, so it stands alone.
 tsne = ["dep:bhtsne"]

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -384,8 +384,8 @@ every other model: `topic_word` (`num_topics × vocab`), `doc_topic`
 `vocabulary`, and `labels`. The embedding-native additions are `topic_vectors`
 and `topic_neighbors` (Top2Vec) and `approximate_distribution` (BERTopic).
 
-They also `save`/`load` like every other model, which is the way to keep a good
-UMAP discovery fit (the discovery is stochastic, the prediction is not):
+They also `save`/`load` like every other model, so a fitted model reloads and
+`transform`s new documents without re-running the pipeline:
 
 ```python
 model.save("topics.tt")
@@ -423,30 +423,26 @@ For statistically-selected phrases instead of every bigram, use
   measures cosine distance — the geometry sentence embeddings are trained for.
   Without this the few highest-variance PCA directions dominate the metric and the
   clusterer under-splits real embeddings into a couple of broad topics.
-- `reducer="umap"` switches to a faithful UMAP reducer (with `n_neighbors`), which
-  separates real document embeddings much better than a linear projection and, on
-  closely spaced themes, splits clusters PCA would merge. It ships in the wheel, so
-  it is opt-in at runtime, not build time.
+- `reducer="umap"` switches to topica's in-house UMAP reducer (with `n_neighbors`),
+  which separates real document embeddings much better than a linear projection
+  and, on closely spaced themes, splits clusters PCA would merge. It is a faithful
+  reimplementation of `umap-learn` (fuzzy simplicial set, `a`/`b` membership curve,
+  and the reference SGD layout), validated to match `umap-learn`'s cluster quality
+  on real sentence embeddings. It ships in the wheel, so it is opt-in at runtime,
+  not build time — pure Rust, with no `umap-learn`/`numba` dependency.
 
-  **One caveat, by design.** The UMAP *discovery* fit is **not reproducible** across
-  runs: the underlying Rust UMAP optimizer's negative sampling is unseeded, so a
-  fixed `seed` does not pin the layout, and `reducer="umap"` emits a warning saying
-  so. This is the one place topica relaxes its determinism guarantee, and it follows
-  BERTopic's own fit-vs-predict split: the reducer runs only during topic
-  *discovery*, while the **prediction phase is deterministic** — `transform` assigns
-  new documents by cosine to the fitted topic vectors (Top2Vec) or by c-TF-IDF
-  (BERTopic) and never re-runs UMAP. So a fitted model maps documents
-  reproducibly even though the discovery that produced it was stochastic. For a
-  fully reproducible fit, keep the default `reducer="pca"`. If your aim is simply to
-  empty the `-1` noise bucket rather than to use UMAP specifically,
-  `clusterer="kmeans"` (above) is the deterministic route.
-- Results are reproducible for a fixed `seed`.
+  Unlike a typical UMAP, topica's is **fully reproducible**: the negative sampling
+  is seeded, so a fixed `seed` pins the layout and the whole `reducer="umap"` fit is
+  deterministic. There is no non-determinism caveat and no warning.
+- Results are reproducible for a fixed `seed`, under either reducer.
 
 !!! note "Faithful to the references"
     On a shared task with shared document embeddings, topica's `Top2Vec` and
     `BERTopic` recover comparable topic structure to the Python `BERTopic`
-    package. Because topica uses its own PCA/UMAP reducer and a different HDBSCAN
-    implementation, exact cluster assignments will differ from the `umap-learn` +
-    `hdbscan` reference; what matches is the kind of topics recovered. The payoff
-    is the dependency footprint: topica runs the pipeline in Rust with none of
-    `torch`, `umap-learn`, or `hdbscan` installed.
+    package. topica's in-house UMAP reducer matches `umap-learn`'s cluster quality
+    on real sentence embeddings (measured by adjusted Rand index against gold
+    labels); because topica uses a different HDBSCAN implementation, exact cluster
+    assignments still differ from the `umap-learn` + `hdbscan` reference, but the
+    recovered topics agree. The payoff is the dependency footprint: topica runs the
+    whole pipeline in Rust with none of `torch`, `umap-learn`, or `hdbscan`
+    installed.

--- a/parity/umap_reference_compare.py
+++ b/parity/umap_reference_compare.py
@@ -1,0 +1,110 @@
+"""Parity check: topica's in-house UMAP reducer vs the reference umap-learn.
+
+Issue #343 reported that the old `reducer="umap"` (delegating to the umap-rs
+crate) recovered ~0.11-0.19 ARI worse cluster structure than umap-learn on real
+sentence embeddings, because umap-rs's layout gradient carried an extra
+`dist_squared` factor in its attractive/repulsive denominators. topica now ships
+a from-scratch UMAP faithful to umap-learn (src/umap.rs); this script measures
+that it reaches umap-learn's cluster quality on the reporter's setup.
+
+Setup: 20 Newsgroups, a balanced 6-category slice, all-mpnet-base-v2 embeddings,
+UMAP to 5-D (cosine, n_neighbors=15, min_dist=0.0), the SAME Euclidean HDBSCAN
+(min_cluster_size=30) on both reducers' output, mean over 3 seeds. Metric is the
+adjusted Rand index of the discovered partition vs the newsgroup labels.
+
+Skips cleanly if the reference stack (sentence-transformers / umap-learn /
+hdbscan / sklearn) is not installed; it is a manual parity tool, not a CI test.
+"""
+
+from __future__ import annotations
+
+import sys
+
+CATS = [
+    "rec.sport.hockey", "sci.space", "talk.politics.guns",
+    "comp.graphics", "sci.med", "soc.religion.christian",
+]
+N_PER = 250
+N_COMPONENTS, N_NEIGHBORS, MIN_CLUSTER = 5, 15, 30
+SEEDS = [0, 1, 2]
+# topica must land within this ARI margin of umap-learn (it typically matches or
+# slightly exceeds it; the margin absorbs seed-to-seed and HDBSCAN-impl noise).
+MARGIN = 0.05
+
+
+def _available() -> bool:
+    import importlib.util as u
+    return all(
+        u.find_spec(m)
+        for m in ("sklearn", "sentence_transformers", "umap", "hdbscan", "numpy")
+    )
+
+
+def _load():
+    import numpy as np
+    from sklearn.datasets import fetch_20newsgroups
+    from sentence_transformers import SentenceTransformer
+
+    ng = fetch_20newsgroups(
+        subset="all", categories=CATS,
+        remove=("headers", "footers", "quotes"), random_state=42,
+    )
+    rng = np.random.default_rng(42)
+    texts, labels = [], []
+    for ci in range(len(CATS)):
+        idx = np.where(np.array(ng.target) == ci)[0]
+        keep = rng.choice(idx, size=min(N_PER, len(idx)), replace=False)
+        for i in keep:
+            texts.append(ng.data[i]); labels.append(ci)
+    model = SentenceTransformer("all-mpnet-base-v2")
+    emb = model.encode(texts, batch_size=64).astype("float64")
+    return emb, np.array(labels)
+
+
+def _ari(truth, pred):
+    import numpy as np
+    from sklearn.metrics import adjusted_rand_score
+    pred = np.asarray(pred)
+    m = pred >= 0
+    return adjusted_rand_score(truth[m], pred[m]) if m.sum() else 0.0
+
+
+def main() -> int:
+    if not _available():
+        print("reference stack (sentence-transformers/umap-learn/hdbscan/sklearn) "
+              "not installed; skipping UMAP parity check.")
+        return 0
+
+    import numpy as np
+    import topica
+    from hdbscan import HDBSCAN
+    from umap import UMAP
+
+    emb, truth = _load()
+
+    def cluster(red):
+        return HDBSCAN(min_cluster_size=MIN_CLUSTER).fit_predict(red)
+
+    topica_ari, ref_ari = [], []
+    for s in SEEDS:
+        t_red = np.asarray(topica.project(emb, N_COMPONENTS, method="umap",
+                                          n_neighbors=N_NEIGHBORS, seed=s))
+        r_red = UMAP(n_neighbors=N_NEIGHBORS, n_components=N_COMPONENTS,
+                     min_dist=0.0, metric="cosine", random_state=s).fit_transform(emb)
+        topica_ari.append(_ari(truth, cluster(t_red)))
+        ref_ari.append(_ari(truth, cluster(r_red)))
+
+    t_mean, r_mean = float(np.mean(topica_ari)), float(np.mean(ref_ari))
+    print(f"topica in-house UMAP ARI: {t_mean:.3f}")
+    print(f"reference umap-learn ARI: {r_mean:.3f}")
+    print(f"gap (topica - reference): {t_mean - r_mean:+.3f}  (margin {MARGIN})")
+
+    if t_mean < r_mean - MARGIN:
+        print("FAIL: topica trails umap-learn by more than the margin.")
+        return 1
+    print("PASS: topica matches umap-learn cluster quality.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -80,6 +80,10 @@ pub mod reduce;
 pub mod represent;
 #[cfg(feature = "embeddings")]
 pub mod top2vec;
+// In-house faithful UMAP reducer (replaces the umap-rs crate). Behind the `umap`
+// feature, which no longer pulls an external dependency.
+#[cfg(feature = "umap")]
+pub mod umap;
 
 #[cfg(feature = "python")]
 mod python;

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -8450,16 +8450,22 @@ fn inspect_semantic_coherence(
 }
 
 /// Warn that a neighbor-preserving projection (UMAP / t-SNE) distorts global
-/// geometry and is not reproducible across runs, so PCA stays the reproducible default.
+/// geometry, so PCA stays the distance-faithful default. UMAP is seeded and
+/// reproducible; t-SNE is additionally not reproducible (its optimizer is
+/// unseeded), so only t-SNE carries the reproducibility caveat.
 fn warn_stochastic(py: Python<'_>, method: &str) -> PyResult<()> {
     let warnings = py.import_bound("warnings")?;
+    let repro = if method == "tsne" {
+        " and is not reproducible across runs"
+    } else {
+        ""
+    };
     warnings.call_method1(
         "warn",
         (format!(
             "method='{method}' preserves local neighborhoods but distorts global \
-             geometry (between-cluster distances and cluster sizes are not meaningful) \
-             and is not reproducible across runs. Use method='pca' for a deterministic, \
-             distance-faithful projection."
+             geometry (between-cluster distances and cluster sizes are not meaningful){repro}. \
+             Use method='pca' for a distance-faithful projection."
         ),),
     )?;
     Ok(())
@@ -8468,8 +8474,9 @@ fn warn_stochastic(py: Python<'_>, method: &str) -> PyResult<()> {
 /// Project a high-dimensional array to a low-dimensional layout (for plotting or
 /// clustering). `method` is "pca" (default, deterministic, distance-faithful),
 /// "umap", or "tsne"; the latter two preserve local neighborhoods but distort
-/// global geometry and are not reproducible (a warning is issued). `data` is a 2D
-/// float array or a list of float lists. Returns an `(n_rows, n_components)` array.
+/// global geometry (a warning is issued). PCA and UMAP are reproducible for a
+/// fixed `seed`; t-SNE is not (its optimizer is unseeded). `data` is a 2D float
+/// array or a list of float lists. Returns an `(n_rows, n_components)` array.
 ///
 /// `n_neighbors` is the local-neighborhood size for the UMAP graph; `perplexity`
 /// is t-SNE's effective neighborhood size; `seed` seeds the reducer (UMAP/PCA)
@@ -12373,11 +12380,11 @@ fn parse_clusterer(
     }
 }
 
-/// For `reducer='umap'`, warn that the topic-discovery fit is not reproducible
-/// (the transform / prediction phase is deterministic regardless), so the default
-/// `reducer='pca'` stays the reproducible choice. Also guards the case (not present
-/// in a standard wheel) where the `umap` feature was not compiled in.
-fn umap_notice(py: Python<'_>, use_umap: bool) -> PyResult<()> {
+/// Guard `reducer='umap'`: error out on the (non-wheel) build where the `umap`
+/// feature was not compiled in. The in-house UMAP reducer is seeded and fully
+/// reproducible for a fixed `seed`, so — unlike the old umap-rs path — there is
+/// no non-determinism to warn about.
+fn umap_notice(_py: Python<'_>, use_umap: bool) -> PyResult<()> {
     if !use_umap {
         return Ok(());
     }
@@ -12387,16 +12394,6 @@ fn umap_notice(py: Python<'_>, use_umap: bool) -> PyResult<()> {
              feature, or use reducer='pca' (the default)",
         ));
     }
-    let warnings = py.import_bound("warnings")?;
-    warnings.call_method1(
-        "warn",
-        (
-            "reducer='umap': the UMAP topic-discovery fit is not reproducible across runs \
-          (the Rust UMAP optimizer's negative sampling is unseeded). The transform / \
-          prediction phase is deterministic regardless. Use reducer='pca' (the default) \
-          for a reproducible fit.",
-        ),
-    )?;
     Ok(())
 }
 

--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -46,12 +46,12 @@ pub fn reduce(
     pca(data, n_components, seed)
 }
 
-/// Project `data` onto `n_components` with UMAP (the `umap-rs` crate). UMAP keeps
-/// local neighborhood structure that a linear projection flattens, so the density
-/// clusterer downstream separates nearby themes PCA would merge. We build the
-/// k-nearest-neighbor graph by brute force (parallel), seed a random initial
-/// layout, and run the crate's layout optimization. Returns `n_rows ×
-/// n_components`, deterministic for a fixed `seed`. Only built under `umap`.
+/// Project `data` onto `n_components` with UMAP. Delegates to the in-house,
+/// umap-learn-faithful reducer in `crate::umap` with the embedding models'
+/// reference-matching defaults: a cosine kNN metric, `min_dist = 0.0` (BERTopic's
+/// setting for tight clusters), `spread = 1.0`, auto epochs, and the standard
+/// negative sampling. Unlike the old umap-rs path this is fully reproducible for
+/// a fixed `seed`. Only built under `umap`.
 #[cfg(feature = "umap")]
 pub fn umap(
     data: &[Vec<f64>],
@@ -59,91 +59,18 @@ pub fn umap(
     n_neighbors: usize,
     seed: u64,
 ) -> Vec<Vec<f64>> {
-    use ndarray::Array2;
-    use rayon::prelude::*;
-    use umap_rs::{GraphParams, Umap, UmapConfig};
-
-    let n = data.len();
-    if n == 0 || n_components == 0 {
-        return vec![Vec::new(); n];
-    }
-    let dim = data[0].len();
-    // umap-rs expects each row to list real neighbors, NOT the point itself, so
-    // we can supply at most n-1 neighbors.
-    let k = n_neighbors.clamp(1, n.saturating_sub(1).max(1));
-
-    let data_f32: Vec<f32> = data
-        .iter()
-        .flat_map(|r| r.iter().map(|&v| v as f32))
-        .collect();
-    let data_arr = Array2::from_shape_vec((n, dim), data_f32).expect("data shape");
-
-    // Brute-force kNN graph, self excluded (umap-rs treats column 0 as a genuine
-    // neighbor and counts only non-zero distances when estimating local density).
-    let knn: Vec<(Vec<u32>, Vec<f32>)> = (0..n)
-        .into_par_iter()
-        .map(|i| {
-            let mut d: Vec<(f32, u32)> = (0..n)
-                .filter(|&j| j != i)
-                .map(|j| {
-                    let mut s = 0.0f32;
-                    for t in 0..dim {
-                        let diff = (data[i][t] - data[j][t]) as f32;
-                        s += diff * diff;
-                    }
-                    (s.sqrt(), j as u32)
-                })
-                .collect();
-            d.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
-            d.truncate(k);
-            (
-                d.iter().map(|&(_, j)| j).collect(),
-                d.iter().map(|&(dd, _)| dd).collect(),
-            )
-        })
-        .collect();
-    let mut idx = Vec::with_capacity(n * k);
-    let mut dist = Vec::with_capacity(n * k);
-    for (ii, dd) in &knn {
-        idx.extend_from_slice(ii);
-        dist.extend_from_slice(dd);
-    }
-    let knn_indices = Array2::from_shape_vec((n, k), idx).expect("knn idx shape");
-    let knn_dists = Array2::from_shape_vec((n, k), dist).expect("knn dist shape");
-
-    // Random initial layout in a small range; the layout optimization expands it.
-    let mut rng = ChaCha8Rng::seed_from_u64(seed);
-    let init_vec: Vec<f32> = (0..n * n_components)
-        .map(|_| rng.gen_range(-1.0f32..1.0))
-        .collect();
-    let init = Array2::from_shape_vec((n, n_components), init_vec).expect("init shape");
-
-    use umap_rs::{ManifoldParams, OptimizationParams};
-    let config = UmapConfig {
+    crate::umap::umap(
+        data,
         n_components,
-        graph: GraphParams {
-            n_neighbors: k,
-            ..Default::default()
-        },
-        manifold: ManifoldParams {
-            min_dist: 0.0,
-            ..Default::default()
-        },
-        optimization: OptimizationParams {
-            n_epochs: Some(500),
-            ..Default::default()
-        },
-    };
-    let fitted = Umap::new(config).fit(
-        data_arr.view(),
-        knn_indices.view(),
-        knn_dists.view(),
-        init.view(),
-    );
-    let emb = fitted.into_embedding();
-    (0..n)
-        .map(|i| (0..n_components).map(|c| emb[[i, c]] as f64).collect())
-        .collect()
+        n_neighbors,
+        0.0, // min_dist
+        1.0, // spread
+        0,   // n_epochs (0 => auto: 500 for <=10k rows)
+        5,   // negative_sample_rate
+        1.0, // repulsion_strength (gamma)
+        "cosine",
+        seed,
+    )
 }
 
 /// Whether the Barnes-Hut t-SNE reducer is compiled in (the `tsne` feature).

--- a/src/umap.rs
+++ b/src/umap.rs
@@ -1,0 +1,567 @@
+//! A faithful, dependency-free UMAP reducer (McInnes, Healy & Melville 2018).
+//!
+//! topica's embedding-clustering heads (BERTopic, Top2Vec) reduce document
+//! embeddings before a density clusterer. PCA (the default) is fast and
+//! deterministic; UMAP separates closely-spaced themes a linear projection
+//! merges. We used to delegate the UMAP path to the `umap-rs` crate, but its
+//! layout gradient diverges from the reference `umap-learn` (an extra
+//! `dist_squared` factor in the attractive/repulsive denominators), so it
+//! recovered noticeably worse cluster structure. This module reimplements UMAP
+//! to match `umap-learn` numerically, staying inside topica's constraints: pure
+//! Rust, BLAS-free, `Vec<Vec<f64>>`, and — because the negative sampling is
+//! seeded with `ChaCha8Rng` — a **fully reproducible** fit, unlike the crate.
+//!
+//! The pipeline mirrors `umap-learn`:
+//!   1. kNN graph (brute force) under a cosine or Euclidean metric.
+//!   2. `smooth_knn_dist`: per-point bandwidth `sigma` and local-connectivity
+//!      offset `rho` calibrating a fuzzy membership of cardinality `log2(k)`.
+//!   3. Fuzzy simplicial set: membership strengths, symmetrized by the fuzzy
+//!      union `P = A + Aᵀ − A ⊙ Aᵀ` (for `set_op_mix_ratio = 1`).
+//!   4. SGD layout: sample edges in proportion to their weight, pull endpoints
+//!      together, push uniformly-drawn negatives apart, with the `umap-learn`
+//!      gradient and the ±4 clip.
+
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use rayon::prelude::*;
+
+/// Fit the `(a, b)` of the low-dimensional membership curve
+/// `1 / (1 + a·x^(2b))` to an offset exponential decay defined by `spread` and
+/// `min_dist`, by gradient descent (the `umap-learn` `find_ab_params`).
+pub fn find_ab_params(spread: f64, min_dist: f64) -> (f64, f64) {
+    let n_points = 300usize;
+    let xv: Vec<f64> = (0..n_points)
+        .map(|i| (spread * 3.0) * (i as f64) / (n_points as f64 - 1.0))
+        .collect();
+    let yv: Vec<f64> = xv
+        .iter()
+        .map(|&x| {
+            if x < min_dist {
+                1.0
+            } else {
+                (-(x - min_dist) / spread).exp()
+            }
+        })
+        .collect();
+
+    let mut a = 1.5;
+    let mut b = 0.9;
+    let lr = 0.01;
+    for _ in 0..1000 {
+        let mut grad_a = 0.0;
+        let mut grad_b = 0.0;
+        let mut total_err = 0.0;
+        for i in 0..n_points {
+            let x = xv[i];
+            let x_2b = x.powf(2.0 * b);
+            let denom = 1.0 + a * x_2b;
+            let err = 1.0 / denom - yv[i];
+            total_err += err * err;
+            grad_a += 2.0 * err * (-x_2b / (denom * denom));
+            if x > 0.0 {
+                grad_b += 2.0 * err * (-2.0 * a * x_2b * x.ln() / (denom * denom));
+            }
+        }
+        a -= lr * grad_a / n_points as f64;
+        b -= lr * grad_b / n_points as f64;
+        a = a.clamp(0.001, 10.0);
+        b = b.clamp(0.001, 10.0);
+        if total_err / (n_points as f64) < 1e-7 {
+            break;
+        }
+    }
+    (a, b)
+}
+
+/// Brute-force k-nearest-neighbor graph. Returns, per point, the indices and
+/// distances of its `k` neighbors **including itself** at column 0 (distance 0),
+/// matching `umap-learn`'s convention. `metric` is `"cosine"` (default; rows are
+/// L2-normalized and distance is `1 − cos`) or `"euclidean"`.
+fn knn_graph(data: &[Vec<f64>], k: usize, metric: &str) -> (Vec<Vec<u32>>, Vec<Vec<f64>>) {
+    let n = data.len();
+    let cosine = metric != "euclidean";
+    // For cosine, precompute unit rows so the neighbor distance is 1 − dot.
+    let unit: Vec<Vec<f64>> = if cosine {
+        data.iter()
+            .map(|row| {
+                let norm: f64 = row.iter().map(|&v| v * v).sum::<f64>().sqrt();
+                if norm > 0.0 {
+                    row.iter().map(|&v| v / norm).collect()
+                } else {
+                    row.clone()
+                }
+            })
+            .collect()
+    } else {
+        Vec::new()
+    };
+
+    let rows: Vec<(Vec<u32>, Vec<f64>)> = (0..n)
+        .into_par_iter()
+        .map(|i| {
+            let mut d: Vec<(f64, u32)> = (0..n)
+                .filter(|&j| j != i)
+                .map(|j| {
+                    let dist = if cosine {
+                        let dot: f64 = unit[i].iter().zip(&unit[j]).map(|(&x, &y)| x * y).sum();
+                        (1.0 - dot).max(0.0)
+                    } else {
+                        data[i]
+                            .iter()
+                            .zip(&data[j])
+                            .map(|(&x, &y)| (x - y) * (x - y))
+                            .sum::<f64>()
+                            .sqrt()
+                    };
+                    (dist, j as u32)
+                })
+                .collect();
+            // k-1 real neighbors; column 0 is self. Full sort is negligible next
+            // to the O(n·dim) distance computation above.
+            d.sort_by(|a, b| a.0.partial_cmp(&b.0).unwrap_or(std::cmp::Ordering::Equal));
+            let take = k.saturating_sub(1).min(d.len());
+            d.truncate(take);
+            let mut idx = Vec::with_capacity(k);
+            let mut dst = Vec::with_capacity(k);
+            idx.push(i as u32);
+            dst.push(0.0);
+            for (dd, jj) in d {
+                idx.push(jj);
+                dst.push(dd);
+            }
+            (idx, dst)
+        })
+        .collect();
+
+    let mut indices = Vec::with_capacity(n);
+    let mut dists = Vec::with_capacity(n);
+    for (idx, dst) in rows {
+        indices.push(idx);
+        dists.push(dst);
+    }
+    (indices, dists)
+}
+
+const SMOOTH_K_TOLERANCE: f64 = 1e-5;
+const MIN_K_DIST_SCALE: f64 = 1e-3;
+
+/// Per-point bandwidth `sigma` and local-connectivity offset `rho`. For each row
+/// we binary-search `sigma` so that `Σ_j exp(-(d_j − rho)/sigma)` over the real
+/// neighbors equals `log2(k)`; `rho` is the distance to the
+/// `local_connectivity`-th nearest non-zero neighbor. Faithful to `umap-learn`.
+fn smooth_knn_dist(
+    knn_dists: &[Vec<f64>],
+    k: usize,
+    local_connectivity: f64,
+    bandwidth: f64,
+) -> (Vec<f64>, Vec<f64>) {
+    let target = (k as f64).log2() * bandwidth;
+    let n_all: f64 = knn_dists.iter().flat_map(|r| r.iter()).copied().sum();
+    let count: usize = knn_dists.iter().map(|r| r.len()).sum();
+    let mean_distances = if count > 0 { n_all / count as f64 } else { 0.0 };
+
+    knn_dists
+        .par_iter()
+        .map(|ith| {
+            let non_zero: Vec<f64> = ith.iter().copied().filter(|&d| d > 0.0).collect();
+            let mut rho = 0.0;
+            if non_zero.len() >= local_connectivity.floor() as usize && !non_zero.is_empty() {
+                let index = local_connectivity.floor() as usize;
+                let interpolation = local_connectivity - local_connectivity.floor();
+                if index > 0 {
+                    rho = non_zero[index - 1];
+                    if interpolation > SMOOTH_K_TOLERANCE {
+                        rho += interpolation * (non_zero[index] - non_zero[index - 1]);
+                    }
+                } else {
+                    rho = interpolation * non_zero[0];
+                }
+            } else if !non_zero.is_empty() {
+                rho = non_zero.iter().copied().fold(0.0, f64::max);
+            }
+
+            // Binary search for sigma.
+            let mut lo = 0.0f64;
+            let mut hi = f64::INFINITY;
+            let mut mid = 1.0f64;
+            for _ in 0..64 {
+                let mut psum = 0.0;
+                for &d in ith.iter().skip(1) {
+                    let dd = d - rho;
+                    psum += if dd > 0.0 { (-(dd) / mid).exp() } else { 1.0 };
+                }
+                if (psum - target).abs() < SMOOTH_K_TOLERANCE {
+                    break;
+                }
+                if psum > target {
+                    hi = mid;
+                    mid = (lo + hi) / 2.0;
+                } else {
+                    lo = mid;
+                    if hi == f64::INFINITY {
+                        mid *= 2.0;
+                    } else {
+                        mid = (lo + hi) / 2.0;
+                    }
+                }
+            }
+            let mut sigma = mid;
+            // Minimum-distance scale floor.
+            if rho > 0.0 {
+                let mean_ith: f64 = ith.iter().sum::<f64>() / ith.len() as f64;
+                if sigma < MIN_K_DIST_SCALE * mean_ith {
+                    sigma = MIN_K_DIST_SCALE * mean_ith;
+                }
+            } else if sigma < MIN_K_DIST_SCALE * mean_distances {
+                sigma = MIN_K_DIST_SCALE * mean_distances;
+            }
+            (sigma, rho)
+        })
+        .unzip()
+}
+
+/// Membership strength of the directed edge `i → j`: `1` inside the local
+/// connectivity radius, else `exp(-(d − rho_i)/sigma_i)`.
+fn membership(d: f64, rho: f64, sigma: f64) -> f64 {
+    if d - rho <= 0.0 || sigma == 0.0 {
+        1.0
+    } else {
+        (-(d - rho) / sigma).exp()
+    }
+}
+
+/// Build the symmetric fuzzy simplicial set as a weighted edge list
+/// `(head, tail, weight)`. Directed memberships are combined by the probabilistic
+/// t-conorm `set_op * (A + Aᵀ) + (1 − 2·set_op)·(A ⊙ Aᵀ)`; for the default
+/// `set_op_mix_ratio = 1` this is `A + Aᵀ − A ⊙ Aᵀ`.
+fn fuzzy_simplicial_set(
+    knn_indices: &[Vec<u32>],
+    knn_dists: &[Vec<f64>],
+    sigmas: &[f64],
+    rhos: &[f64],
+    set_op_mix_ratio: f64,
+) -> Vec<(u32, u32, f64)> {
+    use std::collections::{HashMap, HashSet};
+    let n = knn_indices.len();
+    // Directed strengths keyed by (i, j), i != j. The map is used only for O(1)
+    // lookup of the reverse edge; iteration order below is deterministic.
+    let mut a: HashMap<(u32, u32), f64> = HashMap::new();
+    for i in 0..n {
+        for (col, &j) in knn_indices[i].iter().enumerate() {
+            if j as usize == i {
+                continue;
+            }
+            let v = membership(knn_dists[i][col], rhos[i], sigmas[i]);
+            if v != 0.0 {
+                a.insert((i as u32, j), v);
+            }
+        }
+    }
+    // Symmetrize by iterating points and their neighbors in a fixed order (not
+    // the HashMap's), so the emitted edge list — and thus the SGD update order —
+    // is reproducible.
+    let mut seen: HashSet<(u32, u32)> = HashSet::new();
+    let mut edges = Vec::with_capacity(a.len() * 2);
+    for i in 0..n {
+        let iu = i as u32;
+        for &j in knn_indices[i].iter() {
+            if j as usize == i {
+                continue;
+            }
+            let key = if iu < j { (iu, j) } else { (j, iu) };
+            if !seen.insert(key) {
+                continue;
+            }
+            let val = a.get(&(iu, j)).copied().unwrap_or(0.0);
+            let val_t = a.get(&(j, iu)).copied().unwrap_or(0.0);
+            let combined =
+                set_op_mix_ratio * (val + val_t) + (1.0 - 2.0 * set_op_mix_ratio) * (val * val_t);
+            if combined > 0.0 {
+                // Both directions carry the symmetric weight.
+                edges.push((iu, j, combined));
+                edges.push((j, iu, combined));
+            }
+        }
+    }
+    edges
+}
+
+/// `epochs_per_sample[e] = max_weight / weight[e]`; an edge of maximal weight is
+/// sampled every epoch, lighter edges proportionally less often.
+fn make_epochs_per_sample(weights: &[f64], n_epochs: usize) -> Vec<f64> {
+    let max_w = weights.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+    let max_w = if max_w <= 0.0 { 1.0 } else { max_w };
+    weights
+        .iter()
+        .map(|&w| {
+            let n_samples = n_epochs as f64 * (w / max_w);
+            if n_samples > 0.0 {
+                n_epochs as f64 / n_samples
+            } else {
+                -1.0
+            }
+        })
+        .collect()
+}
+
+#[inline]
+fn clip(v: f64) -> f64 {
+    v.clamp(-4.0, 4.0)
+}
+
+/// SGD layout optimization, faithful to `umap-learn`'s
+/// `optimize_layout_euclidean` (sequential, seeded negative sampling).
+#[allow(clippy::too_many_arguments)]
+fn optimize_layout(
+    embedding: &mut [f64],
+    n: usize,
+    dim: usize,
+    head: &[u32],
+    tail: &[u32],
+    epochs_per_sample: &[f64],
+    a: f64,
+    b: f64,
+    gamma: f64,
+    n_epochs: usize,
+    negative_sample_rate: usize,
+    seed: u64,
+) {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let mut epoch_of_next_sample = epochs_per_sample.to_vec();
+    let epochs_per_negative_sample: Vec<f64> = epochs_per_sample
+        .iter()
+        .map(|&e| e / negative_sample_rate as f64)
+        .collect();
+    let mut epoch_of_next_negative_sample = epochs_per_negative_sample.clone();
+
+    for epoch in 0..n_epochs {
+        let alpha = 1.0 * (1.0 - epoch as f64 / n_epochs as f64);
+        for e in 0..epochs_per_sample.len() {
+            if epochs_per_sample[e] <= 0.0 || epoch_of_next_sample[e] > epoch as f64 {
+                continue;
+            }
+            let j = head[e] as usize;
+            let k = tail[e] as usize;
+            let (jb, kb) = (j * dim, k * dim);
+
+            let mut dist_sq = 0.0;
+            for d in 0..dim {
+                let diff = embedding[jb + d] - embedding[kb + d];
+                dist_sq += diff * diff;
+            }
+            let grad_coeff = if dist_sq > 0.0 {
+                let dpb = dist_sq.powf(b);
+                (-2.0 * a * b * dpb / dist_sq) / (a * dpb + 1.0)
+            } else {
+                0.0
+            };
+            for d in 0..dim {
+                let diff = embedding[jb + d] - embedding[kb + d];
+                let grad_d = clip(grad_coeff * diff) * alpha;
+                embedding[jb + d] += grad_d;
+                embedding[kb + d] -= grad_d;
+            }
+
+            epoch_of_next_sample[e] += epochs_per_sample[e];
+
+            let n_neg = ((epoch as f64 - epoch_of_next_negative_sample[e])
+                / epochs_per_negative_sample[e]) as usize;
+            for _ in 0..n_neg {
+                let k = rng.gen_range(0..n);
+                if k == j {
+                    continue;
+                }
+                let kb = k * dim;
+                let mut dist_sq = 0.0;
+                for d in 0..dim {
+                    let diff = embedding[jb + d] - embedding[kb + d];
+                    dist_sq += diff * diff;
+                }
+                let grad_coeff = if dist_sq > 0.0 {
+                    let dpb = dist_sq.powf(b);
+                    2.0 * gamma * b / ((0.001 + dist_sq) * (a * dpb + 1.0))
+                } else {
+                    0.0
+                };
+                if grad_coeff > 0.0 {
+                    for d in 0..dim {
+                        let diff = embedding[jb + d] - embedding[kb + d];
+                        embedding[jb + d] += clip(grad_coeff * diff) * alpha;
+                    }
+                }
+            }
+            epoch_of_next_negative_sample[e] += n_neg as f64 * epochs_per_negative_sample[e];
+        }
+    }
+}
+
+/// Reduce `data` (`n × features`) to `n_components` with UMAP. `n_neighbors` is
+/// the graph neighborhood; `min_dist`/`spread` shape the embedding; `n_epochs`
+/// the SGD length (0 ⇒ 500 for ≤10k rows, else 200); `negative_sample_rate` and
+/// `repulsion_strength` control the repulsive term; `metric` is `"cosine"`
+/// (default) or `"euclidean"`. Deterministic for a fixed `seed`.
+#[allow(clippy::too_many_arguments)]
+pub fn umap(
+    data: &[Vec<f64>],
+    n_components: usize,
+    n_neighbors: usize,
+    min_dist: f64,
+    spread: f64,
+    n_epochs: usize,
+    negative_sample_rate: usize,
+    repulsion_strength: f64,
+    metric: &str,
+    seed: u64,
+) -> Vec<Vec<f64>> {
+    let n = data.len();
+    if n == 0 || n_components == 0 {
+        return vec![Vec::new(); n];
+    }
+    if n <= n_components + 1 {
+        // Too few points for a meaningful graph; fall back to zeros of the right shape.
+        return vec![vec![0.0; n_components]; n];
+    }
+    let k = n_neighbors.clamp(2, n);
+    let n_epochs = if n_epochs > 0 {
+        n_epochs
+    } else if n <= 10_000 {
+        500
+    } else {
+        200
+    };
+
+    let (knn_indices, knn_dists) = knn_graph(data, k, metric);
+    let (sigmas, rhos) = smooth_knn_dist(&knn_dists, k, 1.0, 1.0);
+    let mut edges = fuzzy_simplicial_set(&knn_indices, &knn_dists, &sigmas, &rhos, 1.0);
+
+    // Prune edges whose weight is below max_weight / n_epochs (they would never
+    // be sampled), matching umap-learn's eliminate_zeros step.
+    let max_w = edges
+        .iter()
+        .map(|&(_, _, w)| w)
+        .fold(f64::NEG_INFINITY, f64::max);
+    let cutoff = if max_w > 0.0 {
+        max_w / n_epochs as f64
+    } else {
+        0.0
+    };
+    edges.retain(|&(_, _, w)| w >= cutoff);
+    if edges.is_empty() {
+        return vec![vec![0.0; n_components]; n];
+    }
+
+    let (a, b) = find_ab_params(spread, min_dist);
+
+    // Random init in [-10, 10], seeded (umap-learn's random-init range).
+    let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0x9E37_79B9_7F4A_7C15);
+    let mut embedding = vec![0.0f64; n * n_components];
+    for v in embedding.iter_mut() {
+        *v = rng.gen_range(-10.0..10.0);
+    }
+
+    let head: Vec<u32> = edges.iter().map(|&(h, _, _)| h).collect();
+    let tail: Vec<u32> = edges.iter().map(|&(_, t, _)| t).collect();
+    let weights: Vec<f64> = edges.iter().map(|&(_, _, w)| w).collect();
+    let eps = make_epochs_per_sample(&weights, n_epochs);
+
+    optimize_layout(
+        &mut embedding,
+        n,
+        n_components,
+        &head,
+        &tail,
+        &eps,
+        a,
+        b,
+        repulsion_strength,
+        n_epochs,
+        negative_sample_rate,
+        seed,
+    );
+
+    (0..n)
+        .map(|i| embedding[i * n_components..(i + 1) * n_components].to_vec())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand::{Rng, SeedableRng};
+    use rand_chacha::ChaCha8Rng;
+
+    #[test]
+    fn ab_params_match_reference() {
+        // umap-learn's find_ab_params(1.0, 0.1) ~= (1.577, 0.895).
+        let (a, b) = find_ab_params(1.0, 0.1);
+        assert!((a - 1.577).abs() < 0.1, "a = {a}");
+        assert!((b - 0.895).abs() < 0.1, "b = {b}");
+    }
+
+    #[test]
+    fn deterministic_for_fixed_seed() {
+        let mut rng = ChaCha8Rng::seed_from_u64(3);
+        let data: Vec<Vec<f64>> = (0..60)
+            .map(|_| (0..8).map(|_| rng.gen::<f64>()).collect())
+            .collect();
+        let a = umap(&data, 2, 15, 0.1, 1.0, 200, 5, 1.0, "cosine", 7);
+        let b = umap(&data, 2, 15, 0.1, 1.0, 200, 5, 1.0, "cosine", 7);
+        assert_eq!(a, b, "UMAP must be reproducible for a fixed seed");
+    }
+
+    #[test]
+    fn separates_three_blobs() {
+        // Three well-separated Gaussian blobs in 10-D should keep each point
+        // nearest its own blob centroid in the 2-D layout.
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let dim = 10;
+        let mut data = Vec::new();
+        let mut truth = Vec::new();
+        for c in 0..3 {
+            let mut center = vec![0.0; dim];
+            center[c] = 20.0;
+            for _ in 0..40 {
+                let row: Vec<f64> = (0..dim)
+                    .map(|t| center[t] + (rng.gen::<f64>() - 0.5) * 4.0)
+                    .collect();
+                data.push(row);
+                truth.push(c);
+            }
+        }
+        let emb = umap(&data, 2, 15, 0.1, 1.0, 500, 5, 1.0, "cosine", 1);
+        assert!(
+            emb.iter().all(|r| r.iter().all(|v| v.is_finite())),
+            "NaN in layout"
+        );
+        // Per-blob centroids.
+        let mut cents = [[0.0f64; 2]; 3];
+        let mut counts = [0.0f64; 3];
+        for (i, &c) in truth.iter().enumerate() {
+            cents[c][0] += emb[i][0];
+            cents[c][1] += emb[i][1];
+            counts[c] += 1.0;
+        }
+        for c in 0..3 {
+            cents[c][0] /= counts[c];
+            cents[c][1] /= counts[c];
+        }
+        let mut correct = 0;
+        for (i, &c) in truth.iter().enumerate() {
+            let nearest = (0..3)
+                .min_by(|&x, &y| {
+                    let dx = (emb[i][0] - cents[x][0]).powi(2) + (emb[i][1] - cents[x][1]).powi(2);
+                    let dy = (emb[i][0] - cents[y][0]).powi(2) + (emb[i][1] - cents[y][1]).powi(2);
+                    dx.partial_cmp(&dy).unwrap()
+                })
+                .unwrap();
+            if nearest == c {
+                correct += 1;
+            }
+        }
+        assert!(
+            correct as f64 / truth.len() as f64 > 0.9,
+            "UMAP did not separate the blobs: {correct}/{}",
+            truth.len()
+        );
+    }
+}

--- a/tests/test_umap_reducer.py
+++ b/tests/test_umap_reducer.py
@@ -1,9 +1,9 @@
 """The optional UMAP reducer for the embedding models.
 
 UMAP is shipped in the wheel as an opt-in (`reducer="umap"`); PCA stays the
-deterministic default. The UMAP *discovery* fit is intentionally not asserted to
-be reproducible (the umap-rs optimizer's negative sampling is unseeded), but it
-must run, warn, and leave the transform / prediction phase deterministic.
+default. topica's in-house UMAP reducer is seeded, so the whole fit is
+reproducible for a fixed `seed` — it must run, NOT warn about non-determinism,
+and give identical results across runs.
 """
 
 import warnings
@@ -27,7 +27,7 @@ def _manifold(seed=0, per=40, k=4):
 
 
 @pytest.mark.parametrize("model_cls", ["BERTopic", "Top2Vec"])
-def test_umap_reducer_runs_and_warns(model_cls):
+def test_umap_reducer_runs_without_warning(model_cls):
     docs, emb = _manifold()
     cls = getattr(topica, model_cls)
     with warnings.catch_warnings(record=True) as w:
@@ -36,8 +36,23 @@ def test_umap_reducer_runs_and_warns(model_cls):
         m.fit(docs, emb)
     # discovers some topics on a clearly-clustered manifold
     assert m.num_topics >= 2
-    # the documented non-determinism is surfaced as a warning
-    assert any("not reproducible" in str(x.message) for x in w)
+    # the in-house UMAP is seeded, so no non-reproducibility warning is emitted
+    assert not any("not reproducible" in str(x.message) for x in w)
+
+
+@pytest.mark.parametrize("model_cls", ["BERTopic", "Top2Vec"])
+def test_umap_fit_is_reproducible(model_cls):
+    docs, emb = _manifold()
+    cls = getattr(topica, model_cls)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        a = cls(reducer="umap", min_cluster_size=15, n_neighbors=15, seed=1)
+        a.fit(docs, emb)
+        b = cls(reducer="umap", min_cluster_size=15, n_neighbors=15, seed=1)
+        b.fit(docs, emb)
+    # seeded reducer + deterministic clusterer => identical fits
+    assert a.num_topics == b.num_topics
+    assert list(a.labels) == list(b.labels)
 
 
 def test_pca_default_is_silent():


### PR DESCRIPTION
Closes #343.

## Problem

The opt-in `reducer="umap"` (delegating to the `umap-rs` crate) recovered markedly worse cluster structure than the reference `umap-learn` on real sentence embeddings: **~0.63 vs ~0.82 ARI** on 20 Newsgroups (6-category slice) / `all-mpnet-base-v2` / Euclidean HDBSCAN.

## Root cause (not what the issue proposed)

The issue suggested spectral init and a cosine kNN metric. An oracle ablation on `umap-learn` ruled **both** out:

- Random-init `umap-learn` already scores ~0.824 → **init is not the lever**.
- L2-normalizing topica's UMAP input (cosine kNN) moved it only 0.642 → 0.648 → **metric is not the lever**.
- Forcing single-threaded only recovered ~0.04 (a minor parallel-SGD race).

The real cause is a **gradient bug in `umap-rs`**: its SGD denominator carries an extra `dist_squared` factor — `a·D^(b+1)+1` where `umap-learn` uses `a·D^b+1` — in **both** the attractive and repulsive terms.

## Fix

Reimplement UMAP from scratch in `src/umap.rs`, faithful to `umap-learn`: `find_ab_params`, a brute-force cosine/Euclidean kNN (self at column 0), `smooth_knn_dist`, the fuzzy simplicial set with union symmetrization, `make_epochs_per_sample`, and a sequential SGD layout with the **correct** gradient and the ±4 clip. Random init suffices (the ablation shows init is not the lever), so no spectral/Lanczos step is needed.

`reduce::umap` now delegates to it with the models' reference-matching defaults (cosine, `min_dist=0.0`, auto epochs). The `umap-rs` dependency is **dropped entirely** — the `umap` feature no longer pulls a crate, removing its transitive tree (sprs, dashmap, tracing, …) from the lockfile (−376 lines).

## Results (same HDBSCAN, mean of 3 seeds)

| | old umap-rs | **in-house** | umap-learn |
|---|--:|--:|--:|
| ARI | 0.63 | **0.828** | 0.818 |

Parity reached, and faster (1.6s vs 3.8s/fit), in pure Rust.

## Bonus: reproducibility

The negative sampling is seeded, so the whole `reducer="umap"` fit is now **fully reproducible**. Removed the old non-reproducibility warning (`umap_notice` is guard-only; `warn_stochastic`'s reproducibility clause is now tsne-only) and rewrote the docs and `test_umap_reducer.py` to assert reproducibility.

## Validation

- `cargo test --lib --features umap` — 196 passed (incl. new `umap` unit tests: a/b-param match, determinism, blob separation).
- Full Python suite — **3166 passed, 30 skipped, 0 failed**.
- fmt / clippy / `mkdocs build --strict` — clean.
- `parity/umap_reference_compare.py` — PASS (0.828 vs 0.818; skips cleanly without the reference stack).

## Follow-up (not in this PR)

Exposing UMAP hyperparameters (`min_dist`/`n_epochs`/`spread`/`metric`/`negative_sample_rate`/`repulsion`) as kwargs on `BERTopic`/`Top2Vec` — issue #343's third ask. The in-house `crate::umap::umap` already accepts them all; it's plumbing through `reduce::reduce` and the PyO3 bindings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012qMBhchZpttn6n3xtvnc5H