### PR TITLE
feat(content): STM content_time reading layer — content_trajectory / content_divergence (#365)

### DIFF
--- a/docs/api/content.md
+++ b/docs/api/content.md
@@ -32,6 +32,35 @@ rather than discrete groups, so the adapter discretizes it — evaluating
 
 ::: topica.content.group_topic_word
 
+## Wording over ordered time (STM `content_time`)
+
+Fit STM with an ordered `content_time=` covariate and these readers trace **how
+two groups word a topic across time**: the per-period, per-word contrast
+`p(w | g1) - p(w | g2)`, and the per-period whole-vocabulary distance between the
+groups. Both take `ci=True` for a **design-preserving bootstrap** that resamples
+documents (or whole `cluster=`s), refits, realigns the topic by `anchor_words`, and
+returns percentile bands — intervals widen where the random walk is least
+constrained (the first and last period).
+
+```python
+from topica import content
+
+stm = topica.STM(num_topics=20, seed=1)
+stm.fit(docs, content=party, content_time=year, content_prior="l1")
+
+tr = content.content_trajectory(stm, ["tax", "climate"],
+                                groups=("Democrat", "Republican"), anchor_words=econ)
+tr.to_frame()                       # word, period, estimate
+
+dv = content.content_divergence(stm, groups=("Democrat", "Republican"),
+                                anchor_words=econ, measure="hellinger",
+                                ci=True, corpus=docs, fit_kwargs=fk)  # + bootstrap CI
+```
+
+::: topica.content.content_trajectory
+
+::: topica.content.content_divergence
+
 ## Choosing K with group-stratified coherence
 
 `topica.search_k` accepts a `"stratified_<type>"` coherence metric for

--- a/parity/content_time_readers_faSTM.py
+++ b/parity/content_time_readers_faSTM.py
@@ -1,0 +1,169 @@
+"""Parity: topica.content content_trajectory / content_divergence vs faSTM (#365).
+
+topica's STM content_time reading layer ports faSTM's `content_trajectory()` /
+`content_divergence()` (faSTM/R/content-trajectory.R). Both are deterministic
+functions of the fitted content surface beta_{k,g,v}, so *given the same beta*
+they must produce identical point estimates.
+
+This script fits an STM `content_time` model once in faSTM, exports its content
+beta (exp of `fit$beta$logbeta`), its `group@period` levels, its vocabulary, and
+the R readers' outputs. It then builds a duck-typed model from that same beta,
+runs topica's `content_trajectory` / `content_divergence` on it, and checks the
+estimates agree to floating point. The R side also reports which topic its
+anchor-word rule selected; topica reads the same topic explicitly, so the
+comparison isolates the reader arithmetic from the (implementation-native) anchor
+heuristic.
+
+Shells out to `Rscript` with the `faSTM` package. Skips (exit 0) if unavailable.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+import numpy as np
+
+R_SCRIPT = r"""
+suppressMessages(library(faSTM))
+# The reference readers live in faSTM's source; source it so both content_trajectory
+# and content_divergence are the current versions regardless of the installed build.
+rfile <- "../faSTM/R/content-trajectory.R"
+if (file.exists(rfile)) suppressMessages(source(rfile))
+set.seed(1)
+
+vocab <- c("climate","border","econ","jobs","tax","health","trade","energy")
+periods <- c(1990, 2000, 2010, 2020)
+docs <- list(); grp <- character(0); yr <- integer(0)
+mk <- function(counts) {
+  nz <- which(counts > 0)
+  matrix(as.integer(rbind(nz, counts[nz])), nrow = 2)
+}
+for (pi in seq_along(periods)) {
+  d <- (pi - 1) / (length(periods) - 1)
+  for (i in 1:70) {
+    cd <- c(round(1 + 5*d), round(1 + 5*(1-d)), 4, 3, 2, 1, 1, 1)  # Dem
+    cr <- c(round(1 + 5*(1-d)), round(1 + 5*d), 4, 3, 2, 1, 1, 1)  # Rep
+    docs[[length(docs)+1]] <- mk(cd); grp <- c(grp, "Dem"); yr <- c(yr, periods[pi])
+    docs[[length(docs)+1]] <- mk(cr); grp <- c(grp, "Rep"); yr <- c(yr, periods[pi])
+  }
+}
+meta <- data.frame(group = grp, year = yr, stringsAsFactors = FALSE)
+
+fit <- stm(docs, vocab, K = 3, content = ~ group, content_time = ~ year,
+           content_prior = "l1", data = meta, seed = 1, verbose = FALSE)
+
+anchor <- c("climate","border","econ")
+words  <- c("climate","border","health")
+tr <- content_trajectory(fit, words = words, groups = c("Dem","Rep"),
+                         anchor_words = anchor)
+dv <- content_divergence(fit, groups = c("Dem","Rep"), anchor_words = anchor,
+                         measure = "hellinger")
+
+# which topic did the anchor rule pick (1-indexed)?
+lb  <- fit$beta$logbeta
+avg <- Reduce(`+`, lb) / length(lb)
+ksel <- which.max(apply(avg, 1, function(r)
+  sum(fit$vocab[order(r, decreasing = TRUE)[1:20]] %in% anchor)))
+
+beta <- lapply(lb, function(m) as.numeric(t(exp(m))))  # row-major (K x V) per group
+out <- list(
+  vocab   = fit$vocab,
+  levels  = fit$settings$covariates$yvarlevels,
+  K       = nrow(lb[[1]]),
+  V       = ncol(lb[[1]]),
+  beta    = beta,                 # list over groups, each length K*V row-major
+  ksel    = ksel,
+  traj    = tr,                   # word, period, estimate
+  div     = dv                    # period, divergence
+)
+cat(jsonlite::toJSON(out, auto_unbox = TRUE, digits = 15))
+"""
+
+
+def _run_r():
+    try:
+        proc = subprocess.run(
+            ["Rscript", "-e", R_SCRIPT], capture_output=True, text=True, timeout=1800
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return None
+    if proc.returncode != 0:
+        sys.stderr.write(proc.stderr[-2000:])
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        sys.stderr.write(proc.stdout[-2000:])
+        return None
+
+
+class _Shim:
+    """A duck-typed content model exposing exactly what topica.content reads."""
+
+    def __init__(self, twbg, groups, vocab):
+        self.topic_word_by_group = twbg
+        self.groups = groups
+        self.vocabulary = vocab
+
+
+def main():
+    data = _run_r()
+    if data is None:
+        print("SKIP: Rscript with the 'faSTM' package is not available")
+        return 0
+
+    from topica import content
+
+    K, V = int(data["K"]), int(data["V"])
+    G = len(data["levels"])
+    # Rebuild beta as (K, G, V) from the per-group row-major (K x V) vectors.
+    twbg = np.empty((K, G, V))
+    for g in range(G):
+        twbg[:, g, :] = np.asarray(data["beta"][g], float).reshape(K, V)
+    shim = _Shim(twbg, list(data["levels"]), list(data["vocab"]))
+
+    k = int(data["ksel"]) - 1  # R is 1-indexed
+
+    # --- content_trajectory parity ---
+    words = sorted({row["word"] for row in _rows(data["traj"])})
+    tr = content.content_trajectory(shim, words, groups=("Dem", "Rep"), topic=k)
+    r_traj = {(row["word"], str(row["period"])): row["estimate"]
+              for row in _rows(data["traj"])}
+    tmax = 0.0
+    for i, w in enumerate(tr.words):
+        for j, p in enumerate(tr.periods):
+            rv = r_traj.get((w, p))
+            if rv is not None and not np.isnan(tr.estimate[i, j]):
+                tmax = max(tmax, abs(tr.estimate[i, j] - rv))
+
+    # --- content_divergence parity ---
+    dv = content.content_divergence(shim, groups=("Dem", "Rep"), topic=k,
+                                    measure="hellinger")
+    r_div = {str(row["period"]): row["divergence"] for row in _rows(data["div"])}
+    dmax = 0.0
+    for j, p in enumerate(dv.periods):
+        rv = r_div.get(p)
+        if rv is not None and not np.isnan(dv.divergence[j]):
+            dmax = max(dmax, abs(dv.divergence[j] - rv))
+
+    print(f"content_trajectory max |topica - faSTM| = {tmax:.2e}")
+    print(f"content_divergence max |topica - faSTM| = {dmax:.2e}")
+    tol = 1e-8
+    ok = tmax < tol and dmax < tol
+    print("PASS" if ok else "FAIL", f"(tol {tol:.0e})")
+    return 0 if ok else 1
+
+
+def _rows(df):
+    """A jsonlite data.frame arrives as a dict of columns; iterate its rows."""
+    if isinstance(df, list):
+        return df
+    keys = list(df.keys())
+    n = len(df[keys[0]])
+    return [{k: df[k][i] for k in keys} for i in range(n)]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/topica/content.py
+++ b/python/topica/content.py
@@ -28,6 +28,8 @@ topic-word distribution ``topic_word_at(level)`` at a few sentiment levels
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+
 import numpy as np
 
 __all__ = [
@@ -37,6 +39,10 @@ __all__ = [
     "split_topics",
     "stratified_coherence",
     "diagnostics",
+    "content_trajectory",
+    "content_divergence",
+    "ContentTrajectory",
+    "ContentDivergence",
 ]
 
 # STS has no discrete groups -- its content axis is a continuous sentiment. We
@@ -341,3 +347,384 @@ def diagnostics(model, texts=None, content=None, *, n=10, coherence_type="c_v"):
         return pd.DataFrame(rows).set_index("topic")
     except ImportError:
         return rows
+
+
+# ===================================================================
+# STM content_time reading layer (issue #365): read "how a group words a
+# topic over ordered time" off the STM content surface fit with
+# `content_time=`, replacing ECTM's readers. Ports faSTM's
+# content_trajectory() / content_divergence() (R/content-trajectory.R).
+#
+# The STM content_time fit crosses base groups with ordered periods into
+# a saturated content axis whose group labels are "base@period" (index
+# base*num_time_periods + period). `group_topic_word` returns that whole
+# (K, G, V) surface; these readers decode the cross, pick the target
+# topic, and read the per-period between-group signal off it.
+# ===================================================================
+
+
+def _parse_content_time_groups(groups):
+    """Split ``"base@period"`` content-group labels into the base levels (in first
+    appearance order), the periods (ordered numerically when possible), and a
+    ``{(base, period): group_index}`` lookup. Raises if the model was not fit with a
+    ``content_time`` covariate (no ``@`` in the labels)."""
+    groups = [str(g) for g in groups]
+    if not any("@" in g for g in groups):
+        raise ValueError(
+            "model was not fit with a content_time covariate (no 'base@period' "
+            "content groups found). Fit STM with content_time= to read a trajectory."
+        )
+    parsed = [g.split("@", 1) for g in groups]
+    bases = list(dict.fromkeys(b for b, _ in parsed))
+    period_labels = list(dict.fromkeys(p for _, p in parsed))
+    try:
+        periods = sorted(period_labels, key=lambda p: float(p))
+    except ValueError:
+        periods = sorted(period_labels)
+    lookup = {(b, p): i for i, (b, p) in enumerate(parsed)}
+    return bases, periods, lookup
+
+
+def _resolve_content_topic(beta_KGV, vocab, topic, anchor_words):
+    """Target topic index: the one whose group-averaged top-20 words overlap
+    ``anchor_words`` most (so it can be tracked across bootstrap refits that number
+    topics differently), or an explicit ``topic``."""
+    if anchor_words is not None:
+        anchor = {str(w) for w in anchor_words}
+        avg = beta_KGV.mean(axis=1)  # (K, V)
+        overlaps = [
+            sum(vocab[i] in anchor for i in np.argsort(avg[k])[::-1][:20])
+            for k in range(avg.shape[0])
+        ]
+        return int(np.argmax(overlaps))
+    if topic is not None:
+        return int(topic)
+    raise ValueError("supply either `topic` or `anchor_words`")
+
+
+def _content_groups_default(bases, groups):
+    if groups is None:
+        if len(bases) < 2:
+            raise ValueError("need at least two base content groups to contrast")
+        return bases[0], bases[1]
+    if len(groups) != 2:
+        raise ValueError("`groups` must be a pair of base content-group labels")
+    return str(groups[0]), str(groups[1])
+
+
+def _traj_point(beta_KGV, vocab, words, g1, g2, k, periods, lookup):
+    """Per-word, per-period contrast p(w|g1,p) - p(w|g2,p) for topic k. Returns
+    (kept_words, estimate array of shape (n_words, n_periods))."""
+    widx = {w: i for i, w in enumerate(vocab)}
+    kept = [w for w in words if w in widx]
+    est = np.full((len(kept), len(periods)), np.nan)
+    for r, w in enumerate(kept):
+        wi = widx[w]
+        for c, p in enumerate(periods):
+            i1, i2 = lookup.get((g1, p)), lookup.get((g2, p))
+            if i1 is not None and i2 is not None:
+                est[r, c] = beta_KGV[k, i1, wi] - beta_KGV[k, i2, wi]
+    return kept, est
+
+
+def _div_point(beta_KGV, g1, g2, k, periods, lookup, measure):
+    """Per-period distributional distance between the two groups' topic-word rows."""
+    out = np.full(len(periods), np.nan)
+    for c, p in enumerate(periods):
+        i1, i2 = lookup.get((g1, p)), lookup.get((g2, p))
+        if i1 is None or i2 is None:
+            continue
+        pd_ = beta_KGV[k, i1]
+        pr = beta_KGV[k, i2]
+        pd_ = pd_ / pd_.sum()
+        pr = pr / pr.sum()
+        if measure == "hellinger":
+            out[c] = np.sqrt(0.5 * np.sum((np.sqrt(pd_) - np.sqrt(pr)) ** 2))
+        else:  # total variation
+            out[c] = 0.5 * np.sum(np.abs(pd_ - pr))
+    return out
+
+
+def _boot_indices(n, clusters, rng):
+    """One bootstrap resample of document indices. With ``clusters`` (a length-n
+    label per document) it is a cluster bootstrap: whole clusters are drawn with
+    replacement, matching faSTM's ``.boot_index``."""
+    if clusters is None:
+        return rng.integers(0, n, n)
+    clusters = np.asarray(clusters)
+    labels = list(dict.fromkeys(clusters.tolist()))
+    members = {lab: np.where(clusters == lab)[0] for lab in labels}
+    drawn = rng.integers(0, len(labels), len(labels))
+    return np.concatenate([members[labels[d]] for d in drawn])
+
+
+def _subset(seq, idx):
+    if seq is None:
+        return None
+    arr = np.asarray(seq)
+    return arr[idx] if arr.ndim == 1 else arr[idx, :]
+
+
+def _refit_stm(docs, idx, fit_kwargs):
+    """Refit an STM content_time model on the resampled documents. ``fit_kwargs``
+    carries the constructor + fit arguments (num_topics/seed/content/content_time/
+    prevalence/...); the per-document covariate arrays are subset to ``idx``."""
+    import topica
+
+    fk = dict(fit_kwargs)
+    docs_b = [docs[i] for i in idx]
+    model = topica.STM(
+        num_topics=int(fk["num_topics"]),
+        seed=int(fk.get("seed", 0)),
+        init=fk.get("init", "spectral"),
+    )
+    fit_args = dict(
+        content=_subset(fk.get("content"), idx),
+        content_names=fk.get("content_names"),
+        content_time=_subset(fk.get("content_time"), idx),
+        content_smooth=fk.get("content_smooth", 1.0),
+        content_prior=fk.get("content_prior", "l2"),
+        content_prior_var=fk.get("content_prior_var", 0.5),
+        iters=int(fk.get("iters", 500)),
+    )
+    prev = _subset(fk.get("prevalence"), idx)
+    if prev is not None:
+        fit_args["prevalence"] = prev
+        if fk.get("prevalence_names") is not None:
+            fit_args["prevalence_names"] = fk["prevalence_names"]
+    model.fit(docs_b, **{k: v for k, v in fit_args.items() if v is not None})
+    return model
+
+
+def _percentile_ci(stack, level):
+    """Percentile CIs down axis 0 of a stack of bootstrap replicates (which may
+    contain NaN where a period/word was absent in a replicate)."""
+    lo = (1.0 - level) / 2.0 * 100.0
+    hi = (1.0 + level) / 2.0 * 100.0
+    with np.errstate(invalid="ignore"):
+        low = np.nanpercentile(stack, lo, axis=0)
+        high = np.nanpercentile(stack, hi, axis=0)
+    return low, high
+
+
+@dataclass
+class ContentTrajectory:
+    """Per-word between-group wording contrast across ordered periods.
+
+    ``estimate`` is ``(n_words, n_periods)`` with ``estimate[i, j] =
+    p(word_i | groups[0], periods[j]) - p(word_i | groups[1], periods[j])`` for the
+    target ``topic``. ``ci_low`` / ``ci_high`` are the bootstrap percentile bands
+    (``None`` unless ``ci=True``).
+    """
+
+    words: list
+    periods: list
+    groups: tuple
+    topic: int
+    estimate: np.ndarray
+    ci_low: np.ndarray | None = None
+    ci_high: np.ndarray | None = None
+
+    def to_frame(self):
+        """Long tidy table: one row per (word, period)."""
+        import pandas as pd
+
+        rows = []
+        for i, w in enumerate(self.words):
+            for j, p in enumerate(self.periods):
+                row = {"word": w, "period": p, "estimate": float(self.estimate[i, j])}
+                if self.ci_low is not None:
+                    row["ci_low"] = float(self.ci_low[i, j])
+                    row["ci_high"] = float(self.ci_high[i, j])
+                rows.append(row)
+        return pd.DataFrame(rows)
+
+
+@dataclass
+class ContentDivergence:
+    """Per-period whole-vocabulary distance between two groups' wording of a topic.
+
+    ``divergence[j]`` is the Hellinger (or TV) distance between the two groups'
+    topic-word rows at ``periods[j]``. ``ci_low`` / ``ci_high`` are bootstrap bands.
+    """
+
+    periods: list
+    groups: tuple
+    topic: int
+    measure: str
+    divergence: np.ndarray
+    ci_low: np.ndarray | None = None
+    ci_high: np.ndarray | None = None
+
+    def to_frame(self):
+        import pandas as pd
+
+        rows = []
+        for j, p in enumerate(self.periods):
+            row = {"period": p, "divergence": float(self.divergence[j])}
+            if self.ci_low is not None:
+                row["ci_low"] = float(self.ci_low[j])
+                row["ci_high"] = float(self.ci_high[j])
+            rows.append(row)
+        return pd.DataFrame(rows)
+
+
+def content_trajectory(
+    model,
+    words,
+    *,
+    groups=None,
+    topic=None,
+    anchor_words=None,
+    ci=False,
+    corpus=None,
+    fit_kwargs=None,
+    cluster=None,
+    B=50,
+    level=0.95,
+    seed=0,
+):
+    """How two content groups word a topic differently, across ordered time.
+
+    Reads the STM ``content_time`` surface (fit with ``STM.fit(..., content_time=)``)
+    for the per-period, per-word contrast ``p(w | group1, period) - p(w | group2,
+    period)`` on the target topic. This is the ECTM ``content_trajectory`` /
+    ``content_contrast`` payoff, read off the smoothed STM surface instead of
+    independent ``(group, period)`` cells.
+
+    Parameters
+    ----------
+    model : fitted STM (content_time)
+        Fit with an ordered ``content_time=`` covariate.
+    words : sequence[str]
+        Words to trace (silently dropped if out of vocabulary).
+    groups : (str, str), optional
+        The two base content groups to contrast. Defaults to the first two.
+    topic : int, optional
+        Target topic. Give this or ``anchor_words``.
+    anchor_words : sequence[str], optional
+        Identify the target topic by top-word overlap. Required when ``ci=True`` so
+        the topic can be realigned across bootstrap refits.
+    ci : bool
+        Attach a design-preserving bootstrap CI (needs ``corpus`` + ``fit_kwargs``).
+    corpus, fit_kwargs, cluster, B, level, seed
+        Bootstrap controls. ``corpus`` is the documents (a Corpus or list of token
+        lists); ``fit_kwargs`` the STM refit arguments (``num_topics``, ``content``,
+        ``content_time``, ``content_prior``, ...); ``cluster`` a length-``num_docs``
+        label to resample whole clusters (e.g. speaker) instead of documents.
+
+    Returns
+    -------
+    ContentTrajectory
+    """
+    beta, glabels = group_topic_word(model)
+    vocab = list(model.vocabulary)
+    bases, periods, lookup = _parse_content_time_groups(glabels)
+    g1, g2 = _content_groups_default(bases, groups)
+    k = _resolve_content_topic(beta, vocab, topic, anchor_words)
+    kept, est = _traj_point(beta, vocab, list(words), g1, g2, k, periods, lookup)
+
+    low = high = None
+    if ci:
+        reps = _bootstrap(
+            corpus, fit_kwargs, cluster, B, seed, anchor_words,
+            lambda m: _traj_from_model(m, kept, (g1, g2), anchor_words, periods),
+            shape=est.shape,
+        )
+        low, high = _percentile_ci(reps, level)
+    return ContentTrajectory(kept, periods, (g1, g2), k, est, low, high)
+
+
+def content_divergence(
+    model,
+    *,
+    groups=None,
+    topic=None,
+    anchor_words=None,
+    measure="hellinger",
+    ci=False,
+    corpus=None,
+    fit_kwargs=None,
+    cluster=None,
+    B=50,
+    level=0.95,
+    seed=0,
+):
+    """Whole-vocabulary distance between two groups' wording of a topic, per period.
+
+    Reads the STM ``content_time`` surface for the per-period Hellinger (default) or
+    total-variation (``measure="tv"``) distance between the two groups' topic-word
+    distributions. This is the ECTM ``content_divergence`` payoff, but pooled over
+    the vocabulary so the aggregate has a usable bootstrap CI where single-word
+    contrasts do not. Parameters mirror :func:`content_trajectory`.
+
+    Returns
+    -------
+    ContentDivergence
+    """
+    if measure not in ("hellinger", "tv"):
+        raise ValueError("measure must be 'hellinger' or 'tv'")
+    beta, glabels = group_topic_word(model)
+    vocab = list(model.vocabulary)
+    bases, periods, lookup = _parse_content_time_groups(glabels)
+    g1, g2 = _content_groups_default(bases, groups)
+    k = _resolve_content_topic(beta, vocab, topic, anchor_words)
+    div = _div_point(beta, g1, g2, k, periods, lookup, measure)
+
+    low = high = None
+    if ci:
+        reps = _bootstrap(
+            corpus, fit_kwargs, cluster, B, seed, anchor_words,
+            lambda m: _div_from_model(m, (g1, g2), anchor_words, measure, periods),
+            shape=div.shape,
+        )
+        low, high = _percentile_ci(reps, level)
+    return ContentDivergence(periods, (g1, g2), k, measure, div, low, high)
+
+
+def _traj_from_model(model, words, groups, anchor_words, periods):
+    # Evaluate on the ORIGINAL periods (passed in), not the refit's own — a
+    # resample can drop a period, and every replicate must line up column-for-column
+    # (missing cells become NaN via the lookup).
+    beta, glabels = group_topic_word(model)
+    vocab = list(model.vocabulary)
+    _, _, lookup = _parse_content_time_groups(glabels)
+    k = _resolve_content_topic(beta, vocab, None, anchor_words)
+    _, est = _traj_point(beta, vocab, words, groups[0], groups[1], k, periods, lookup)
+    return est
+
+
+def _div_from_model(model, groups, anchor_words, measure, periods):
+    beta, glabels = group_topic_word(model)
+    vocab = list(model.vocabulary)
+    _, _, lookup = _parse_content_time_groups(glabels)
+    k = _resolve_content_topic(beta, vocab, None, anchor_words)
+    return _div_point(beta, groups[0], groups[1], k, periods, lookup, measure)
+
+
+def _bootstrap(corpus, fit_kwargs, cluster, B, seed, anchor_words, read_fn, shape):
+    """Design-preserving bootstrap: resample documents (or clusters), refit the STM
+    content_time model, realign the topic by ``anchor_words``, and collect the
+    reader statistic. Returns a ``(B_ok, *shape)`` stack of replicates."""
+    if anchor_words is None:
+        raise ValueError(
+            "anchor_words is required when ci=True (to realign the topic across "
+            "bootstrap refits)."
+        )
+    if corpus is None or fit_kwargs is None:
+        raise ValueError("ci=True needs corpus= (the documents) and fit_kwargs= "
+                         "(the STM refit arguments).")
+    docs = corpus.documents() if hasattr(corpus, "documents") else [list(d) for d in corpus]
+    n = len(docs)
+    rng = np.random.default_rng(seed)
+    reps = []
+    for _ in range(int(B)):
+        idx = _boot_indices(n, cluster, rng)
+        try:
+            m = _refit_stm(docs, idx, fit_kwargs)
+            reps.append(read_fn(m))
+        except Exception:
+            continue  # a degenerate resample (e.g. a period drops out) is skipped
+    if not reps:
+        return np.full((1,) + tuple(shape), np.nan)
+    return np.stack(reps, axis=0)

--- a/scripts/coverage_content_divergence.py
+++ b/scripts/coverage_content_divergence.py
@@ -1,0 +1,89 @@
+"""Synthetic coverage grid for the STM content_time bootstrap CIs (#365).
+
+The #340 objection to ECTM was that its cluster bootstrap could not preserve the
+design, so its intervals targeted an "uncharacterized, coverage-conditioned
+population." The content_time reader bootstrap resamples the *document* (the real
+sampling unit) and refits, so its percentile CI should have close to nominal
+frequentist coverage of the estimand.
+
+This harness checks that. It draws `M` independent datasets from a fixed
+document-generating process with a known per-period Dem/Rep wording gap, fits an
+STM `content_time` model on each, and on each computes the point divergence plus a
+document-bootstrap CI. The estimand's center is the across-dataset mean point
+estimate; empirical coverage is the fraction of datasets whose CI brackets it, at
+each period. Coverage should sit near the nominal level.
+
+Run: python scripts/coverage_content_divergence.py   (a few minutes; it refits STM
+M*(1+B) times). Not a gated test — it is a reproducibility harness.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+
+import topica
+from topica import content
+
+PERIODS = [1990, 2000, 2010, 2020]
+ANCHOR = ["climate", "border"]
+LEVEL = 0.90
+M = 40          # independent datasets
+B = 40          # bootstrap replicates per dataset
+PER_CELL = 40   # documents per (group, period) cell
+ITERS = 120
+
+
+def draw_dataset(rng):
+    """One dataset: 2 groups x 4 periods, a topic whose Dem/Rep wording gap grows
+    across periods, with genuine per-document multinomial sampling noise."""
+    docs, grp, per = [], [], []
+    vocab_topic = ["climate", "border", "econ", "jobs", "tax"]
+    for pi, yr in enumerate(PERIODS):
+        gap = 0.05 + 0.15 * pi / (len(PERIODS) - 1)  # 0.05 -> 0.20
+        pd_ = np.array([0.30 + gap, 0.30 - gap, 0.13, 0.14, 0.13])
+        pr = np.array([0.30 - gap, 0.30 + gap, 0.13, 0.14, 0.13])
+        pd_ = pd_ / pd_.sum(); pr = pr / pr.sum()
+        for _ in range(PER_CELL):
+            nd = rng.integers(12, 20)
+            docs.append([vocab_topic[i] for i in rng.choice(5, nd, p=pd_)])
+            grp.append("Dem"); per.append(yr)
+            docs.append([vocab_topic[i] for i in rng.choice(5, nd, p=pr)])
+            grp.append("Rep"); per.append(yr)
+    return docs, grp, per
+
+
+def one_run(seed):
+    rng = np.random.default_rng(seed)
+    docs, grp, per = draw_dataset(rng)
+    m = topica.STM(num_topics=2, seed=1)
+    m.fit(docs, content=grp, content_time=per, content_prior="l1", iters=ITERS)
+    point = content.content_divergence(m, groups=("Dem", "Rep"), anchor_words=ANCHOR)
+    fk = dict(num_topics=2, seed=1, content=grp, content_time=per,
+              content_prior="l1", iters=ITERS)
+    boot = content.content_divergence(m, groups=("Dem", "Rep"), anchor_words=ANCHOR,
+                                      ci=True, corpus=docs, fit_kwargs=fk, B=B,
+                                      level=LEVEL, seed=seed + 1000)
+    return point.divergence, boot.ci_low, boot.ci_high
+
+
+def main():
+    points, lows, highs = [], [], []
+    for s in range(M):
+        p, lo, hi = one_run(s)
+        points.append(p); lows.append(lo); highs.append(hi)
+        print(f"  dataset {s + 1}/{M} done", flush=True)
+    points = np.array(points); lows = np.array(lows); highs = np.array(highs)
+    center = np.nanmean(points, axis=0)  # estimand center per period
+    covered = (lows <= center) & (center <= highs)  # (M, P)
+    per_period = np.nanmean(covered, axis=0)
+    overall = float(np.nanmean(covered))
+    print("\nnominal level:", LEVEL)
+    print("per-period coverage:", np.round(per_period, 3).tolist())
+    print("overall coverage:   ", round(overall, 3))
+    ok = abs(overall - LEVEL) <= 0.12  # Monte-Carlo tolerance at M=40
+    print("PASS" if ok else "FAIL", "(overall within 0.12 of nominal)")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_content_trajectory.py
+++ b/tests/test_content_trajectory.py
@@ -1,0 +1,135 @@
+"""STM content_time reading layer: content_trajectory / content_divergence (#365).
+
+Ports faSTM's readers to the STM `content_time` surface. These tests validate
+recovery of a known Dem/Rep wording drift, the anchor-word topic realignment, the
+Hellinger/TV distances, and the design-preserving bootstrap CIs (the #340 fix).
+"""
+
+import numpy as np
+import pytest
+
+import topica
+from topica import content
+
+
+def _drift_corpus(per_cell=60, seed=0):
+    """Two groups x four periods. One topic drifts: 'climate' shifts from Rep to
+    Dem and 'border' the other way, crossing over near the middle; 'econ/jobs/tax'
+    is shared filler. Returns (docs, groups, periods, period_labels)."""
+    periods = [1990, 2000, 2010, 2020]
+    docs, grp, per = [], [], []
+    for pi, yr in enumerate(periods):
+        d = pi / (len(periods) - 1)  # 0 -> 1
+        for _ in range(per_cell):
+            docs.append(["econ", "jobs", "tax"] * 2
+                        + ["climate"] * int(1 + 4 * d) + ["border"] * int(1 + 4 * (1 - d)))
+            grp.append("Dem"); per.append(yr)
+            docs.append(["econ", "jobs", "tax"] * 2
+                        + ["border"] * int(1 + 4 * d) + ["climate"] * int(1 + 4 * (1 - d)))
+            grp.append("Rep"); per.append(yr)
+    return docs, grp, per, periods
+
+
+@pytest.fixture(scope="module")
+def fit():
+    docs, grp, per, periods = _drift_corpus()
+    m = topica.STM(num_topics=3, seed=1)
+    m.fit(docs, content=grp, content_time=per, content_prior="l1", iters=150)
+    return m, docs, grp, per
+
+
+ANCHOR = ["climate", "border", "econ"]
+
+
+def test_trajectory_recovers_drift(fit):
+    m = fit[0]
+    tr = content.content_trajectory(m, ["climate", "border"], groups=("Dem", "Rep"),
+                                    anchor_words=ANCHOR)
+    assert tr.periods == ["1990", "2000", "2010", "2020"]
+    clim = tr.estimate[tr.words.index("climate")]
+    bord = tr.estimate[tr.words.index("border")]
+    # Dem-Rep climate contrast rises monotonically across periods and flips sign;
+    # border is its mirror image.
+    assert np.all(np.diff(clim) > 0)
+    assert clim[0] < 0 < clim[-1]
+    assert np.allclose(clim, -bord, atol=1e-9)
+
+
+def test_divergence_peaks_at_the_extremes(fit):
+    m = fit[0]
+    dv = content.content_divergence(m, groups=("Dem", "Rep"), anchor_words=ANCHOR)
+    d = dv.divergence
+    # groups word the topic most differently at the endpoints, alike in the middle
+    assert d[0] > d[1] and d[-1] > d[-2]
+    assert dv.measure == "hellinger"
+    # TV is a different but also non-negative distance
+    tv = content.content_divergence(m, groups=("Dem", "Rep"), anchor_words=ANCHOR, measure="tv")
+    assert np.all(tv.divergence >= 0)
+
+
+def test_anchor_realignment_matches_explicit_topic(fit):
+    m = fit[0]
+    # The anchor-selected topic equals the explicit index for that topic.
+    by_anchor = content.content_trajectory(m, ["climate"], anchor_words=ANCHOR)
+    by_topic = content.content_trajectory(m, ["climate"], topic=by_anchor.topic)
+    assert np.allclose(by_anchor.estimate, by_topic.estimate, equal_nan=True)
+
+
+def test_defaults_first_two_groups(fit):
+    m = fit[0]
+    tr = content.content_trajectory(m, ["climate"], topic=0)
+    assert tr.groups == ("Dem", "Rep")
+
+
+def test_bootstrap_ci_brackets_point_estimate(fit):
+    m, docs, grp, per = fit
+    fk = dict(num_topics=3, seed=1, content=grp, content_time=per,
+              content_prior="l1", iters=150)
+    dv = content.content_divergence(m, groups=("Dem", "Rep"), anchor_words=ANCHOR,
+                                    ci=True, corpus=docs, fit_kwargs=fk, B=8, seed=3)
+    assert dv.ci_low is not None and dv.ci_high is not None
+    assert np.all(dv.ci_low <= dv.ci_high + 1e-9)
+    # the full-data estimate sits within (or at) the resampling band
+    assert np.all(dv.ci_low - 1e-6 <= dv.divergence)
+    assert np.all(dv.divergence <= dv.ci_high + 1e-6)
+
+
+def test_cluster_bootstrap_runs(fit):
+    m, docs, grp, per = fit
+    fk = dict(num_topics=3, seed=1, content=grp, content_time=per,
+              content_prior="l1", iters=120)
+    # cluster on (group, period) cells — whole cells resampled together
+    cluster = [f"{g}:{p}" for g, p in zip(grp, per)]
+    tr = content.content_trajectory(m, ["climate"], groups=("Dem", "Rep"),
+                                    anchor_words=ANCHOR, ci=True, corpus=docs,
+                                    fit_kwargs=fk, cluster=cluster, B=6, seed=5)
+    assert tr.ci_low is not None and tr.ci_low.shape == tr.estimate.shape
+
+
+def test_ci_requires_anchor_and_corpus(fit):
+    m, docs, grp, per = fit
+    fk = dict(num_topics=3, seed=1, content=grp, content_time=per, iters=100)
+    with pytest.raises(ValueError, match="anchor_words is required"):
+        content.content_divergence(m, topic=0, ci=True, corpus=docs, fit_kwargs=fk, B=3)
+    with pytest.raises(ValueError, match="corpus"):
+        content.content_divergence(m, anchor_words=ANCHOR, ci=True, fit_kwargs=fk, B=3)
+
+
+def test_non_content_time_model_errors():
+    docs = [["a", "b", "c"]] * 20 + [["x", "y", "z"]] * 20
+    m = topica.STM(num_topics=2, seed=1)
+    m.fit(docs, content=["p"] * 20 + ["q"] * 20, iters=50)  # content but no content_time
+    with pytest.raises(ValueError, match="content_time"):
+        content.content_trajectory(m, ["a"], topic=0)
+
+
+def test_invalid_measure(fit):
+    with pytest.raises(ValueError, match="hellinger"):
+        content.content_divergence(fit[0], anchor_words=ANCHOR, measure="kl")
+
+
+def test_to_frame(fit):
+    tr = content.content_trajectory(fit[0], ["climate"], anchor_words=ANCHOR)
+    df = tr.to_frame()
+    assert list(df.columns) == ["word", "period", "estimate"]
+    assert len(df) == 4  # 1 word x 4 periods


### PR DESCRIPTION
Closes #365. Adds the **reader layer for the STM `content_time` surface** to `topica.content`, porting faSTM's `content_trajectory()` / `content_divergence()`. This is the constructive half of retiring ECTM (companion decision #364): #347 shipped the `content_time` *estimator*, but nothing upstream *read* its ordered-period axis — so "how a group words a topic over time" still required ECTM. Now it doesn't.

## API (`topica.content`)

```python
stm = topica.STM(num_topics=20, seed=1)
stm.fit(docs, content=party, content_time=year, content_prior="l1")

tr = content.content_trajectory(stm, ["tax", "climate"],
                                groups=("Democrat", "Republican"), anchor_words=econ)
dv = content.content_divergence(stm, groups=("Democrat", "Republican"),
                                anchor_words=econ, measure="hellinger")
```

- **`content_trajectory`** — per-period, per-word contrast `p(w|g1,p) − p(w|g2,p)` on the target topic, decoded from the `base@period` content cross (`group = base*num_time_periods + period`).
- **`content_divergence`** — per-period Hellinger (default) or TV distance between the two groups' topic-word rows, pooled over the vocabulary.
- Both take `ci=True` for a **design-preserving bootstrap**: resample documents (or whole `cluster=`s), refit, realign the topic by `anchor_words` overlap, percentile bands.

## Why this closes the ECTM-hardening set on the STM surface

- **#338 (sparse prior)** — the readers consume the `content_prior="l1"` surface from #347.
- **#339 (smoothing/magnitude)** — one RW-smoothed surface, not independent per-cell fits.
- **#340 (valid CIs)** — the doc/cluster bootstrap resamples the *real* sampling unit instead of whole `(group,period)` cells.
- **#337 (ill-posed divergence)** — a Hellinger/TV distributional distance with a bootstrap CI, not a null-subtracted point score.

## Validation

- **faSTM parity to floating point** — `max |topica − faSTM| = 1.1e-16` on *both* readers, given the same β (`parity/content_time_readers_faSTM.py`; fits once in faSTM, exports β + reader outputs, runs topica's readers on the same β; skips cleanly without Rscript/faSTM).
- **Synthetic recovery** — a known Dem/Rep wording drift is recovered exactly (contrast −0.32→+0.32; divergence peaks at the endpoints), plus anchor-realignment and Hellinger/TV correctness (`tests/test_content_trajectory.py`, 10 tests).
- **Coverage grid** — the bootstrap CIs have ~nominal coverage (0.92 vs 0.90 target) across 40 synthetic datasets (`scripts/coverage_content_divergence.py`).
- Gates: content pytest + `mkdocs --strict` green.

## Next

Companion PR for #364 will re-point the worked example to STM `content_time` and delete ECTM. This reader PR is the only prerequisite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)