### PR TITLE
ECTM statistical-hardening set: debiased divergence, parametric CIs, prior selection, sparse content prior (#337, #338, #339, #340)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -789,6 +789,7 @@ class ECTM:
         content_prior_var: float = 1.0,
         period_smooth: float = 5.0,
         interaction_shrink: float = 2.0,
+        content_prior: str = "l2",
         inference: str = "batch",
         batch_size: int = 256,
         tau: float = 64.0,
@@ -809,6 +810,9 @@ class ECTM:
         content_prior_var); a first-order random walk across periods with precision
         period_smooth (larger = smoother / more pooling across adjacent periods);
         and an extra L2 factor interaction_shrink on the group-by-time term.
+        content_prior="l2" (default) uses that Gaussian ridge; content_prior="l1"
+        swaps in a sparsity-inducing Laplace prior (rate 1/content_prior_var,
+        solved by FISTA) for exclusive top-word lists and sharper Delta contrasts.
 
         inference="batch" (default) is full-batch variational EM. inference="svi"
         is minibatch stochastic VI for corpora too large to fit in batch: iters

--- a/python/topica/ectm.py
+++ b/python/topica/ectm.py
@@ -263,6 +263,199 @@ def content_divergence(model, topic: int, group_a, group_b):
 
 
 # ---------------------------------------------------------------------------
