### PR TITLE
feat(bertopic): GMM soft doc_topic — mixture membership for multi-topic docs (#357)

### DIFF
--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -396,6 +396,20 @@ somewhere. Two ways out:
   assert -1 not in model.labels
   ```
 
+  With `clusterer="gmm"`, BERTopic's `doc_topic` is the GMM's **soft** membership
+  (the EM posterior responsibilities, rows summing to one), not the c-TF-IDF
+  approximate distribution — a genuine mixture `θ` for documents that span several
+  topics, where hard clustering assigns only one. The hard `labels` stay the row
+  argmax. (This applies to the base fit; combining `gmm` with `nr_topics` topic
+  reduction reverts `doc_topic` to the c-TF-IDF distribution.)
+
+  ```python
+  model = topica.BERTopic(clusterer="gmm", num_clusters=20, seed=1)
+  model.fit(docs, doc_emb)
+  theta  = model.doc_topic          # (D, 20) soft membership from GMM responsibilities
+  labels = theta.argmax(1)          # == model.labels
+  ```
+
 - **Use a fixed-K, every-document model.** `EmbeddingLDA`, `FASTopic`, and `ETM`
   are embedding-driven but give every document a full topic distribution `θ` with
   no noise bucket. In our testing `EmbeddingLDA` gave the best recovery when the

--- a/src/bertopic.rs
+++ b/src/bertopic.rs
@@ -173,16 +173,30 @@ pub fn fit_bertopic(
     if did_pca {
         reduce::l2_normalize_rows(&mut reduced);
     }
-    let mut labels = cluster::cluster_points(
-        &reduced,
-        clusterer,
-        num_clusters,
-        min_cluster_size,
-        min_samples,
-        resolution,
-        knn_neighbors,
-        seed,
-    );
+    // For GMM (without topic reduction) we capture the EM posterior
+    // responsibilities as a soft doc-topic membership (issue #357). With
+    // `nr_topics`, the c-TF-IDF merge is a hard-label operation that soft
+    // responsibilities can't compose through while keeping `argmax == label`, so
+    // we use hard GMM labels there and fall back to the c-TF-IDF `doc_topic`, as
+    // every non-GMM clusterer does.
+    let gmm_soft_path = clusterer == "gmm" && nr_topics.is_none();
+    let (mut labels, gmm_soft) = if gmm_soft_path {
+        let (labels, soft) =
+            cluster::gmm_soft_labels(&reduced, num_clusters.unwrap_or(min_cluster_size), seed);
+        (labels, Some(soft))
+    } else {
+        let labels = cluster::cluster_points(
+            &reduced,
+            clusterer,
+            num_clusters,
+            min_cluster_size,
+            min_samples,
+            resolution,
+            knn_neighbors,
+            seed,
+        );
+        (labels, None)
+    };
     let mut num_topics = topic_count(&labels);
 
     // (3) optional topic reduction: merge the most c-TF-IDF-similar topics.
@@ -216,7 +230,13 @@ pub fn fit_bertopic(
             }
         }
     }
-    let doc_topic = approximate_distribution(docs, &ctfidf_raw, &idf, num_topics, window, stride);
+    // GMM contributes a calibrated soft membership (the EM responsibilities); every
+    // other clusterer uses the c-TF-IDF approximate distribution. `argmax` of the
+    // GMM `doc_topic` equals `labels`, so the hard and soft views agree.
+    let doc_topic = match gmm_soft {
+        Some(soft) => normalize_rows(soft),
+        None => approximate_distribution(docs, &ctfidf_raw, &idf, num_topics, window, stride),
+    };
 
     BertopicModel {
         num_topics,
@@ -296,6 +316,24 @@ fn merge_topic(labels: &mut [i64], drop: usize, keep: usize) {
             *l -= 1;
         }
     }
+}
+
+/// Row-normalize a matrix to sum to one per row (a zero row becomes uniform).
+fn normalize_rows(mut m: Vec<Vec<f64>>) -> Vec<Vec<f64>> {
+    for row in m.iter_mut() {
+        let s: f64 = row.iter().sum();
+        if s > 0.0 {
+            for x in row.iter_mut() {
+                *x /= s;
+            }
+        } else if !row.is_empty() {
+            let u = 1.0 / row.len() as f64;
+            for x in row.iter_mut() {
+                *x = u;
+            }
+        }
+    }
+    m
 }
 
 /// The soft document-topic distribution. For each document we slide a `window` of

--- a/src/cluster.rs
+++ b/src/cluster.rs
@@ -278,22 +278,15 @@ pub fn agglomerative_labels(points: &[Vec<f64>], k: usize) -> Vec<i64> {
     labels
 }
 
-/// Gaussian mixture (diagonal covariance) fit by EM with k-means++ initialization.
-///
-/// Like `kmeans_labels` this is a fixed-`k`, assign-everything clusterer (no `-1`
-/// noise bucket), so it needs `num_clusters`. Unlike k-means it models each
-/// component's per-dimension spread, which lets elongated or unequal-variance
-/// topics separate where k-means (equal, spherical clusters) would split them
-/// wrongly; the EM posterior is also a *soft* membership, collapsed here to the
-/// argmax component for the `Vec<i64>` interface. Deterministic for a fixed
-/// `seed`. `k` is clamped to `1..=n`, empty components are dropped so the ids form
-/// a dense `0..m` range, and a `reg_covar` floor (a tiny fraction of the mean
-/// feature variance) keeps a component's variance from collapsing to zero on
-/// coincident points — the singular-covariance failure GMM otherwise hits.
-pub fn gmm_labels(points: &[Vec<f64>], k: usize, seed: u64) -> Vec<i64> {
+/// Run the diagonal-covariance GMM EM and return `(raw component label per point,
+/// posterior responsibilities)`. Labels are the argmax component in `0..kc` (not
+/// yet densified); `resp[i]` is the length-`kc` soft membership of point `i`. The
+/// public `gmm_labels` / `gmm_soft_labels` wrap this. See `gmm_labels` for the
+/// modeling notes (k-means++ init, log-sum-exp E-step, `reg_covar` floor).
+fn gmm_fit(points: &[Vec<f64>], k: usize, seed: u64) -> (Vec<i64>, Vec<Vec<f64>>) {
     let n = points.len();
     if n == 0 {
-        return Vec::new();
+        return (Vec::new(), Vec::new());
     }
     let dim = points[0].len();
     let k = k.clamp(1, n);
@@ -391,7 +384,7 @@ pub fn gmm_labels(points: &[Vec<f64>], k: usize, seed: u64) -> Vec<i64> {
         prev_ll = ll;
     }
 
-    // Hard assignment: each point to its most-likely component.
+    // Hard assignment: each point to its most-likely component (raw ids in 0..kc).
     let mut labels = vec![0i64; n];
     for i in 0..n {
         let mut best = 0usize;
@@ -404,8 +397,70 @@ pub fn gmm_labels(points: &[Vec<f64>], k: usize, seed: u64) -> Vec<i64> {
         }
         labels[i] = best as i64;
     }
+    (labels, resp)
+}
+
+/// Gaussian mixture (diagonal covariance) fit by EM with k-means++ initialization.
+///
+/// Like `kmeans_labels` this is a fixed-`k`, assign-everything clusterer (no `-1`
+/// noise bucket), so it needs `num_clusters`. Unlike k-means it models each
+/// component's per-dimension spread, which lets elongated or unequal-variance
+/// topics separate where k-means (equal, spherical clusters) would split them
+/// wrongly; the EM posterior is also a *soft* membership, exposed by
+/// `gmm_soft_labels` and collapsed here to the argmax component for the `Vec<i64>`
+/// interface. Deterministic for a fixed `seed`. `k` is clamped to `1..=n`, empty
+/// components are dropped so the ids form a dense `0..m` range, and a `reg_covar`
+/// floor (a tiny fraction of the mean feature variance) keeps a component's
+/// variance from collapsing to zero on coincident points.
+pub fn gmm_labels(points: &[Vec<f64>], k: usize, seed: u64) -> Vec<i64> {
+    let (mut labels, _resp) = gmm_fit(points, k, seed);
     densify(&mut labels);
     labels
+}
+
+/// GMM clustering that also returns each document's *soft* membership — the EM
+/// posterior responsibilities as a `(n, num_topics)` matrix whose rows sum to one.
+/// This is the mixture representation hard clustering can't give: a document that
+/// sits between topics gets a blend instead of a single label. Returns
+/// `(labels, doc_topic)`, both over the same dense `0..num_topics` set (empty
+/// components dropped in lockstep, and each row renormalized over the surviving
+/// components). `doc_topic[i].argmax()` equals `labels[i]` — the surviving
+/// components always include every document's argmax.
+pub fn gmm_soft_labels(points: &[Vec<f64>], k: usize, seed: u64) -> (Vec<i64>, Vec<Vec<f64>>) {
+    let (raw, resp) = gmm_fit(points, k, seed);
+    if raw.is_empty() {
+        return (Vec::new(), Vec::new());
+    }
+    // Kept components = those that are some document's argmax (matches `densify`).
+    let mut kept: Vec<usize> = raw.iter().map(|&l| l as usize).collect();
+    kept.sort_unstable();
+    kept.dedup();
+    let remap: HashMap<usize, usize> = kept
+        .iter()
+        .enumerate()
+        .map(|(new, &old)| (old, new))
+        .collect();
+    let k_final = kept.len();
+
+    let labels: Vec<i64> = raw.iter().map(|&l| remap[&(l as usize)] as i64).collect();
+    let doc_topic: Vec<Vec<f64>> = resp
+        .iter()
+        .map(|row| {
+            let mut r: Vec<f64> = kept.iter().map(|&c| row[c]).collect();
+            let s: f64 = r.iter().sum();
+            if s > 0.0 {
+                for x in r.iter_mut() {
+                    *x /= s;
+                }
+            } else {
+                for x in r.iter_mut() {
+                    *x = 1.0 / k_final as f64;
+                }
+            }
+            r
+        })
+        .collect();
+    (labels, doc_topic)
 }
 
 // ===================================================================
@@ -1001,6 +1056,37 @@ mod tests {
             assert!(labels.contains(&id), "id {id} missing -> not dense");
         }
         assert_eq!(labels, gmm_labels(&pts, 5, 1), "same seed -> same labels");
+    }
+
+    // gmm_soft_labels returns a (n, num_topics) soft membership whose rows sum to
+    // one, whose argmax equals the hard labels, and whose hard labels match
+    // gmm_labels exactly (same EM, same densify).
+    #[test]
+    fn gmm_soft_labels_are_normalized_and_consistent() {
+        let pts = two_blobs();
+        let (labels, soft) = gmm_soft_labels(&pts, 3, 1);
+        assert_eq!(
+            labels,
+            gmm_labels(&pts, 3, 1),
+            "hard labels must match gmm_labels"
+        );
+        let k = (*labels.iter().max().unwrap() + 1) as usize;
+        assert_eq!(soft.len(), pts.len());
+        for (i, row) in soft.iter().enumerate() {
+            assert_eq!(row.len(), k, "each row has one column per topic");
+            let s: f64 = row.iter().sum();
+            assert!((s - 1.0).abs() < 1e-9, "row {i} sums to {s}, not 1");
+            let argmax = row
+                .iter()
+                .enumerate()
+                .max_by(|a, b| a.1.partial_cmp(b.1).unwrap())
+                .unwrap()
+                .0;
+            assert_eq!(
+                argmax as i64, labels[i],
+                "soft argmax must equal hard label"
+            );
+        }
     }
 
     // Three well-separated blobs in embedding space. The graph clusterer discovers

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13356,7 +13356,9 @@ impl Top2Vec {
 /// defined by class-based TF-IDF over their documents' words, so no word
 /// embeddings are needed. `nr_topics` merges the most similar topics down to a
 /// target count; `doc_topic` is the approximate distribution (a sliding window's
-/// c-TF-IDF compared to each topic). You bring the document embeddings.
+/// c-TF-IDF compared to each topic) — except with `clusterer="gmm"` (and no
+/// `nr_topics`), where it is the GMM's soft posterior membership. You bring the
+/// document embeddings.
 ///
 /// No embedder of your own? `topica.llm_embed(texts, model=...)` builds the
 /// matrix (OpenAI, or offline `sentence-transformers`).

--- a/tests/test_gmm_soft_doctopic.py
+++ b/tests/test_gmm_soft_doctopic.py
@@ -1,0 +1,78 @@
+"""GMM soft doc_topic for BERTopic (#357).
+
+With clusterer="gmm", `doc_topic` is the GMM posterior responsibilities — a soft
+mixture membership — instead of the c-TF-IDF approximate distribution. Documents
+that sit between topics get a blend; the hard `labels` remain the row argmax.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+
+def _blobs(k=4, per=60, dim=10, spread=1.1, sep=1.2, seed=0):
+    rng = np.random.default_rng(seed)
+    centers = rng.normal(0, sep, (k, dim))
+    emb, docs = [], []
+    for c in range(k):
+        for _ in range(per):
+            emb.append(centers[c] + rng.normal(0, spread, dim))
+            docs.append([f"w{c}_{i}" for i in rng.integers(0, 5, 4)])
+    return docs, np.array(emb)
+
+
+def test_gmm_doc_topic_is_soft_and_consistent():
+    docs, emb = _blobs()
+    m = topica.BERTopic(clusterer="gmm", num_clusters=4, n_components=10, seed=1)
+    m.fit(docs, emb)
+    dt = np.asarray(m.doc_topic)
+    # Shape matches the topic count; rows are a distribution.
+    assert dt.shape == (len(docs), m.num_topics)
+    assert np.allclose(dt.sum(axis=1), 1.0)
+    # The hard labels are the soft argmax.
+    assert np.array_equal(dt.argmax(axis=1), np.asarray(m.labels))
+
+
+def test_gmm_doc_topic_has_genuine_mixtures():
+    # On overlapping topics, some documents get a real blend (not one-hot).
+    docs, emb = _blobs(spread=1.1, sep=1.2)
+    m = topica.BERTopic(clusterer="gmm", num_clusters=4, n_components=10, seed=1)
+    m.fit(docs, emb)
+    dt = np.asarray(m.doc_topic)
+    max_prob = dt.max(axis=1)
+    assert (max_prob < 0.9).sum() >= 5, "expected some multi-topic documents"
+    assert max_prob.min() < 0.8
+
+
+def test_gmm_with_nr_topics_falls_back_to_ctfidf():
+    # With topic reduction, the soft responsibilities can't compose through the
+    # hard c-TF-IDF merge, so doc_topic falls back to the c-TF-IDF distribution
+    # (still a valid (n, num_topics) distribution).
+    docs, emb = _blobs()
+    m = topica.BERTopic(clusterer="gmm", num_clusters=6, nr_topics=3, n_components=10, seed=1)
+    m.fit(docs, emb)
+    dt = np.asarray(m.doc_topic)
+    assert m.num_topics == 3
+    assert dt.shape == (len(docs), 3)
+    assert np.allclose(dt.sum(axis=1), 1.0)
+
+
+def test_non_gmm_doc_topic_unchanged():
+    # kmeans keeps the c-TF-IDF approximate distribution; still a valid distribution
+    # whose argmax is the label, but not the GMM responsibilities.
+    docs, emb = _blobs()
+    m = topica.BERTopic(clusterer="kmeans", num_clusters=4, n_components=10, seed=1)
+    m.fit(docs, emb)
+    dt = np.asarray(m.doc_topic)
+    assert dt.shape[1] == m.num_topics
+    assert np.allclose(dt.sum(axis=1), 1.0)
+
+
+def test_gmm_soft_is_deterministic():
+    docs, emb = _blobs()
+    a = topica.BERTopic(clusterer="gmm", num_clusters=4, n_components=10, seed=1)
+    a.fit(docs, emb)
+    b = topica.BERTopic(clusterer="gmm", num_clusters=4, n_components=10, seed=1)
+    b.fit(docs, emb)
+    assert np.array_equal(np.asarray(a.doc_topic), np.asarray(b.doc_topic))


### PR DESCRIPTION
Closes #357. With `clusterer="gmm"`, BERTopic's `doc_topic` is now the GMM's **soft** posterior membership (the EM responsibilities) instead of the c-TF-IDF approximate distribution. Follow-on to the `gmm` clusterer (#353).

## Why

Cluster-based topic models assign **one topic per document** — a documented weakness on multi-topic / longer docs (in the #357 benchmarking, hard clustering LRAP 0.62 vs LDA 0.93 on Reuters multi-label). GMM already computes each document's soft membership in its E-step and threw it away. Exposing it gives cluster-based BERTopic a genuine mixture `θ` for exactly the cases where single-assignment is the bottleneck — without leaving the embedding pipeline for LDA.

## API

```python
m = topica.BERTopic(clusterer="gmm", num_clusters=20, seed=1)
m.fit(docs, doc_embeddings=emb)
theta  = m.doc_topic       # (D, 20) soft membership from GMM responsibilities, rows sum to 1
labels = theta.argmax(1)   # == m.labels
```

## Implementation

- **`cluster.rs`** — factored the EM into `gmm_fit`; `gmm_labels` wraps it (**bit-identical**, its tests still pass), and new `gmm_soft_labels` returns `(labels, responsibilities)`. The K-alignment detail: GMM drops empty components and densifies labels, so the responsibility columns are reduced to the surviving components **in lockstep** and each row renormalized over them — making `doc_topic.argmax(1) == labels` true by construction.
- **`bertopic.rs`** — `fit_bertopic` uses the soft path for `gmm` without `nr_topics`. With `nr_topics`, the c-TF-IDF topic merge is a hard-label operation that soft responsibilities can't compose through while preserving `argmax==label`, so it **falls back to the c-TF-IDF `doc_topic`** (documented). All other clusterers are unchanged. `doc_topic` serializes exactly as before — no save-format change.
- **Scope**: BERTopic only. Top2Vec keeps its centroid-cosine `doc_topic` (a soft membership of a different kind), per the issue.

## Validation

On overlapping topics the output is a genuine mixture: mean max-prob ~0.94 with real 2–3 way blends (e.g. `[0.24, 0.35, 0.40, 0.01]`); rows sum to 1; `argmax == labels`; deterministic. On well-separated data it correctly approaches one-hot (that's the right GMM answer).

- **Rust**: `gmm_soft_labels` normalized, argmax==hard, matches `gmm_labels`; 201 lib tests pass.
- **Python** (`tests/test_gmm_soft_doctopic.py`): soft+consistent, genuine mixtures, `nr_topics` fallback, non-gmm unchanged, determinism.
- Gates: clippy, embedding pytest (263), save/load round-trip, `mkdocs --strict` all green.

This is the last of the 355–358 batch — #355/#356/#358 are merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)