### PR TITLE
feat(cluster): expose leiden/louvain resolution and knn_neighbors kwargs (#358)

### DIFF
--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -355,6 +355,16 @@ somewhere. Two ways out:
   assert -1 not in model.labels
   ```
 
+  "Auto" does not mean unsteerable. `resolution` (default 1.0) trades off how many
+  topics they find — raise it for a fine-grained corpus, lower it for broad themes;
+  the secondary `knn_neighbors` (default 15) does the same more weakly (smaller =
+  more, tighter topics). Both are ignored by the other clusterers.
+
+  ```python
+  fine  = topica.BERTopic(clusterer="leiden", resolution=2.0, seed=1)   # more topics
+  broad = topica.BERTopic(clusterer="leiden", resolution=0.5, seed=1)   # fewer topics
+  ```
+
 - **Switch to a fixed-K clusterer.** Pass `clusterer="kmeans"`, `"gmm"`, or
   `"agglomerative"` with `num_clusters=K` to BERTopic or Top2Vec. All three assign
   every document to one of `K` clusters, so there is no `-1` label (and the topic

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2623,6 +2623,8 @@ class Top2Vec:
         n_neighbors: int = 15,
         clusterer: str = "hdbscan",
         num_clusters: int | None = None,
+        resolution: float = 1.0,
+        knn_neighbors: int = 15,
         seed: int = 42,
     ) -> None: ...
     def fit(
@@ -2714,6 +2716,8 @@ class BERTopic:
         reduce_frequent: bool = False,
         clusterer: str = "hdbscan",
         num_clusters: int | None = None,
+        resolution: float = 1.0,
+        knn_neighbors: int = 15,
         seed: int = 42,
     ) -> None: ...
     def fit(

--- a/src/bertopic.rs
+++ b/src/bertopic.rs
@@ -149,6 +149,8 @@ pub fn fit_bertopic(
     reduce_frequent: bool,
     clusterer: &str,
     num_clusters: Option<usize>,
+    resolution: f64,
+    knn_neighbors: usize,
     seed: u64,
 ) -> BertopicModel {
     let emb_dim = doc_embeddings.first().map_or(0, |r| r.len());
@@ -177,6 +179,8 @@ pub fn fit_bertopic(
         num_clusters,
         min_cluster_size,
         min_samples,
+        resolution,
+        knn_neighbors,
         seed,
     );
     let mut num_topics = topic_count(&labels);
@@ -478,7 +482,7 @@ mod tests {
         // HDBSCAN gets the cluster count wrong.
         let raw = crate::reduce::pca(&emb, 5, 7);
         let raw_k = topic_count(&crate::cluster::cluster_points(
-            &raw, "hdbscan", None, 15, 5, 7,
+            &raw, "hdbscan", None, 15, 5, 1.0, 15, 7,
         ));
         assert_ne!(raw_k, 4, "raw PCA clustering should mis-count the 4 rays");
         // L2-normalized: each point maps to its ray direction, cleanly separable
@@ -486,7 +490,7 @@ mod tests {
         let mut normed = crate::reduce::pca(&emb, 5, 7);
         crate::reduce::l2_normalize_rows(&mut normed);
         let norm_k = topic_count(&crate::cluster::cluster_points(
-            &normed, "hdbscan", None, 15, 5, 7,
+            &normed, "hdbscan", None, 15, 5, 1.0, 15, 7,
         ));
         assert_eq!(
             norm_k, 4,
@@ -495,7 +499,8 @@ mod tests {
         // The shipped pipeline normalizes on the PCA path, so fit_bertopic itself
         // recovers block-pure topics (each topic's top words from one planted block).
         let m = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 5, None, 4, 1, false, false, "hdbscan", None, 7,
+            &docs, &emb, vocab, 5, false, 15, 15, 5, None, 4, 1, false, false, "hdbscan", None,
+            1.0, 15, 7,
         );
         assert_eq!(
             m.num_topics, 4,
@@ -517,7 +522,8 @@ mod tests {
     fn recovers_topics_via_ctfidf() {
         let (docs, emb, vocab) = planted(3, 40, 1);
         let m = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 1,
+            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None,
+            1.0, 15, 1,
         );
         assert!(
             m.num_topics >= 3,
@@ -542,7 +548,8 @@ mod tests {
     fn nr_topics_reduces_to_target() {
         let (docs, emb, vocab) = planted(4, 40, 2);
         let full = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 2,
+            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None,
+            1.0, 15, 2,
         );
         assert!(full.num_topics >= 3);
         let reduced = fit_bertopic(
@@ -561,6 +568,8 @@ mod tests {
             false,
             "hdbscan",
             None,
+            1.0,
+            15,
             2,
         );
         assert_eq!(reduced.num_topics, 2, "should reduce to 2 topics");
@@ -570,7 +579,8 @@ mod tests {
     fn approximate_distribution_favors_own_topic() {
         let (docs, emb, vocab) = planted(3, 40, 3);
         let m = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 3,
+            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None,
+            1.0, 15, 3,
         );
         // A document made only of block-0 words should put its largest mass on the
         // topic whose top words are block 0.
@@ -589,7 +599,8 @@ mod tests {
     fn bertopic_conforms() {
         let (docs, emb, vocab) = planted(3, 40, 1);
         let m = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None, 1,
+            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None,
+            1.0, 15, 1,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -12,15 +12,6 @@ use rand::{Rng, SeedableRng};
 use rand_chacha::ChaCha8Rng;
 use std::collections::HashMap;
 
-/// Default resolution (γ) for the `"louvain"` / `"leiden"` graph clusterers. 1.0
-/// is the standard modularity resolution; on the #352 benchmark it discovers a
-/// sensible topic count on both easy and fine-grained corpora. Exposing it as a
-/// Python kwarg (the main knob for steering the auto-discovered K) is the planned
-/// follow-up.
-const DEFAULT_RESOLUTION: f64 = 1.0;
-/// Default neighborhood size for the k-NN graph the graph clusterers build.
-const DEFAULT_KNN: usize = 15;
-
 /// Cluster `points` (row-major; each row is one embedding vector) with HDBSCAN.
 ///
 /// Returns one label per point: cluster ids are a dense `0..n_clusters` range
@@ -81,22 +72,26 @@ pub fn hdbscan_labels(
 /// (default; uses `min_cluster_size`/`min_samples`), `"kmeans"`, `"gmm"`, or
 /// `"agglomerative"` (all three use `num_clusters`, falling back to
 /// `min_cluster_size` if it is `None`), or the auto-K graph clusterers
-/// `"louvain"` / `"leiden"` (modularity on a k-NN graph; no `num_clusters`).
-/// Unknown names fall back to HDBSCAN.
+/// `"louvain"` / `"leiden"` (modularity on a k-NN graph; steered by `resolution`
+/// and `knn_k`, no `num_clusters`). `resolution`/`knn_k` are ignored by the
+/// non-graph clusterers. Unknown names fall back to HDBSCAN.
+#[allow(clippy::too_many_arguments)]
 pub fn cluster_points(
     points: &[Vec<f64>],
     clusterer: &str,
     num_clusters: Option<usize>,
     min_cluster_size: usize,
     min_samples: usize,
+    resolution: f64,
+    knn_k: usize,
     seed: u64,
 ) -> Vec<i64> {
     match clusterer {
         "kmeans" => kmeans_labels(points, num_clusters.unwrap_or(min_cluster_size), seed),
         "gmm" => gmm_labels(points, num_clusters.unwrap_or(min_cluster_size), seed),
         "agglomerative" => agglomerative_labels(points, num_clusters.unwrap_or(min_cluster_size)),
-        "louvain" => graph_labels(points, DEFAULT_RESOLUTION, DEFAULT_KNN, seed, false),
-        "leiden" => graph_labels(points, DEFAULT_RESOLUTION, DEFAULT_KNN, seed, true),
+        "louvain" => graph_labels(points, resolution, knn_k, seed, false),
+        "leiden" => graph_labels(points, resolution, knn_k, seed, true),
         _ => hdbscan_labels(points, min_cluster_size, min_samples),
     }
 }
@@ -1031,7 +1026,7 @@ mod tests {
     #[test]
     fn louvain_separates_blobs_and_assigns_everything() {
         let pts = three_blobs();
-        let labels = graph_labels(&pts, DEFAULT_RESOLUTION, DEFAULT_KNN, 0, false);
+        let labels = graph_labels(&pts, 1.0, 15, 0, false);
         assert_eq!(labels.len(), 120);
         // Auto-K, every point assigned (no -1 noise bucket).
         assert!(labels.iter().all(|&l| l >= 0), "no point may be noise");
@@ -1063,8 +1058,8 @@ mod tests {
     #[test]
     fn louvain_is_deterministic_and_dense() {
         let pts = three_blobs();
-        let a = graph_labels(&pts, DEFAULT_RESOLUTION, DEFAULT_KNN, 7, false);
-        let b = graph_labels(&pts, DEFAULT_RESOLUTION, DEFAULT_KNN, 7, false);
+        let a = graph_labels(&pts, 1.0, 15, 7, false);
+        let b = graph_labels(&pts, 1.0, 15, 7, false);
         assert_eq!(a, b, "same seed -> same labels");
         // dense 0..=max
         let max = *a.iter().max().unwrap();
@@ -1076,17 +1071,8 @@ mod tests {
     #[test]
     fn graph_labels_handles_trivial_inputs() {
         for refine in [false, true] {
-            assert!(graph_labels(&[], DEFAULT_RESOLUTION, DEFAULT_KNN, 0, refine).is_empty());
-            assert_eq!(
-                graph_labels(
-                    &[vec![1.0, 2.0]],
-                    DEFAULT_RESOLUTION,
-                    DEFAULT_KNN,
-                    0,
-                    refine
-                ),
-                vec![0]
-            );
+            assert!(graph_labels(&[], 1.0, 15, 0, refine).is_empty());
+            assert_eq!(graph_labels(&[vec![1.0, 2.0]], 1.0, 15, 0, refine), vec![0]);
         }
     }
 
@@ -1098,7 +1084,7 @@ mod tests {
     fn leiden_communities_are_connected_and_pure() {
         use std::collections::HashSet;
         let pts = three_blobs();
-        let labels = graph_labels(&pts, DEFAULT_RESOLUTION, DEFAULT_KNN, 0, true);
+        let labels = graph_labels(&pts, 1.0, 15, 0, true);
         assert_eq!(labels.len(), 120);
         assert!(labels.iter().all(|&l| l >= 0), "no point may be noise");
 
@@ -1120,7 +1106,7 @@ mod tests {
 
         // Connectivity: BFS within each community over the same k-NN graph the
         // clusterer built.
-        let g = knn_graph(&pts, DEFAULT_KNN);
+        let g = knn_graph(&pts, 15);
         let k = (*labels.iter().max().unwrap() + 1) as usize;
         for c in 0..k as i64 {
             let members: Vec<usize> = (0..labels.len()).filter(|&i| labels[i] == c).collect();
@@ -1148,8 +1134,8 @@ mod tests {
     #[test]
     fn leiden_is_deterministic() {
         let pts = three_blobs();
-        let a = graph_labels(&pts, DEFAULT_RESOLUTION, DEFAULT_KNN, 3, true);
-        let b = graph_labels(&pts, DEFAULT_RESOLUTION, DEFAULT_KNN, 3, true);
+        let a = graph_labels(&pts, 1.0, 15, 3, true);
+        let b = graph_labels(&pts, 1.0, 15, 3, true);
         assert_eq!(a, b, "same seed -> same labels");
     }
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -12633,6 +12633,23 @@ fn parse_clusterer(
     }
 }
 
+/// Validate the graph-clusterer knobs. `resolution` (γ) must be positive;
+/// `knn_neighbors` must be at least 1. These are used only by the ``"louvain"`` /
+/// ``"leiden"`` clusterers and ignored otherwise, but they are validated
+/// unconditionally so a bad value is a clear error at construction rather than a
+/// silent no-op.
+fn parse_graph_params(resolution: f64, knn_neighbors: usize) -> PyResult<(f64, usize)> {
+    if !resolution.is_finite() || resolution <= 0.0 {
+        return Err(PyValueError::new_err(format!(
+            "resolution must be a positive finite number, got {resolution}"
+        )));
+    }
+    if knn_neighbors < 1 {
+        return Err(PyValueError::new_err("knn_neighbors must be >= 1"));
+    }
+    Ok((resolution, knn_neighbors))
+}
+
 /// Guard `reducer='umap'`: error out on the (non-wheel) build where the `umap`
 /// feature was not compiled in. The in-house UMAP reducer is seeded and fully
 /// reproducible for a fixed `seed`, so — unlike the old umap-rs path — there is
@@ -12677,6 +12694,8 @@ pub struct Top2Vec {
     min_samples: usize,
     clusterer: String,
     num_clusters: Option<usize>,
+    resolution: f64,
+    knn_neighbors: usize,
     seed: u64,
     fitted: bool,
     has_word_vectors: bool,
@@ -12728,11 +12747,15 @@ impl Top2Vec {
     ///
     /// `reducer` is the dimensionality-reduction method, ``"pca"`` (default,
     /// deterministic) or ``"umap"`` (stochastic); `n_neighbors` is the
-    /// neighborhood size for the reducer; `seed` seeds the deterministic phases.
+    /// neighborhood size for the reducer. `resolution` (default 1.0) and
+    /// `knn_neighbors` (default 15) steer the ``"louvain"``/``"leiden"`` graph
+    /// clusterers — higher `resolution` yields more, smaller topics; they are
+    /// ignored by the other clusterers. `seed` seeds the deterministic phases.
     #[new]
     #[pyo3(signature = (*, n_components=5, min_cluster_size=15, min_samples=None,
                         reducer="pca", n_neighbors=15, clusterer="hdbscan",
-                        num_clusters=None, seed=42))]
+                        num_clusters=None, resolution=1.0, knn_neighbors=15, seed=42))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         n_components: usize,
         min_cluster_size: usize,
@@ -12741,6 +12764,8 @@ impl Top2Vec {
         n_neighbors: usize,
         clusterer: &str,
         num_clusters: Option<i64>,
+        resolution: f64,
+        knn_neighbors: usize,
         seed: u64,
     ) -> PyResult<Self> {
         if min_cluster_size < 2 {
@@ -12748,6 +12773,7 @@ impl Top2Vec {
         }
         let use_umap = parse_reducer(reducer)?;
         let (clusterer, num_clusters) = parse_clusterer(clusterer, num_clusters)?;
+        let (resolution, knn_neighbors) = parse_graph_params(resolution, knn_neighbors)?;
         Ok(Top2Vec {
             n_components,
             use_umap,
@@ -12756,6 +12782,8 @@ impl Top2Vec {
             min_samples: min_samples.unwrap_or(min_cluster_size),
             clusterer,
             num_clusters,
+            resolution,
+            knn_neighbors,
             seed,
             fitted: false,
             has_word_vectors: false,
@@ -12859,6 +12887,7 @@ impl Top2Vec {
         );
         let clusterer = self.clusterer.clone();
         let num_clusters = self.num_clusters;
+        let (resolution, knn_neighbors) = (self.resolution, self.knn_neighbors);
         let model = py.allow_threads(move || {
             top2vec::fit_top2vec(
                 &corpus.docs,
@@ -12872,6 +12901,8 @@ impl Top2Vec {
                 ms,
                 &clusterer,
                 num_clusters,
+                resolution,
+                knn_neighbors,
                 seed,
             )
         });
@@ -13194,6 +13225,11 @@ impl Top2Vec {
             min_samples: s.min_samples,
             clusterer: s.clusterer,
             num_clusters: s.num_clusters,
+            // resolution/knn_neighbors are fit-time knobs; the fitted result is
+            // fully captured by the stored model, so a loaded model just carries
+            // the defaults (it never re-clusters).
+            resolution: 1.0,
+            knn_neighbors: 15,
             seed: s.seed,
             fitted: s.fitted,
             has_word_vectors: s.has_word_vectors,
@@ -13248,6 +13284,8 @@ pub struct BERTopic {
     reduce_frequent: bool,
     clusterer: String,
     num_clusters: Option<usize>,
+    resolution: f64,
+    knn_neighbors: usize,
     seed: u64,
     fitted: bool,
     topic_names: Vec<String>,
@@ -13320,12 +13358,15 @@ impl BERTopic {
     /// auto-K graph clusterers ``"louvain"`` / ``"leiden"``, ``"kmeans"``,
     /// ``"gmm"`` (diagonal-covariance Gaussian mixture), or ``"agglomerative"``;
     /// `num_clusters` sets the target count for the last three (ignored by HDBSCAN
-    /// and the auto-K clusterers). `seed` seeds the deterministic phases.
+    /// and the auto-K clusterers). `resolution` (default 1.0) and `knn_neighbors`
+    /// (default 15) steer the ``"louvain"``/``"leiden"`` clusterers — higher
+    /// `resolution` yields more, smaller topics; ignored by the others. `seed`
+    /// seeds the deterministic phases.
     #[new]
     #[pyo3(signature = (*, n_components=5, min_cluster_size=15, min_samples=None,
                         nr_topics=None, window=4, stride=1, reducer="pca", n_neighbors=15,
                         bm25=false, reduce_frequent=false, clusterer="hdbscan",
-                        num_clusters=None, seed=42))]
+                        num_clusters=None, resolution=1.0, knn_neighbors=15, seed=42))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         n_components: usize,
@@ -13340,6 +13381,8 @@ impl BERTopic {
         reduce_frequent: bool,
         clusterer: &str,
         num_clusters: Option<i64>,
+        resolution: f64,
+        knn_neighbors: usize,
         seed: u64,
     ) -> PyResult<Self> {
         if min_cluster_size < 2 {
@@ -13347,6 +13390,7 @@ impl BERTopic {
         }
         let use_umap = parse_reducer(reducer)?;
         let (clusterer, num_clusters) = parse_clusterer(clusterer, num_clusters)?;
+        let (resolution, knn_neighbors) = parse_graph_params(resolution, knn_neighbors)?;
         Ok(BERTopic {
             n_components,
             use_umap,
@@ -13360,6 +13404,8 @@ impl BERTopic {
             reduce_frequent,
             clusterer,
             num_clusters,
+            resolution,
+            knn_neighbors,
             seed,
             fitted: false,
             topic_names: Vec::new(),
@@ -13427,6 +13473,7 @@ impl BERTopic {
         );
         let clusterer = self.clusterer.clone();
         let num_clusters = self.num_clusters;
+        let (resolution, knn_neighbors) = (self.resolution, self.knn_neighbors);
         let model = py.allow_threads(move || {
             bertopic::fit_bertopic(
                 &corpus.docs,
@@ -13444,6 +13491,8 @@ impl BERTopic {
                 rf,
                 &clusterer,
                 num_clusters,
+                resolution,
+                knn_neighbors,
                 seed,
             )
         });
@@ -13729,6 +13778,9 @@ impl BERTopic {
             reduce_frequent: s.reduce_frequent,
             clusterer: s.clusterer,
             num_clusters: s.num_clusters,
+            // Fit-time knobs; a loaded model never re-clusters, so defaults suffice.
+            resolution: 1.0,
+            knn_neighbors: 15,
             seed: s.seed,
             fitted: s.fitted,
             topic_names,

--- a/src/top2vec.rs
+++ b/src/top2vec.rs
@@ -175,6 +175,8 @@ pub fn fit_top2vec(
     min_samples: usize,
     clusterer: &str,
     num_clusters: Option<usize>,
+    resolution: f64,
+    knn_neighbors: usize,
     seed: u64,
 ) -> Top2VecModel {
     let n_docs = doc_embeddings.len();
@@ -208,6 +210,8 @@ pub fn fit_top2vec(
         num_clusters,
         min_cluster_size,
         min_samples,
+        resolution,
+        knn_neighbors,
         seed,
     );
     let num_topics = labels
@@ -356,7 +360,7 @@ mod tests {
         }
 
         let m = fit_top2vec(
-            &docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1,
+            &docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1.0, 15, 1,
         );
         assert!(
             m.num_topics >= 2,
@@ -392,7 +396,7 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..5).map(|_| vec![0u32]).collect();
         let word_emb = vec![vec![1.0, 0.0]];
         let m = fit_top2vec(
-            &docs, &doc_emb, &word_emb, 1, 2, false, 15, 5, 2, "hdbscan", None, 1,
+            &docs, &doc_emb, &word_emb, 1, 2, false, 15, 5, 2, "hdbscan", None, 1.0, 15, 1,
         );
         assert_eq!(m.num_topics, 0);
         assert!(m.topic_vectors.is_empty());
@@ -428,7 +432,7 @@ mod tests {
             word_emb.push(jitter(&mut rng, c));
         }
         let m = fit_top2vec(
-            &docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1,
+            &docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1.0, 15, 1,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -292,6 +292,53 @@ def test_clusterer_validation():
     topica.Top2Vec(clusterer="leiden")
 
 
+def _overlapping_blobs(k=8, per=40, dim=15, spread=1.6, seed=0):
+    rng = np.random.default_rng(seed)
+    centers = rng.normal(0, 2.0, (k, dim))
+    emb, docs = [], []
+    for c in range(k):
+        for _ in range(per):
+            emb.append(centers[c] + rng.normal(0, spread, dim))
+            docs.append([f"w{c}_{i}" for i in rng.integers(0, 6, 6)])
+    return docs, np.array(emb)
+
+
+@pytest.mark.parametrize("clusterer", ["louvain", "leiden"])
+def test_resolution_steers_topic_count(clusterer):
+    # #358: higher resolution -> more, smaller topics for the graph clusterers.
+    docs, emb = _overlapping_blobs()
+    lo = topica.BERTopic(clusterer=clusterer, resolution=0.5, min_cluster_size=5, seed=1)
+    lo.fit(docs, emb)
+    hi = topica.BERTopic(clusterer=clusterer, resolution=3.0, min_cluster_size=5, seed=1)
+    hi.fit(docs, emb)
+    assert hi.num_topics > lo.num_topics
+
+
+def test_knn_neighbors_steers_topic_count():
+    # #358: smaller knn_neighbors -> more, tighter communities. The effect is
+    # weaker than resolution, so use a fine-grained corpus where it bites.
+    docs, emb = _overlapping_blobs(k=20, per=40, dim=30, spread=1.4)
+    small = topica.Top2Vec(clusterer="leiden", knn_neighbors=5, min_cluster_size=5, seed=1)
+    small.fit(docs, emb)
+    large = topica.Top2Vec(clusterer="leiden", knn_neighbors=30, min_cluster_size=5, seed=1)
+    large.fit(docs, emb)
+    assert small.num_topics > large.num_topics
+
+
+def test_resolution_ignored_by_nongraph_and_validated():
+    # #358: resolution/knn_neighbors are accepted but ignored for non-graph
+    # clusterers, and invalid values error at construction.
+    docs, emb = _overlapping_blobs()
+    m = topica.BERTopic(
+        clusterer="kmeans", num_clusters=4, resolution=3.0, knn_neighbors=8, seed=1
+    )
+    m.fit(docs, emb)
+    assert m.num_topics == 4
+    for bad in (dict(resolution=0.0), dict(resolution=-1.0), dict(knn_neighbors=0)):
+        with pytest.raises(ValueError):
+            topica.BERTopic(clusterer="leiden", **bad)
+
+
 def test_report_is_callable():
     # #12: report(model) works as a one-call overview (alias for summary).
     assert callable(topica.report)


### PR DESCRIPTION
Closes #358. Exposes the graph clusterers' `resolution` (γ) and k-NN neighborhood as Python kwargs, so `clusterer="leiden"`/`"louvain"` can steer the number of topics they discover. Follow-up to #352/#354.

## Why

`graph_labels` already took `resolution`, but the Python path hardcoded `1.0`/`15`, so the auto-K clusterers were unsteerable. Resolution is the knob that trades off topic count — "auto" shouldn't mean "unsteerable."

## API

```python
topica.BERTopic(clusterer="leiden", resolution=2.0)   # more, smaller topics
topica.BERTopic(clusterer="leiden", resolution=0.5)   # fewer, broader topics
topica.Top2Vec(clusterer="louvain", knn_neighbors=8)  # secondary knob
```

- `resolution=1.0` (default, unchanged) and `knn_neighbors=15` (default) added to both builders and the `.pyi` stub.
- Validated at construction (`resolution` positive & finite, `knn_neighbors >= 1`) via a new `parse_graph_params`.
- **Ignored, without error, by the non-graph clusterers.**

## Implementation

Threaded builder → `fit_bertopic`/`fit_top2vec` → `cluster_points` → `graph_labels` (which already accepted them). These are **fit-time knobs**: a loaded model never re-clusters, so they're not serialized and **save/load is unchanged** (verified by the round-trip tests).

## Validation

End to end on 20 fine-grained gaussian topics:

| resolution | discovered K | | knn_neighbors | discovered K |
|---|---|---|---|---|
| 0.5 | 12 | | 5 | 17 |
| 1.0 | 15 | | 15 | 15 |
| 2.0 | 17 | | 30 | 12 |
| 4.0 | 20 | | | |

Matches the #358 sweep (resolution moves K across the useful range). Python tests cover resolution + knn steering (both BERTopic and Top2Vec), ignored-for-non-graph, and the validation errors. Gates: 200 Rust tests, 258 embedding pytest, save/load round-trip, `cargo fmt`/clippy, `mkdocs --strict` all green.

This is the last of the four embedding-clustering issues in the 355–358 batch (355 `agreement` is #359; 356 diagnostics and 357 gmm-soft-θ remain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)