### PR TITLE
feat(embedding): expose UMAP hyperparameters on BERTopic/Top2Vec and project (#346)

### DIFF
--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -493,6 +493,17 @@ For statistically-selected phrases instead of every bigram, use
   Unlike a typical UMAP, topica's is **fully reproducible**: the negative sampling
   is seeded, so a fixed `seed` pins the layout and the whole `reducer="umap"` fit is
   deterministic. There is no non-determinism caveat and no warning.
+- The UMAP layout is tunable. Beyond `n_neighbors`, `reducer="umap"` accepts
+  `min_dist` (minimum spacing of points in the embedding; lower packs clusters
+  tighter — the default `0.0` matches BERTopic), `spread`, `n_epochs` (`0` = auto:
+  500 for ≤10k rows), `negative_sample_rate`, `repulsion_strength`, and `metric`
+  (`"cosine"` default, or `"euclidean"`). All default to `umap-learn`'s values, so
+  touching nothing reproduces the reference; they are ignored under `reducer="pca"`.
+  The same knobs are on `topica.project(method="umap", ...)`.
+
+  ```python
+  model = topica.BERTopic(reducer="umap", min_dist=0.1, n_neighbors=30, seed=1)
+  ```
 - Results are reproducible for a fixed `seed`, under either reducer.
 
 !!! note "Faithful to the references"

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -33,6 +33,12 @@ def project(
     method: str = "pca",
     n_neighbors: int = 15,
     perplexity: float = 30.0,
+    min_dist: float = 0.0,
+    spread: float = 1.0,
+    n_epochs: int = 0,
+    negative_sample_rate: int = 5,
+    repulsion_strength: float = 1.0,
+    metric: str = "cosine",
     seed: int = 0,
 ) -> numpy.typing.NDArray[numpy.float64]:
     """Project a high-dimensional array to `n_components` for plotting or clustering.
@@ -2626,6 +2632,12 @@ class Top2Vec:
         resolution: float = 1.0,
         knn_neighbors: int = 15,
         diagnostics: bool = True,
+        min_dist: float = 0.0,
+        spread: float = 1.0,
+        n_epochs: int = 0,
+        negative_sample_rate: int = 5,
+        repulsion_strength: float = 1.0,
+        metric: str = "cosine",
         seed: int = 42,
     ) -> None: ...
     def fit(
@@ -2720,6 +2732,12 @@ class BERTopic:
         resolution: float = 1.0,
         knn_neighbors: int = 15,
         diagnostics: bool = True,
+        min_dist: float = 0.0,
+        spread: float = 1.0,
+        n_epochs: int = 0,
+        negative_sample_rate: int = 5,
+        repulsion_strength: float = 1.0,
+        metric: str = "cosine",
         seed: int = 42,
     ) -> None: ...
     def fit(

--- a/src/bertopic.rs
+++ b/src/bertopic.rs
@@ -151,6 +151,7 @@ pub fn fit_bertopic(
     num_clusters: Option<usize>,
     resolution: f64,
     knn_neighbors: usize,
+    umap_params: &reduce::UmapParams,
     seed: u64,
 ) -> BertopicModel {
     let emb_dim = doc_embeddings.first().map_or(0, |r| r.len());
@@ -159,7 +160,14 @@ pub fn fit_bertopic(
     // agglomerative assign every document instead.
     let did_reduce = emb_dim > n_components && n_components > 0;
     let mut reduced: Vec<Vec<f64>> = if did_reduce {
-        reduce::reduce(doc_embeddings, n_components, use_umap, n_neighbors, seed)
+        reduce::reduce(
+            doc_embeddings,
+            n_components,
+            use_umap,
+            n_neighbors,
+            umap_params,
+            seed,
+        )
     } else {
         doc_embeddings.to_vec()
     };
@@ -537,8 +545,25 @@ mod tests {
         // The shipped pipeline normalizes on the PCA path, so fit_bertopic itself
         // recovers block-pure topics (each topic's top words from one planted block).
         let m = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 5, None, 4, 1, false, false, "hdbscan", None,
-            1.0, 15, 7,
+            &docs,
+            &emb,
+            vocab,
+            5,
+            false,
+            15,
+            15,
+            5,
+            None,
+            4,
+            1,
+            false,
+            false,
+            "hdbscan",
+            None,
+            1.0,
+            15,
+            &crate::reduce::UmapParams::default(),
+            7,
         );
         assert_eq!(
             m.num_topics, 4,
@@ -560,8 +585,25 @@ mod tests {
     fn recovers_topics_via_ctfidf() {
         let (docs, emb, vocab) = planted(3, 40, 1);
         let m = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None,
-            1.0, 15, 1,
+            &docs,
+            &emb,
+            vocab,
+            5,
+            false,
+            15,
+            15,
+            2,
+            None,
+            4,
+            1,
+            false,
+            false,
+            "hdbscan",
+            None,
+            1.0,
+            15,
+            &crate::reduce::UmapParams::default(),
+            1,
         );
         assert!(
             m.num_topics >= 3,
@@ -586,8 +628,25 @@ mod tests {
     fn nr_topics_reduces_to_target() {
         let (docs, emb, vocab) = planted(4, 40, 2);
         let full = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None,
-            1.0, 15, 2,
+            &docs,
+            &emb,
+            vocab,
+            5,
+            false,
+            15,
+            15,
+            2,
+            None,
+            4,
+            1,
+            false,
+            false,
+            "hdbscan",
+            None,
+            1.0,
+            15,
+            &crate::reduce::UmapParams::default(),
+            2,
         );
         assert!(full.num_topics >= 3);
         let reduced = fit_bertopic(
@@ -608,6 +667,7 @@ mod tests {
             None,
             1.0,
             15,
+            &crate::reduce::UmapParams::default(),
             2,
         );
         assert_eq!(reduced.num_topics, 2, "should reduce to 2 topics");
@@ -617,8 +677,25 @@ mod tests {
     fn approximate_distribution_favors_own_topic() {
         let (docs, emb, vocab) = planted(3, 40, 3);
         let m = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None,
-            1.0, 15, 3,
+            &docs,
+            &emb,
+            vocab,
+            5,
+            false,
+            15,
+            15,
+            2,
+            None,
+            4,
+            1,
+            false,
+            false,
+            "hdbscan",
+            None,
+            1.0,
+            15,
+            &crate::reduce::UmapParams::default(),
+            3,
         );
         // A document made only of block-0 words should put its largest mass on the
         // topic whose top words are block 0.
@@ -637,8 +714,25 @@ mod tests {
     fn bertopic_conforms() {
         let (docs, emb, vocab) = planted(3, 40, 1);
         let m = fit_bertopic(
-            &docs, &emb, vocab, 5, false, 15, 15, 2, None, 4, 1, false, false, "hdbscan", None,
-            1.0, 15, 1,
+            &docs,
+            &emb,
+            vocab,
+            5,
+            false,
+            15,
+            15,
+            2,
+            None,
+            4,
+            1,
+            false,
+            false,
+            "hdbscan",
+            None,
+            1.0,
+            15,
+            &crate::reduce::UmapParams::default(),
+            1,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -8730,9 +8730,16 @@ fn warn_stochastic(py: Python<'_>, method: &str) -> PyResult<()> {
 ///
 /// `n_neighbors` is the local-neighborhood size for the UMAP graph; `perplexity`
 /// is t-SNE's effective neighborhood size; `seed` seeds the reducer (UMAP/PCA)
-/// for reproducibility.
+/// for reproducibility. The remaining kwargs tune the UMAP layout (ignored by
+/// `pca`/`tsne`): `min_dist` (minimum spacing of points in the embedding),
+/// `spread` (its scale), `n_epochs` (0 = auto), `negative_sample_rate`,
+/// `repulsion_strength`, and `metric` (`"cosine"` or `"euclidean"`); the defaults
+/// match `umap-learn`.
 #[pyfunction]
-#[pyo3(signature = (data, n_components=2, *, method="pca", n_neighbors=15, perplexity=30.0, seed=0))]
+#[pyo3(signature = (data, n_components=2, *, method="pca", n_neighbors=15, perplexity=30.0,
+                    min_dist=0.0, spread=1.0, n_epochs=0, negative_sample_rate=5,
+                    repulsion_strength=1.0, metric="cosine", seed=0))]
+#[allow(clippy::too_many_arguments)]
 fn project<'py>(
     py: Python<'py>,
     data: &Bound<'py, PyAny>,
@@ -8740,9 +8747,23 @@ fn project<'py>(
     method: &str,
     n_neighbors: usize,
     perplexity: f64,
+    min_dist: f64,
+    spread: f64,
+    n_epochs: usize,
+    negative_sample_rate: usize,
+    repulsion_strength: f64,
+    metric: &str,
     seed: u64,
 ) -> PyResult<Bound<'py, PyArray2<f64>>> {
     let rows = parse_features(data)?;
+    let umap_params = parse_umap_params(
+        min_dist,
+        spread,
+        n_epochs,
+        negative_sample_rate,
+        repulsion_strength,
+        metric,
+    )?;
     match method {
         "pca" => {}
         "umap" => {
@@ -8780,6 +8801,7 @@ fn project<'py>(
             n_components,
             &method,
             n_neighbors,
+            &umap_params,
             perplexity,
             0.5,
             1000,
@@ -12650,6 +12672,53 @@ fn parse_graph_params(resolution: f64, knn_neighbors: usize) -> PyResult<(f64, u
     Ok((resolution, knn_neighbors))
 }
 
+/// Validate the UMAP layout hyperparameters and pack them into a
+/// `reduce::UmapParams`. Only used when `reducer="umap"`; the defaults reproduce
+/// the previous hardcoded reference configuration, so a caller that leaves them
+/// alone gets identical layouts. Validated unconditionally so a bad value (a
+/// negative `min_dist`, an unknown `metric`) is a clear error at construction.
+#[allow(clippy::too_many_arguments)]
+fn parse_umap_params(
+    min_dist: f64,
+    spread: f64,
+    n_epochs: usize,
+    negative_sample_rate: usize,
+    repulsion_strength: f64,
+    metric: &str,
+) -> PyResult<crate::reduce::UmapParams> {
+    if !min_dist.is_finite() || min_dist < 0.0 {
+        return Err(PyValueError::new_err(format!(
+            "min_dist must be a non-negative finite number, got {min_dist}"
+        )));
+    }
+    if !spread.is_finite() || spread <= 0.0 {
+        return Err(PyValueError::new_err(format!(
+            "spread must be a positive finite number, got {spread}"
+        )));
+    }
+    if !repulsion_strength.is_finite() || repulsion_strength <= 0.0 {
+        return Err(PyValueError::new_err(format!(
+            "repulsion_strength must be a positive finite number, got {repulsion_strength}"
+        )));
+    }
+    if negative_sample_rate < 1 {
+        return Err(PyValueError::new_err("negative_sample_rate must be >= 1"));
+    }
+    if metric != "cosine" && metric != "euclidean" {
+        return Err(PyValueError::new_err(format!(
+            "unknown metric {metric:?}; expected 'cosine' or 'euclidean'"
+        )));
+    }
+    Ok(crate::reduce::UmapParams {
+        min_dist,
+        spread,
+        n_epochs,
+        negative_sample_rate,
+        repulsion_strength,
+        metric: metric.to_string(),
+    })
+}
+
 /// Post-fit sanity checks for the embedding-clustering pipeline (issue #356). The
 /// reduce→cluster pipeline decides almost everything and its failure modes are
 /// silent — the run completes and returns a model with no signal that the result
@@ -12768,6 +12837,7 @@ pub struct Top2Vec {
     num_clusters: Option<usize>,
     resolution: f64,
     knn_neighbors: usize,
+    umap_params: crate::reduce::UmapParams,
     diagnostics: bool,
     seed: u64,
     fitted: bool,
@@ -12826,12 +12896,18 @@ impl Top2Vec {
     /// ignored by the other clusterers. `diagnostics` (default True) emits a
     /// one-time warning after fitting if the clustering looks degenerate (near-total
     /// collapse, a very high noise fraction, or gross over-splitting); pass False to
-    /// silence it. `seed` seeds the deterministic phases.
+    /// silence it. When `reducer="umap"`, `min_dist` / `spread` / `n_epochs`
+    /// (0 = auto) / `negative_sample_rate` / `repulsion_strength` / `metric`
+    /// (``"cosine"`` or ``"euclidean"``) tune the UMAP layout; the defaults match
+    /// `umap-learn`, and they are ignored under `reducer="pca"`. `seed` seeds the
+    /// deterministic phases.
     #[new]
     #[pyo3(signature = (*, n_components=5, min_cluster_size=15, min_samples=None,
                         reducer="pca", n_neighbors=15, clusterer="hdbscan",
                         num_clusters=None, resolution=1.0, knn_neighbors=15,
-                        diagnostics=true, seed=42))]
+                        diagnostics=true, min_dist=0.0, spread=1.0, n_epochs=0,
+                        negative_sample_rate=5, repulsion_strength=1.0, metric="cosine",
+                        seed=42))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         n_components: usize,
@@ -12844,6 +12920,12 @@ impl Top2Vec {
         resolution: f64,
         knn_neighbors: usize,
         diagnostics: bool,
+        min_dist: f64,
+        spread: f64,
+        n_epochs: usize,
+        negative_sample_rate: usize,
+        repulsion_strength: f64,
+        metric: &str,
         seed: u64,
     ) -> PyResult<Self> {
         if min_cluster_size < 2 {
@@ -12852,6 +12934,14 @@ impl Top2Vec {
         let use_umap = parse_reducer(reducer)?;
         let (clusterer, num_clusters) = parse_clusterer(clusterer, num_clusters)?;
         let (resolution, knn_neighbors) = parse_graph_params(resolution, knn_neighbors)?;
+        let umap_params = parse_umap_params(
+            min_dist,
+            spread,
+            n_epochs,
+            negative_sample_rate,
+            repulsion_strength,
+            metric,
+        )?;
         Ok(Top2Vec {
             n_components,
             use_umap,
@@ -12862,6 +12952,7 @@ impl Top2Vec {
             num_clusters,
             resolution,
             knn_neighbors,
+            umap_params,
             diagnostics,
             seed,
             fitted: false,
@@ -12967,6 +13058,7 @@ impl Top2Vec {
         let clusterer = self.clusterer.clone();
         let num_clusters = self.num_clusters;
         let (resolution, knn_neighbors) = (self.resolution, self.knn_neighbors);
+        let umap_params = self.umap_params.clone();
         let model = py.allow_threads(move || {
             top2vec::fit_top2vec(
                 &corpus.docs,
@@ -12982,6 +13074,7 @@ impl Top2Vec {
                 num_clusters,
                 resolution,
                 knn_neighbors,
+                &umap_params,
                 seed,
             )
         });
@@ -13312,11 +13405,12 @@ impl Top2Vec {
             min_samples: s.min_samples,
             clusterer: s.clusterer,
             num_clusters: s.num_clusters,
-            // resolution/knn_neighbors are fit-time knobs; the fitted result is
-            // fully captured by the stored model, so a loaded model just carries
-            // the defaults (it never re-clusters).
+            // resolution/knn_neighbors/umap_params are fit-time knobs; the fitted
+            // result is fully captured by the stored model, so a loaded model just
+            // carries the defaults (it never re-reduces or re-clusters).
             resolution: 1.0,
             knn_neighbors: 15,
+            umap_params: crate::reduce::UmapParams::default(),
             // Fit-time flag; a loaded model won't re-fit, so it just carries the
             // default (diagnostics only fire during fit()).
             diagnostics: true,
@@ -13378,6 +13472,7 @@ pub struct BERTopic {
     num_clusters: Option<usize>,
     resolution: f64,
     knn_neighbors: usize,
+    umap_params: crate::reduce::UmapParams,
     diagnostics: bool,
     seed: u64,
     fitted: bool,
@@ -13456,14 +13551,19 @@ impl BERTopic {
     /// `resolution` yields more, smaller topics; ignored by the others.
     /// `diagnostics` (default True) emits a one-time warning after fitting if the
     /// clustering looks degenerate (near-total collapse, a very high noise
-    /// fraction, or gross over-splitting); pass False to silence it. `seed` seeds
-    /// the deterministic phases.
+    /// fraction, or gross over-splitting); pass False to silence it. When
+    /// `reducer="umap"`, `min_dist` / `spread` / `n_epochs` (0 = auto) /
+    /// `negative_sample_rate` / `repulsion_strength` / `metric` (``"cosine"`` or
+    /// ``"euclidean"``) tune the UMAP layout (`umap-learn` defaults; ignored under
+    /// `reducer="pca"`). `seed` seeds the deterministic phases.
     #[new]
     #[pyo3(signature = (*, n_components=5, min_cluster_size=15, min_samples=None,
                         nr_topics=None, window=4, stride=1, reducer="pca", n_neighbors=15,
                         bm25=false, reduce_frequent=false, clusterer="hdbscan",
                         num_clusters=None, resolution=1.0, knn_neighbors=15,
-                        diagnostics=true, seed=42))]
+                        diagnostics=true, min_dist=0.0, spread=1.0, n_epochs=0,
+                        negative_sample_rate=5, repulsion_strength=1.0, metric="cosine",
+                        seed=42))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         n_components: usize,
@@ -13481,6 +13581,12 @@ impl BERTopic {
         resolution: f64,
         knn_neighbors: usize,
         diagnostics: bool,
+        min_dist: f64,
+        spread: f64,
+        n_epochs: usize,
+        negative_sample_rate: usize,
+        repulsion_strength: f64,
+        metric: &str,
         seed: u64,
     ) -> PyResult<Self> {
         if min_cluster_size < 2 {
@@ -13489,6 +13595,14 @@ impl BERTopic {
         let use_umap = parse_reducer(reducer)?;
         let (clusterer, num_clusters) = parse_clusterer(clusterer, num_clusters)?;
         let (resolution, knn_neighbors) = parse_graph_params(resolution, knn_neighbors)?;
+        let umap_params = parse_umap_params(
+            min_dist,
+            spread,
+            n_epochs,
+            negative_sample_rate,
+            repulsion_strength,
+            metric,
+        )?;
         Ok(BERTopic {
             n_components,
             use_umap,
@@ -13504,6 +13618,7 @@ impl BERTopic {
             num_clusters,
             resolution,
             knn_neighbors,
+            umap_params,
             diagnostics,
             seed,
             fitted: false,
@@ -13573,6 +13688,7 @@ impl BERTopic {
         let clusterer = self.clusterer.clone();
         let num_clusters = self.num_clusters;
         let (resolution, knn_neighbors) = (self.resolution, self.knn_neighbors);
+        let umap_params = self.umap_params.clone();
         let model = py.allow_threads(move || {
             bertopic::fit_bertopic(
                 &corpus.docs,
@@ -13592,6 +13708,7 @@ impl BERTopic {
                 num_clusters,
                 resolution,
                 knn_neighbors,
+                &umap_params,
                 seed,
             )
         });
@@ -13885,9 +14002,11 @@ impl BERTopic {
             reduce_frequent: s.reduce_frequent,
             clusterer: s.clusterer,
             num_clusters: s.num_clusters,
-            // Fit-time knobs; a loaded model never re-clusters, so defaults suffice.
+            // Fit-time knobs; a loaded model never re-reduces or re-clusters, so
+            // defaults suffice.
             resolution: 1.0,
             knn_neighbors: 15,
+            umap_params: crate::reduce::UmapParams::default(),
             // Fit-time flag; diagnostics only fire during fit(), so a loaded model
             // carries the default.
             diagnostics: true,

--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -860,7 +860,17 @@ mod tsne_tests {
         let data: Vec<Vec<f64>> = (0..20)
             .map(|_| (0..6).map(|_| rng.gen::<f64>()).collect())
             .collect();
-        let emb = project(&data, 2, "tsne", 15, 30.0, 0.5, 250, 0);
+        let emb = project(
+            &data,
+            2,
+            "tsne",
+            15,
+            &UmapParams::default(),
+            30.0,
+            0.5,
+            250,
+            0,
+        );
         assert_eq!(emb.len(), 20);
         assert!(emb
             .iter()

--- a/src/reduce.rs
+++ b/src/reduce.rs
@@ -25,8 +25,39 @@ pub fn umap_available() -> bool {
     cfg!(feature = "umap")
 }
 
+/// The UMAP layout hyperparameters (everything past `n_components`/`n_neighbors`),
+/// carried as one value so the reduce pipeline doesn't grow six positional
+/// arguments. `Default` is the reference configuration the embedding models used
+/// before these became tunable — `cosine` metric, `min_dist = 0.0` (BERTopic's
+/// setting for tight clusters), `spread = 1.0`, auto epochs (`n_epochs = 0` →
+/// 500 for ≤10k rows), and the standard negative sampling — so a caller that
+/// leaves it default gets exactly the previous behavior.
+#[derive(Clone, Debug)]
+pub struct UmapParams {
+    pub min_dist: f64,
+    pub spread: f64,
+    pub n_epochs: usize,
+    pub negative_sample_rate: usize,
+    pub repulsion_strength: f64,
+    pub metric: String,
+}
+
+impl Default for UmapParams {
+    fn default() -> Self {
+        Self {
+            min_dist: 0.0,
+            spread: 1.0,
+            n_epochs: 0,
+            negative_sample_rate: 5,
+            repulsion_strength: 1.0,
+            metric: "cosine".to_string(),
+        }
+    }
+}
+
 /// Reduce `data` to `n_components` with either UMAP (`use_umap`) or randomized
-/// PCA. The embedding heads call this so the reducer is a single switch. When the
+/// PCA. The embedding heads call this so the reducer is a single switch. `umap`
+/// carries UMAP's layout hyperparameters (ignored on the PCA path). When the
 /// `umap` feature is not compiled, this always uses PCA (callers that expose UMAP
 /// should reject the request earlier via `umap_available`).
 pub fn reduce(
@@ -34,41 +65,41 @@ pub fn reduce(
     n_components: usize,
     use_umap: bool,
     n_neighbors: usize,
+    umap_params: &UmapParams,
     seed: u64,
 ) -> Vec<Vec<f64>> {
     #[cfg(feature = "umap")]
     {
         if use_umap {
-            return umap(data, n_components, n_neighbors, seed);
+            return umap(data, n_components, n_neighbors, umap_params, seed);
         }
     }
-    let _ = (use_umap, n_neighbors);
+    let _ = (use_umap, n_neighbors, umap_params);
     pca(data, n_components, seed)
 }
 
-/// Project `data` onto `n_components` with UMAP. Delegates to the in-house,
-/// umap-learn-faithful reducer in `crate::umap` with the embedding models'
-/// reference-matching defaults: a cosine kNN metric, `min_dist = 0.0` (BERTopic's
-/// setting for tight clusters), `spread = 1.0`, auto epochs, and the standard
-/// negative sampling. Unlike the old umap-rs path this is fully reproducible for
-/// a fixed `seed`. Only built under `umap`.
+/// Project `data` onto `n_components` with UMAP, using the layout hyperparameters
+/// in `params` (see [`UmapParams`]). Delegates to the in-house,
+/// umap-learn-faithful reducer in `crate::umap`; unlike the old umap-rs path it is
+/// fully reproducible for a fixed `seed`. Only built under `umap`.
 #[cfg(feature = "umap")]
 pub fn umap(
     data: &[Vec<f64>],
     n_components: usize,
     n_neighbors: usize,
+    params: &UmapParams,
     seed: u64,
 ) -> Vec<Vec<f64>> {
     crate::umap::umap(
         data,
         n_components,
         n_neighbors,
-        0.0, // min_dist
-        1.0, // spread
-        0,   // n_epochs (0 => auto: 500 for <=10k rows)
-        5,   // negative_sample_rate
-        1.0, // repulsion_strength (gamma)
-        "cosine",
+        params.min_dist,
+        params.spread,
+        params.n_epochs,
+        params.negative_sample_rate,
+        params.repulsion_strength,
+        &params.metric,
         seed,
     )
 }
@@ -142,11 +173,13 @@ pub fn tsne(
 /// deterministic), `"umap"`, or `"tsne"`. UMAP and t-SNE fall back to PCA when their
 /// feature is not compiled in; callers that expose them should gate on
 /// `umap_available` / `tsne_available` first and surface a clear error instead.
+#[allow(clippy::too_many_arguments)]
 pub fn project(
     data: &[Vec<f64>],
     n_components: usize,
     method: &str,
     n_neighbors: usize,
+    umap_params: &UmapParams,
     perplexity: f64,
     theta: f64,
     epochs: usize,
@@ -156,11 +189,11 @@ pub fn project(
         "umap" => {
             #[cfg(feature = "umap")]
             {
-                umap(data, n_components, n_neighbors, seed)
+                umap(data, n_components, n_neighbors, umap_params, seed)
             }
             #[cfg(not(feature = "umap"))]
             {
-                let _ = n_neighbors;
+                let _ = (n_neighbors, umap_params);
                 pca(data, n_components, seed)
             }
         }
@@ -744,7 +777,7 @@ mod umap_tests {
                 truth.push(c);
             }
         }
-        let emb = umap(&data, 2, 10, 1);
+        let emb = umap(&data, 2, 10, &UmapParams::default(), 1);
         assert_eq!(emb.len(), data.len());
         assert_eq!(emb[0].len(), 2);
         assert!(

--- a/src/top2vec.rs
+++ b/src/top2vec.rs
@@ -177,6 +177,7 @@ pub fn fit_top2vec(
     num_clusters: Option<usize>,
     resolution: f64,
     knn_neighbors: usize,
+    umap_params: &reduce::UmapParams,
     seed: u64,
 ) -> Top2VecModel {
     let n_docs = doc_embeddings.len();
@@ -189,7 +190,14 @@ pub fn fit_top2vec(
     // (1) Reduce, unless the embeddings are already at or below the target dim.
     let did_reduce = emb_dim > n_components && n_components > 0;
     let mut reduced: Vec<Vec<f64>> = if did_reduce {
-        reduce::reduce(doc_embeddings, n_components, use_umap, n_neighbors, seed)
+        reduce::reduce(
+            doc_embeddings,
+            n_components,
+            use_umap,
+            n_neighbors,
+            umap_params,
+            seed,
+        )
     } else {
         doc_embeddings.to_vec()
     };
@@ -360,7 +368,21 @@ mod tests {
         }
 
         let m = fit_top2vec(
-            &docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1.0, 15, 1,
+            &docs,
+            &doc_emb,
+            &word_emb,
+            10,
+            5,
+            false,
+            15,
+            5,
+            2,
+            "hdbscan",
+            None,
+            1.0,
+            15,
+            &crate::reduce::UmapParams::default(),
+            1,
         );
         assert!(
             m.num_topics >= 2,
@@ -396,7 +418,21 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..5).map(|_| vec![0u32]).collect();
         let word_emb = vec![vec![1.0, 0.0]];
         let m = fit_top2vec(
-            &docs, &doc_emb, &word_emb, 1, 2, false, 15, 5, 2, "hdbscan", None, 1.0, 15, 1,
+            &docs,
+            &doc_emb,
+            &word_emb,
+            1,
+            2,
+            false,
+            15,
+            5,
+            2,
+            "hdbscan",
+            None,
+            1.0,
+            15,
+            &crate::reduce::UmapParams::default(),
+            1,
         );
         assert_eq!(m.num_topics, 0);
         assert!(m.topic_vectors.is_empty());
@@ -432,7 +468,21 @@ mod tests {
             word_emb.push(jitter(&mut rng, c));
         }
         let m = fit_top2vec(
-            &docs, &doc_emb, &word_emb, 10, 5, false, 15, 5, 2, "hdbscan", None, 1.0, 15, 1,
+            &docs,
+            &doc_emb,
+            &word_emb,
+            10,
+            5,
+            false,
+            15,
+            5,
+            2,
+            "hdbscan",
+            None,
+            1.0,
+            15,
+            &crate::reduce::UmapParams::default(),
+            1,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/tests/test_umap_hyperparams.py
+++ b/tests/test_umap_hyperparams.py
@@ -1,0 +1,102 @@
+"""UMAP hyperparameters exposed on BERTopic/Top2Vec and topica.project (#346).
+
+The in-house UMAP reducer already accepted min_dist/spread/n_epochs/
+negative_sample_rate/repulsion_strength/metric; these tests check they are now
+reachable from Python, change the layout, keep the reference defaults
+(non-breaking), and are validated.
+"""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import topica
+
+
+def _umap_available():
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            topica.project(np.random.default_rng(0).normal(0, 1, (20, 6)), 2, method="umap")
+        return True
+    except RuntimeError:
+        return False
+
+
+umap_only = pytest.mark.skipif(not _umap_available(), reason="build without the umap feature")
+
+
+@pytest.fixture
+def X():
+    return np.random.default_rng(0).normal(0, 1, (200, 20))
+
+
+@umap_only
+def test_project_umap_params_change_layout(X):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        base = topica.project(X, 5, method="umap", seed=1)
+        far = topica.project(X, 5, method="umap", min_dist=0.8, seed=1)
+        euc = topica.project(X, 5, method="umap", metric="euclidean", seed=1)
+        again = topica.project(X, 5, method="umap", seed=1)
+    assert not np.allclose(base, far), "min_dist should change the layout"
+    assert not np.allclose(base, euc), "metric should change the layout"
+    assert np.allclose(base, again), "same params + seed must reproduce"
+
+
+@umap_only
+def test_project_umap_defaults_are_the_reference(X):
+    # Leaving the kwargs alone must equal passing the documented reference defaults.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        implicit = topica.project(X, 5, method="umap", seed=3)
+        explicit = topica.project(
+            X, 5, method="umap", min_dist=0.0, spread=1.0, n_epochs=0,
+            negative_sample_rate=5, repulsion_strength=1.0, metric="cosine", seed=3,
+        )
+    assert np.allclose(implicit, explicit)
+
+
+@umap_only
+def test_bertopic_umap_params_fit_and_reproduce():
+    rng = np.random.default_rng(0)
+    centers = rng.normal(0, 4, (5, 20))
+    emb, docs = [], []
+    for c in range(5):
+        for _ in range(50):
+            emb.append(centers[c] + rng.normal(0, 1, 20))
+            docs.append([f"w{c}"])
+    emb = np.array(emb)
+    kw = dict(reducer="umap", clusterer="kmeans", num_clusters=5, min_dist=0.5,
+              metric="euclidean", seed=1)
+    a = topica.BERTopic(**kw)
+    a.fit(docs, emb)
+    b = topica.BERTopic(**kw)
+    b.fit(docs, emb)
+    assert list(a.labels) == list(b.labels)
+    assert a.num_topics == 5
+
+
+def test_umap_param_validation():
+    for bad in (
+        dict(min_dist=-0.1),
+        dict(spread=0.0),
+        dict(repulsion_strength=0.0),
+        dict(negative_sample_rate=0),
+        dict(metric="cosin"),
+    ):
+        with pytest.raises(ValueError):
+            topica.BERTopic(reducer="umap", **bad)
+        with pytest.raises(ValueError):
+            topica.Top2Vec(reducer="umap", **bad)
+
+
+def test_umap_params_accepted_but_harmless_under_pca():
+    # The kwargs exist regardless of reducer; under pca they're simply ignored.
+    rng = np.random.default_rng(0)
+    emb = rng.normal(0, 1, (60, 10))
+    docs = [["a", "b"] for _ in range(60)]
+    m = topica.BERTopic(reducer="pca", min_dist=0.5, metric="euclidean", seed=1)
+    m.fit(docs, emb)  # must not raise
+    assert m.num_topics >= 0


### PR DESCRIPTION
Closes #346. Exposes the six UMAP layout hyperparameters — `min_dist`, `spread`, `n_epochs`, `negative_sample_rate`, `repulsion_strength`, `metric` — as kwargs on `BERTopic` / `Top2Vec` and `topica.project`. Follow-up to #343/#345 (the in-house UMAP rebuild).

## Why

The in-house UMAP core (`crate::umap::umap`) already accepted all of these; they were just hardcoded to reference defaults in `reduce::umap` and unreachable from Python. So this is pure plumbing — no new algorithm. `BERTopic`/`Top2Vec` previously surfaced only `n_components` and `n_neighbors`; these knobs are for users who want to *deviate* and tune for their corpus.

## API

```python
model = topica.BERTopic(reducer="umap", min_dist=0.1, n_neighbors=30, metric="euclidean", seed=1)
coords = topica.project(X, 5, method="umap", min_dist=0.5)
```

## Implementation

- **`reduce.rs`** — a `UmapParams` struct whose `Default` **is** the previous hardcoded reference config (cosine, `min_dist=0.0`, `spread=1.0`, auto epochs, standard sampling), carried through `reduce::reduce` / `reduce::umap` / `reduce::project` instead of six positional args.
- Threaded through `fit_bertopic` / `fit_top2vec`.
- The six kwargs added to both constructors (+ structs, load defaults, `.pyi`) and to `topica.project`, validated by `parse_umap_params` (`metric` ∈ {cosine, euclidean}, `min_dist ≥ 0`, `spread`/`repulsion_strength > 0`, `negative_sample_rate ≥ 1`).
- **Non-breaking**: defaults match `umap-learn`, so leaving them alone reproduces the previous layout exactly; ignored under `reducer="pca"`. Fit-time knobs, not serialized.

## Validation

Verified end to end: `min_dist` and `metric` change the UMAP layout; the implicit default equals passing the explicit reference values; `reducer="umap"` fits are deterministic for a fixed seed; every bad value errors at construction.

- **Python** (`tests/test_umap_hyperparams.py`, umap-feature guarded): layout change, default == reference, deterministic fit, validation for both models, pca-harmless.
- Gates: 204 Rust tests, embedding pytest (263), save/load round-trip, `cargo fmt`/clippy, `mkdocs --strict` all green.

Note: the `bertopic` package takes a whole `umap_model=` object; topica's `reducer=` is a string selecting a Rust path, so flat kwargs are the idiomatic equivalent (as the issue notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)