### PR TITLE
feat(mcmc): multi-chain R-hat / ESS for the Gibbs models

### DIFF
--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -114,6 +114,17 @@ of the diagnostics guide.
 
 ::: topica.autocorrelation
 
+Multi-chain Gelman-Rubin R-hat and cross-chain ESS, from several fits of the same
+model at different seeds. See the
+[R-hat section](../guides/diagnostics.md#do-independent-chains-agree-r-hat) of the
+diagnostics guide.
+
+::: topica.multichain_diagnostics
+
+::: topica.MultiChainDiagnostics
+
+::: topica.rhat
+
 ## Held-out likelihood
 
 Build a within-corpus word-heldout set — the analogue of R `stm`'s

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -381,11 +381,52 @@ The underlying estimators are also exposed directly for any trace you hold —
 initial-positive-sequence `tau`), and `topica.effective_sample_size` (`N / tau`,
 for one chain or columnwise over a `(draws, params)` matrix).
 
-Multi-chain R-hat (Gelman-Rubin), which needs several seeds run and compared, is
-not yet exposed ([issue #269](https://github.com/nealcaren/topica/issues/269));
-these single-chain diagnostics are the cheap first cut. The variational models
-(STM, CTM, …) converge a bound and have no MCMC chain — `mcmc_diagnostics` warns
-if you point it at one.
+The variational models (STM, CTM, …) converge a bound and have no MCMC chain —
+`mcmc_diagnostics` warns if you point it at one.
+
+### Do independent chains agree? (R-hat)
+
+A single chain can plateau, look well-mixed, and still have settled into a mode
+the sampler happened to reach from its seed. The Gelman-Rubin R-hat answers the
+question one chain cannot: fit the same model at several seeds and check whether
+the chains converged to a *common* distribution. R-hat compares the variance
+between chains to the variance within each — near 1 they agree, above ~1.01 they
+have not mixed.
+
+```python
+chains = []
+for seed in (1, 2, 3, 4):
+    m = topica.LDA(num_topics=20, seed=seed)
+    m.fit(docs, iters=2000, num_theta_draws=200)
+    chains.append(m)
+
+d = topica.multichain_diagnostics(chains)
+print(d.summary())
+# Multi-chain diagnostics for LDA (4 chains, inference=gibbs)
+#   log-likelihood R-hat    : 1.008 (ESS 640, n=1000)
+#   topic-prevalence R-hat  : max 1.021 / median 1.004 over 20 aligned topics
+#   topic alignment (Jaccard): min 0.71 (low -> that topic's R-hat is not comparable)
+#   -> chains mixed
+
+d.loglik_rhat        # R-hat of the log-likelihood trace (permutation-invariant)
+d.topic_rhat         # (num_topics,) per-topic R-hat of aligned topic prevalence
+d.topic_alignment    # (num_topics,) how well each topic matched across chains
+d.converged          # every reported R-hat <= 1.01
+```
+
+Two views are reported. The **log-likelihood R-hat** is the headline: the
+log-likelihood is permutation-invariant, so it compares chains directly with no
+alignment. The **per-topic R-hat** is finer but needs care — topic 3 in one chain
+need not be topic 3 in another, so `multichain_diagnostics` first aligns the
+topics across chains (a Hungarian match on the topic-word matrix, the same
+machinery [`align_topics`](../api/diagnostics.md#topica.align_topics) uses) and then compares each
+aligned topic's per-draw prevalence. Read `topic_rhat` next to `topic_alignment`:
+a topic with a low alignment Jaccard did not line up across chains, so its R-hat
+is comparing different topics and means nothing.
+
+The R-hat estimator itself — rank-normalized split-R-hat (Vehtari et al. 2021) —
+is exposed directly as `topica.rhat(chains)` for any set of chains you hold, in
+the same spirit as the single-chain primitives above.
 
 ## Visualization
 

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -199,6 +199,9 @@ from .mcmc import (  # noqa: E402
     autocorrelation,
     integrated_autocorr_time,
     McmcDiagnostics,
+    rhat,
+    multichain_diagnostics,
+    MultiChainDiagnostics,
 )
 from .registry import list_models, ModelInfo, REGISTRY  # noqa: E402  model taxonomy / discovery
 
@@ -437,6 +440,9 @@ __all__ = [
     "autocorrelation",
     "integrated_autocorr_time",
     "McmcDiagnostics",
+    "rhat",
+    "multichain_diagnostics",
+    "MultiChainDiagnostics",
     "perplexity",
     "make_heldout",
     "eval_heldout",

--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -41,6 +41,9 @@ from .mcmc import (
     autocorrelation as autocorrelation,
     integrated_autocorr_time as integrated_autocorr_time,
     McmcDiagnostics as McmcDiagnostics,
+    rhat as rhat,
+    multichain_diagnostics as multichain_diagnostics,
+    MultiChainDiagnostics as MultiChainDiagnostics,
 )
 from .effects import (
     estimate_effect as estimate_effect,

--- a/python/topica/mcmc.py
+++ b/python/topica/mcmc.py
@@ -16,9 +16,23 @@ the thinned ``theta_draws``.
 - :func:`mcmc_diagnostics` -- read the log-likelihood trace and ``theta_draws``
   off a fitted Gibbs model and summarize both.
 
-Single-chain autocorrelation and ESS are the cheap diagnostics that land here.
-Multi-chain R-hat (Gelman-Rubin) needs a multi-chain runner and is tracked
-separately (issue #269).
+Run the same model at several seeds and the multi-chain diagnostics compare the
+chains against each other -- the question a single chain cannot answer:
+
+- :func:`rhat` -- the rank-normalized split-R-hat (Gelman-Rubin, in the improved
+  form of Vehtari et al. 2021) for a set of chains. ``R-hat`` near 1 means the
+  chains agree; a value above ~1.01 means they have not converged to a common
+  distribution.
+- :func:`multichain_diagnostics` -- take several fitted Gibbs models (same corpus,
+  different seeds) and report R-hat and multi-chain ESS on the permutation-invariant
+  log-likelihood trace, plus per-topic R-hat on each topic's prevalence after the
+  topics are aligned across chains (Hungarian match on the topic-word matrix).
+
+.. note::
+   Topic indices are label-switched across seeds -- topic 3 in one chain need not
+   be topic 3 in another -- so :func:`multichain_diagnostics` aligns the topics
+   before comparing them. The alignment quality is reported per topic; a topic
+   that did not align well makes its R-hat meaningless, so read the two together.
 
 .. note::
    ``theta_draws`` are *thinned* MCMC draws (``num_theta_draws`` samples spaced
@@ -275,3 +289,464 @@ def mcmc_diagnostics(model, *, warn: bool = True) -> McmcDiagnostics:
         loglik_ess=ll_ess,
         theta_ess=theta_ess,
     )
+
+
+# ---------------------------------------------------------------------------
+# Multi-chain diagnostics: R-hat (Gelman-Rubin) and cross-chain ESS.
+# ---------------------------------------------------------------------------
+
+
+def _ndtri(p: np.ndarray) -> np.ndarray:
+    """Inverse of the standard-normal CDF (probit), Acklam's rational approximation.
+
+    Pure numpy so the R-hat primitive carries no SciPy dependency. Accurate to
+    ~1e-9 on ``(0, 1)``; the boundaries map to +-inf. Used only for the
+    rank-normalization of R-hat, where inputs sit safely inside the open interval.
+    """
+    p = np.asarray(p, dtype=float)
+    a = [-3.969683028665376e01, 2.209460984245205e02, -2.759285104469687e02,
+         1.383577518672690e02, -3.066479806614716e01, 2.506628277459239e00]
+    b = [-5.447609879822406e01, 1.615858368580409e02, -1.556989798598866e02,
+         6.680131188771972e01, -1.328068155288572e01]
+    c = [-7.784894002430293e-03, -3.223964580411365e-01, -2.400758277161838e00,
+         -2.549732539343734e00, 4.374664141464968e00, 2.938163982698783e00]
+    d = [7.784695709041462e-03, 3.224671290700398e-01, 2.445134137142996e00,
+         3.754408661907416e00]
+    out = np.empty_like(p)
+    lo, hi = 0.02425, 1.0 - 0.02425
+    lower = p < lo
+    upper = p > hi
+    middle = ~(lower | upper)
+    # lower tail
+    if np.any(lower):
+        q = np.sqrt(-2.0 * np.log(p[lower]))
+        out[lower] = (((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / \
+            ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0)
+    # upper tail
+    if np.any(upper):
+        q = np.sqrt(-2.0 * np.log(1.0 - p[upper]))
+        out[upper] = -(((((c[0] * q + c[1]) * q + c[2]) * q + c[3]) * q + c[4]) * q + c[5]) / \
+            ((((d[0] * q + d[1]) * q + d[2]) * q + d[3]) * q + 1.0)
+    # central region
+    if np.any(middle):
+        q = p[middle] - 0.5
+        r = q * q
+        out[middle] = (((((a[0] * r + a[1]) * r + a[2]) * r + a[3]) * r + a[4]) * r + a[5]) * q / \
+            (((((b[0] * r + b[1]) * r + b[2]) * r + b[3]) * r + b[4]) * r + 1.0)
+    return out
+
+
+def _rankdata_average(a: np.ndarray) -> np.ndarray:
+    """Ranks of a 1-D array with ties averaged (SciPy's ``rankdata`` default)."""
+    a = np.asarray(a, dtype=float).ravel()
+    n = a.size
+    sorter = np.argsort(a, kind="mergesort")
+    inv = np.empty(n, dtype=int)
+    inv[sorter] = np.arange(n)
+    a_sorted = a[sorter]
+    obs = np.concatenate(([True], a_sorted[1:] != a_sorted[:-1]))
+    dense = np.cumsum(obs)[inv]
+    # positions where each distinct value's run starts (plus the end sentinel)
+    starts = np.concatenate((np.nonzero(obs)[0], [n]))
+    return 0.5 * (starts[dense] + starts[dense - 1] + 1)
+
+
+def _as_chain_matrix(chains) -> np.ndarray:
+    """Coerce chains to a ``(n_chains, n_draws)`` float matrix.
+
+    Accepts a 2-D array or a sequence of 1-D chains; unequal-length chains are
+    truncated to the shortest so every chain contributes the same number of draws.
+    """
+    if isinstance(chains, np.ndarray) and chains.ndim == 2:
+        return np.asarray(chains, dtype=float)
+    rows = [np.asarray(c, dtype=float).ravel() for c in chains]
+    if not rows:
+        raise ValueError("no chains supplied")
+    n = min(r.size for r in rows)
+    return np.array([r[:n] for r in rows], dtype=float)
+
+
+def _split_chains(chains: np.ndarray) -> np.ndarray:
+    """Split each chain into two non-overlapping halves (split-R-hat).
+
+    Splitting turns ``m`` chains of length ``n`` into ``2m`` chains of length
+    ``n // 2``, which lets R-hat detect within-chain non-stationarity (a chain
+    still drifting looks like two disagreeing half-chains). Chains too short to
+    split are returned unchanged.
+    """
+    m, n = chains.shape
+    half = n // 2
+    if half < 2:
+        return chains
+    return np.concatenate((chains[:, :half], chains[:, n - half:]), axis=0)
+
+
+def _rank_normalize(chains: np.ndarray) -> np.ndarray:
+    """Rank-normalize pooled draws to standard-normal scores (Vehtari 2021).
+
+    Pooling all draws, ranking, and mapping the ranks through the normal quantile
+    makes R-hat robust to heavy tails and non-normality -- the improvement over
+    the classical Gelman-Rubin statistic.
+    """
+    shape = chains.shape
+    ranks = _rankdata_average(chains.ravel())
+    total = ranks.size
+    quantile = (ranks - 0.375) / (total + 0.25)
+    return _ndtri(quantile).reshape(shape)
+
+
+def _classic_rhat(chains: np.ndarray) -> float:
+    """Gelman-Rubin potential scale reduction on ``(m, n)`` chains (no splitting)."""
+    m, n = chains.shape
+    if n < 2:
+        return float("nan")
+    chain_means = chains.mean(axis=1)
+    within = chains.var(axis=1, ddof=1).mean()          # W
+    if within <= 0:
+        # every chain is constant: converged iff they share the same constant
+        return 1.0 if np.ptp(chain_means) == 0 else float("inf")
+    between = n * chain_means.var(ddof=1)               # B
+    var_plus = (n - 1) / n * within + between / n
+    return float(np.sqrt(var_plus / within))
+
+
+def rhat(chains, *, split: bool = True, rank_normalize: bool = True) -> float:
+    """Gelman-Rubin R-hat (potential scale reduction) across MCMC chains.
+
+    Compares the variance *between* chains to the variance *within* each chain.
+    At convergence the chains are draws from one distribution and ``R-hat`` -> 1;
+    a value above roughly ``1.01`` means the chains have not mixed to a common
+    target and the run needs more sweeps (Vehtari et al. 2021).
+
+    Parameters
+    ----------
+    chains : 2-D array or sequence of 1-D chains
+        ``(n_chains, n_draws)``, or a list of per-chain traces. Unequal-length
+        chains are truncated to the shortest. At least two chains are required.
+    split : bool, default True
+        Split each chain in half before comparing (split-R-hat), so a single
+        chain that has not stopped drifting is caught as two disagreeing halves.
+    rank_normalize : bool, default True
+        Rank-normalize the pooled draws first (the improved, tail-robust R-hat).
+        Set ``False`` for the classical Gelman-Rubin statistic on the raw scale.
+
+    Returns
+    -------
+    float
+        The R-hat statistic. ``inf`` if the chains are constant but disagree;
+        ``1.0`` if they share a single constant value.
+    """
+    mat = _as_chain_matrix(chains)
+    if mat.shape[0] < 2:
+        raise ValueError("R-hat needs at least two chains")
+    work = _split_chains(mat) if split else mat
+    if rank_normalize:
+        work = _rank_normalize(work)
+    return _classic_rhat(work)
+
+
+def _multichain_ess(chains: np.ndarray) -> float:
+    """Cross-chain effective sample size on ``(m, n)`` chains (Vehtari 2021).
+
+    Combines the within- and between-chain autocorrelation into a single ESS for
+    the pooled draws, using Geyer's initial-monotone-sequence truncation. Mirrors
+    the ``posterior`` package's bulk-ESS on already rank-normalized, split chains.
+    """
+    m, n = chains.shape
+    if n < 4 or m < 1:
+        return float("nan")
+    chain_means = chains.mean(axis=1)
+    # unbiased within-chain variance and the combined variance estimate var_plus
+    within = chains.var(axis=1, ddof=1).mean()
+    if within <= 0:
+        return float("nan")
+    between = chain_means.var(ddof=1) if m > 1 else 0.0
+    var_plus = (n - 1) / n * within + between
+    # mean over chains of each chain's (biased, /n) autocovariance
+    acov = np.mean([_autocovariance(chains[i]) for i in range(m)], axis=0)
+    # rescale the biased /n autocovariance to the /(n-1) within-chain variance
+    rho = 1.0 - (within - acov * n / (n - 1)) / var_plus
+    rho[0] = 1.0
+    # Geyer initial-monotone-sequence: sum positive, non-increasing paired sums
+    tau = 1.0
+    prev_pair = np.inf
+    for t in range(1, n - 1, 2):
+        pair = rho[t] + rho[t + 1]
+        if pair <= 0:
+            break
+        pair = min(pair, prev_pair)      # enforce monotone non-increasing
+        tau += 2.0 * pair
+        prev_pair = pair
+    tau = max(tau, 1.0)
+    return float(m * n / tau)
+
+
+@dataclass
+class MultiChainDiagnostics:
+    """Multi-chain (Gelman-Rubin) diagnostics for a set of fitted Gibbs models.
+
+    Attributes
+    ----------
+    model : str
+        The model class name (all chains must share it).
+    inference : str or None
+        The model's inference engine from the registry.
+    n_chains : int
+        Number of chains compared.
+    n_draws : int
+        Retained ``theta_draws`` per chain used for the topic-level statistics.
+    loglik_rhat : float or None
+        R-hat of the (post-warmup) log-likelihood trace across chains -- the
+        permutation-invariant "did the chains agree?" headline. ``None`` when the
+        chains recorded no usable log-likelihood trace.
+    loglik_ess : float or None
+        Cross-chain effective sample size of the log-likelihood trace.
+    loglik_n : int or None
+        Post-warmup trace length per chain used for the log-likelihood statistics.
+    topic_rhat : numpy.ndarray or None
+        Per-topic R-hat of each aligned topic's per-draw prevalence, shape
+        ``(num_topics,)``. ``None`` when the chains retained no ``theta_draws``.
+    topic_ess : numpy.ndarray or None
+        Per-topic cross-chain ESS of the aligned topic prevalence.
+    topic_alignment : numpy.ndarray or None
+        Per-topic alignment quality: the minimum top-word Jaccard of the topic to
+        its reference-chain match across the other chains. Low values flag topics
+        whose R-hat compares topics that did not line up.
+    reference : int or None
+        Index of the chain used as the alignment reference.
+    """
+
+    model: str
+    inference: str | None
+    n_chains: int
+    n_draws: int
+    loglik_rhat: float | None
+    loglik_ess: float | None
+    loglik_n: int | None
+    topic_rhat: np.ndarray | None
+    topic_ess: np.ndarray | None
+    topic_alignment: np.ndarray | None
+    reference: int | None
+
+    @property
+    def topic_rhat_max(self) -> float | None:
+        return None if self.topic_rhat is None else float(np.max(self.topic_rhat))
+
+    @property
+    def topic_rhat_median(self) -> float | None:
+        return None if self.topic_rhat is None else float(np.median(self.topic_rhat))
+
+    @property
+    def converged(self) -> bool:
+        """Whether every reported R-hat clears the conventional 1.01 threshold."""
+        rhats = []
+        if self.loglik_rhat is not None:
+            rhats.append(self.loglik_rhat)
+        if self.topic_rhat is not None:
+            rhats.append(float(np.max(self.topic_rhat)))
+        return bool(rhats) and all(r <= 1.01 for r in rhats)
+
+    def summary(self) -> str:
+        """A short human-readable table of the multi-chain diagnostics."""
+        lines = [
+            f"Multi-chain diagnostics for {self.model} "
+            f"({self.n_chains} chains, inference={self.inference})",
+        ]
+        if self.loglik_rhat is not None:
+            ess = "n/a" if self.loglik_ess is None else f"{self.loglik_ess:.0f}"
+            lines.append(
+                f"  log-likelihood R-hat    : {self.loglik_rhat:.3f} "
+                f"(ESS {ess}, n={self.loglik_n})"
+            )
+        else:
+            lines.append("  log-likelihood trace    : none recorded")
+        if self.topic_rhat is not None:
+            lines.append(
+                f"  topic-prevalence R-hat  : max {self.topic_rhat_max:.3f} / "
+                f"median {self.topic_rhat_median:.3f} over {self.topic_rhat.size} "
+                f"aligned topics"
+            )
+            worst_align = float(np.min(self.topic_alignment))
+            lines.append(
+                f"  topic alignment (Jaccard): min {worst_align:.2f} "
+                f"(low -> that topic's R-hat is not comparable)"
+            )
+        else:
+            lines.append("  topic-prevalence R-hat  : no theta_draws retained")
+        verdict = "chains mixed" if self.converged else "not converged (R-hat > 1.01)"
+        lines.append(f"  -> {verdict}")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return self.summary()
+
+
+def _loglik_values(model) -> np.ndarray | None:
+    hist = getattr(model, "log_likelihood_history", None)
+    if not hist:
+        hist = getattr(model, "fit_history", None)
+    if not hist:
+        return None
+    return np.array([float(v) for _, v in hist], dtype=float)
+
+
+def multichain_diagnostics(
+    chains,
+    *,
+    warmup: float = 0.5,
+    metric: str = "cosine",
+    reference: int = 0,
+    warn: bool = True,
+) -> MultiChainDiagnostics:
+    """Gelman-Rubin diagnostics across several fitted Gibbs models.
+
+    Fit the same model at several seeds on the same corpus, pass the fitted
+    models here, and this reports whether the chains agree. Two views are
+    computed: R-hat and cross-chain ESS on the permutation-invariant
+    log-likelihood trace, and per-topic R-hat on each topic's prevalence after
+    the topics are aligned across chains (topic indices are label-switched across
+    seeds, so alignment comes first).
+
+    Parameters
+    ----------
+    chains : sequence of fitted topica models
+        At least two fits of the *same* model class on the *same* corpus at
+        different seeds. The topic-level statistics need ``theta_draws`` on every
+        chain (fit with ``keep_theta_draws=True``, the default).
+    warmup : float, default 0.5
+        Fraction of each log-likelihood trace to discard from the front as
+        burn-in before computing R-hat. The ``theta_draws`` are already the last
+        post-warmup thinned samples, so the warmup fraction applies to the
+        log-likelihood trace only.
+    metric : str, default "cosine"
+        Topic-word distance metric for the cross-chain alignment (passed to
+        :func:`topica.align_topics`).
+    reference : int, default 0
+        Index of the chain whose topic order the others are aligned to.
+    warn : bool, default True
+        Warn when the chains are not Gibbs samplers, disagree on class, or lack
+        the traces a statistic needs.
+
+    Returns
+    -------
+    MultiChainDiagnostics
+
+    Raises
+    ------
+    ValueError
+        If fewer than two chains are supplied.
+    """
+    chains = list(chains)
+    if len(chains) < 2:
+        raise ValueError(
+            "multichain_diagnostics needs at least two chains "
+            "(the same model fit at different seeds)."
+        )
+    names = {type(m).__name__ for m in chains}
+    name = type(chains[0]).__name__
+    if warn and len(names) > 1:
+        warnings.warn(
+            f"chains are not all the same model class ({sorted(names)}); "
+            "R-hat compares them as if they share a target distribution.",
+            stacklevel=2,
+        )
+    info = REGISTRY.get(name)
+    inference = info.inference if info is not None else None
+    if warn and inference is not None and inference != "gibbs":
+        warnings.warn(
+            f"{name} uses {inference!r} inference, not Gibbs sampling; multi-chain "
+            "R-hat is a diagnostic for MCMC samplers.",
+            stacklevel=2,
+        )
+    if not 0 <= reference < len(chains):
+        raise ValueError(f"reference index {reference} out of range for {len(chains)} chains")
+    if not 0.0 <= warmup < 1.0:
+        raise ValueError("warmup must be in [0, 1)")
+
+    # --- log-likelihood R-hat (permutation-invariant) --------------------
+    ll_rhat = ll_ess = ll_n = None
+    ll_traces = [_loglik_values(m) for m in chains]
+    if all(t is not None and t.size >= 4 for t in ll_traces):
+        common = min(t.size for t in ll_traces)
+        start = int(common * warmup)
+        post = np.array([t[start:common] for t in ll_traces], dtype=float)
+        if post.shape[1] >= 4:
+            ll_rhat = rhat(post)
+            ll_ess = _multichain_ess(_rank_normalize(_split_chains(post)))
+            ll_n = int(post.shape[1])
+    elif warn:
+        warnings.warn(
+            "not every chain recorded a usable log-likelihood trace; skipping the "
+            "log-likelihood R-hat. Fit with check_every > 0 to record one.",
+            stacklevel=2,
+        )
+
+    # --- per-topic R-hat on aligned topic prevalence ---------------------
+    topic_rhat = topic_ess = topic_alignment = None
+    ref_idx = reference
+    draws = [getattr(m, "theta_draws", None) for m in chains]
+    if all(d is not None for d in draws):
+        from .validation import align_topics
+
+        arrs = [np.asarray(d, dtype=float) for d in draws]  # (n_draws, n_docs, K)
+        n_draws = min(a.shape[0] for a in arrs)
+        K = arrs[ref_idx].shape[2]
+        ref_model = chains[ref_idx]
+        # prevalence trace per (chain, topic): mean over docs of each draw's theta
+        prevalence = np.empty((len(chains), K, n_draws), dtype=float)
+        alignment = np.ones((len(chains), K), dtype=float)
+        ref_sets = _topic_word_sets(ref_model)
+        for c, model in enumerate(chains):
+            if c == ref_idx:
+                perm = list(range(K))
+            else:
+                pairs = align_topics(ref_model, model, metric=metric)
+                perm = list(range(K))
+                for i, j, _ in pairs:
+                    perm[i] = j
+                alignment[c] = _alignment_jaccard(ref_sets, _topic_word_sets(model), perm)
+            aligned = arrs[c][:n_draws][:, :, perm]         # (n_draws, n_docs, K)
+            prevalence[c] = aligned.mean(axis=1).T          # (K, n_draws)
+        topic_rhat = np.array([rhat(prevalence[:, k, :]) for k in range(K)])
+        topic_ess = np.array([
+            _multichain_ess(_rank_normalize(_split_chains(prevalence[:, k, :])))
+            for k in range(K)
+        ])
+        topic_alignment = alignment.min(axis=0)
+    elif warn:
+        warnings.warn(
+            f"{name} chains retained no theta_draws; skipping per-topic R-hat. "
+            "Refit with keep_theta_draws=True.",
+            stacklevel=2,
+        )
+
+    n_draws_reported = 0 if topic_rhat is None else int(min(a.shape[0] for a in arrs))
+    return MultiChainDiagnostics(
+        model=name,
+        inference=inference,
+        n_chains=len(chains),
+        n_draws=n_draws_reported,
+        loglik_rhat=ll_rhat,
+        loglik_ess=ll_ess,
+        loglik_n=ll_n,
+        topic_rhat=topic_rhat,
+        topic_ess=topic_ess,
+        topic_alignment=topic_alignment,
+        reference=ref_idx if topic_rhat is not None else None,
+    )
+
+
+def _topic_word_sets(model, topn: int = 10):
+    """Per-topic set of top-``topn`` term indices from a model's topic-word matrix."""
+    beta = np.asarray(model.topic_word, dtype=float)
+    return [set(np.argsort(beta[t])[::-1][:topn].tolist()) for t in range(beta.shape[0])]
+
+
+def _alignment_jaccard(ref_sets, other_sets, perm) -> np.ndarray:
+    """Top-word Jaccard of each reference topic to its matched topic under ``perm``."""
+    out = np.zeros(len(ref_sets))
+    for i, rs in enumerate(ref_sets):
+        os = other_sets[perm[i]]
+        union = rs | os
+        out[i] = (len(rs & os) / len(union)) if union else 0.0
+    return out

--- a/tests/test_mcmc.py
+++ b/tests/test_mcmc.py
@@ -148,3 +148,131 @@ def test_mcmc_diagnostics_warn_false_is_silent(fitted_lda):
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # any warning would fail the test
         topica.mcmc_diagnostics(fitted_lda, warn=False)
+
+
+# ---------------------------------------------------------------------------
+# Multi-chain diagnostics: R-hat (Gelman-Rubin) and cross-chain ESS.
+# ---------------------------------------------------------------------------
+
+
+def test_rhat_of_well_mixed_chains_is_near_one():
+    rng = np.random.default_rng(10)
+    chains = rng.standard_normal((4, 4000))
+    assert topica.rhat(chains) == pytest.approx(1.0, abs=0.01)
+
+
+def test_rhat_flags_chains_that_disagree():
+    rng = np.random.default_rng(11)
+    # four chains centered far apart never mixed to a common target
+    chains = rng.standard_normal((4, 4000)) + np.array([[0.0], [5.0], [10.0], [15.0]])
+    assert topica.rhat(chains) > 1.2
+
+
+def test_rhat_of_identical_constant_chains_is_one():
+    assert topica.rhat(np.ones((3, 200))) == pytest.approx(1.0)
+
+
+def test_rhat_split_detects_within_chain_drift():
+    # two chains, each a slow linear ramp: no between-chain spread but each half
+    # disagrees with the other, which split-R-hat is designed to catch.
+    ramp = np.linspace(0.0, 10.0, 2000)
+    chains = np.vstack([ramp, ramp])
+    assert topica.rhat(chains, split=True) > 1.1
+    # without splitting the drift is invisible (chain means are identical)
+    assert topica.rhat(chains, split=False) == pytest.approx(1.0, abs=0.05)
+
+
+def test_rhat_accepts_unequal_length_chains():
+    rng = np.random.default_rng(12)
+    a = rng.standard_normal(3000)
+    b = rng.standard_normal(2000)
+    r = topica.rhat([a, b])  # truncated to the shorter
+    assert r == pytest.approx(1.0, abs=0.03)
+
+
+def test_rhat_requires_two_chains():
+    with pytest.raises(ValueError, match="two chains"):
+        topica.rhat(np.zeros((1, 100)))
+
+
+def test_ndtri_matches_scipy_when_available():
+    scipy_stats = pytest.importorskip("scipy.stats")
+    from topica.mcmc import _ndtri
+
+    p = np.array([1e-4, 0.01, 0.2, 0.5, 0.8, 0.99, 0.9999])
+    assert np.allclose(_ndtri(p), scipy_stats.norm.ppf(p), atol=1e-6)
+
+
+@pytest.fixture(scope="module")
+def lda_chains():
+    rng = np.random.default_rng(0)
+    vocabs = [
+        ["cat", "dog", "pet", "fur", "paw"],
+        ["stock", "bond", "market", "trade", "bank"],
+        ["star", "planet", "orbit", "moon", "galaxy"],
+    ]
+    docs = []
+    for _ in range(120):
+        topic = rng.integers(0, 3)
+        docs.append(list(rng.choice(vocabs[topic], size=25)))
+    corpus = topica.Corpus.from_documents(docs)
+    chains = []
+    for seed in (1, 2, 3, 4):
+        model = LDA(num_topics=3, seed=seed)
+        model.fit(corpus, iters=400, num_theta_draws=80)
+        chains.append(model)
+    return chains
+
+
+def test_multichain_diagnostics_on_lda(lda_chains):
+    d = topica.multichain_diagnostics(lda_chains)
+    assert d.model == "LDA"
+    assert d.inference == "gibbs"
+    assert d.n_chains == 4
+    # log-likelihood R-hat is computed on the permutation-invariant trace
+    assert d.loglik_rhat is not None and d.loglik_rhat >= 1.0
+    assert d.loglik_ess is not None
+    # per-topic R-hat over the three aligned topics
+    assert d.topic_rhat.shape == (3,)
+    assert d.topic_ess.shape == (3,)
+    assert d.topic_alignment.shape == (3,)
+    # a clean three-topic corpus aligns its topics across seeds
+    assert d.topic_alignment.min() > 0.5
+    assert "LDA" in d.summary()
+    assert isinstance(d.converged, bool)
+
+
+def test_multichain_diagnostics_requires_two_chains(lda_chains):
+    with pytest.raises(ValueError, match="two chains"):
+        topica.multichain_diagnostics(lda_chains[:1])
+
+
+def test_multichain_diagnostics_without_theta_draws_warns():
+    docs = [["a", "b", "c"], ["d", "e", "f"]] * 20
+    corpus = topica.Corpus.from_documents(docs)
+    chains = []
+    for seed in (1, 2):
+        model = LDA(num_topics=2, seed=seed)
+        model.fit(corpus, iters=80, keep_theta_draws=False)
+        chains.append(model)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        d = topica.multichain_diagnostics(chains)
+    assert any("theta_draws" in str(w.message) for w in caught)
+    assert d.topic_rhat is None
+    # the log-likelihood R-hat still lands from the retained trace
+    assert d.loglik_rhat is not None
+
+
+def test_multichain_diagnostics_warns_for_variational_models():
+    docs = [["a", "b", "c"], ["d", "e", "f"]] * 20
+    corpus = topica.Corpus.from_documents(docs)
+    chains = []
+    for seed in (1, 2):
+        model = topica.CTM(num_topics=2, seed=seed)
+        model.fit(corpus, iters=15)
+        chains.append(model)
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        topica.multichain_diagnostics(chains)
+    assert any("not Gibbs" in str(w.message) for w in caught)


### PR DESCRIPTION
Closes the remaining half of #269. Single-chain MCMC diagnostics landed in #336; this adds the multi-chain **Gelman-Rubin** view a Bayesian workflow expects. Fit the same model at several seeds and check whether the chains converged to a *common* target, rather than each chain settling into its own mode.

## What

- **`topica.rhat(chains)`** — rank-normalized split-R-hat (Vehtari et al. 2021), a pure-numpy primitive. Split each chain to catch within-chain drift, rank-normalize for tail robustness. No SciPy dependency (in-house Acklam probit).
- **`topica.multichain_diagnostics(chains)`** — takes several fitted Gibbs models (same corpus, different seeds) and reports:
  - **log-likelihood R-hat + cross-chain ESS** — the permutation-invariant headline, no alignment needed.
  - **per-topic R-hat** on each topic's per-draw prevalence, after aligning topics across chains (Hungarian match on the topic-word matrix, reusing `align_topics`). Ships a per-topic **alignment Jaccard** so a topic that did not line up flags its own R-hat as non-comparable.
- **`MultiChainDiagnostics`** dataclass with `.summary()` and `.converged`.

```python
chains = [topica.LDA(num_topics=20, seed=s) for s in (1,2,3,4)]
for m in chains: m.fit(docs, iters=2000, num_theta_draws=200)
print(topica.multichain_diagnostics(chains).summary())
# Multi-chain diagnostics for LDA (4 chains, inference=gibbs)
#   log-likelihood R-hat    : 1.008 (ESS 640, n=1000)
#   topic-prevalence R-hat  : max 1.021 / median 1.004 over 20 aligned topics
#   topic alignment (Jaccard): min 0.71 (low -> that topic's R-hat is not comparable)
#   -> chains mixed
```

## Design

Confirmed with Neal: the user passes **already-fitted chains** (matches the `ensemble()` idiom) rather than a factory/refit runner — Gibbs models don't expose their full constructor spec, so auto-cloning a fitted instance is fragile. A valid R-hat needs within-chain draws, so the per-topic statistic runs on `theta_draws` (real MCMC draws), aligned via the final `topic_word`.

## Validation

11 new tests (24 total in `test_mcmc.py`): `rhat` recovers ~1 on well-mixed chains, flags disagreeing and drifting chains, split catches within-chain drift, probit matches SciPy; the model wrapper on 4 real LDA chains; the no-draws / non-Gibbs / single-chain guards. `mkdocs build --strict`, naming/registry/conformance/coverage suites all green.

## Docs

- `guides/diagnostics.md` — a "Do independent chains agree? (R-hat)" section (the label-switching caveat spelled out).
- `api/diagnostics.md` — API reference for the new surface.

No version bump (feature PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LUJQnjFKBPuhFbZUpyu5U