### PR TITLE
feat(design): accept numeric DataFrames/Series as covariate matrices (drop .to_numpy(float))

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ print(topica.summary(model))                  # top words per topic
 `from_dataframe` keeps your metadata aligned to the documents that survive pruning, so the same corpus feeds a structural topic model that relates topic prevalence to a covariate, with a well-calibrated hypothesis test:
 
 ```python
-prevalence = corpus.metadata[["treatment"]].to_numpy(float)
+prevalence = corpus.metadata[["treatment"]]   # a numeric DataFrame goes straight in
 
 stm = topica.STM(num_topics=5, seed=42)
 stm.fit(corpus, prevalence, prevalence_names=["treatment"])

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -95,6 +95,49 @@ class TopicEffect:
         )
 
 
+def _coerce_design(X, feature_names):
+    """Coerce a design-matrix argument to a float64 ``(n, p)`` array.
+
+    Accepts a numpy array (any numeric dtype), a numeric pandas/Polars
+    DataFrame or Series, or a list of number rows — so callers no longer have to
+    pre-cast with ``.to_numpy(float)``. A 1-D input becomes an ``(n, 1)`` column.
+    When ``feature_names`` is not given and the input is a DataFrame, the column
+    labels are used as feature names. A non-numeric column (strings, a pandas
+    ``Categorical``) raises a directive error pointing at
+    :func:`topica.design_matrix` / :func:`topica.one_hot` rather than surfacing a
+    cryptic numpy cast failure.
+
+    Returns ``(X_float64, names_or_None)``.
+    """
+    inferred = None
+    if hasattr(X, "select_dtypes"):  # pandas DataFrame
+        bad = [str(c) for c in X.select_dtypes(exclude="number").columns]
+        if bad:
+            raise ValueError(
+                f"covariate column(s) {bad} are non-numeric and cannot be cast to "
+                "float. Encode categorical covariates first with "
+                "topica.design_matrix(formula, data) or topica.one_hot(...), then "
+                "pass the resulting numeric matrix."
+            )
+        inferred = [str(c) for c in X.columns]
+    elif hasattr(X, "name") and hasattr(X, "to_numpy") and getattr(X, "ndim", None) == 1:
+        # pandas/Polars Series: a single named covariate column.
+        inferred = [str(X.name)] if X.name is not None else None
+
+    try:
+        arr = np.asarray(X, dtype=np.float64)
+    except (ValueError, TypeError) as e:
+        raise ValueError(
+            "could not convert the covariates to a float64 matrix; encode "
+            "categorical covariates with topica.design_matrix / topica.one_hot "
+            f"first (numpy: {e})"
+        ) from e
+    if arr.ndim == 1:
+        arr = arr[:, None]
+    names = list(feature_names) if feature_names is not None else inferred
+    return arr, names
+
+
 def _ols(y, X, hat, XtX_inv, dof, weights=None):
     """One (weighted) OLS fit. Returns (beta, cov, r2).
 
@@ -428,15 +471,12 @@ def estimate_effect(
     else:
         raise ValueError("doc_topic must be 2-D (num_docs, K) or 3-D (nsims, num_docs, K)")
 
-    X = np.asarray(X, dtype=np.float64)
-    if X.ndim == 1:
-        X = X[:, None]
+    X, names = _coerce_design(X, feature_names)
     if X.shape[0] != n:
         raise ValueError(f"X has {X.shape[0]} rows but doc_topic has {n} documents")
 
-    names = list(feature_names) if feature_names is not None else [
-        f"feature_{i}" for i in range(X.shape[1])
-    ]
+    if names is None:
+        names = [f"feature_{i}" for i in range(X.shape[1])]
     if len(names) != X.shape[1]:
         raise ValueError("feature_names length must match X columns")
     if add_intercept:

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -3193,9 +3193,18 @@ fn top_word_ids_phi(phi: &Array2<f64>, num_topics: usize, n: usize) -> Vec<Vec<u
         .collect()
 }
 
-/// Parse a feature matrix (a 2D numpy float array or a list of float lists)
-/// into `[num_docs][num_features]`.
+/// Parse a feature matrix into `[num_docs][num_features]`.
+///
+/// Accepts, in order of preference: an f64 numpy array (zero-copy fast path); a
+/// plain Python list of number lists; or anything else array-like that numpy can
+/// cast to float64 — a numpy int/bool/f32 array, a numeric pandas or Polars
+/// frame/Series, or a 1-D column (reshaped to `(n, 1)`). This means callers no
+/// longer have to pre-cast with `.to_numpy(float)`; a `corpus.metadata[[...]]`
+/// frame of integers goes straight in. A non-numeric column (strings, a pandas
+/// `Categorical`) cannot be cast and raises a directive error pointing at the
+/// design-matrix helpers instead of a cryptic numpy failure.
 fn parse_features(data: &Bound<'_, PyAny>) -> PyResult<Vec<Vec<f64>>> {
+    // Fast path: already an f64 2-D array — no copy through numpy.
     if let Ok(arr) = data.extract::<PyReadonlyArray2<f64>>() {
         let a = arr.as_array();
         let (rows, cols) = (a.shape()[0], a.shape()[1]);
@@ -3203,9 +3212,74 @@ fn parse_features(data: &Bound<'_, PyAny>) -> PyResult<Vec<Vec<f64>>> {
             .map(|i| (0..cols).map(|j| a[[i, j]]).collect())
             .collect());
     }
-    data.extract::<Vec<Vec<f64>>>().map_err(|_| {
-        PyValueError::new_err("features must be a 2D float array or a list of float lists")
-    })
+    // Plain Python list-of-lists of numbers (PyO3 coerces ints to f64).
+    if let Ok(v) = data.extract::<Vec<Vec<f64>>>() {
+        return Ok(v);
+    }
+    // Anything else array-like: coerce to float64 via numpy.
+    coerce_features_f64(data)
+}
+
+/// Coerce an arbitrary array-like to `[rows][cols]` f64 by routing it through
+/// `numpy.asarray(x, "float64")`. 1-D inputs (a single-covariate Series/array)
+/// become an `(n, 1)` column. A cast failure is turned into a directive error.
+fn coerce_features_f64(data: &Bound<'_, PyAny>) -> PyResult<Vec<Vec<f64>>> {
+    let py = data.py();
+    let np = py.import_bound("numpy")?;
+    let arr = match np.call_method1("asarray", (data, "float64")) {
+        Ok(a) => a,
+        Err(_) => return Err(features_cast_error(data)),
+    };
+    let ndim: usize = arr.getattr("ndim")?.extract()?;
+    let arr2 = match ndim {
+        1 => arr.call_method1("reshape", ((-1_i64, 1_i64),))?,
+        2 => arr,
+        n => {
+            return Err(PyValueError::new_err(format!(
+                "features must be a 1-D or 2-D array; got a {n}-D array"
+            )))
+        }
+    };
+    let ro = arr2.extract::<PyReadonlyArray2<f64>>()?;
+    let a = ro.as_array();
+    let (rows, cols) = (a.shape()[0], a.shape()[1]);
+    Ok((0..rows)
+        .map(|i| (0..cols).map(|j| a[[i, j]]).collect())
+        .collect())
+}
+
+/// Build the error raised when an input cannot be cast to float64. When the
+/// input is a pandas DataFrame, the offending non-numeric columns are named.
+fn features_cast_error(data: &Bound<'_, PyAny>) -> PyErr {
+    if let Ok(cols) = non_numeric_pandas_columns(data) {
+        if !cols.is_empty() {
+            return PyValueError::new_err(format!(
+                "covariate column(s) {cols:?} are non-numeric and cannot be cast to \
+                 float. Encode categorical covariates first with \
+                 topica.design_matrix(formula, data) or topica.one_hot(...), then pass \
+                 the resulting numeric matrix."
+            ));
+        }
+    }
+    PyValueError::new_err(
+        "could not convert the input to a float64 matrix. Pass a numeric \
+         array/DataFrame (a 2-D matrix or a 1-D column); if these are categorical \
+         covariates, encode them first with topica.design_matrix / topica.one_hot.",
+    )
+}
+
+/// Names of the non-numeric columns of a pandas DataFrame, or an empty vector
+/// when `data` is not a pandas DataFrame (or has string-incompatible labels).
+fn non_numeric_pandas_columns(data: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
+    let py = data.py();
+    if !data.hasattr("select_dtypes").unwrap_or(false) {
+        return Ok(vec![]);
+    }
+    let kwargs = PyDict::new_bound(py);
+    kwargs.set_item("exclude", "number")?;
+    let sub = data.call_method("select_dtypes", (), Some(&kwargs))?;
+    let cols = sub.getattr("columns")?.call_method0("tolist")?;
+    Ok(cols.extract::<Vec<String>>().unwrap_or_default())
 }
 
 /// Parse the optional caller-supplied base topic-word init (K×V) for the warm-start

--- a/tests/test_design_coercion.py
+++ b/tests/test_design_coercion.py
@@ -1,0 +1,72 @@
+"""Design-matrix coercion: a covariate matrix no longer has to be pre-cast with
+``.to_numpy(float)``. A numeric DataFrame/Series (or an int array) goes straight
+into ``STM.fit`` and ``estimate_effect``; a non-numeric column raises a directive
+error pointing at the design-matrix helpers.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import topica
+from topica import STM, estimate_effect
+
+
+@pytest.fixture(scope="module")
+def corpus_meta():
+    docs, treat = [], []
+    for i in range(120):
+        t = i % 2
+        docs.append(["threat", "fear", "danger"] * 2 if t else ["calm", "neutral", "ok"] * 2)
+        treat.append(t)
+    corpus = topica.Corpus.from_documents(docs)
+    meta = pd.DataFrame({"treatment": treat})  # int64 column
+    return corpus, meta
+
+
+def test_stm_fit_accepts_int_dataframe(corpus_meta):
+    corpus, meta = corpus_meta
+    a = STM(num_topics=3, seed=42)
+    a.fit(corpus, meta[["treatment"]].to_numpy(float), prevalence_names=["treatment"], iters=20)
+    b = STM(num_topics=3, seed=42)
+    b.fit(corpus, meta[["treatment"]], prevalence_names=["treatment"], iters=20)
+    # Coercing internally must not change the fit.
+    assert np.array_equal(np.asarray(a.doc_topic), np.asarray(b.doc_topic))
+    assert np.array_equal(np.asarray(a.topic_word), np.asarray(b.topic_word))
+
+
+def test_stm_fit_accepts_series(corpus_meta):
+    corpus, meta = corpus_meta
+    m = STM(num_topics=3, seed=42)
+    m.fit(corpus, meta["treatment"], prevalence_names=["treatment"], iters=20)
+    assert m.doc_topic.shape == (corpus.num_docs, 3)
+
+
+def test_stm_fit_categorical_raises_directive(corpus_meta):
+    corpus, meta = corpus_meta
+    bad = meta[["treatment"]].copy()
+    bad["party"] = np.where(bad["treatment"] > 0, "dem", "rep")
+    with pytest.raises(ValueError) as exc:
+        STM(num_topics=3, seed=42).fit(corpus, bad, iters=5)
+    msg = str(exc.value)
+    assert "party" in msg
+    assert "design_matrix" in msg or "one_hot" in msg
+
+
+def test_estimate_effect_infers_names_from_dataframe(corpus_meta):
+    corpus, meta = corpus_meta
+    m = STM(num_topics=3, seed=42)
+    m.fit(corpus, meta[["treatment"]], prevalence_names=["treatment"], iters=20)
+    eff = estimate_effect(m, meta[["treatment"]])
+    assert eff[0].feature_names == ["intercept", "treatment"]
+
+
+def test_estimate_effect_categorical_raises_directive(corpus_meta):
+    corpus, meta = corpus_meta
+    m = STM(num_topics=3, seed=42)
+    m.fit(corpus, meta[["treatment"]], prevalence_names=["treatment"], iters=20)
+    bad = meta[["treatment"]].copy()
+    bad["party"] = np.where(bad["treatment"] > 0, "dem", "rep")
+    with pytest.raises(ValueError) as exc:
+        estimate_effect(m, bad)
+    assert "party" in str(exc.value)


### PR DESCRIPTION
## What

Covariate/design matrices no longer have to be pre-cast with `.to_numpy(float)`. A numeric pandas/Polars DataFrame or Series (or an int/bool/f32 array) now goes straight into `STM.fit` and `estimate_effect`.

Before:
```python
prevalence = corpus.metadata[["treatment"]].to_numpy(float)
stm.fit(corpus, prevalence, prevalence_names=["treatment"])
```
After:
```python
prevalence = corpus.metadata[["treatment"]]   # numeric DataFrame goes straight in
stm.fit(corpus, prevalence, prevalence_names=["treatment"])
```

## How

- **`parse_features` (Rust, `src/python/mod.rs`)** — the single choke point every Rust covariate model routes through (STM, ECTM, STS, keyATM, and embedding inputs). Keeps the zero-copy f64 fast path and list-of-lists, then coerces anything else array-like to float64 via `numpy.asarray(x, "float64")`; a 1-D column becomes `(n, 1)`. A failed cast raises a directive error that **names the offending non-numeric pandas columns** and points at `topica.design_matrix` / `topica.one_hot`.
- **`estimate_effect` (Python, `python/topica/stm.py`)** — new `_coerce_design` does the same coercion and error, and **infers `feature_names` from DataFrame column labels** when not supplied.

## Policy

Numeric frames auto-coerce silently. Categorical/string columns **error and point to `design_matrix`/`one_hot`** rather than being auto-dummy-coded — this preserves the "use the same design in `fit` and `estimate_effect`" contract by keeping encoding explicit and in one place.

## Verification

- Fits are **bit-identical** to the old `.to_numpy(float)` path (`doc_topic`, `topic_word`).
- New `tests/test_design_coercion.py` (5 tests): int DataFrame, Series, categorical→directive error, name inference, `estimate_effect` categorical error.
- 177 covariate-related pytests green; `cargo test --lib` 157 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)