+# Debiased content divergence (issue #337)
+# ---------------------------------------------------------------------------
+
+def _tv(p, q) -> float:
+    """Total-variation distance ``0.5 * sum_v |p_v - q_v|`` between two rows."""
+    return float(0.5 * np.abs(np.asarray(p) - np.asarray(q)).sum())
+
+
+def _doc_word_counts(docs, vocab):
+    """Dense ``(num_docs, V)`` word-count matrix over ``vocab`` (out-of-vocab
+    tokens dropped)."""
+    index = {w: i for i, w in enumerate(vocab)}
+    counts = np.zeros((len(docs), len(vocab)), dtype=np.float64)
+    for d, toks in enumerate(docs):
+        for w in toks:
+            j = index.get(w)
+            if j is not None:
+                counts[d, j] += 1.0
+    return counts
+
+
+def _theta_weighted_dist(counts, theta, topic, doc_idx, alpha=1e-6):
+    """The topic-``topic`` word distribution implied by a set of documents:
+    the θ-weighted word frequency ``sum_d θ_{d,topic} c_{d,·}`` normalized. This
+    is the *data-side* estimate of a (group, period) cell's topic vocabulary —
+    consistent for the true cell distribution and, unlike the model's smoothed
+    β surface, linear in the counts, so it debiases cleanly."""
+    if len(doc_idx) == 0:
+        return None
+    w = theta[doc_idx, topic][:, None] * counts[doc_idx]
+    total = w.sum(axis=0) + alpha
+    return total / total.sum()
+
+
+def content_divergence_debiased(
+    model,
+    topic: int,
+    group_a,
+    group_b,
+    *,
+    docs,
+    groups,
+    periods,
+    n_splits: int = 8,
+    se_blocks: int = 0,
+    seed: int = 0,
+):
+    """Finite-sample-debiased content divergence between two groups for ``topic``.
+
+    The raw plug-in :func:`content_divergence` reports ``TV(β̂_a, β̂_b)`` off the
+    fitted content surface, which carries a **finite-sample floor**: comparing two
+    *estimated* high-dimensional word distributions inflates the total-variation
+    distance above the true ``TV(β_a, β_b)`` even when the two groups are identical
+    (Gentzkow–Shapiro–Taddy 2019; Lupu 2017). That plug-in — and the
+    null-subtraction ``observed − mean(shuffled)`` — is a good screening score but
+    estimates no defined population quantity. This estimator differences the noise
+    out so the reported contrast targets one.
+
+    **Estimand and consistency.** For each ``(group, period)`` cell this reads the
+    topic's word distribution as the θ-weighted empirical word frequency (the fitted
+    ``model``'s ``doc_topic`` weights times the raw counts), which is *consistent*
+    for the cell's true topic-word distribution. Splitting the cell's documents into
+    disjoint halves gives two independent estimates that share the **single** fit's
+    topic orientation, so the divergence decomposes as
+
+        E[TV_cross-group] = signal + floor ,   E[TV_within-group] = floor ,
+
+    and the difference isolates the signal. As documents per cell grow the floor
+    (and the split's own variance) vanish and the estimate → ``TV(β_a, β_b)``. It
+    uses only ``model``, so unlike a cross-fit split-sample it never compares β
+    across independently-fit models (whose per-fit non-identifiability leaves a
+    *non-vanishing* floor that over-subtracts the signal).
+
+    Parameters
+    ----------
+    model : fitted :class:`~topica.ECTM`
+        The reference fit; supplies ``doc_topic`` (θ), ``vocabulary`` and ``periods``.
+    topic : int
+        Topic index.
+    group_a, group_b : str or int
+        The two content groups to contrast.
+    docs, groups, periods : array-like (num_docs,)
+        The documents and their per-document content/period labels — the same
+        corpus, ``content=`` and ``times=`` passed to :meth:`ECTM.fit`.
+    n_splits : int
+        Random half-splits to average over. More splits lower the estimator's own
+        Monte-Carlo variance. Averaging keeps the point estimate stable on thin cells.
+    se_blocks : int
+        If > 1, also return a **delete-block jackknife** standard error over
+        documents (partition docs into ``se_blocks`` blocks, recompute the whole
+        per-period estimate leaving each block out, take the jackknife SD). 0
+        (default) skips it and returns ``nan`` SEs; sampling confidence *bands* are
+        better obtained from :func:`content_trajectory_ci` (issue #340).
+    seed : int
+        Master RNG seed.
+
+    Returns
+    -------
+    list of (period_label, estimate, se)
+        Per-period debiased divergence, in period order. Note that raw and
+        null-subtracted TV do **not** converge to the population divergence as the
+        corpus grows; this estimator does.
+    """
+    docs = list(docs)
+    groups = [str(g) for g in groups]
+    periods = [_period_label(p) for p in periods]
+    n = len(docs)
+    if not (len(groups) == len(periods) == n):
+        raise ValueError(
+            f"docs, groups, periods must have equal length; got "
+            f"{n}, {len(groups)}, {len(periods)}"
+        )
+
+    vocab = list(model.vocabulary)
+    counts = _doc_word_counts(docs, vocab)
+    theta = np.asarray(model.doc_topic, dtype=np.float64)
+    if theta.shape[0] != n:
+        raise ValueError(
+            f"corpus has {n} documents but model.doc_topic has {theta.shape[0]} "
+            "rows; pass the same documents the model was fit on"
+        )
+    if topic < 0 or topic >= theta.shape[1]:
+        raise ValueError(f"topic {topic} out of range [0, {theta.shape[1]})")
+
+    plabels = [str(p) for p in model.periods]
+    ga, gb = str(group_a), str(group_b)
+
+    # cell (group, period) -> document indices
+    cells = {}
+    for i, (g, p) in enumerate(zip(groups, periods)):
+        cells.setdefault((g, p), []).append(i)
+
+    def _estimate(active_mask, rng):
+        """Debiased per-period vector over the documents flagged in ``active_mask``,
+        averaged over ``n_splits`` random cell-stratified half-splits."""
+        acc = np.zeros(len(plabels))
+        used = 0
+        for _ in range(n_splits):
+            row = np.full(len(plabels), np.nan)
+            ok = True
+            for t, pl in enumerate(plabels):
+                ia = [i for i in cells.get((ga, pl), []) if active_mask[i]]
+                ib = [i for i in cells.get((gb, pl), []) if active_mask[i]]
+                if len(ia) < 2 or len(ib) < 2:
+                    ok = False
+                    break
+                rng.shuffle(ia); rng.shuffle(ib)
+                a1, a2 = ia[: len(ia) // 2], ia[len(ia) // 2:]
+                b1, b2 = ib[: len(ib) // 2], ib[len(ib) // 2:]
+                pa1 = _theta_weighted_dist(counts, theta, topic, a1)
+                pa2 = _theta_weighted_dist(counts, theta, topic, a2)
+                pb1 = _theta_weighted_dist(counts, theta, topic, b1)
+                pb2 = _theta_weighted_dist(counts, theta, topic, b2)
+                between = 0.5 * (_tv(pa1, pb2) + _tv(pa2, pb1))
+                within = 0.5 * (_tv(pa1, pa2) + _tv(pb1, pb2))
+                row[t] = between - within
+            if ok:
+                acc += row
+                used += 1
+        if used == 0:
+            raise RuntimeError(
+                "every cell has fewer than 4 documents for one of the groups; "
+                "debiasing needs at least 2 documents per half per cell"
+            )
+        return acc / used
+
+    rng = np.random.default_rng(seed)
+    all_active = np.ones(n, dtype=bool)
+    est = _estimate(all_active, rng)
+
+    # Optional delete-block jackknife SE over documents.
+    se = np.full(len(plabels), np.nan)
+    if se_blocks and se_blocks > 1:
+        order = list(range(n))
+        np.random.default_rng(seed + 1).shuffle(order)
+        loo = []
+        for b in range(se_blocks):
+            drop = set(order[b::se_blocks])
+            mask = np.array([i not in drop for i in range(n)])
+            try:
+                loo.append(_estimate(mask, np.random.default_rng(seed + 100 + b)))
+            except RuntimeError:
+                continue
+        if len(loo) > 1:
+            loo = np.vstack(loo)
+            g = loo.shape[0]
+            # jackknife SD of the delete-block replicates
+            se = np.sqrt((g - 1) / g * np.sum((loo - loo.mean(axis=0)) ** 2, axis=0))
+
+    return [(pl, float(est[i]), float(se[i])) for i, pl in enumerate(plabels)]
+
+
+# ---------------------------------------------------------------------------
 # Content-divergence placebo (issue #230)
 # ---------------------------------------------------------------------------
 

--- a/python/topica/ectm.py
+++ b/python/topica/ectm.py
@@ -131,52 +131,135 @@ def content_contrast_se(model, topic, group_a, group_b, period, groups, periods,
     return [(vocab[i], float(contrast[i]), float(se[i])) for i in order]
 
 
+def _match_anchor_topic(m, anchor):
+    """Topic index in ``m`` whose top words overlap ``anchor`` most."""
+    best, best_ov = 0, -1
+    for k in range(m.num_topics):
+        ov = len(anchor & {w for w, _ in m.top_words(len(anchor), topic=k)})
+        if ov > best_ov:
+            best, best_ov = k, ov
+    return best
+
+
+def _simulate_from_ectm(model, docs, groups, periods, rng):
+    """Draw one synthetic corpus from the fitted ECTM's generative model, holding
+    each document's length, group and period fixed. For a document with topic
+    weights ``θ_d`` in cell ``(g_d, t_d)``, each of its ``len(doc)`` tokens draws a
+    topic ``k ~ θ_d`` then a word ``v ~ β_{k, g_d, t_d}``. Returns a list of token
+    lists aligned to ``docs`` (``groups``/``periods`` are unchanged)."""
+    vocab = list(model.vocabulary)
+    theta = np.asarray(model.doc_topic, dtype=np.float64)
+    k = theta.shape[1]
+    period_index = {str(p): t for t, p in enumerate(model.periods)}
+    # β cube per (group, period) label -> (K, V), fetched once.
+    beta_cache = {}
+
+    def _beta(g, plabel):
+        key = (str(g), plabel)
+        if key not in beta_cache:
+            beta_cache[key] = np.asarray(model.content_word_dist(g, period_index[plabel]))
+        return beta_cache[key]
+
+    sim = []
+    for d, doc in enumerate(docs):
+        length = len(doc)
+        if length == 0:
+            sim.append([])
+            continue
+        th = theta[d]
+        th = th / th.sum() if th.sum() > 0 else np.full(k, 1.0 / k)
+        beta = _beta(groups[d], str(periods[d]))
+        # tokens per topic, then words per topic — bag of words, order irrelevant.
+        z_counts = rng.multinomial(length, th)
+        wcount = np.zeros(len(vocab))
+        for kk in np.nonzero(z_counts)[0]:
+            row = beta[kk]
+            row = row / row.sum() if row.sum() > 0 else np.full(len(vocab), 1.0 / len(vocab))
+            wcount += rng.multinomial(int(z_counts[kk]), row)
+        toks = []
+        for j in np.nonzero(wcount)[0]:
+            toks.extend([vocab[j]] * int(wcount[j]))
+        sim.append(toks)
+    return sim
+
+
 def content_trajectory_ci(refit, docs, groups, periods, *, anchor_words, word, contrast,
+                          method="cluster", model=None,
                           clusters=None, n_boot=40, ci=0.95, seed=0):
-    """Cluster-bootstrap confidence band for a content trajectory.
+    """Confidence band for a content trajectory, by cluster or parametric bootstrap.
 
-    The content-side estimates are MAP point values; this resamples the data and
-    refits to put uncertainty on them. ``refit(docs, groups, periods)`` must return
-    a freshly fitted :class:`ECTM` with your settings (a closure capturing
-    ``num_topics``, ``iters``, the priors, etc.).
+    The content-side estimates are MAP point values; this resamples and refits to
+    put uncertainty on them. ``refit(docs, groups, periods)`` must return a freshly
+    fitted :class:`ECTM` with your settings (a closure capturing ``num_topics``,
+    ``iters``, the priors, etc.). Topics are not aligned across refits, so each
+    bootstrap's topic is matched to the reference by top-word overlap with
+    ``anchor_words`` (e.g. ``[w for w, _ in model.top_words(20, topic=k)]``).
+    Returns ``(period_label, mean, ci_low, ci_high)`` for the ``contrast``
+    trajectory of ``word`` (same ``contrast`` semantics as
+    :func:`content_trajectory`).
 
-    ``clusters`` is a per-document id (e.g. the source document a paragraph came
-    from, or a ``(party, year)`` platform key) that is resampled *with
-    replacement*; pass it whenever documents within a cluster are not independent,
-    so the band reflects the number of independent units rather than the number of
-    paragraphs. ``None`` resamples documents individually.
+    ``method`` selects the resampling design:
 
-    Topics are not aligned across refits, so each bootstrap's topic is matched to
-    the reference by top-word overlap with ``anchor_words`` (e.g.
-    ``[w for w, _ in model.top_words(20, topic=k)]``). Returns a list of
-    ``(period_label, mean, ci_low, ci_high)`` for the ``contrast`` trajectory of
-    ``word`` (same ``contrast`` semantics as :func:`content_trajectory`).
+    - ``"cluster"`` (default): nonparametric cluster bootstrap. ``clusters`` is a
+      per-document id (e.g. the source document a paragraph came from, or a
+      ``(party, year)`` platform key) resampled *with replacement*; pass it whenever
+      documents within a cluster are not independent, so the band reflects the
+      number of independent units rather than the number of paragraphs. ``None``
+      resamples documents individually. **Prefer this when there are many
+      independent clusters per cell.**
+    - ``"parametric"``: parametric bootstrap from the fitted generative model. Draw
+      ``n_boot`` synthetic corpora from the fit (each document keeps its length,
+      group and period; tokens are generated from ``θ̂`` and the per-cell ``β̂``),
+      refit each, and take quantiles. The target is well defined — the fitted DGP —
+      so coverage is checkable on synthetic ground truth. **Prefer this for thin,
+      one-observation-per-cell designs** (e.g. one manifesto per ``(party,
+      election)``), where the cluster bootstrap cannot preserve the design because
+      no resample can redraw whole clusters and keep every cell present; its
+      interval then conditions on retaining coverage and has no established nominal
+      coverage. Pass the fitted reference in ``model=`` to simulate from it, or
+      leave ``model=None`` to fit it once via ``refit``.
+
+    Parameters
+    ----------
+    model : fitted :class:`~topica.ECTM`, optional
+        The reference fit the parametric bootstrap simulates from. Ignored by the
+        cluster method. If ``None`` under ``method="parametric"``, it is obtained
+        once as ``refit(docs, groups, periods)``.
     """
+    if method not in ("cluster", "parametric"):
+        raise ValueError(f"method must be 'cluster' or 'parametric', got {method!r}")
+
     rng = np.random.default_rng(seed)
     docs = list(docs)
     groups = list(groups)
     periods = list(periods)
     n = len(docs)
-    clusters = list(range(n)) if clusters is None else list(clusters)
-    uniq = list(dict.fromkeys(clusters))
-    by_cluster = {}
-    for i, c in enumerate(clusters):
-        by_cluster.setdefault(c, []).append(i)
     anchor = set(anchor_words)
     lo_q, hi_q = (1 - ci) / 2 * 100, (1 + ci) / 2 * 100
     acc = {}  # period_label -> [values]
-    for _ in range(n_boot):
-        pick = rng.integers(0, len(uniq), len(uniq))
-        idx = [i for j in pick for i in by_cluster[uniq[j]]]
-        m = refit([docs[i] for i in idx], [groups[i] for i in idx], [periods[i] for i in idx])
-        # match the topic by top-word overlap with the anchor signature
-        best, best_ov = 0, -1
-        for k in range(m.num_topics):
-            ov = len(anchor & {w for w, _ in m.top_words(len(anchor), topic=k)})
-            if ov > best_ov:
-                best, best_ov = k, ov
-        for p, v in content_trajectory(m, best, word, contrast=contrast):
-            acc.setdefault(p, []).append(v)
+
+    if method == "cluster":
+        clusters = list(range(n)) if clusters is None else list(clusters)
+        uniq = list(dict.fromkeys(clusters))
+        by_cluster = {}
+        for i, c in enumerate(clusters):
+            by_cluster.setdefault(c, []).append(i)
+        for _ in range(n_boot):
+            pick = rng.integers(0, len(uniq), len(uniq))
+            idx = [i for j in pick for i in by_cluster[uniq[j]]]
+            m = refit([docs[i] for i in idx], [groups[i] for i in idx], [periods[i] for i in idx])
+            best = _match_anchor_topic(m, anchor)
+            for p, v in content_trajectory(m, best, word, contrast=contrast):
+                acc.setdefault(p, []).append(v)
+    else:  # parametric
+        ref = model if model is not None else refit(docs, groups, periods)
+        for _ in range(n_boot):
+            sim_docs = _simulate_from_ectm(ref, docs, groups, periods, rng)
+            m = refit(sim_docs, groups, periods)
+            best = _match_anchor_topic(m, anchor)
+            for p, v in content_trajectory(m, best, word, contrast=contrast):
+                acc.setdefault(p, []).append(v)
+
     out = []
     for p in sorted(acc, key=lambda s: _period_sort_key(s)):
         a = np.array(acc[p])

--- a/python/topica/ectm.py
+++ b/python/topica/ectm.py
@@ -800,3 +800,175 @@ def content_placebo(
         group_a=str(group_a),
         group_b=str(group_b),
     )
+
+
+# ---------------------------------------------------------------------------
+# Content-prior hyperparameter selection (issue #339)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class ContentPriorSelection:
+    """Result of :func:`tune_content_prior`: the held-out-selected content-prior
+    hyperparameters plus the full scan.
+
+    Attributes
+    ----------
+    best : dict
+        The selected ``{"content_prior_var", "interaction_shrink",
+        "period_smooth"}``, ready to splat into :meth:`ECTM.fit`.
+    best_score : float
+        Held-out mean per-document log-likelihood at ``best`` (higher is better).
+    table : list[dict]
+        One row per grid point — the three hyperparameters plus ``heldout_loglik``
+        — sorted best first, ready for ``pandas.DataFrame``.
+    n_docs, n_tokens : int
+        Scored held-out documents and tokens (shared across grid points).
+    """
+
+    best: dict
+    best_score: float
+    table: list
+    n_docs: int
+    n_tokens: int
+
+
+def _ectm_heldout_loglik(model, heldout, times, content):
+    """Held-out word log-likelihood for a fitted ECTM, scored the ECTM-native way.
+
+    ``eval_heldout`` needs ``model.transform`` to infer a held-out document's
+    topic mixture, which ECTM does not expose. Instead we score each withheld
+    token under the document's *own* fitted mixture and its cell's content
+    surface: ``p(w) = sum_k θ_{d,k} · β_{k, g_d, t_d, w}``, where ``θ`` is the
+    mixture the fit inferred from the retained tokens. Returns
+    ``(mean_per_doc_loglik, n_tokens, n_docs)``."""
+    vocab = list(model.vocabulary)
+    vindex = {w: i for i, w in enumerate(vocab)}
+    theta = np.asarray(model.doc_topic, dtype=np.float64)
+    period_index = {str(p): t for t, p in enumerate(model.periods)}
+    beta_cache = {}
+
+    def _beta(g, plabel):
+        key = (str(g), plabel)
+        if key not in beta_cache:
+            beta_cache[key] = np.asarray(model.content_word_dist(g, period_index[plabel]))
+        return beta_cache[key]
+
+    total, n_tokens, n_docs = 0.0, 0, 0
+    for di, held in heldout.missing:
+        pw = theta[di] @ _beta(content[di], str(times[di]))
+        pw = np.clip(pw, 1e-12, None)
+        ll, c = 0.0, 0
+        for w in held:
+            j = vindex.get(w)
+            if j is not None:
+                ll += float(np.log(pw[j]))
+                c += 1
+        if c > 0:
+            total += ll
+            n_tokens += c
+            n_docs += 1
+    mean = total / n_docs if n_docs else float("nan")
+    return mean, n_tokens, n_docs
+
+
+def tune_content_prior(
+    fit,
+    docs,
+    times,
+    content,
+    *,
+    content_prior_var=(0.5, 1.0, 2.0),
+    interaction_shrink=(1.2, 1.5, 2.0),
+    period_smooth=(5.0,),
+    prop_docs: float = 0.5,
+    prop_words: float = 0.5,
+    seed: int = 0,
+):
+    """Select ECTM's content-prior hyperparameters by held-out predictive fit.
+
+    The content-prior knobs — the coefficient variance ``content_prior_var`` (σ²),
+    ``interaction_shrink`` and ``period_smooth`` — are otherwise set by hand, and
+    the reported divergence *magnitude* moves with them, inviting a
+    researcher-degrees-of-freedom criticism. This grid-searches them by a
+    within-corpus word-heldout log-likelihood (R stm's ``make.heldout`` /
+    ``eval.heldout`` design), so the fit is reproducible without hand-tuning.
+
+    Parameters
+    ----------
+    fit : callable(docs, times, content, *, content_prior_var, interaction_shrink,
+        period_smooth) -> fitted ECTM
+        Fits a model with your other settings fixed (a closure capturing
+        ``num_topics``, ``iters``, ``seed``, ``init``, ...). Called once per grid
+        point on the held-out *training* corpus.
+    docs, times, content : array-like (num_docs,)
+        The corpus and its per-document period/content labels.
+    content_prior_var, interaction_shrink, period_smooth : sequence of float
+        Candidate values for each hyperparameter; their Cartesian product is the
+        grid. Pass a single-element sequence to hold one fixed.
+    prop_docs, prop_words : float
+        Fraction of documents sampled and fraction of each sampled document's
+        tokens withheld (passed to :func:`~topica.diagnostics.make_heldout`).
+    seed : int
+        Seed for the held-out split.
+
+    Returns
+    -------
+    :class:`ContentPriorSelection`
+        ``best`` (the selected hyperparameters), ``best_score`` and the full
+        ``table``. Report the selected values alongside the fit; refit on the full
+        corpus with ``**selection.best``.
+
+    Notes
+    -----
+    ECTM exposes no ``transform``, so scoring uses an ECTM-native predictive
+    likelihood (:func:`_ectm_heldout_loglik`) rather than the generic
+    ``eval_heldout``. The held-out split is fixed across grid points, so scores are
+    comparable. This is the held-out arm of #339; an empirical-Bayes (type-II ML)
+    variant that maximizes the variational bound for the prior variances is a
+    natural follow-up.
+    """
+    from itertools import product
+
+    from .validation import make_heldout
+
+    docs = list(docs)
+    times = [str(t) for t in times]
+    content = [str(c) for c in content]
+    if not (len(times) == len(content) == len(docs)):
+        raise ValueError(
+            f"docs, times, content must have equal length; got "
+            f"{len(docs)}, {len(times)}, {len(content)}"
+        )
+
+    heldout = make_heldout(docs, prop_docs=prop_docs, prop_words=prop_words, seed=seed)
+
+    table = []
+    n_docs = n_tokens = 0
+    for cpv, ishrink, psmooth in product(content_prior_var, interaction_shrink, period_smooth):
+        m = fit(heldout.documents, times, content,
+                content_prior_var=cpv, interaction_shrink=ishrink, period_smooth=psmooth)
+        ll, ntok, ndoc = _ectm_heldout_loglik(m, heldout, times, content)
+        n_docs, n_tokens = ndoc, ntok
+        table.append({
+            "content_prior_var": float(cpv),
+            "interaction_shrink": float(ishrink),
+            "period_smooth": float(psmooth),
+            "heldout_loglik": float(ll),
+        })
+
+    table.sort(key=lambda r: r["heldout_loglik"], reverse=True)
+    if not table:
+        raise ValueError("the hyperparameter grid is empty")
+    top = table[0]
+    best = {
+        "content_prior_var": top["content_prior_var"],
+        "interaction_shrink": top["interaction_shrink"],
+        "period_smooth": top["period_smooth"],
+    }
+    return ContentPriorSelection(
+        best=best,
+        best_score=top["heldout_loglik"],
+        table=table,
+        n_docs=n_docs,
+        n_tokens=n_tokens,
+    )

--- a/python/topica/ectm.py
+++ b/python/topica/ectm.py
@@ -956,7 +956,7 @@ def tune_content_prior(
         grid. Pass a single-element sequence to hold one fixed.
     prop_docs, prop_words : float
         Fraction of documents sampled and fraction of each sampled document's
-        tokens withheld (passed to :func:`~topica.diagnostics.make_heldout`).
+        tokens withheld (passed to :func:`~topica.make_heldout`).
     seed : int
         Seed for the held-out split.
 

--- a/python/topica/ectm.py
+++ b/python/topica/ectm.py
@@ -141,16 +141,59 @@ def _match_anchor_topic(m, anchor):
     return best
 
 
-def _simulate_from_ectm(model, docs, groups, periods, rng):
+def _theta_sampler(model, k):
+    """Return a callable ``() -> θ`` that draws a fresh topic-proportion vector
+    from the fitted logistic-normal, or ``None`` when the parameters to do so are
+    unavailable (then the caller falls back to the fitted per-document ``θ̂``).
+
+    A parametric bootstrap must regenerate the topic proportions, not freeze them:
+    holding ``θ̂`` fixed and resampling only tokens omits the document-level
+    topic-mixture variance, so the refits barely differ and the resulting band is
+    **too narrow** (empirically under-covers). We reconstruct the fitted marginal
+    ``η ~ N(μ̂, Σ̂)`` from the per-document logistic-normal parameters — ``μ̂`` the
+    mean of ``eta_mean`` and, by the law of total variance, ``Σ̂`` the between-doc
+    covariance of ``eta_mean`` plus the mean within-doc ``eta_cov`` — then draw
+    ``θ = softmax([η, 0])``."""
+    em = getattr(model, "eta_mean", None)
+    if em is None:
+        return None
+    em = np.asarray(em, dtype=np.float64)
+    if em.ndim != 2 or em.shape[0] < 2 or em.shape[1] != k - 1:
+        return None
+    mu = em.mean(axis=0)
+    between = np.cov(em, rowvar=False).reshape(k - 1, k - 1)
+    ec = getattr(model, "eta_cov", None)
+    within = np.asarray(ec, dtype=np.float64).mean(axis=0) if ec is not None else 0.0
+    cov = between + within + 1e-9 * np.eye(k - 1)
+    try:
+        chol = np.linalg.cholesky(cov)
+    except np.linalg.LinAlgError:
+        chol = np.diag(np.sqrt(np.clip(np.diag(cov), 0.0, None)))
+
+    def draw(rng):
+        eta = np.append(mu + chol @ rng.standard_normal(k - 1), 0.0)
+        z = np.exp(eta - eta.max())
+        return z / z.sum()
+
+    return draw
+
+
+def _simulate_from_ectm(model, docs, groups, periods, rng, resample_theta=True):
     """Draw one synthetic corpus from the fitted ECTM's generative model, holding
-    each document's length, group and period fixed. For a document with topic
-    weights ``θ_d`` in cell ``(g_d, t_d)``, each of its ``len(doc)`` tokens draws a
-    topic ``k ~ θ_d`` then a word ``v ~ β_{k, g_d, t_d}``. Returns a list of token
-    lists aligned to ``docs`` (``groups``/``periods`` are unchanged)."""
+    each document's length, group and period fixed. Each of a document's tokens
+    draws a topic ``k ~ θ_d`` then a word ``v ~ β_{k, g_d, t_d}``.
+
+    With ``resample_theta`` (default), each document's ``θ_d`` is redrawn from the
+    fitted logistic-normal (:func:`_theta_sampler`) so the bootstrap propagates
+    the document-level topic-mixture variance — without this the parametric band
+    under-covers. Falls back to the fitted ``θ̂`` when the logistic-normal
+    parameters are unavailable (e.g. ``keep_eta_cov=False``). Returns token lists
+    aligned to ``docs`` (``groups``/``periods`` unchanged)."""
     vocab = list(model.vocabulary)
     theta = np.asarray(model.doc_topic, dtype=np.float64)
     k = theta.shape[1]
     period_index = {str(p): t for t, p in enumerate(model.periods)}
+    sampler = _theta_sampler(model, k) if resample_theta else None
     # β cube per (group, period) label -> (K, V), fetched once.
     beta_cache = {}
 
@@ -166,8 +209,11 @@ def _simulate_from_ectm(model, docs, groups, periods, rng):
         if length == 0:
             sim.append([])
             continue
-        th = theta[d]
-        th = th / th.sum() if th.sum() > 0 else np.full(k, 1.0 / k)
+        if sampler is not None:
+            th = sampler(rng)
+        else:
+            th = theta[d]
+            th = th / th.sum() if th.sum() > 0 else np.full(k, 1.0 / k)
         beta = _beta(groups[d], str(periods[d]))
         # tokens per topic, then words per topic — bag of words, order irrelevant.
         z_counts = rng.multinomial(length, th)
@@ -209,9 +255,12 @@ def content_trajectory_ci(refit, docs, groups, periods, *, anchor_words, word, c
       independent clusters per cell.**
     - ``"parametric"``: parametric bootstrap from the fitted generative model. Draw
       ``n_boot`` synthetic corpora from the fit (each document keeps its length,
-      group and period; tokens are generated from ``θ̂`` and the per-cell ``β̂``),
-      refit each, and take quantiles. The target is well defined — the fitted DGP —
-      so coverage is checkable on synthetic ground truth. **Prefer this for thin,
+      group and period; its topic mixture is redrawn from the fitted
+      logistic-normal and tokens are generated from that and the per-cell ``β̂`` —
+      resampling ``θ`` rather than freezing it is what gives the band nominal
+      width), refit each, and take quantiles. The target is well defined — the
+      fitted DGP — so coverage is checkable on synthetic ground truth. **Prefer
+      this for thin,
       one-observation-per-cell designs** (e.g. one manifesto per ``(party,
       election)``), where the cluster bootstrap cannot preserve the design because
       no resample can redraw whole clusters and keep every cell present; its

--- a/src/ectm.rs
+++ b/src/ectm.rs
@@ -208,6 +208,7 @@ fn solve_and_blend_content(
     rw_kp: f64,
     rw_kgp: f64,
     shrink_kgp: f64,
+    content_l1: f64,
     rho: f64,
     inner_iters: usize,
     seed_mean: &[f64],
@@ -236,6 +237,7 @@ fn solve_and_blend_content(
         rw_kp,
         rw_kgp,
         shrink_kgp,
+        content_l1,
         inner_iters,
         seed_mean,
     );
@@ -263,6 +265,83 @@ fn solve_and_blend_content(
     (num.sqrt()) / (den.sqrt() + 1e-12)
 }
 
+/// Soft-thresholding operator `sign(z)·max(|z|-g, 0)` — the proximal map of the
+/// L1 penalty and the source of exact zeros under the sparse content prior.
+fn soft_threshold(z: f64, g: f64) -> f64 {
+    if z > g {
+        z - g
+    } else if z < -g {
+        z + g
+    } else {
+        0.0
+    }
+}
+
+/// Minimize `f(x) + lam·Σ_i |x_i − anchor_i|` by FISTA with backtracking line
+/// search (Beck & Teboulle 2009). `f_and_grad` supplies the smooth part's value
+/// and gradient (already in minimization form). The L1 term is non-smooth at its
+/// anchor, so plain L-BFGS cannot produce exact zeros; the proximal step
+/// (soft-thresholding around `anchor`) does. Only invoked for the L1 content
+/// prior (`lam > 0`); the L2 default keeps the original L-BFGS solve bit-exact.
+fn fista_l1<F>(x0: Vec<f64>, f_and_grad: F, lam: f64, anchor: &[f64], max_iter: usize) -> Vec<f64>
+where
+    F: Fn(&[f64]) -> (f64, Vec<f64>),
+{
+    let n = x0.len();
+    // Proximal-gradient step from `y` with inverse-Lipschitz step `t`.
+    let prox_step = |y: &[f64], g: &[f64], t: f64| -> Vec<f64> {
+        let thr = lam * t;
+        (0..n)
+            .map(|i| {
+                let a = anchor.get(i).copied().unwrap_or(0.0);
+                a + soft_threshold(y[i] - t * g[i] - a, thr)
+            })
+            .collect::<Vec<f64>>()
+    };
+    let mut x = x0.clone();
+    let mut y = x0;
+    let mut t_step = 1.0f64;
+    let mut theta = 1.0f64;
+    for _ in 0..max_iter {
+        let (fy, gy) = f_and_grad(&y);
+        // Backtracking: shrink the step until the quadratic upper bound holds.
+        let mut step = t_step * 2.0;
+        let x_new = loop {
+            let cand = prox_step(&y, &gy, step);
+            let (fc, _) = f_and_grad(&cand);
+            let mut dot = 0.0;
+            let mut sq = 0.0;
+            for i in 0..n {
+                let d = cand[i] - y[i];
+                dot += gy[i] * d;
+                sq += d * d;
+            }
+            if fc <= fy + dot + sq / (2.0 * step) + 1e-12 || step < 1e-12 {
+                break cand;
+            }
+            step *= 0.5;
+        };
+        t_step = step;
+        // Nesterov momentum.
+        let theta_next = (1.0 + (1.0 + 4.0 * theta * theta).sqrt()) / 2.0;
+        let beta = (theta - 1.0) / theta_next;
+        let mut num = 0.0;
+        let mut den = 0.0;
+        for i in 0..n {
+            let d = x_new[i] - x[i];
+            num += d * d;
+            den += x[i] * x[i];
+            y[i] = x_new[i] + beta * d;
+        }
+        x = x_new;
+        theta = theta_next;
+        if num.sqrt() / (den.sqrt() + 1e-12) < 1e-5 {
+            break;
+        }
+    }
+    x
+}
+
 /// MAP-update the content deviations κ from the variational expected
 /// (topic×group×period×word) counts, then rebuild per-cell β.
 ///
@@ -288,6 +367,7 @@ fn optimize_content(
     rw_kp: f64,
     rw_kgp: f64,
     shrink_kgp: f64,
+    content_l1: f64,
     max_iter: usize,
     seed_mean: &[f64],
 ) -> Vec<Vec<Vec<f64>>> {
@@ -317,9 +397,12 @@ fn optimize_content(
 
     let inv_var = 1.0 / sigma2;
 
-    let x = lbfgs_minimize(
-        x0,
-        |flat| {
+    // Smooth part of the negative log-posterior (to *minimize*): the
+    // multinomial-logit NLL, the L2 priors, and the random-walk penalties. Under
+    // the L1 (sparse Laplace) content prior the L2 stays as a small ridge for
+    // identifiability and conditioning while FISTA adds the non-smooth |κ| term.
+    let smooth = |flat: &[f64]| -> (f64, Vec<f64>) {
+        {
             let kt_i = |t: usize, w: usize| flat[t * v + w];
             let kkp_i = |t: usize, per: usize, w: usize| flat[off_kp + (t * p + per) * v + w];
             let kkg_i = |t: usize, grp: usize, w: usize| flat[off_kg + (t * g + grp) * v + w];
@@ -423,11 +506,22 @@ fn optimize_content(
             }
 
             (-value, grad.iter().map(|gv| -gv).collect())
-        },
-        max_iter,
-        7,
-        1e-4,
-    );
+        }
+    };
+
+    let x = if content_l1 > 0.0 {
+        // L1 (sparse Laplace) prior on the content deviations: κT is pulled
+        // toward `seed_mean` (0 except at seeded entries), every other block
+        // toward 0. Solved by FISTA so the deviations reach exact zeros — sparse,
+        // readable top-word lists and sharp per-cell Δ contrasts (SAGE-style).
+        let mut anchor = vec![0.0f64; n_t + n_kp + n_kg + n_kgp];
+        for (i, a) in anchor.iter_mut().enumerate().take(n_t) {
+            *a = seed_mean.get(i).copied().unwrap_or(0.0);
+        }
+        fista_l1(x0, smooth, content_l1, &anchor, max_iter.max(200))
+    } else {
+        lbfgs_minimize(x0, smooth, max_iter, 7, 1e-4)
+    };
 
     for t in 0..k {
         kt[t].copy_from_slice(&x[t * v..(t + 1) * v]);
@@ -471,6 +565,7 @@ pub fn fit_ectm<R: Rng>(
     rw_kp: f64,
     rw_kgp: f64,
     shrink_kgp: f64,
+    content_l1: f64,
     keep_nu: bool,
     diagonal: bool,
     init_spectral: bool,
@@ -703,6 +798,7 @@ pub fn fit_ectm<R: Rng>(
             rw_kp,
             rw_kgp,
             shrink_kgp,
+            content_l1,
             20,
             seed_mean,
         );
@@ -774,6 +870,7 @@ pub fn fit_ectm_svi<R: Rng>(
     rw_kp: f64,
     rw_kgp: f64,
     shrink_kgp: f64,
+    content_l1: f64,
     keep_nu: bool,
     diagonal: bool,
     init_spectral: bool,
@@ -1025,6 +1122,7 @@ pub fn fit_ectm_svi<R: Rng>(
                     rw_kp,
                     rw_kgp,
                     shrink_kgp,
+                    content_l1,
                     rho_k,
                     kiters,
                     seed_mean,
@@ -1064,6 +1162,7 @@ pub fn fit_ectm_svi<R: Rng>(
             rw_kp,
             rw_kgp,
             shrink_kgp,
+            content_l1,
             rho_k,
             kiters,
             seed_mean,
@@ -1271,6 +1370,7 @@ mod tests {
             5.0,
             5.0,
             2.0,
+            0.0,
             true,
             false,
             init_spectral,
@@ -1362,5 +1462,76 @@ mod tests {
         assert!(base.is_empty(), "check_conformance: {base:?}");
         let ln = crate::conformance::check_logistic_normal(&m);
         assert!(ln.is_empty(), "check_logistic_normal: {ln:?}");
+    }
+
+    // FISTA recovers the closed-form lasso solution of a separable quadratic:
+    // minimize 0.5‖x − target‖² + λ‖x‖₁ has solution soft_threshold(target, λ),
+    // with entries below λ driven to *exact* zero. This directly exercises the
+    // sparse-content solver independent of the ECTM likelihood.
+    #[test]
+    fn fista_l1_recovers_soft_threshold() {
+        let target = [3.0f64, -2.0, 0.5, -0.3, 0.05];
+        let lam = 1.0;
+        let f_and_grad = |x: &[f64]| {
+            let mut val = 0.0;
+            let mut grad = vec![0.0; x.len()];
+            for i in 0..x.len() {
+                let d = x[i] - target[i];
+                val += 0.5 * d * d;
+                grad[i] = d;
+            }
+            (val, grad)
+        };
+        let anchor = vec![0.0; target.len()];
+        let x = fista_l1(vec![0.0; target.len()], f_and_grad, lam, &anchor, 500);
+        let expected: Vec<f64> = target.iter().map(|&t| soft_threshold(t, lam)).collect();
+        for (xi, ei) in x.iter().zip(&expected) {
+            assert!((xi - ei).abs() < 1e-4, "got {x:?}, expected {expected:?}");
+        }
+        // entries with |target| <= lam are pinned to exact zero (sparsity).
+        assert_eq!(x[2], 0.0);
+        assert_eq!(x[3], 0.0);
+        assert_eq!(x[4], 0.0);
+    }
+
+    // The L1 content prior drives the between-group content deviations toward
+    // zero: with a strong penalty the group κ collapse, so the two groups' fitted
+    // word distributions coincide (no spurious wording contrast). The L2 default
+    // keeps a nonzero contrast. Verifies the flag reaches the estimator and the
+    // proximal solve sparsifies end-to-end.
+    #[test]
+    fn l1_content_prior_sparsifies_group_contrast() {
+        let (docs, groups, periods) = growing_contrast_corpus();
+        let fit = |content_l1: f64| {
+            let mut rng = ChaCha8Rng::seed_from_u64(1);
+            fit_ectm(
+                &docs, 2, 4, &groups, 2, &periods, 3, 60, 0.0, 0.0, None, 1.0, 5.0, 5.0, 2.0,
+                content_l1, true, false, true, &[], &mut rng,
+            )
+        };
+        // Total between-group L1 wording distance over cells.
+        let contrast = |m: &EctmModel| -> f64 {
+            let mut tot = 0.0;
+            for t in 0..m.num_periods {
+                let a = &m.content_beta[m.cell(0, t)];
+                let b = &m.content_beta[m.cell(1, t)];
+                for k in 0..m.num_topics {
+                    for w in 0..a[k].len() {
+                        tot += (a[k][w] - b[k][w]).abs();
+                    }
+                }
+            }
+            tot
+        };
+        // Sparsity increases monotonically with the penalty; a strong penalty
+        // collapses even this (deliberately strong) 4-word group signal.
+        let c_l2 = contrast(&fit(0.0));
+        let c_mid = contrast(&fit(50.0));
+        let c_strong = contrast(&fit(1000.0));
+        assert!(c_mid < c_l2, "L1 should reduce the contrast: L2={c_l2}, L1={c_mid}");
+        assert!(
+            c_strong < 0.25 * c_l2,
+            "strong L1 should largely collapse the group contrast: L2={c_l2}, strong={c_strong}"
+        );
     }
 }

--- a/src/ectm.rs
+++ b/src/ectm.rs
@@ -1506,7 +1506,14 @@ mod tests {
         };
         let anchor = vec![0.0; target.len()];
         let penalize = vec![true; target.len()];
-        let x = fista_l1(vec![0.0; target.len()], f_and_grad, lam, &anchor, &penalize, 500);
+        let x = fista_l1(
+            vec![0.0; target.len()],
+            f_and_grad,
+            lam,
+            &anchor,
+            &penalize,
+            500,
+        );
         let expected: Vec<f64> = target.iter().map(|&t| soft_threshold(t, lam)).collect();
         for (xi, ei) in x.iter().zip(&expected) {
             assert!((xi - ei).abs() < 1e-4, "got {x:?}, expected {expected:?}");
@@ -1528,8 +1535,27 @@ mod tests {
         let fit = |content_l1: f64| {
             let mut rng = ChaCha8Rng::seed_from_u64(1);
             fit_ectm(
-                &docs, 2, 4, &groups, 2, &periods, 3, 60, 0.0, 0.0, None, 1.0, 5.0, 5.0, 2.0,
-                content_l1, true, false, true, &[], &mut rng,
+                &docs,
+                2,
+                4,
+                &groups,
+                2,
+                &periods,
+                3,
+                60,
+                0.0,
+                0.0,
+                None,
+                1.0,
+                5.0,
+                5.0,
+                2.0,
+                content_l1,
+                true,
+                false,
+                true,
+                &[],
+                &mut rng,
             )
         };
         // Total between-group L1 wording distance over cells.
@@ -1551,7 +1577,10 @@ mod tests {
         let c_l2 = contrast(&fit(0.0));
         let c_mid = contrast(&fit(50.0));
         let c_strong = contrast(&fit(1000.0));
-        assert!(c_mid < c_l2, "L1 should reduce the contrast: L2={c_l2}, L1={c_mid}");
+        assert!(
+            c_mid < c_l2,
+            "L1 should reduce the contrast: L2={c_l2}, L1={c_mid}"
+        );
         assert!(
             c_strong < 0.25 * c_l2,
             "strong L1 should largely collapse the group contrast: L2={c_l2}, strong={c_strong}"

--- a/src/ectm.rs
+++ b/src/ectm.rs
@@ -277,24 +277,40 @@ fn soft_threshold(z: f64, g: f64) -> f64 {
     }
 }
 
-/// Minimize `f(x) + lam·Σ_i |x_i − anchor_i|` by FISTA with backtracking line
-/// search (Beck & Teboulle 2009). `f_and_grad` supplies the smooth part's value
-/// and gradient (already in minimization form). The L1 term is non-smooth at its
-/// anchor, so plain L-BFGS cannot produce exact zeros; the proximal step
-/// (soft-thresholding around `anchor`) does. Only invoked for the L1 content
-/// prior (`lam > 0`); the L2 default keeps the original L-BFGS solve bit-exact.
-fn fista_l1<F>(x0: Vec<f64>, f_and_grad: F, lam: f64, anchor: &[f64], max_iter: usize) -> Vec<f64>
+/// Minimize `f(x) + lam·Σ_{i:penalize} |x_i − anchor_i|` by FISTA with
+/// backtracking line search (Beck & Teboulle 2009). `f_and_grad` supplies the
+/// smooth part's value and gradient (already in minimization form). The L1 term
+/// is non-smooth at its anchor, so plain L-BFGS cannot produce exact zeros; the
+/// proximal step (soft-thresholding around `anchor`) does. `penalize[i]` gates
+/// which coordinates carry the L1 term — for ECTM only the group and group×time
+/// contrast blocks (κG, κGP) are sparsified; the topic baseline κT and the
+/// topic×time drift κP keep their L2 so topic vocabularies stay coherent.
+/// Coordinates with `penalize[i] == false` take a plain gradient step (threshold
+/// 0). Only invoked for the L1 content prior (`lam > 0`); the L2 default keeps
+/// the original L-BFGS solve bit-exact.
+fn fista_l1<F>(
+    x0: Vec<f64>,
+    f_and_grad: F,
+    lam: f64,
+    anchor: &[f64],
+    penalize: &[bool],
+    max_iter: usize,
+) -> Vec<f64>
 where
     F: Fn(&[f64]) -> (f64, Vec<f64>),
 {
     let n = x0.len();
     // Proximal-gradient step from `y` with inverse-Lipschitz step `t`.
     let prox_step = |y: &[f64], g: &[f64], t: f64| -> Vec<f64> {
-        let thr = lam * t;
         (0..n)
             .map(|i| {
-                let a = anchor.get(i).copied().unwrap_or(0.0);
-                a + soft_threshold(y[i] - t * g[i] - a, thr)
+                let grad_step = y[i] - t * g[i];
+                if penalize.get(i).copied().unwrap_or(false) {
+                    let a = anchor.get(i).copied().unwrap_or(0.0);
+                    a + soft_threshold(grad_step - a, lam * t)
+                } else {
+                    grad_step
+                }
             })
             .collect::<Vec<f64>>()
     };
@@ -304,8 +320,9 @@ where
     let mut theta = 1.0f64;
     for _ in 0..max_iter {
         let (fy, gy) = f_and_grad(&y);
-        // Backtracking: shrink the step until the quadratic upper bound holds.
-        let mut step = t_step * 2.0;
+        // Backtracking: start from the last accepted step (reused, not doubled)
+        // and shrink until the quadratic upper bound holds.
+        let mut step = t_step;
         let x_new = loop {
             let cand = prox_step(&y, &gy, step);
             let (fc, _) = f_and_grad(&cand);
@@ -510,15 +527,20 @@ fn optimize_content(
     };
 
     let x = if content_l1 > 0.0 {
-        // L1 (sparse Laplace) prior on the content deviations: κT is pulled
-        // toward `seed_mean` (0 except at seeded entries), every other block
-        // toward 0. Solved by FISTA so the deviations reach exact zeros — sparse,
-        // readable top-word lists and sharp per-cell Δ contrasts (SAGE-style).
-        let mut anchor = vec![0.0f64; n_t + n_kp + n_kg + n_kgp];
-        for (i, a) in anchor.iter_mut().enumerate().take(n_t) {
-            *a = seed_mean.get(i).copied().unwrap_or(0.0);
+        // L1 (sparse Laplace) prior on the *contrast* deviations only: the group
+        // block κG (off_kg..off_kgp) and the group×time block κGP (off_kgp..end)
+        // are sparsified toward 0, giving a principled "this cell's wording
+        // differs on *these* words" story and sharper Δ contrasts (SAGE-style).
+        // The topic baseline κT and the topic×time drift κP keep their L2 so the
+        // topic vocabularies stay coherent — sparsifying κT deletes topic words
+        // and hurts coherence. Solved by FISTA (exact zeros; L-BFGS cannot).
+        let total = n_t + n_kp + n_kg + n_kgp;
+        let anchor = vec![0.0f64; total];
+        let mut penalize = vec![false; total];
+        for pflag in penalize.iter_mut().take(total).skip(off_kg) {
+            *pflag = true;
         }
-        fista_l1(x0, smooth, content_l1, &anchor, max_iter.max(200))
+        fista_l1(x0, smooth, content_l1, &anchor, &penalize, max_iter.max(60))
     } else {
         lbfgs_minimize(x0, smooth, max_iter, 7, 1e-4)
     };
@@ -1483,7 +1505,8 @@ mod tests {
             (val, grad)
         };
         let anchor = vec![0.0; target.len()];
-        let x = fista_l1(vec![0.0; target.len()], f_and_grad, lam, &anchor, 500);
+        let penalize = vec![true; target.len()];
+        let x = fista_l1(vec![0.0; target.len()], f_and_grad, lam, &anchor, &penalize, 500);
         let expected: Vec<f64> = target.iter().map(|&t| soft_threshold(t, lam)).collect();
         for (xi, ei) in x.iter().zip(&expected) {
             assert!((xi - ei).abs() < 1e-4, "got {x:?}, expected {expected:?}");

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7841,8 +7841,14 @@ impl ECTM {
     /// precision `period_smooth` (larger ⇒ smoother, more pooling across adjacent
     /// periods); and an extra L2 factor `interaction_shrink` on the group×time
     /// term (larger ⇒ the changing contrast is pulled harder toward zero unless
-    /// the data demand it). EM runs until the relative change in the variational
-    /// bound drops below `convergence_tol` or `iters` iterations are reached.
+    /// the data demand it). `content_prior` selects the deviation prior:
+    /// ``"l2"`` (default) is the Gaussian ridge above; ``"l1"`` swaps in a
+    /// sparsity-inducing Laplace prior (solved by FISTA) that drives the κ to
+    /// exact zeros, for more exclusive top-word lists and sharper per-cell Δ
+    /// contrasts (SAGE-style). Under ``"l1"`` the penalty rate is `1/content_prior_var`,
+    /// so a tighter `content_prior_var` sparsifies harder. EM runs until the
+    /// relative change in the variational bound drops below `convergence_tol` or
+    /// `iters` iterations are reached.
     /// `prevalence_names`, `content_names`, and `period_names` are human-readable
     /// labels for the columns of the prevalence and content design matrices and for
     /// the time periods, surfaced in the effect outputs. `inference` selects the
@@ -7867,6 +7873,7 @@ impl ECTM {
     #[pyo3(signature = (data, times, content, *, prevalence=None, prevalence_names=None,
                         content_names=None, period_names=None, iters=500, convergence_tol=1e-5,
                         content_prior_var=1.0, period_smooth=5.0, interaction_shrink=2.0,
+                        content_prior="l2",
                         inference="batch", batch_size=256, tau=64.0, kappa=0.7,
                         content_every=0, seeds=None, seed_strength=4.0,
                         keep_eta_cov=true, num_threads=None))]
@@ -7886,6 +7893,7 @@ impl ECTM {
         content_prior_var: f64,
         period_smooth: f64,
         interaction_shrink: f64,
+        content_prior: &str,
         inference: &str,
         batch_size: usize,
         tau: f64,
@@ -7914,6 +7922,20 @@ impl ECTM {
         if interaction_shrink <= 0.0 {
             return Err(PyValueError::new_err("interaction_shrink must be > 0"));
         }
+        // Content-deviation prior: "l2" (default, Gaussian ridge) keeps the
+        // original solve bit-exact; "l1" adds a sparsity-inducing Laplace prior
+        // solved by FISTA, for exclusive top-word lists and sharp Δ contrasts
+        // (SAGE-style). The L1 rate is tied to the variance knob (1/σ²) so a
+        // tighter `content_prior_var` shrinks harder, matching the L2 semantics.
+        let content_l1 = match content_prior {
+            "l2" => 0.0,
+            "l1" => 1.0 / content_prior_var,
+            other => {
+                return Err(PyValueError::new_err(format!(
+                    "unknown content_prior {other:?}; expected \"l2\" or \"l1\""
+                )))
+            }
+        };
 
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -8088,6 +8110,7 @@ impl ECTM {
                         period_smooth,
                         period_smooth,
                         interaction_shrink,
+                        content_l1,
                         keep_eta_cov,
                         diagonal,
                         init_spectral,
@@ -8111,6 +8134,7 @@ impl ECTM {
                         period_smooth,
                         period_smooth,
                         interaction_shrink,
+                        content_l1,
                         keep_eta_cov,
                         diagonal,
                         init_spectral,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7843,10 +7843,15 @@ impl ECTM {
     /// term (larger ⇒ the changing contrast is pulled harder toward zero unless
     /// the data demand it). `content_prior` selects the deviation prior:
     /// ``"l2"`` (default) is the Gaussian ridge above; ``"l1"`` swaps in a
-    /// sparsity-inducing Laplace prior (solved by FISTA) that drives the κ to
-    /// exact zeros, for more exclusive top-word lists and sharper per-cell Δ
-    /// contrasts (SAGE-style). Under ``"l1"`` the penalty rate is `1/content_prior_var`,
-    /// so a tighter `content_prior_var` sparsifies harder. EM runs until the
+    /// sparsity-inducing Laplace prior (solved by FISTA) on the **group and
+    /// group×time contrast blocks** (κG, κGP), driving them to exact zeros for a
+    /// sharper "this cell differs on *these* words" story and more exclusive
+    /// contrasts (SAGE-style). The topic baseline κT and topic×time drift κP keep
+    /// their L2, so topic vocabularies stay coherent (sparsifying κT deletes topic
+    /// words and hurts coherence). Under ``"l1"`` the penalty rate is
+    /// `1/content_prior_var`, so a tighter `content_prior_var` sparsifies harder;
+    /// prefer a mild penalty — on real corpora it lifts exclusivity at negligible
+    /// coherence cost, while a strong one trades coherence away. EM runs until the
     /// relative change in the variational bound drops below `convergence_tol` or
     /// `iters` iterations are reached.
     /// `prevalence_names`, `content_names`, and `period_names` are human-readable

--- a/tests/test_ectm.py
+++ b/tests/test_ectm.py
@@ -534,3 +534,103 @@ def test_content_divergence_debiased_validates_inputs():
     with pytest.raises(ValueError):
         content_divergence_debiased(m, 0, "A", "B", docs=docs[:10], groups=groups,
                                     periods=times, n_splits=2)
+
+
+# ---------------------------------------------------------------------------
+# Parametric-bootstrap CIs for content trajectories (issue #340)
+# ---------------------------------------------------------------------------
+
+_T0_WORDS = ["alpha", "beta", "gamma", "delta"]
+_T1_WORDS = ["one", "two", "three", "four"]
+
+
+def _two_topic_doc(rng, topic, group, per, length=14):
+    """A document from one of two well-separated topics. Topic 0 carries a
+    group-by-time content drift: group A stays on {alpha,beta}; group B shifts
+    toward {gamma,delta} as periods advance. Topic 1 is shared across groups."""
+    if topic == 0:
+        if group == "A":
+            p = np.array([0.45, 0.45, 0.05, 0.05])
+        else:
+            w = min(0.3 * per, 1.0)
+            p = np.array([0.45, 0.45, 0.05, 0.05]) * (1 - w) + \
+                np.array([0.05, 0.05, 0.45, 0.45]) * w
+        p = p / p.sum()
+        return [_T0_WORDS[i] for i in rng.choice(4, length, p=p)]
+    return [_T1_WORDS[i] for i in rng.choice(4, length, p=[0.4, 0.3, 0.2, 0.1])]
+
+
+def _two_topic_corpus(reps, seed=0):
+    rng = np.random.default_rng(seed)
+    docs, groups, times = [], [], []
+    for _ in range(reps):
+        for per in range(3):
+            for g in ("A", "B"):
+                docs.append(_two_topic_doc(rng, 0, g, per)); groups.append(g); times.append(2000 + per)
+                docs.append(_two_topic_doc(rng, 1, g, per)); groups.append(g); times.append(2000 + per)
+    return docs, groups, times
+
+
+def _fit_two_topic(docs, groups, periods):
+    m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+    m.fit(docs, times=periods, content=groups, iters=70,
+          period_smooth=2.0, interaction_shrink=1.5)
+    return m
+
+
+def _drift_topic(m):
+    return 0 if set(w for w, _ in m.top_words(4, topic=0)) & set(_T0_WORDS) else 1
+
+
+def test_content_trajectory_ci_parametric_covers_dgp():
+    """The parametric bootstrap simulates from the fitted DGP, so its band is
+    centered on and covers the reference model's own content trajectory (the
+    well-defined target), and recovers the planted group-by-time drift."""
+    from topica.ectm import content_trajectory_ci
+
+    docs, groups, times = _two_topic_corpus(45, seed=1)
+    m = _fit_two_topic(docs, groups, times)
+    k = _drift_topic(m)
+    truth = [v for _, v in content_trajectory(m, k, "gamma", contrast=("A", "B"))]
+    anchor = [w for w, _ in m.top_words(4, topic=k)]
+    band = content_trajectory_ci(
+        _fit_two_topic, docs, groups, times, anchor_words=anchor,
+        word="gamma", contrast=("A", "B"), method="parametric", model=m,
+        n_boot=15, seed=3)
+
+    assert len(band) == m.num_periods
+    covered = 0
+    for (_, mean, lo, hi), tv in zip(band, truth):
+        assert lo <= mean <= hi
+        covered += lo <= tv <= hi
+    # band covers the DGP truth at (nearly) every period
+    assert covered >= len(truth) - 1
+    # recovers the drift: group B pulls "gamma" up over time, so A-B falls
+    assert band[-1][1] < band[0][1] - 0.1
+
+
+def test_content_trajectory_ci_parametric_fits_reference_when_model_none():
+    """method='parametric' with model=None obtains the reference DGP via refit."""
+    from topica.ectm import content_trajectory_ci
+
+    docs, groups, times = _two_topic_corpus(35, seed=2)
+    m = _fit_two_topic(docs, groups, times)
+    k = _drift_topic(m)
+    anchor = [w for w, _ in m.top_words(4, topic=k)]
+    band = content_trajectory_ci(
+        _fit_two_topic, docs, groups, times, anchor_words=anchor,
+        word="gamma", contrast=("A", "B"), method="parametric", model=None,
+        n_boot=10, seed=4)
+    assert len(band) == m.num_periods
+    for _, mean, lo, hi in band:
+        assert lo <= mean <= hi
+
+
+def test_content_trajectory_ci_bad_method():
+    from topica.ectm import content_trajectory_ci
+
+    docs, groups, times = _two_topic_corpus(10, seed=0)
+    with pytest.raises(ValueError):
+        content_trajectory_ci(_fit_two_topic, docs, groups, times,
+                              anchor_words=["alpha"], word="gamma",
+                              contrast=("A", "B"), method="nope", n_boot=2)

--- a/tests/test_ectm.py
+++ b/tests/test_ectm.py
@@ -417,3 +417,120 @@ def test_seeds_ignore_unknown_words():
     """Words outside the vocabulary are silently skipped (no crash)."""
     m = _fit(seed=1, seeds={0: ["x", "notaword"]}, seed_strength=5.0)
     assert np.asarray(m.topic_word).shape[0] == 2
+
+
+# ---------------------------------------------------------------------------
+# Debiased content divergence (issue #337)
+# ---------------------------------------------------------------------------
+
+_DEBIAS_VOCAB = [f"w{i}" for i in range(8)]
+_DEBIAS_BASE = np.array([0.25, 0.2, 0.15, 0.12, 0.1, 0.08, 0.06, 0.04])
+_DEBIAS_ALT = _DEBIAS_BASE[::-1].copy()
+
+
+def _sampled_corpus(n_per_cell, strength, doc_len=12, seed=0):
+    """Generative synthetic with real multinomial sampling noise (unlike the
+    degenerate ``_corpus`` where every doc in a cell is identical). Group A holds
+    ``_DEBIAS_BASE``; group B mixes toward ``_DEBIAS_ALT`` with weight growing
+    over periods, so the planted between-group TV is 0 in period 0 and grows."""
+    rng = np.random.default_rng(seed)
+    docs, groups, times = [], [], []
+    for per in range(3):
+        for g in ("A", "B"):
+            if g == "A":
+                p = _DEBIAS_BASE
+            else:
+                w = min(strength * per, 1.0)
+                p = (1 - w) * _DEBIAS_BASE + w * _DEBIAS_ALT
+            p = p / p.sum()
+            for _ in range(n_per_cell):
+                toks = rng.choice(len(_DEBIAS_VOCAB), size=doc_len, p=p)
+                docs.append([_DEBIAS_VOCAB[t] for t in toks])
+                groups.append(g)
+                times.append(2000 + per)
+    return docs, groups, times
+
+
+def _planted_tv(strength):
+    out = []
+    for per in range(3):
+        w = min(strength * per, 1.0)
+        pb = (1 - w) * _DEBIAS_BASE + w * _DEBIAS_ALT
+        pb = pb / pb.sum()
+        out.append(0.5 * np.abs(_DEBIAS_BASE / _DEBIAS_BASE.sum() - pb).sum())
+    return np.array(out)
+
+
+def _fit_sampled(docs, groups, times):
+    m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+    m.fit(docs, times=times, content=groups, iters=100,
+          period_smooth=2.0, interaction_shrink=1.5)
+    return m
+
+
+def test_content_divergence_debiased_removes_floor():
+    """Identical groups have zero true content divergence, but the raw plug-in
+    reports a positive finite-sample floor. The debiased estimator removes it."""
+    from topica.ectm import content_divergence_debiased
+
+    docs, groups, times = _sampled_corpus(160, strength=0.0, seed=3)
+    m = _fit_sampled(docs, groups, times)
+    raw = np.array([d for _, d in content_divergence(m, 0, "A", "B")])
+    deb = np.array([v for _, v, _ in content_divergence_debiased(
+        m, 0, "A", "B", docs=docs, groups=groups, periods=times, n_splits=8, seed=1)])
+    # raw carries a positive floor; debiased sits at ~0 and below the raw floor.
+    assert np.abs(deb).mean() < 0.02
+    assert np.abs(deb).mean() < raw.mean() + 1e-9
+
+
+def test_content_divergence_debiased_converges_to_planted_tv():
+    """With a genuine planted contrast, the debiased estimate tracks the known
+    TV and beats the raw plug-in's error; the raw floor overstates the null
+    period while understating nothing it needs to recover."""
+    from topica.ectm import content_divergence_debiased
+
+    truth = _planted_tv(0.5)
+    docs, groups, times = _sampled_corpus(200, strength=0.5, seed=7)
+    m = _fit_sampled(docs, groups, times)
+    raw = np.array([d for _, d in content_divergence(m, 0, "A", "B")])
+    deb = np.array([v for _, v, _ in content_divergence_debiased(
+        m, 0, "A", "B", docs=docs, groups=groups, periods=times, n_splits=8, seed=1)])
+    # debiased is closer to the planted truth than the raw plug-in on average,
+    assert np.mean(np.abs(deb - truth)) < np.mean(np.abs(raw - truth))
+    # recovers the null period (period 0) and the growing contrast (period 2).
+    assert abs(deb[0]) < 0.05
+    assert deb[2] > deb[0] + 0.25
+
+
+def test_content_divergence_debiased_jackknife_se():
+    """se_blocks>1 attaches a delete-block jackknife SE; it is finite and small
+    on a well-sampled corpus."""
+    from topica.ectm import content_divergence_debiased
+
+    docs, groups, times = _sampled_corpus(120, strength=0.5, seed=5)
+    m = _fit_sampled(docs, groups, times)
+    rows = content_divergence_debiased(
+        m, 0, "A", "B", docs=docs, groups=groups, periods=times,
+        n_splits=6, se_blocks=5, seed=1)
+    assert len(rows) == m.num_periods
+    for _, _, se in rows:
+        assert np.isfinite(se) and se >= 0.0
+
+
+def test_content_divergence_debiased_validates_inputs():
+    from topica.ectm import content_divergence_debiased
+
+    docs, groups, times = _sampled_corpus(20, strength=0.5, seed=1)
+    m = _fit_sampled(docs, groups, times)
+    # length mismatch
+    with pytest.raises(ValueError):
+        content_divergence_debiased(m, 0, "A", "B", docs=docs, groups=groups[:-1],
+                                    periods=times, n_splits=2)
+    # topic out of range
+    with pytest.raises(ValueError):
+        content_divergence_debiased(m, 9, "A", "B", docs=docs, groups=groups,
+                                    periods=times, n_splits=2)
+    # wrong document count vs the fitted model
+    with pytest.raises(ValueError):
+        content_divergence_debiased(m, 0, "A", "B", docs=docs[:10], groups=groups,
+                                    periods=times, n_splits=2)

--- a/tests/test_ectm.py
+++ b/tests/test_ectm.py
@@ -636,6 +636,32 @@ def test_content_trajectory_ci_bad_method():
                               contrast=("A", "B"), method="nope", n_boot=2)
 
 
+def test_parametric_simulation_resamples_theta():
+    """The parametric bootstrap must redraw each document's topic mixture from the
+    fitted logistic-normal, not freeze it — freezing θ omits the document-level
+    variance and makes the band under-cover. Guards the coverage fix."""
+    from topica.ectm import _simulate_from_ectm, _theta_sampler
+
+    docs, groups, times = _two_topic_corpus(30, seed=1)
+    m = _fit_two_topic(docs, groups, times)
+
+    # the logistic-normal sampler is available and draws valid distributions
+    sampler = _theta_sampler(m, m.num_topics)
+    assert sampler is not None
+    th = sampler(np.random.default_rng(0))
+    assert th.shape == (m.num_topics,)
+    assert abs(th.sum() - 1.0) < 1e-9 and (th >= 0).all()
+
+    # two simulated corpora with different seeds differ (θ is resampled) ...
+    a = _simulate_from_ectm(m, docs, groups, times, np.random.default_rng(1))
+    b = _simulate_from_ectm(m, docs, groups, times, np.random.default_rng(2))
+    assert a != b
+    # ... and disabling resampling still yields a valid corpus (fallback path)
+    frozen = _simulate_from_ectm(m, docs, groups, times, np.random.default_rng(1),
+                                 resample_theta=False)
+    assert len(frozen) == len(docs)
+
+
 # ---------------------------------------------------------------------------
 # Content-prior hyperparameter selection (issue #339)
 # ---------------------------------------------------------------------------

--- a/tests/test_ectm.py
+++ b/tests/test_ectm.py
@@ -462,7 +462,7 @@ def _planted_tv(strength):
 
 
 def _fit_sampled(docs, groups, times):
-    m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+    m = topica.ECTM(num_topics=2, seed=1, init="spectral")
     m.fit(docs, times=times, content=groups, iters=100,
           period_smooth=2.0, interaction_shrink=1.5)
     return m
@@ -572,7 +572,7 @@ def _two_topic_corpus(reps, seed=0):
 
 
 def _fit_two_topic(docs, groups, periods):
-    m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+    m = topica.ECTM(num_topics=2, seed=1, init="spectral")
     m.fit(docs, times=periods, content=groups, iters=70,
           period_smooth=2.0, interaction_shrink=1.5)
     return m
@@ -667,7 +667,7 @@ def test_parametric_simulation_resamples_theta():
 # ---------------------------------------------------------------------------
 
 def _tune_fit(docs, times, content, *, content_prior_var, interaction_shrink, period_smooth):
-    m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+    m = topica.ECTM(num_topics=2, seed=1, init="spectral")
     m.fit(docs, times=times, content=content, iters=55,
           content_prior_var=content_prior_var,
           interaction_shrink=interaction_shrink, period_smooth=period_smooth)
@@ -739,7 +739,7 @@ def test_content_prior_l1_runs_and_preserves_topics():
     """The L1 content prior fits, and at a mild penalty still recovers the two
     well-separated topics (sparsity should not destroy topic structure)."""
     docs, groups, times = _two_topic_corpus(40, seed=1)
-    m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+    m = topica.ECTM(num_topics=2, seed=1, init="spectral")
     m.fit(docs, times=times, content=groups, iters=60,
           content_prior="l1", content_prior_var=1.0,
           interaction_shrink=1.5, period_smooth=2.0)
@@ -755,7 +755,7 @@ def test_content_prior_l1_sparsifies_group_contrast():
     docs, groups, times = _two_topic_corpus(40, seed=1)
 
     def fit(prior, cpv):
-        m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+        m = topica.ECTM(num_topics=2, seed=1, init="spectral")
         m.fit(docs, times=times, content=groups, iters=60,
               content_prior=prior, content_prior_var=cpv,
               interaction_shrink=1.5, period_smooth=2.0)
@@ -774,7 +774,7 @@ def test_content_prior_l1_sparsifies_contrast_not_baseline():
     docs, groups, times = _two_topic_corpus(40, seed=1)
 
     def fit(prior, cpv):
-        m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+        m = topica.ECTM(num_topics=2, seed=1, init="spectral")
         m.fit(docs, times=times, content=groups, iters=60,
               content_prior=prior, content_prior_var=cpv,
               interaction_shrink=1.5, period_smooth=2.0)
@@ -800,7 +800,7 @@ def test_content_prior_l2_is_default_and_l1_differs():
     docs, groups, times = _two_topic_corpus(30, seed=2)
 
     def fit(**kw):
-        m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+        m = topica.ECTM(num_topics=2, seed=1, init="spectral")
         m.fit(docs, times=times, content=groups, iters=50,
               interaction_shrink=1.5, period_smooth=2.0, **kw)
         return m
@@ -814,6 +814,6 @@ def test_content_prior_l2_is_default_and_l1_differs():
 
 def test_content_prior_invalid_raises():
     docs, groups, times = _two_topic_corpus(8, seed=0)
-    m = topica.models.ECTM(num_topics=2, seed=1)
+    m = topica.ECTM(num_topics=2, seed=1)
     with pytest.raises(Exception):
         m.fit(docs, times=times, content=groups, iters=10, content_prior="bogus")

--- a/tests/test_ectm.py
+++ b/tests/test_ectm.py
@@ -740,6 +740,35 @@ def test_content_prior_l1_sparsifies_group_contrast():
     assert a_l1 < a_l2
 
 
+def test_content_prior_l1_sparsifies_contrast_not_baseline():
+    """The rework's key property: L1 sparsifies the group/interaction *contrasts*
+    (κG, κGP) but leaves the topic baseline κT on L2, so the topic vocabularies
+    stay as broad as under L2 (sparsifying κT would delete topic words and hurt
+    coherence). Guards against regressing to sparsifying every κ block."""
+    docs, groups, times = _two_topic_corpus(40, seed=1)
+
+    def fit(prior, cpv):
+        m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+        m.fit(docs, times=times, content=groups, iters=60,
+              content_prior=prior, content_prior_var=cpv,
+              interaction_shrink=1.5, period_smooth=2.0)
+        return m
+
+    def baseline_entropy(m):
+        tw = np.asarray(m.topic_word)
+        ent = 0.0
+        for k in range(m.num_topics):
+            p = tw[k] / tw[k].sum()
+            ent += float(-(p * np.log(p + 1e-12)).sum())
+        return ent
+
+    m_l2, m_l1 = fit("l2", 1.0), fit("l1", 0.05)
+    # topic baseline stays at least as broad under L1 (κT not sparsified) ...
+    assert baseline_entropy(m_l1) >= 0.98 * baseline_entropy(m_l2)
+    # ... while the between-group wording contrast is sparser.
+    assert _group_wording_activity(m_l1) < _group_wording_activity(m_l2)
+
+
 def test_content_prior_l2_is_default_and_l1_differs():
     """content_prior defaults to 'l2'; 'l1' changes the fitted content surface."""
     docs, groups, times = _two_topic_corpus(30, seed=2)

--- a/tests/test_ectm.py
+++ b/tests/test_ectm.py
@@ -691,3 +691,74 @@ def test_tune_content_prior_validates_inputs():
         tune_content_prior(_tune_fit, docs, times[:-1], groups,
                            content_prior_var=(1.0,), interaction_shrink=(1.5,),
                            period_smooth=(5.0,))
+
+
+# ---------------------------------------------------------------------------
+# Sparse (L1 / Laplace) content prior (issue #338)
+# ---------------------------------------------------------------------------
+
+def _group_wording_activity(m):
+    """Total between-group L1 wording distance summed over topics and periods —
+    how much the two groups' fitted vocabularies differ overall."""
+    total = 0.0
+    for k in range(m.num_topics):
+        for t in range(m.num_periods):
+            a = np.asarray(m.content_word_dist("A", t))[k]
+            b = np.asarray(m.content_word_dist("B", t))[k]
+            total += np.abs(a - b).sum()
+    return total
+
+
+def test_content_prior_l1_runs_and_preserves_topics():
+    """The L1 content prior fits, and at a mild penalty still recovers the two
+    well-separated topics (sparsity should not destroy topic structure)."""
+    docs, groups, times = _two_topic_corpus(40, seed=1)
+    m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+    m.fit(docs, times=times, content=groups, iters=60,
+          content_prior="l1", content_prior_var=1.0,
+          interaction_shrink=1.5, period_smooth=2.0)
+    # each topic's top words come from one of the two disjoint vocabularies
+    for k in range(2):
+        top = set(w for w, _ in m.top_words(4, topic=k))
+        assert top <= set(_T0_WORDS) or top <= set(_T1_WORDS), top
+
+
+def test_content_prior_l1_sparsifies_group_contrast():
+    """A stronger L1 penalty (smaller content_prior_var ⇒ larger 1/σ² rate)
+    shrinks the total between-group wording relative to the L2 default."""
+    docs, groups, times = _two_topic_corpus(40, seed=1)
+
+    def fit(prior, cpv):
+        m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+        m.fit(docs, times=times, content=groups, iters=60,
+              content_prior=prior, content_prior_var=cpv,
+              interaction_shrink=1.5, period_smooth=2.0)
+        return m
+
+    a_l2 = _group_wording_activity(fit("l2", 1.0))
+    a_l1 = _group_wording_activity(fit("l1", 0.02))
+    assert a_l1 < a_l2
+
+
+def test_content_prior_l2_is_default_and_l1_differs():
+    """content_prior defaults to 'l2'; 'l1' changes the fitted content surface."""
+    docs, groups, times = _two_topic_corpus(30, seed=2)
+
+    def fit(**kw):
+        m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+        m.fit(docs, times=times, content=groups, iters=50,
+              interaction_shrink=1.5, period_smooth=2.0, **kw)
+        return m
+
+    default = _group_wording_activity(fit())
+    explicit_l2 = _group_wording_activity(fit(content_prior="l2"))
+    l1 = _group_wording_activity(fit(content_prior="l1", content_prior_var=0.05))
+    assert default == explicit_l2       # default is l2, bit-exact
+    assert l1 != default                # l1 changes the fit
+
+
+def test_content_prior_invalid_raises():
+    docs, groups, times = _two_topic_corpus(8, seed=0)
+    m = topica.models.ECTM(num_topics=2, seed=1)
+    with pytest.raises(Exception):
+        m.fit(docs, times=times, content=groups, iters=10, content_prior="bogus")

--- a/tests/test_ectm.py
+++ b/tests/test_ectm.py
@@ -634,3 +634,60 @@ def test_content_trajectory_ci_bad_method():
         content_trajectory_ci(_fit_two_topic, docs, groups, times,
                               anchor_words=["alpha"], word="gamma",
                               contrast=("A", "B"), method="nope", n_boot=2)
+
+
+# ---------------------------------------------------------------------------
+# Content-prior hyperparameter selection (issue #339)
+# ---------------------------------------------------------------------------
+
+def _tune_fit(docs, times, content, *, content_prior_var, interaction_shrink, period_smooth):
+    m = topica.models.ECTM(num_topics=2, seed=1, init="spectral")
+    m.fit(docs, times=times, content=content, iters=55,
+          content_prior_var=content_prior_var,
+          interaction_shrink=interaction_shrink, period_smooth=period_smooth)
+    return m
+
+
+def test_tune_content_prior_selects_and_reports():
+    """Grid-search returns a best combo drawn from the grid, a complete table
+    sorted best-first, and rejects a pathologically tight content prior."""
+    from topica.ectm import tune_content_prior
+
+    docs, groups, times = _two_topic_corpus(30, seed=1)
+    sel = tune_content_prior(
+        _tune_fit, docs, times, groups,
+        content_prior_var=(0.05, 1.0, 5.0), interaction_shrink=(1.5,),
+        period_smooth=(5.0,), seed=0)
+
+    assert len(sel.table) == 3  # 3 x 1 x 1 grid
+    scores = [r["heldout_loglik"] for r in sel.table]
+    assert scores == sorted(scores, reverse=True)  # sorted best-first
+    assert sel.best_score == scores[0]
+    assert sel.best["content_prior_var"] in (0.05, 1.0, 5.0)
+    assert sel.n_docs > 0 and sel.n_tokens > 0
+    # the tightest prior (0.05) should not win — it over-shrinks the content
+    assert sel.best["content_prior_var"] != 0.05
+
+
+def test_tune_content_prior_reproducible():
+    """A fixed held-out seed makes the selection reproducible (the #339 point:
+    no hand-tuning, same answer every run)."""
+    from topica.ectm import tune_content_prior
+
+    docs, groups, times = _two_topic_corpus(30, seed=2)
+    kw = dict(content_prior_var=(0.5, 2.0), interaction_shrink=(1.5,),
+              period_smooth=(5.0,), seed=0)
+    a = tune_content_prior(_tune_fit, docs, times, groups, **kw)
+    b = tune_content_prior(_tune_fit, docs, times, groups, **kw)
+    assert a.best == b.best
+    assert a.best_score == b.best_score
+
+
+def test_tune_content_prior_validates_inputs():
+    from topica.ectm import tune_content_prior
+
+    docs, groups, times = _two_topic_corpus(10, seed=0)
+    with pytest.raises(ValueError):
+        tune_content_prior(_tune_fit, docs, times[:-1], groups,
+                           content_prior_var=(1.0,), interaction_shrink=(1.5,),
+                           period_smooth=(5.0,))


### PR DESCRIPTION
> Supersedes #341, which GitHub auto-closed when its base branch `feat/content-priors` (PR #347) was squash-merged and deleted. Same commits, rebased cleanly onto `main`; no content change.

Implements the full ECTM statistical-hardening set from the pre-submission peer review. #337/#339/#340 are Python-only (`topica.ectm`); #338 touches the Rust content M-step. All ECTM tests pass (Rust + 42 Python).

## #337 — debiased content-divergence estimand
`content_divergence_debiased(...)` replaces the ad hoc null-subtraction with a single-fit, θ-weighted split-sample estimator that has a defined population target and converges to the true TV as documents per cell grow. (The issue's literal two-refit construction is unsound for ECTM — details in #337.)

## #340 — parametric-bootstrap CIs
`content_trajectory_ci(..., method="parametric")` draws synthetic corpora from the fitted DGP and refits, giving a divergence interval with a well-defined target and checkable coverage for thin one-observation-per-cell designs. Default cluster bootstrap unchanged.

## #339 — held-out selection of content-prior hyperparameters
`tune_content_prior(...)` grid-searches `content_prior_var` / `interaction_shrink` / `period_smooth` by a within-corpus word-heldout log-likelihood, so the fit is reproducible without hand-tuning. (Uses an ECTM-native predictive score — `eval_heldout` can't score ECTM; details in #339.)

## #338 — sparsity-inducing L1 content prior
`ECTM.fit(..., content_prior="l1")` swaps the Gaussian ridge on the **group/interaction contrast blocks (κG, κGP)** for a Laplace prior, solved by FISTA (exact zeros). The topic baseline κT and topic×time drift κP stay on L2 so topic vocabularies remain coherent. Default `"l2"` is bit-exact with before.

**Empirically validated on poliblog** (real corpus): a first version that sparsified *every* κ block (including κT) made topics markedly less coherent (UMass −41.8 → −46.6) and was 11.5× slower — it failed the issue's bar. The reworked contrast-only version lifts FREX exclusivity (+0.25) and sharpens group contrasts (19.8 → 14.0) at negligible coherence cost (−0.97) and 3.6× time. Honest caveat: it **preserves** coherence rather than improving it above LDA — mild penalties are the useful regime; strong ones trade coherence away. The ARD/spike-and-slab variant the issue also floats is left as follow-up.

## Testing
The existing `_corpus` fixture has identical documents per cell and can't exercise sampling noise, so the new tests add generative synthetic corpora (real multinomial sampling; a two-topic corpus with planted group-by-time drift). Real-corpus (poliblog) validations for #337/#339/#340 are in progress and will be summarized in the issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0123S255tEvRkaejahoMbo6x