### PR TITLE
feat(embedding): warn on degenerate BERTopic/Top2Vec pipelines (#356)

### DIFF
--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -333,6 +333,22 @@ caveat: the per-time *prevalence* trajectory (`eta`) is weakly identified in DET
 either — so read the topic-word evolution (`beta_over_time`), which is stable, and
 do not over-interpret a single `eta` trajectory.
 
+## Post-fit diagnostics
+
+The reduce→cluster pipeline decides almost everything, and its failure modes are
+*silent*: a bad configuration still returns a model. BERTopic and Top2Vec run a
+cheap post-fit check and emit a one-time `warnings.warn` when the result looks
+degenerate — near-total **collapse** (1–2 topics on a sizeable corpus, usually
+unnormalized coordinates or too large a `min_cluster_size`), a very **high noise
+fraction** (most documents left unassigned), or gross **over-splitting** (far more
+topics than the corpus supports). Each message names a concrete fix. The
+thresholds are conservative; silence it with `diagnostics=False`:
+
+```python
+model = topica.BERTopic(seed=1)                    # warns if the fit is degenerate
+model = topica.BERTopic(diagnostics=False, seed=1) # silent
+```
+
 ## Avoiding the `-1` noise bucket
 
 HDBSCAN (the default) discovers the topic count but leaves sparse documents

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2625,6 +2625,7 @@ class Top2Vec:
         num_clusters: int | None = None,
         resolution: float = 1.0,
         knn_neighbors: int = 15,
+        diagnostics: bool = True,
         seed: int = 42,
     ) -> None: ...
     def fit(
@@ -2718,6 +2719,7 @@ class BERTopic:
         num_clusters: int | None = None,
         resolution: float = 1.0,
         knn_neighbors: int = 15,
+        diagnostics: bool = True,
         seed: int = 42,
     ) -> None: ...
     def fit(

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -12650,6 +12650,78 @@ fn parse_graph_params(resolution: f64, knn_neighbors: usize) -> PyResult<(f64, u
     Ok((resolution, knn_neighbors))
 }
 
+/// Post-fit sanity checks for the embedding-clustering pipeline (issue #356). The
+/// reduce→cluster pipeline decides almost everything and its failure modes are
+/// silent — the run completes and returns a model with no signal that the result
+/// is garbage. This emits a `warnings.warn` (never an error) for the common
+/// degenerate signatures, each naming a concrete fix. Thresholds are deliberately
+/// conservative to avoid false positives, and the whole check is opt-out via the
+/// `diagnostics=False` constructor flag. `num_topics == 0` is handled separately by
+/// the caller (a stronger "no clusters" warning), so it is skipped here.
+fn emit_cluster_diagnostics(
+    py: Python<'_>,
+    model_name: &str,
+    clusterer: &str,
+    num_topics: usize,
+    labels: &[i64],
+) -> PyResult<()> {
+    let n = labels.len();
+    if n == 0 || num_topics == 0 {
+        return Ok(());
+    }
+    // Auto-K clusterers discover the count; the fixed-K ones (kmeans/gmm/
+    // agglomerative) return exactly what the user asked for, so collapse and
+    // over-split are not meaningful signals there.
+    let auto_k = matches!(clusterer, "hdbscan" | "louvain" | "leiden");
+    let warn = |msg: String| -> PyResult<()> {
+        let warnings = py.import_bound("warnings")?;
+        warnings.call_method1("warn", (msg,))?;
+        Ok(())
+    };
+
+    // (1) Collapse: an auto-K run that finds only 1-2 topics on a non-trivial
+    // corpus almost always means the geometry is wrong (unnormalized coordinates)
+    // or min_cluster_size is too large.
+    if auto_k && num_topics <= 2 && n >= 200 {
+        warn(format!(
+            "{model_name}: clustering produced only {num_topics} topic(s) from {n} \
+             documents. This usually means the reduced coordinates were poorly \
+             separated (try reducer=\"umap\", or check embedding quality) or \
+             min_cluster_size is too large."
+        ))?;
+    }
+
+    // (2) High noise: only HDBSCAN produces a `-1` bucket; a large one means most
+    // documents went unassigned.
+    let noise = labels.iter().filter(|&&l| l < 0).count();
+    let noise_frac = noise as f64 / n as f64;
+    if noise_frac > 0.5 {
+        warn(format!(
+            "{model_name}: {pct}% of documents were left unassigned (-1 noise). \
+             Lower min_cluster_size/min_samples, or switch to a clusterer that \
+             assigns every document (clusterer=\"leiden\", or \"kmeans\"/\"gmm\" \
+             with num_clusters).",
+            pct = (noise_frac * 100.0).round() as i64
+        ))?;
+    }
+
+    // (3) Over-split: an auto-K run with far more topics than a corpus that size
+    // can support (HDBSCAN over-splits embedding data in particular).
+    if auto_k && n >= 200 && num_topics > 20 && (num_topics as f64) > (n as f64) / 10.0 {
+        let remedy = if clusterer == "hdbscan" {
+            "consider clusterer=\"kmeans\"/\"gmm\" with num_clusters, or \
+             clusterer=\"leiden\""
+        } else {
+            "lower `resolution` (or raise `knn_neighbors`)"
+        };
+        warn(format!(
+            "{model_name}: discovered {num_topics} topics from {n} documents, which \
+             may be an over-split; {remedy}."
+        ))?;
+    }
+    Ok(())
+}
+
 /// Guard `reducer='umap'`: error out on the (non-wheel) build where the `umap`
 /// feature was not compiled in. The in-house UMAP reducer is seeded and fully
 /// reproducible for a fixed `seed`, so — unlike the old umap-rs path — there is
@@ -12696,6 +12768,7 @@ pub struct Top2Vec {
     num_clusters: Option<usize>,
     resolution: f64,
     knn_neighbors: usize,
+    diagnostics: bool,
     seed: u64,
     fitted: bool,
     has_word_vectors: bool,
@@ -12750,11 +12823,15 @@ impl Top2Vec {
     /// neighborhood size for the reducer. `resolution` (default 1.0) and
     /// `knn_neighbors` (default 15) steer the ``"louvain"``/``"leiden"`` graph
     /// clusterers — higher `resolution` yields more, smaller topics; they are
-    /// ignored by the other clusterers. `seed` seeds the deterministic phases.
+    /// ignored by the other clusterers. `diagnostics` (default True) emits a
+    /// one-time warning after fitting if the clustering looks degenerate (near-total
+    /// collapse, a very high noise fraction, or gross over-splitting); pass False to
+    /// silence it. `seed` seeds the deterministic phases.
     #[new]
     #[pyo3(signature = (*, n_components=5, min_cluster_size=15, min_samples=None,
                         reducer="pca", n_neighbors=15, clusterer="hdbscan",
-                        num_clusters=None, resolution=1.0, knn_neighbors=15, seed=42))]
+                        num_clusters=None, resolution=1.0, knn_neighbors=15,
+                        diagnostics=true, seed=42))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         n_components: usize,
@@ -12766,6 +12843,7 @@ impl Top2Vec {
         num_clusters: Option<i64>,
         resolution: f64,
         knn_neighbors: usize,
+        diagnostics: bool,
         seed: u64,
     ) -> PyResult<Self> {
         if min_cluster_size < 2 {
@@ -12784,6 +12862,7 @@ impl Top2Vec {
             num_clusters,
             resolution,
             knn_neighbors,
+            diagnostics,
             seed,
             fitted: false,
             has_word_vectors: false,
@@ -12914,6 +12993,14 @@ impl Top2Vec {
                     "Top2Vec: clustering found no clusters (num_topics=0). Lower \
                  min_cluster_size, add data, or check the scale of your embeddings.",
                 ),
+            )?;
+        } else if self.diagnostics {
+            emit_cluster_diagnostics(
+                py,
+                "Top2Vec",
+                &self.clusterer,
+                model.num_topics,
+                &model.labels,
             )?;
         }
         let k = model.num_topics;
@@ -13230,6 +13317,9 @@ impl Top2Vec {
             // the defaults (it never re-clusters).
             resolution: 1.0,
             knn_neighbors: 15,
+            // Fit-time flag; a loaded model won't re-fit, so it just carries the
+            // default (diagnostics only fire during fit()).
+            diagnostics: true,
             seed: s.seed,
             fitted: s.fitted,
             has_word_vectors: s.has_word_vectors,
@@ -13286,6 +13376,7 @@ pub struct BERTopic {
     num_clusters: Option<usize>,
     resolution: f64,
     knn_neighbors: usize,
+    diagnostics: bool,
     seed: u64,
     fitted: bool,
     topic_names: Vec<String>,
@@ -13360,13 +13451,17 @@ impl BERTopic {
     /// `num_clusters` sets the target count for the last three (ignored by HDBSCAN
     /// and the auto-K clusterers). `resolution` (default 1.0) and `knn_neighbors`
     /// (default 15) steer the ``"louvain"``/``"leiden"`` clusterers — higher
-    /// `resolution` yields more, smaller topics; ignored by the others. `seed`
-    /// seeds the deterministic phases.
+    /// `resolution` yields more, smaller topics; ignored by the others.
+    /// `diagnostics` (default True) emits a one-time warning after fitting if the
+    /// clustering looks degenerate (near-total collapse, a very high noise
+    /// fraction, or gross over-splitting); pass False to silence it. `seed` seeds
+    /// the deterministic phases.
     #[new]
     #[pyo3(signature = (*, n_components=5, min_cluster_size=15, min_samples=None,
                         nr_topics=None, window=4, stride=1, reducer="pca", n_neighbors=15,
                         bm25=false, reduce_frequent=false, clusterer="hdbscan",
-                        num_clusters=None, resolution=1.0, knn_neighbors=15, seed=42))]
+                        num_clusters=None, resolution=1.0, knn_neighbors=15,
+                        diagnostics=true, seed=42))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         n_components: usize,
@@ -13383,6 +13478,7 @@ impl BERTopic {
         num_clusters: Option<i64>,
         resolution: f64,
         knn_neighbors: usize,
+        diagnostics: bool,
         seed: u64,
     ) -> PyResult<Self> {
         if min_cluster_size < 2 {
@@ -13406,6 +13502,7 @@ impl BERTopic {
             num_clusters,
             resolution,
             knn_neighbors,
+            diagnostics,
             seed,
             fitted: false,
             topic_names: Vec::new(),
@@ -13504,6 +13601,14 @@ impl BERTopic {
                     "BERTopic: clustering found no clusters (num_topics=0). Lower \
                  min_cluster_size, add data, or check the scale of your embeddings.",
                 ),
+            )?;
+        } else if self.diagnostics {
+            emit_cluster_diagnostics(
+                py,
+                "BERTopic",
+                &self.clusterer,
+                model.num_topics,
+                &model.labels,
             )?;
         }
         let k = model.num_topics;
@@ -13781,6 +13886,9 @@ impl BERTopic {
             // Fit-time knobs; a loaded model never re-clusters, so defaults suffice.
             resolution: 1.0,
             knn_neighbors: 15,
+            // Fit-time flag; diagnostics only fire during fit(), so a loaded model
+            // carries the default.
+            diagnostics: true,
             seed: s.seed,
             fitted: s.fitted,
             topic_names,

--- a/tests/test_pipeline_diagnostics.py
+++ b/tests/test_pipeline_diagnostics.py
@@ -1,0 +1,105 @@
+"""Post-fit degenerate-pipeline warnings for BERTopic/Top2Vec (#356).
+
+The reduce->cluster pipeline fails silently: a bad configuration still returns a
+model. These tests check that the common degenerate signatures (collapse to 1-2
+topics, a high `-1` noise fraction, gross over-splitting) emit a warning naming a
+fix, that the warning is opt-out via `diagnostics=False`, and that a healthy fit
+stays quiet.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import topica
+
+
+def _fit_capture(model, docs, emb):
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        model.fit(docs, emb)
+    return [str(x.message) for x in w]
+
+
+def test_collapse_warns():
+    # Two clean blobs -> HDBSCAN finds only 2 topics on a 300-doc corpus.
+    rng = np.random.default_rng(0)
+    emb = np.vstack([rng.normal(0, 0.3, (150, 6)), rng.normal(8, 0.3, (150, 6))])
+    docs = [[f"w{i % 6}"] for i in range(300)]
+    msgs = _fit_capture(topica.BERTopic(min_cluster_size=15, seed=1), docs, emb)
+    assert any("only 2 topic" in m for m in msgs), msgs
+
+
+def test_collapse_not_warned_for_fixed_k():
+    # kmeans with num_clusters=2 legitimately returns 2 topics — not a collapse.
+    rng = np.random.default_rng(0)
+    emb = np.vstack([rng.normal(0, 0.3, (150, 6)), rng.normal(8, 0.3, (150, 6))])
+    docs = [[f"w{i % 6}"] for i in range(300)]
+    msgs = _fit_capture(
+        topica.BERTopic(clusterer="kmeans", num_clusters=2, seed=1), docs, emb
+    )
+    assert not any("only 2 topic" in m for m in msgs), msgs
+
+
+def test_high_noise_warns():
+    # dim == n_components -> no PCA/normalize; wide scatter stays HDBSCAN noise.
+    rng = np.random.default_rng(7)
+    emb = np.vstack([
+        rng.normal([0, 0, 0, 0, 0], 0.15, (60, 5)),
+        rng.normal([30, 30, 0, 0, 0], 0.15, (60, 5)),
+        rng.uniform(-60, 60, (220, 5)),
+    ])
+    docs = [[f"w{i % 6}"] for i in range(len(emb))]
+    m = topica.BERTopic(n_components=5, min_cluster_size=20, min_samples=8, seed=1)
+    msgs = _fit_capture(m, docs, emb)
+    assert any("unassigned" in x for x in msgs), msgs
+
+
+def test_over_split_warns():
+    # Many tiny well-separated blobs -> HDBSCAN over-splits far past n/10.
+    rng = np.random.default_rng(1)
+    centers = rng.normal(0, 6, (60, 20))
+    emb, docs = [], []
+    for c in range(60):
+        for _ in range(8):
+            emb.append(centers[c] + rng.normal(0, 0.15, 20))
+            docs.append([f"w{c}"])
+    emb = np.array(emb)
+    msgs = _fit_capture(topica.BERTopic(min_cluster_size=3, seed=1), docs, emb)
+    assert any("over-split" in m for m in msgs), msgs
+
+
+def test_diagnostics_false_suppresses():
+    rng = np.random.default_rng(0)
+    emb = np.vstack([rng.normal(0, 0.3, (150, 6)), rng.normal(8, 0.3, (150, 6))])
+    docs = [[f"w{i % 6}"] for i in range(300)]
+    msgs = _fit_capture(
+        topica.BERTopic(min_cluster_size=15, diagnostics=False, seed=1), docs, emb
+    )
+    assert not any("only 2 topic" in m or "over-split" in m or "unassigned" in m for m in msgs), msgs
+
+
+def test_healthy_fit_is_quiet():
+    # Six clean, well-populated blobs: a sensible topic count, no noise.
+    rng = np.random.default_rng(0)
+    centers = rng.normal(0, 4, (6, 15))
+    emb, docs = [], []
+    for c in range(6):
+        for _ in range(50):
+            emb.append(centers[c] + rng.normal(0, 0.6, 15))
+            docs.append([f"w{c}_{i}" for i in rng.integers(0, 5, 4)])
+    emb = np.array(emb)
+    m = topica.BERTopic(clusterer="leiden", seed=1)
+    msgs = _fit_capture(m, docs, emb)
+    assert not any(
+        "only" in x or "over-split" in x or "unassigned" in x for x in msgs
+    ), (m.num_topics, msgs)
+
+
+def test_top2vec_also_diagnoses():
+    rng = np.random.default_rng(0)
+    emb = np.vstack([rng.normal(0, 0.3, (150, 6)), rng.normal(8, 0.3, (150, 6))])
+    docs = [[f"w{i % 6}"] for i in range(300)]
+    msgs = _fit_capture(topica.Top2Vec(min_cluster_size=15, seed=1), docs, emb)
+    assert any("Top2Vec" in m and "only 2 topic" in m for m in msgs), msgs


### PR DESCRIPTION
Closes #356. Emits a one-time `warnings.warn` after fitting a BERTopic/Top2Vec model when the clustering shows a degenerate signature.

## Why

The reduce→cluster pipeline decides almost everything and its failure modes are **silent** — the run completes and returns a model with no signal that the result is garbage. From the #356 benchmarking: the naive default collapsed to 2 topics (ARI ~0.01), and UMAP+HDBSCAN over-split to 78–92 topics, both looking like "it worked."

## Behavior

After clustering, if `diagnostics=True` (new constructor kwarg, default), warn on any of:

- **Collapse** — an auto-K run finding only 1–2 topics on a corpus of ≥200 docs (usually unnormalized coordinates or too-large `min_cluster_size`).
- **High noise** — >50% of documents left in the `-1` bucket.
- **Over-split** — an auto-K run with >20 topics and >n/10 (HDBSCAN over-splits embedding data in particular).

Each message names a concrete fix (normalize / lower `min_cluster_size` / try `gmm`/`leiden` / lower `resolution`). It's a nudge, not an error.

## Conservative by design (avoids false positives)

- Collapse and over-split fire **only for the auto-K clusterers** (`hdbscan`/`louvain`/`leiden`) — never for `kmeans`/`gmm`/`agglomerative`, where the count is the user's explicit choice.
- Thresholds are deliberately loose (≥200 docs, >50% noise, >n/10 topics).
- Opt out entirely with `diagnostics=False`.
- `num_topics==0` keeps its existing, stronger "no clusters" warning (not double-warned).
- Fit-time flag, not serialized (a loaded model never re-clusters).

## Tests

`tests/test_pipeline_diagnostics.py` (7): each signature firing, the auto-K-only gating (kmeans stays quiet), suppression via `diagnostics=False`, a **quiet healthy fit**, and Top2Vec parity. Gates: 200 Rust tests, embedding pytest, `cargo fmt`/clippy, `mkdocs --strict` all green.

Rebased on top of #360 (resolution kwargs); the two compose (`clusterer="leiden", resolution=2.0, diagnostics=True`). This is #356 of the 355–358 batch; #355/#358 are merged, #357 (GMM soft θ) remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)