### PR TITLE
feat(models): Scholar content — topic-covariate word deviations (neural SAGE) (#376)

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ thread count), or `llm-bounded`.
 | `SAGE` | text, metadata | gibbs | seed-reproducible | Sparse additive generative model: the same topic worded differently across groups. |
 | `DMR` | text, metadata | gibbs | seed-reproducible | Dirichlet-multinomial regression: a document-metadata prior on topic proportions. |
 | `GDMR` | text, metadata | gibbs | seed-reproducible | Generalized DMR with a smooth (Legendre-basis) prior over continuous covariates. |
-| `Scholar` | text, metadata, labels | vae | seed-reproducible | SCHOLAR (Card et al. 2018): a ProdLDA VAE with covariate-shifted topic-prevalence prior and an optional supervised label head (neural STM prevalence + sLDA). |
+| `Scholar` | text, metadata, labels | vae | seed-reproducible | SCHOLAR (Card et al. 2018): a ProdLDA VAE with a covariate-shifted prevalence prior, an optional supervised label head, and optional content (topic-covariate) word deviations — neural STM prevalence + sLDA + SAGE. |
 
 ### Guided & supervised
 
@@ -221,7 +221,7 @@ As such, Topica stands on a generation of open topic-modeling research and code.
 - [**Polylingual Topic Models**](https://aclanthology.org/D09-1092/) (Mimno, Wallach, Naradowsky, Smith & McCallum, 2009) — `PolylingualLDA`: LDA over aligned document tuples that share one topic distribution, giving topics aligned across many languages; validated against MALLET's `PolylingualTopicModel` as a black-box oracle
 - [**DiscLDA**](https://papers.nips.cc/paper/2008/hash/7b13b2203029ed80337f27127a9f1d28-Abstract.html) (Lacoste-Julien, Sha & Jordan, 2008) — `DiscLDA`: discriminative LDA with per-class and shared topic blocks; the fixed block-transform variant, validated against the paper's 20 Newsgroups feature-classification result (no reference implementation exists, so it is paper-derived)
 - [**ProdLDA / AVITM**](https://arxiv.org/abs/1703.01488) (Srivastava & Sutton, 2017) — `ProdLDA`: autoencoding variational inference and the product-of-experts word model
-- [**SCHOLAR**](https://aclanthology.org/P18-1189/) (Card, Tan & Smith, 2018; reference [dallascard/scholar](https://github.com/dallascard/scholar), Apache-2.0) — `Scholar`: metadata in a ProdLDA VAE — a covariate-dependent topic-prevalence prior (the neural analog of STM/DMR prevalence) and an optional supervised label head (neural sLDA), on topica's ProdLDA backbone, validated against the reference as a numerical oracle
+- [**SCHOLAR**](https://aclanthology.org/P18-1189/) (Card, Tan & Smith, 2018; reference [dallascard/scholar](https://github.com/dallascard/scholar), Apache-2.0) — `Scholar`: metadata in a ProdLDA VAE — a covariate-dependent topic-prevalence prior (neural STM prevalence), an optional supervised label head (neural sLDA), and optional content/topic-covariate word deviations (neural SAGE), on topica's ProdLDA backbone, validated against the reference as a numerical oracle
 - [**BERTopic**](https://github.com/MaartenGr/BERTopic) (Grootendorst, 2022) and [**Top2Vec**](https://github.com/ddangelov/Top2Vec) (Angelov, 2020) — `BERTopic`, `Top2Vec`: the embedding-clustering pipeline, class-based TF-IDF, and the `reduce → cluster → represent` design
 - [**ETM**](https://github.com/adjidieng/ETM) (Dieng, Ruiz & Blei, 2020) — `ETM`: the Embedded Topic Model (per-document variational EM and an amortized VAE)
 - [**DETM**](https://github.com/adjidieng/DETM) (Dieng, Ruiz & Blei, 2019) — `DETM`: the Dynamic Embedded Topic Model (structured amortized variational inference with a hand-coded LSTM)

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -55,7 +55,7 @@ generated from `python/topica/registry.py`.
 | `SAGE` | text, metadata | gibbs | seed-reproducible | Sparse additive generative model: the same topic worded differently across groups. |
 | `DMR` | text, metadata | gibbs | seed-reproducible | Dirichlet-multinomial regression: a document-metadata prior on topic proportions. |
 | `GDMR` | text, metadata | gibbs | seed-reproducible | Generalized DMR with a smooth (Legendre-basis) prior over continuous covariates. |
-| `Scholar` | text, metadata, labels | vae | seed-reproducible | SCHOLAR (Card et al. 2018): a ProdLDA VAE with covariate-shifted topic-prevalence prior and an optional supervised label head (neural STM prevalence + sLDA). |
+| `Scholar` | text, metadata, labels | vae | seed-reproducible | SCHOLAR (Card et al. 2018): a ProdLDA VAE with a covariate-shifted prevalence prior, an optional supervised label head, and optional content (topic-covariate) word deviations — neural STM prevalence + sLDA + SAGE. |
 
 ### Guided & supervised
 
@@ -427,12 +427,36 @@ dominates the label loss that its encoder does not learn to copy the label — s
 effect is backbone- and regime-dependent, not a flaw in the reference. The label
 supervision that shapes the topics, the classifier loss, is unchanged either way.
 
-Topic-covariate (content) deviations — SCHOLAR's third metadata role, the neural
-analog of SAGE — are a planned follow-up.
+### Content (topic covariates)
+
+Pass `content=` (a numeric matrix) to add SCHOLAR's third metadata role: content
+covariates that change *how* topics are worded across groups, the neural analog of
+[`SAGE`](#sage). Each content covariate gets a per-word deviation added to the
+decoder logits (`content_effects`, shape `(n_content, vocab)`); with
+`interactions=True` the model also learns topic×covariate deviations. `l1_content_reg`
+applies a fixed-strength L2 (ridge) penalty that shrinks the deviations. This is a
+simplification of the reference, which reweights the penalty per weight each epoch to
+approximate an L1 (sparsity-inducing) prior; topica's fixed ridge shrinks but does not
+sparsify. Both default to `0.0` (unpenalized additive deviations). The base
+per-word background lives in the shared ProdLDA decoder (its batchnorm shift), not a
+separate content bias term.
+
+```python
+m = topica.Scholar(num_topics=20, content_names=["outlet"], seed=1)
+m.fit(docs, content=G)                 # G is (num_docs, n_content), numeric
+m.content_effects                      # (n_content, vocab): per-covariate word shifts
+```
+
+Unlike labels, a content covariate is observed at prediction, so it enters the
+encoder alongside the prevalence covariates (no train/test inconsistency) and also
+drives the decoder deviations. All three roles compose:
+`m.fit(docs, covariates=X, labels=y, content=G)` fits the prevalence prior, the
+supervised head, and the content deviations together.
 
 `topica`'s [`estimate_effect`](covariates.md) still works on any model's `θ`
-post-hoc; Scholar's added value is putting the covariates *into* the fit, which
-better identifies the topics and exposes `covariate_effects` as a first-class output.
+post-hoc; Scholar's added value is putting the metadata *into* the fit, which better
+identifies the topics and exposes `covariate_effects` / `content_effects` as
+first-class outputs.
 
 ## NarrativeTM
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3124,17 +3124,23 @@ class Scholar:
         *,
         covariates: object | None = None,
         covariate_names: list[str] | None = None,
+        content: object | None = None,
+        content_names: list[str] | None = None,
+        interactions: bool = False,
         alpha: float = 1.0,
         hidden_size: int = 100,
         dropout: float = 0.2,
         batch_size: int = 200,
         lr: float = 0.002,
         l2_prior_reg: float = 0.0,
+        l1_content_reg: float = 0.0,
         convergence_tol: float = 0.0,
         seed: int = 42,
     ) -> None:
-        """``covariates`` (a (num_docs, n_covars) numeric matrix) may be given here or
-        at fit(). ``l2_prior_reg`` is the L2 penalty on the covariate weights."""
+        """``covariates`` (prevalence) and ``content`` (topic-covariate) numeric
+        matrices may be given here or at fit(). ``interactions`` adds topic-covariate
+        interaction deviations; ``l2_prior_reg``/``l1_content_reg`` regularize the
+        covariate/content weights."""
         ...
     def fit(
         self,
@@ -3142,12 +3148,13 @@ class Scholar:
         *,
         covariates: object | None = None,
         labels: object | None = None,
+        content: object | None = None,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
     ) -> None:
-        """Fit on a Corpus or list of token lists with prior ``covariates`` and/or
-        supervised ``labels`` (one per document, str or int). At least one of
-        covariates or labels must be given. `iters` sets the number of epochs."""
+        """Fit on a Corpus or list of token lists with prior ``covariates``, supervised
+        ``labels`` (str/int, one per document), and/or topic-covariate ``content``. At
+        least one of covariates, labels, or content must be given."""
         ...
     @property
     def num_topics(self) -> int: ...
@@ -3161,6 +3168,12 @@ class Scholar:
         ...
     @property
     def covariate_names(self) -> list[str]: ...
+    @property
+    def content_effects(self) -> numpy.typing.NDArray[numpy.float64]:
+        """Content (topic-covariate) word deviations, shape (n_content, vocab)."""
+        ...
+    @property
+    def content_names(self) -> list[str]: ...
     @property
     def classes(self) -> list[str]:
         """Sorted class labels (predict_proba column order); empty if fit without labels."""
@@ -3190,16 +3203,25 @@ class Scholar:
     ) -> list[tuple[str, float]] | list[list[tuple[str, float]]]: ...
     def coherence(self, n: int = 10) -> numpy.typing.NDArray[numpy.float64]: ...
     def transform(
-        self, data: Corpus | Sequence[Sequence[str]], covariates: object | None = None
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        covariates: object | None = None,
+        content: object | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]: ...
     def predict_proba(
-        self, data: Corpus | Sequence[Sequence[str]], covariates: object | None = None
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        covariates: object | None = None,
+        content: object | None = None,
     ) -> numpy.typing.NDArray[numpy.float64]:
         """Class probabilities (num_docs, n_classes), columns in `classes` order.
         Requires a label-trained model."""
         ...
     def predict(
-        self, data: Corpus | Sequence[Sequence[str]], covariates: object | None = None
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        covariates: object | None = None,
+        content: object | None = None,
     ) -> list[str]:
         """Predicted class label per document. Requires a label-trained model."""
         ...

--- a/python/topica/registry.py
+++ b/python/topica/registry.py
@@ -118,7 +118,7 @@ REGISTRY: dict[str, ModelInfo] = {
            "Generalized DMR with a smooth (Legendre-basis) prior over continuous covariates.",
            "guides/models.md#gdmr"),
         _m("Scholar", "covariates", ("text", "metadata", "labels"), "vae", "seed-reproducible", (),
-           "SCHOLAR (Card et al. 2018): a ProdLDA VAE with covariate-shifted topic-prevalence prior and an optional supervised label head (neural STM prevalence + sLDA).",
+           "SCHOLAR (Card et al. 2018): a ProdLDA VAE with a covariate-shifted prevalence prior, an optional supervised label head, and optional content (topic-covariate) word deviations — neural STM prevalence + sLDA + SAGE.",
            "guides/models.md#scholar"),
         _m("NarrativeTM", "covariates", ("text",), "gibbs", "seed-reproducible", ("temporal",),
            "Intra-document narrative trajectory model: captures how topic prevalence shifts across the progress of a text.",

--- a/src/infoctm.rs
+++ b/src/infoctm.rs
@@ -521,14 +521,14 @@ fn elbo_step<R: Rng>(
         prior_mus: None,
     };
     let (loss, cache, stats) = batch_forward(
-        &s.w, &s.bn_mu, &s.bn_lv, &s.bn_dec, prior_mu, prior_var, alpha_vec, opts, &batch,
+        &s.w, &s.bn_mu, &s.bn_lv, &s.bn_dec, prior_mu, prior_var, alpha_vec, opts, &batch, None,
     );
     s.bn_mu.update_running(&stats[0].0, &stats[0].1);
     s.bn_lv.update_running(&stats[1].0, &stats[1].1);
     s.bn_dec.update_running(&stats[2].0, &stats[2].1);
     let mut g = Grad::zeros(&s.w);
     batch_backward(
-        &s.w, prior_mu, prior_var, alpha_vec, opts, &batch, &cache, &mut g, None, None,
+        &s.w, prior_mu, prior_var, alpha_vec, opts, &batch, &cache, &mut g, None, None, None,
     );
     g.scale(1.0 / n as f64);
     (loss / n as f64, g)

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -342,6 +342,14 @@ pub(crate) struct Grad {
 }
 
 impl Grad {
+    /// The `w_mu` encoder-head gradient block. Exposed `pub(crate)` so `scholar`'s
+    /// content-interaction FD test can confirm the interaction's gradient into `theta`
+    /// reaches the encoder.
+    #[cfg(test)]
+    pub(crate) fn w_mu(&self) -> &[f64] {
+        &self.w_mu
+    }
+
     pub(crate) fn zeros(w: &Weights) -> Self {
         Grad {
             w1: vec![0.0; w.w1.len()],
@@ -571,6 +579,29 @@ pub(crate) struct Batch<'a> {
     /// (`src/scholar.rs`), which shifts topic prevalence by document metadata. Only
     /// the mean varies; the prior variance stays the shared Laplace `prior_var`.
     pub(crate) prior_mus: Option<&'a [Vec<f64>]>,
+}
+
+/// SCHOLAR content (topic-covariate) decoder deviation (`src/scholar.rs`). The
+/// unnormalized decoder logit gains `sum_c beta_c[c]*TC[i][c]` (per-covariate word
+/// shifts, the SAGE mechanism) and, when `beta_ci` is set, the topic-covariate
+/// interaction `sum_{t,c} beta_ci[t,c]*theta_do[i][t]*TC[i][c]`. `None` on the shared
+/// `batch_forward`/`batch_backward` leaves the decoder untouched (ProdLDA/InfoCTM and
+/// the covariate/label Scholar paths stay byte-identical).
+pub(crate) struct ContentFwd<'a> {
+    /// Topic-covariate rows, batch order, `n x c`.
+    pub(crate) tc: &'a [Vec<f64>],
+    /// Per-covariate word deviations `beta_c`, `c x V` row-major.
+    pub(crate) beta_c: &'a [f64],
+    /// Topic-covariate interaction weights `beta_ci`, `(K*c) x V` row-major, or `None`.
+    pub(crate) beta_ci: Option<&'a [f64]>,
+    /// Number of topic covariates `c`.
+    pub(crate) c: usize,
+}
+
+/// Gradient accumulators for the content deviation, mirroring [`ContentFwd`].
+pub(crate) struct ContentGrad {
+    pub(crate) beta_c: Vec<f64>,
+    pub(crate) beta_ci: Option<Vec<f64>>,
 }
 
 /// Caches retained from the batch forward for the backward pass.
@@ -826,6 +857,7 @@ pub(crate) fn batch_forward(
     alpha: &[f64],
     opts: &AvitmOptions,
     batch: &Batch,
+    content: Option<&ContentFwd>,
 ) -> (f64, BatchCache, [(Vec<f64>, Vec<f64>); 3]) {
     let (k, v) = (w.k, w.v);
     let n = batch.xns.len();
@@ -930,6 +962,37 @@ pub(crate) fn batch_forward(
                 let base = t * v;
                 for j in 0..v {
                     row[j] += w_t * w.beta[base + j];
+                }
+            }
+        }
+        // SCHOLAR content deviation: per-covariate word shifts (+ optional
+        // topic-covariate interactions on theta_do).
+        if let Some(ct) = content {
+            let tc_i = &ct.tc[i];
+            for (cc, &tcv) in tc_i.iter().enumerate().take(ct.c) {
+                if tcv != 0.0 {
+                    let base = cc * v;
+                    for j in 0..v {
+                        row[j] += ct.beta_c[base + j] * tcv;
+                    }
+                }
+            }
+            if let Some(bci) = ct.beta_ci {
+                for t in 0..k {
+                    let w_t = theta_do[i][t];
+                    if w_t == 0.0 {
+                        continue;
+                    }
+                    for (cc, &tcv) in tc_i.iter().enumerate().take(ct.c) {
+                        if tcv == 0.0 {
+                            continue;
+                        }
+                        let coef = w_t * tcv;
+                        let base = (t * ct.c + cc) * v;
+                        for j in 0..v {
+                            row[j] += bci[base + j] * coef;
+                        }
+                    }
                 }
             }
         }
@@ -1069,6 +1132,7 @@ pub(crate) fn batch_backward(
     g: &mut Grad,
     mut d_prior_mu: Option<&mut [Vec<f64>]>,
     dtheta_extra: Option<&[Vec<f64>]>,
+    content: Option<(&ContentFwd, &mut ContentGrad)>,
 ) {
     let (h, k, v) = (w.hidden, w.k, w.v);
     let n = batch.xns.len();
@@ -1089,7 +1153,13 @@ pub(crate) fn batch_backward(
     }
     let dlogit_raw = BatchNorm::backward(&dlogit, &c.bn_dec);
 
-    // logit_raw = theta_do . beta.
+    let (content_fwd, mut content_grad): (Option<&ContentFwd>, Option<&mut ContentGrad>) =
+        match content {
+            Some((f, g)) => (Some(f), Some(g)),
+            None => (None, None),
+        };
+
+    // logit_raw = theta_do . beta  (+ SCHOLAR content deviation).
     let mut dtheta_do = vec![vec![0.0; k]; n];
     for i in 0..n {
         for t in 0..k {
@@ -1100,7 +1170,38 @@ pub(crate) fn batch_backward(
                 acc += dl * w.beta[base + j];
                 g.beta[base + j] += c.theta_do[i][t] * dl;
             }
+            // Content interaction beta_ci[t,c]*theta_do[i][t]*tc[i][c]: adds to both
+            // dtheta_do (through theta_do) and the beta_ci gradient.
+            if let (Some(cf), Some(cg)) = (content_fwd, content_grad.as_deref_mut()) {
+                if let (Some(bci), Some(gci)) = (cf.beta_ci, cg.beta_ci.as_deref_mut()) {
+                    let tc_i = &cf.tc[i];
+                    for (cc, &tcv) in tc_i.iter().enumerate().take(cf.c) {
+                        if tcv == 0.0 {
+                            continue;
+                        }
+                        let cbase = (t * cf.c + cc) * v;
+                        for j in 0..v {
+                            let dl = dlogit_raw[i][j];
+                            acc += dl * bci[cbase + j] * tcv;
+                            gci[cbase + j] += c.theta_do[i][t] * tcv * dl;
+                        }
+                    }
+                }
+            }
             dtheta_do[i][t] = acc;
+        }
+        // Content main deviation beta_c[c]*tc[i][c]: gradient independent of the topic.
+        if let (Some(cf), Some(cg)) = (content_fwd, content_grad.as_deref_mut()) {
+            let tc_i = &cf.tc[i];
+            for (cc, &tcv) in tc_i.iter().enumerate().take(cf.c) {
+                if tcv == 0.0 {
+                    continue;
+                }
+                let cbase = cc * v;
+                for j in 0..v {
+                    cg.beta_c[cbase + j] += dlogit_raw[i][j] * tcv;
+                }
+            }
         }
     }
 
@@ -1617,7 +1718,7 @@ pub fn fit_avitm<R: Rng>(
             };
 
             let (loss, cache, stats) = batch_forward(
-                &w, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha_vec, &opts, &batch,
+                &w, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha_vec, &opts, &batch, None,
             );
             bn_mu.update_running(&stats[0].0, &stats[0].1);
             bn_lv.update_running(&stats[1].0, &stats[1].1);
@@ -1626,6 +1727,7 @@ pub fn fit_avitm<R: Rng>(
             let mut g = Grad::zeros(&w);
             batch_backward(
                 &w, &prior_mu, &prior_var, &alpha_vec, &opts, &batch, &cache, &mut g, None, None,
+                None,
             );
             g.scale(1.0 / n as f64);
             opt.step(&mut w, &g);
@@ -1715,7 +1817,7 @@ mod tests {
         let bn_lv = BatchNorm::new(w.k);
         let bn_dec = BatchNorm::new(w.v);
         batch_forward(
-            w, &bn_mu, &bn_lv, &bn_dec, prior_mu, prior_var, alpha, opts, batch,
+            w, &bn_mu, &bn_lv, &bn_dec, prior_mu, prior_var, alpha, opts, batch, None,
         )
         .0
     }
@@ -1777,11 +1879,11 @@ mod tests {
         let bn_lv = BatchNorm::new(k);
         let bn_dec = BatchNorm::new(v);
         let (_, cache, _) = batch_forward(
-            &w0, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha, &opts, &batch,
+            &w0, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha, &opts, &batch, None,
         );
         let mut g = Grad::zeros(&w0);
         batch_backward(
-            &w0, &prior_mu, &prior_var, &alpha, &opts, &batch, &cache, &mut g, None, None,
+            &w0, &prior_mu, &prior_var, &alpha, &opts, &batch, &cache, &mut g, None, None, None,
         );
 
         let fd = 1e-6;

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -19,13 +19,15 @@ fn extract_labels(y: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
     ))
 }
 
-/// SCHOLAR (Card, Tan & Smith 2018): a ProdLDA/AVITM VAE with document metadata.
-/// Prior (prevalence) covariates shift the document-topic prior mean,
-/// `mu_0 = W . covariates`, so a covariate that co-occurs with a topic raises that
-/// topic's prevalence (the neural analog of STM/DMR prevalence; `covariate_effects`
-/// is the covariate-by-topic matrix). Supervised `labels` add a softmax classifier
-/// off `theta` trained jointly, shaping the topics to be predictive (neural sLDA;
-/// `predict`/`predict_proba`/`classes`). Built on topica's ProdLDA backbone.
+/// SCHOLAR (Card, Tan & Smith 2018): a ProdLDA/AVITM VAE with document metadata in
+/// three roles. Prior (prevalence) `covariates` shift the topic-prior mean, so a
+/// covariate that co-occurs with a topic raises its prevalence (neural STM/DMR
+/// prevalence; `covariate_effects`). Supervised `labels` add a softmax classifier off
+/// `theta`, shaping the topics to be predictive (neural sLDA;
+/// `predict`/`predict_proba`/`classes`). Content (topic-covariate) `content` adds
+/// per-covariate word deviations to the decoder, so the same topic is worded
+/// differently across groups (neural SAGE; `content_effects`). All three compose.
+/// Built on topica's ProdLDA backbone.
 #[pyclass(module = "topica")]
 pub struct Scholar {
     num_topics: usize,
@@ -37,9 +39,14 @@ pub struct Scholar {
     l2_prior_reg: f64,
     convergence_tol: f64,
     seed: u64,
+    l1_content_reg: f64,
+    interactions: bool,
     // Covariates optionally supplied at construction (else at fit).
     covariates: Option<Vec<Vec<f64>>>,
     covariate_names: Option<Vec<String>>,
+    // Content (topic-covariate) covariates optionally supplied at construction.
+    content: Option<Vec<Vec<f64>>>,
+    content_names: Option<Vec<String>>,
     // Sorted unique class labels (empty when fit without labels), the order of
     // `predict_proba` columns and `classes`.
     classes: Vec<String>,
@@ -62,6 +69,12 @@ struct ScholarState {
     seed: u64,
     covariate_names: Vec<String>,
     #[serde(default)]
+    content_names: Vec<String>,
+    #[serde(default)]
+    l1_content_reg: f64,
+    #[serde(default)]
+    interactions: bool,
+    #[serde(default)]
     classes: Vec<String>,
     fitted: bool,
     topic_names: Vec<String>,
@@ -81,6 +94,13 @@ struct ScholarState {
     bc: Option<Vec<f64>>,
     #[serde(default)]
     n_labels: Option<usize>,
+    // Content decoder deviations (empty when fit without content covariates).
+    #[serde(default)]
+    beta_c: Option<Vec<f64>>,
+    #[serde(default)]
+    beta_ci: Option<Vec<f64>>,
+    #[serde(default)]
+    n_topic_covars: Option<usize>,
     // Base VAE weights.
     w_v: Option<usize>,
     w_e: Option<usize>,
@@ -166,6 +186,62 @@ impl Scholar {
         }
         Ok(pcs)
     }
+
+    /// Resolve the content (topic-covariate) matrix for this call: prefer the one
+    /// passed here, else the one given at construction; validate row count and width.
+    fn resolve_content(
+        &self,
+        provided: Option<&Bound<'_, PyAny>>,
+        num_docs: usize,
+    ) -> PyResult<Vec<Vec<f64>>> {
+        let tcs = match provided {
+            Some(obj) => parse_features(obj)?,
+            None => self.content.clone().ok_or_else(|| {
+                PyValueError::new_err(
+                    "content is required: pass content= to Scholar(...) or to fit()",
+                )
+            })?,
+        };
+        if tcs.len() != num_docs {
+            return Err(PyValueError::new_err(format!(
+                "content has {} rows but there are {num_docs} documents",
+                tcs.len()
+            )));
+        }
+        if tcs.is_empty() || tcs[0].is_empty() {
+            return Err(PyValueError::new_err(
+                "content must have at least one column",
+            ));
+        }
+        let width = tcs[0].len();
+        if tcs.iter().any(|r| r.len() != width) {
+            return Err(PyValueError::new_err(
+                "all content rows must have the same number of columns",
+            ));
+        }
+        Ok(tcs)
+    }
+
+    /// Resolve content for a prediction call: empty rows when the model was fit
+    /// without content, else the parsed matrix validated to the fitted width.
+    fn pred_content(
+        &self,
+        content: Option<&Bound<'_, PyAny>>,
+        num_docs: usize,
+    ) -> PyResult<Vec<Vec<f64>>> {
+        let n_tc = self.model.as_ref().map(|m| m.n_topic_covars).unwrap_or(0);
+        if n_tc == 0 {
+            return Ok(vec![Vec::new(); num_docs]);
+        }
+        let tcs = self.resolve_content(content, num_docs)?;
+        if tcs[0].len() != n_tc {
+            return Err(PyValueError::new_err(format!(
+                "content has {} columns but the model was fit with {n_tc}",
+                tcs[0].len()
+            )));
+        }
+        Ok(tcs)
+    }
 }
 
 #[pymethods]
@@ -180,20 +256,25 @@ impl Scholar {
     /// `convergence_tol > 0` stops early on the relative epoch-ELBO change. Pass
     /// `iters` to :meth:`fit` for the number of epochs.
     #[new]
-    #[pyo3(signature = (num_topics, *, covariates=None, covariate_names=None, alpha=1.0,
-                        hidden_size=100, dropout=0.2, batch_size=200, lr=0.002,
-                        l2_prior_reg=0.0, convergence_tol=0.0, seed=42))]
+    #[pyo3(signature = (num_topics, *, covariates=None, covariate_names=None, content=None,
+                        content_names=None, interactions=false, alpha=1.0, hidden_size=100,
+                        dropout=0.2, batch_size=200, lr=0.002, l2_prior_reg=0.0,
+                        l1_content_reg=0.0, convergence_tol=0.0, seed=42))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
         covariates: Option<&Bound<'_, PyAny>>,
         covariate_names: Option<Vec<String>>,
+        content: Option<&Bound<'_, PyAny>>,
+        content_names: Option<Vec<String>>,
+        interactions: bool,
         alpha: f64,
         hidden_size: usize,
         dropout: f64,
         batch_size: usize,
         lr: f64,
         l2_prior_reg: f64,
+        l1_content_reg: f64,
         convergence_tol: f64,
         seed: u64,
     ) -> PyResult<Self> {
@@ -211,6 +292,11 @@ impl Scholar {
                 "l2_prior_reg must be >= 0 and finite",
             ));
         }
+        if !(l1_content_reg >= 0.0 && l1_content_reg.is_finite()) {
+            return Err(PyValueError::new_err(
+                "l1_content_reg must be >= 0 and finite",
+            ));
+        }
         let covariates = match covariates {
             Some(obj) => Some(parse_features(obj)?),
             None => None,
@@ -224,6 +310,19 @@ impl Scholar {
                 )));
             }
         }
+        let content = match content {
+            Some(obj) => Some(parse_features(obj)?),
+            None => None,
+        };
+        if let (Some(tcs), Some(names)) = (&content, &content_names) {
+            if !tcs.is_empty() && names.len() != tcs[0].len() {
+                return Err(PyValueError::new_err(format!(
+                    "content_names has length {} but content has {} columns",
+                    names.len(),
+                    tcs[0].len()
+                )));
+            }
+        }
         Ok(Scholar {
             num_topics,
             hidden_size,
@@ -232,10 +331,14 @@ impl Scholar {
             batch_size,
             lr,
             l2_prior_reg,
+            l1_content_reg,
+            interactions,
             convergence_tol,
             seed,
             covariates,
             covariate_names,
+            content,
+            content_names,
             classes: Vec::new(),
             fitted: false,
             topic_names: Vec::new(),
@@ -244,17 +347,21 @@ impl Scholar {
         })
     }
 
-    /// Fit on `data` (a Corpus or list of token lists) with prior `covariates` and/or
-    /// supervised `labels` (one per document, str or int). At least one of covariates
-    /// or labels must be given. `iters` sets the number of epochs (default 200);
+    /// Fit on `data` (a Corpus or list of token lists) with prior `covariates`,
+    /// supervised `labels` (str/int, one per document), and/or topic-covariate
+    /// `content` (a numeric matrix). At least one of covariates, labels, or content
+    /// must be given. `iters` sets the number of epochs (default 200);
     /// `convergence_tol` overrides the constructor value for this run.
-    #[pyo3(signature = (data, *, covariates=None, labels=None, iters=None, convergence_tol=None))]
+    #[pyo3(signature = (data, *, covariates=None, labels=None, content=None, iters=None,
+                        convergence_tol=None))]
+    #[allow(clippy::too_many_arguments)]
     fn fit(
         &mut self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         covariates: Option<&Bound<'_, PyAny>>,
         labels: Option<&Bound<'_, PyAny>>,
+        content: Option<&Bound<'_, PyAny>>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
     ) -> PyResult<()> {
@@ -309,12 +416,14 @@ impl Scholar {
         };
         let n_labels = classes.len();
 
-        // Covariates (optional): empty rows when absent, but require at least one of
-        // covariates / labels so the model has some metadata to condition on.
+        // Covariates / content (optional): empty rows when absent. Require at least
+        // one of covariates / labels / content so the model has metadata to condition on.
         let has_covars = covariates.is_some() || self.covariates.is_some();
-        if !has_covars && label_idx.is_none() {
+        let has_content = content.is_some() || self.content.is_some();
+        if !has_covars && label_idx.is_none() && !has_content {
             return Err(PyValueError::new_err(
-                "Scholar needs covariates and/or labels: pass covariates= and/or labels=",
+                "Scholar needs covariates, labels, and/or content: pass covariates=, labels=, \
+                 and/or content=",
             ));
         }
         let pcs = if has_covars {
@@ -323,6 +432,12 @@ impl Scholar {
             vec![Vec::new(); num_docs]
         };
         let n_prior_covars = pcs[0].len();
+        let tcs = if has_content {
+            self.resolve_content(content, num_docs)?
+        } else {
+            vec![Vec::new(); num_docs]
+        };
+        let n_topic_covars = tcs[0].len();
 
         let num_types = corpus.num_types();
         if num_types < self.num_topics {
@@ -336,9 +451,16 @@ impl Scholar {
                 .map(|c| format!("covariate_{c}"))
                 .collect(),
         };
+        let content_names = match &self.content_names {
+            Some(n) if n.len() == n_topic_covars => n.clone(),
+            _ => (0..n_topic_covars)
+                .map(|c| format!("content_{c}"))
+                .collect(),
+        };
         let tol = convergence_tol.unwrap_or(self.convergence_tol);
         let ep = iters.unwrap_or(200);
-        let (k, h, a, dp, bs, lr, l2) = (
+        let interactions = self.interactions && n_topic_covars > 0;
+        let (k, h, a, dp, bs, lr, l2, l1c) = (
             self.num_topics,
             self.hidden_size,
             self.alpha,
@@ -346,6 +468,7 @@ impl Scholar {
             self.batch_size,
             self.lr,
             self.l2_prior_reg,
+            self.l1_content_reg,
         );
         let seed = self.seed;
         let (model, corpus) = py.allow_threads(move || {
@@ -355,6 +478,10 @@ impl Scholar {
                 &pcs,
                 label_idx.as_deref(),
                 n_labels,
+                &tcs,
+                n_topic_covars,
+                interactions,
+                l1c,
                 k,
                 num_types,
                 n_prior_covars,
@@ -373,6 +500,7 @@ impl Scholar {
         self.model = Some(model);
         self.corpus = Some(corpus);
         self.covariate_names = Some(names);
+        self.content_names = Some(content_names);
         self.classes = classes;
         self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
         self.fitted = true;
@@ -409,6 +537,22 @@ impl Scholar {
     fn covariate_names(&self) -> PyResult<Vec<String>> {
         self.fitted_model()?;
         Ok(self.covariate_names.clone().unwrap_or_default())
+    }
+
+    /// Content (topic-covariate) word deviations `(n_content, vocab)`. Entry
+    /// ``[c][j]`` is how much content covariate `c` shifts the unnormalized log-word
+    /// weight of word `j` — the SAGE "same topic, worded differently across groups"
+    /// deviations. Empty if fit without content covariates.
+    #[getter]
+    fn content_effects<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        Ok(vecs_to_arr2(&self.fitted_model()?.content_effects()).to_pyarray_bound(py))
+    }
+
+    /// The content covariate column names, in the order of `content_effects` rows.
+    #[getter]
+    fn content_names(&self) -> PyResult<Vec<String>> {
+        self.fitted_model()?;
+        Ok(self.content_names.clone().unwrap_or_default())
     }
 
     /// The class labels (sorted), in the order of `predict_proba` columns. Empty if
@@ -521,32 +665,35 @@ impl Scholar {
         )
     }
 
-    /// Held-out topic proportions for new documents. `covariates` (one row per
-    /// document) enter the encoder exactly as at fit time and must have the same
-    /// number of columns; pass `None` when the model was fit without covariates.
+    /// Held-out topic proportions for new documents. `covariates` and `content` (one
+    /// row per document) enter the encoder exactly as at fit time and must have the
+    /// same number of columns; pass `None` for either the model was not fit with.
     /// Returns `(num_docs, num_topics)`.
-    #[pyo3(signature = (data, covariates=None))]
+    #[pyo3(signature = (data, covariates=None, content=None))]
     fn transform<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
         covariates: Option<&Bound<'py, PyAny>>,
+        content: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
         let m = self.fitted_model()?;
         let docs = docs_to_ids(data, &self.corpus.as_ref().unwrap().id_to_word)?;
         let pcs = self.pred_covariates(covariates, docs.len())?;
-        Ok(vecs_to_arr2(&m.transform(&docs, &pcs)).to_pyarray_bound(py))
+        let tcs = self.pred_content(content, docs.len())?;
+        Ok(vecs_to_arr2(&m.transform(&docs, &pcs, &tcs)).to_pyarray_bound(py))
     }
 
     /// Class-probability predictions `softmax(wc . theta + bc)` for new documents,
     /// shape `(num_docs, n_classes)`, columns in `classes` order. Requires a
-    /// label-trained model. `covariates` as in `transform`.
-    #[pyo3(signature = (data, covariates=None))]
+    /// label-trained model. `covariates`/`content` as in `transform`.
+    #[pyo3(signature = (data, covariates=None, content=None))]
     fn predict_proba<'py>(
         &self,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
         covariates: Option<&Bound<'py, PyAny>>,
+        content: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
         let m = self.fitted_model()?;
         if m.n_labels == 0 {
@@ -556,17 +703,19 @@ impl Scholar {
         }
         let docs = docs_to_ids(data, &self.corpus.as_ref().unwrap().id_to_word)?;
         let pcs = self.pred_covariates(covariates, docs.len())?;
-        Ok(vecs_to_arr2(&m.predict_proba(&docs, &pcs)).to_pyarray_bound(py))
+        let tcs = self.pred_content(content, docs.len())?;
+        Ok(vecs_to_arr2(&m.predict_proba(&docs, &pcs, &tcs)).to_pyarray_bound(py))
     }
 
     /// Predicted class label per document (argmax of `predict_proba`), as strings in
     /// `classes` space. Requires a label-trained model.
-    #[pyo3(signature = (data, covariates=None))]
+    #[pyo3(signature = (data, covariates=None, content=None))]
     fn predict(
         &self,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         covariates: Option<&Bound<'_, PyAny>>,
+        content: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Vec<String>> {
         let m = self.fitted_model()?;
         if m.n_labels == 0 {
@@ -576,8 +725,9 @@ impl Scholar {
         }
         let docs = docs_to_ids(data, &self.corpus.as_ref().unwrap().id_to_word)?;
         let pcs = self.pred_covariates(covariates, docs.len())?;
+        let tcs = self.pred_content(content, docs.len())?;
         let _ = py;
-        let proba = m.predict_proba(&docs, &pcs);
+        let proba = m.predict_proba(&docs, &pcs, &tcs);
         Ok(proba
             .iter()
             .map(|p| {
@@ -622,6 +772,9 @@ impl Scholar {
                 convergence_tol: self.convergence_tol,
                 seed: self.seed,
                 covariate_names: self.covariate_names.clone().unwrap_or_default(),
+                content_names: self.content_names.clone().unwrap_or_default(),
+                l1_content_reg: self.l1_content_reg,
+                interactions: self.interactions,
                 classes: self.classes.clone(),
                 fitted: self.fitted,
                 topic_names: self.topic_names.clone(),
@@ -636,6 +789,9 @@ impl Scholar {
                 wc: Some(m.wc.clone()),
                 bc: Some(m.bc.clone()),
                 n_labels: Some(m.n_labels),
+                beta_c: Some(m.beta_c.clone()),
+                beta_ci: m.beta_ci.clone(),
+                n_topic_covars: Some(m.n_topic_covars),
                 w_v: Some(m.base.weights.v),
                 w_e: Some(m.base.weights.e),
                 w_hidden: Some(m.base.weights.hidden),
@@ -705,6 +861,10 @@ impl Scholar {
                 wc: s.wc.unwrap_or_default(),
                 bc: s.bc.unwrap_or_default(),
                 n_labels: s.n_labels.unwrap_or(0),
+                beta_c: s.beta_c.unwrap_or_default(),
+                beta_ci: s.beta_ci,
+                n_topic_covars: s.n_topic_covars.unwrap_or(0),
+                interactions: s.interactions,
             })
         } else {
             None
@@ -717,6 +877,8 @@ impl Scholar {
             batch_size: s.batch_size,
             lr: s.lr,
             l2_prior_reg: s.l2_prior_reg,
+            l1_content_reg: s.l1_content_reg,
+            interactions: s.interactions,
             convergence_tol: s.convergence_tol,
             seed: s.seed,
             covariates: None,
@@ -724,6 +886,12 @@ impl Scholar {
                 None
             } else {
                 Some(s.covariate_names)
+            },
+            content: None,
+            content_names: if s.content_names.is_empty() {
+                None
+            } else {
+                Some(s.content_names)
             },
             classes: s.classes,
             fitted: s.fitted,

--- a/src/scholar.rs
+++ b/src/scholar.rs
@@ -1,42 +1,40 @@
 //! SCHOLAR (Card, Tan & Smith, "Neural Models for Documents with Metadata",
-//! ACL 2018; reference `dallascard/scholar`, Apache-2.0) — the prior-covariate
-//! ("prevalence") path.
+//! ACL 2018; reference `dallascard/scholar`, Apache-2.0).
 //!
-//! SCHOLAR extends a ProdLDA/AVITM VAE with document metadata in three roles. This
-//! module implements the first: **prior covariates** `PC`, which shift the
-//! document-topic *prior mean* by `mu_0[i] = W . PC[i]`. The KL then pulls each
-//! document's posterior toward that covariate-dependent mean, so a covariate that
-//! co-occurs with a topic raises that topic's prevalence — the neural analog of
-//! STM/DMR prevalence covariates. `W` (the fitted `covariate_effects`) reads as a
-//! covariate-by-topic prevalence-effect matrix. The reference flags this "upstream"
-//! prior as future work in the paper (footnote 4) but implements it in code.
+//! SCHOLAR extends a ProdLDA/AVITM VAE with document metadata in three roles, all
+//! implemented here on topica's existing ProdLDA VAE (`crate::prodlda`) — the encoder,
+//! reparameterization, decoder, batchnorm, Adam, and reconstruction loss are reused
+//! through the shared `batch_forward`/`batch_backward`, each role threaded in through
+//! a gated, no-op-when-unused hook so ProdLDA/InfoCTM stay byte-identical:
 //!
-//! We build directly on topica's existing ProdLDA VAE (`crate::prodlda`) rather than
-//! re-deriving a VAE: the encoder, reparameterization, decoder, batchnorm, Adam, and
-//! reconstruction loss are reused verbatim through the shared `batch_forward` /
-//! `batch_backward`. The prior covariates enter in two faithful places:
-//!   1. **Encoder input.** The reference concatenates `PC` to the encoder input; we
-//!      route `PC` through the existing dense-embedding channel (`InputMode::BowEmb`
-//!      with `emb_dim = n_prior_covars`), which is exactly "extra dense columns on
-//!      the first encoder layer" — no encoder change.
-//!   2. **Prior mean.** A new weight block `prior_w` (`K x n_prior_covars`, the
-//!      reference's `Linear(n_prior_covars, K, bias=False)`) sets the per-document
-//!      prior mean, threaded into the shared Gaussian KL via `Batch::prior_mus`. Its
-//!      gradient comes back through the `batch_backward` `d_prior_mu` out-param and
-//!      maps to `dW = sum_i d_prior_mu[i] (x) PC[i]` (plus the L2 prior penalty).
+//!   1. **Prior covariates** `PC` (prevalence) — a weight block `prior_w`
+//!      (`K x n_prior_covars`, the reference's `Linear(n_prior_covars, K, bias=False)`)
+//!      sets a per-document prior *mean* `mu_0 = W . PC`, so a covariate that co-occurs
+//!      with a topic raises its prevalence (neural STM/DMR prevalence; the fitted `W`
+//!      is `covariate_effects`). Threaded via `Batch::prior_mus` and the
+//!      `batch_backward` `d_prior_mu` out-param. `PC` also enters the encoder.
+//!   2. **Labels** `Y` (supervised) — a softmax classifier head `wc`/`bc` off `theta`
+//!      whose cross-entropy loss shapes the topics to be predictive (neural sLDA).
+//!      Its gradient into `theta` is injected via `batch_backward`'s `dtheta_extra`.
+//!      Unlike the reference, labels do NOT enter the encoder (see `fit_scholar`).
+//!   3. **Content / topic covariates** `TC` — per-covariate word deviations `beta_c`
+//!      (and optional topic-covariate interactions `beta_ci`) added to the decoder
+//!      logits, so the same topic is worded differently across groups (neural SAGE;
+//!      the fitted `beta_c` is `content_effects`). Threaded via the shared
+//!      `ContentFwd`/`ContentGrad` hook. `TC` also enters the encoder.
 //!
-//! Because topica's ProdLDA is the two-layer AVITM encoder (Srivastava & Sutton
-//! 2017) rather than the reference's single embedding layer, this is a
-//! mechanism-faithful port on topica's backbone, not a bit-for-bit clone of
-//! `dallascard/scholar` — the same design choice topica's `ProdLDA` already makes.
-//! The prior covariate path is Gaussian (logistic-normal) only: a prior-*mean* shift
-//! is only defined for the `Prior::Laplace` latent, so Scholar fixes that prior.
+//! Because topica's ProdLDA is the two-layer AVITM encoder (Srivastava & Sutton 2017)
+//! rather than the reference's single embedding layer, this is a mechanism-faithful
+//! port on topica's backbone, not a bit-for-bit clone of `dallascard/scholar` — the
+//! same design choice topica's `ProdLDA` already makes. The prior is Gaussian
+//! (logistic-normal) only: a prior-*mean* shift is only defined for `Prior::Laplace`.
 
 use rand::Rng;
 
 use crate::prodlda::{
     batch_backward, batch_forward, laplace_prior, normalized_bow, randn, raw_bow, Adam,
-    AvitmOptions, Batch, BatchNorm, Grad, InputMode, Optim, Prior, ProdldaModel, Weights,
+    AvitmOptions, Batch, BatchNorm, ContentFwd, ContentGrad, Grad, InputMode, Optim, Prior,
+    ProdldaModel, Weights,
 };
 
 /// Numerically stable softmax (local copy; `prodlda::softmax` is private).
@@ -64,6 +62,14 @@ pub struct ScholarModel {
     pub wc: Vec<f64>,
     pub bc: Vec<f64>,
     pub n_labels: usize,
+    /// Content (topic-covariate) decoder deviations `beta_c`, `n_topic_covars x V`
+    /// row-major (the reference's `beta_c_layer.weight.T`): per-covariate word shifts.
+    pub beta_c: Vec<f64>,
+    /// Optional topic-covariate interaction weights `beta_ci`, `(K*n_topic_covars) x V`
+    /// row-major; `None` unless the model was fit with `interactions`.
+    pub beta_ci: Option<Vec<f64>>,
+    pub n_topic_covars: usize,
+    pub interactions: bool,
 }
 
 impl ScholarModel {
@@ -88,19 +94,57 @@ impl ScholarModel {
             .collect()
     }
 
-    /// Held-out topic proportions for new documents given their prior covariates. The
-    /// covariates enter the encoder as at fit time. Labels are never an encoder input
-    /// (see `fit_scholar`), so prediction and training use the same encoder path.
-    pub fn transform(&self, docs: &[Vec<u32>], pcs: &[Vec<f64>]) -> Vec<Vec<f64>> {
-        self.base.transform_with_emb(docs, pcs)
+    /// The per-covariate word-deviation matrix `(n_topic_covars, V)` (`beta_c`).
+    /// Entry `[c][j]` is how much topic covariate `c` shifts the unnormalized log-word
+    /// weight of word `j` — the SAGE "same topic, worded differently across groups"
+    /// deviations. Empty when fit without content covariates.
+    pub fn content_effects(&self) -> Vec<Vec<f64>> {
+        let (tc, v) = (self.n_topic_covars, self.base.num_types);
+        (0..tc)
+            .map(|c| self.beta_c[c * v..(c + 1) * v].to_vec())
+            .collect()
+    }
+
+    /// Build encoder features `[pc ; tc]` for new documents (both covariate blocks
+    /// enter the encoder; labels never do). `tcs` may be empty when the model has no
+    /// content covariates.
+    fn encoder_feats(&self, pcs: &[Vec<f64>], tcs: &[Vec<f64>]) -> Vec<Vec<f64>> {
+        pcs.iter()
+            .enumerate()
+            .map(|(i, pc)| {
+                let mut f = pc.clone();
+                if self.n_topic_covars > 0 {
+                    f.extend_from_slice(&tcs[i]);
+                }
+                f
+            })
+            .collect()
+    }
+
+    /// Held-out topic proportions for new documents given their prior covariates and
+    /// topic covariates. Both enter the encoder as at fit time; labels are never an
+    /// encoder input (see `fit_scholar`), so prediction and training use the same path.
+    pub fn transform(
+        &self,
+        docs: &[Vec<u32>],
+        pcs: &[Vec<f64>],
+        tcs: &[Vec<f64>],
+    ) -> Vec<Vec<f64>> {
+        let feats = self.encoder_feats(pcs, tcs);
+        self.base.transform_with_emb(docs, &feats)
     }
 
     /// Class-probability predictions `softmax(wc . theta + bc)` for new documents,
     /// shape `(num_docs, n_labels)`. `theta` is the posterior mean from the words (and
     /// covariates). Empty rows if the model was fit without labels.
-    pub fn predict_proba(&self, docs: &[Vec<u32>], pcs: &[Vec<f64>]) -> Vec<Vec<f64>> {
+    pub fn predict_proba(
+        &self,
+        docs: &[Vec<u32>],
+        pcs: &[Vec<f64>],
+        tcs: &[Vec<f64>],
+    ) -> Vec<Vec<f64>> {
         let k = self.base.num_topics;
-        let theta = self.transform(docs, pcs);
+        let theta = self.transform(docs, pcs, tcs);
         theta
             .iter()
             .map(|th| {
@@ -145,6 +189,10 @@ pub fn fit_scholar<R: Rng>(
     pcs: &[Vec<f64>],
     labels: Option<&[usize]>,
     n_labels: usize,
+    tcs: &[Vec<f64>],
+    n_topic_covars: usize,
+    interactions: bool,
+    l1_content_reg: f64,
     num_topics: usize,
     num_types: usize,
     n_prior_covars: usize,
@@ -158,8 +206,21 @@ pub fn fit_scholar<R: Rng>(
     em_tol: f64,
     rng: &mut R,
 ) -> ScholarModel {
-    let (k, v, pc) = (num_topics, num_types, n_prior_covars);
+    let (k, v, pc, tc) = (num_topics, num_types, n_prior_covars, n_topic_covars);
     let d = docs.len();
+    // Encoder input concatenates prior covariates and topic covariates (both are
+    // always observed, at train and test — no leak). Labels stay out of the encoder.
+    // With tc == 0 and pc unchanged this is the prevalence/label path unchanged.
+    let feats: Vec<Vec<f64>> = (0..d)
+        .map(|i| {
+            let mut f = pcs[i].clone();
+            if tc > 0 {
+                f.extend_from_slice(&tcs[i]);
+            }
+            f
+        })
+        .collect();
+    let emb_dim = pc + tc;
     let xn: Vec<Vec<(usize, f64)>> = docs.iter().map(|doc| normalized_bow(doc)).collect();
     let bows: Vec<Vec<(usize, f64)>> = docs.iter().map(|doc| raw_bow(doc)).collect();
     let totals: Vec<f64> = bows
@@ -193,11 +254,21 @@ pub fn fit_scholar<R: Rng>(
     // reproduce a leak against `dallascard/scholar` — the BOW reconstruction term
     // dominates the label cross-entropy ~100:1), so the effect is backbone- and
     // regime-dependent, not a claim that the reference is broken.
-    let mut w = Weights::new(v, pc, hidden, k, InputMode::BowEmb, rng);
+    let mut w = Weights::new(v, emb_dim, hidden, k, InputMode::BowEmb, rng);
     // Covariate weight block: zero init, so topics start covariate-agnostic and the
     // prevalence effect is learned from data (deterministic, no extra RNG draws).
     let mut prior_w = vec![0.0; k * pc];
     let mut prior_w_opt = Adam::new(prior_w.len(), lr, 0.99, 0.0);
+    // Content (topic-covariate) decoder deviations: beta_c (C x V) per-covariate word
+    // shifts, and optional beta_ci ((K*C) x V) topic-covariate interactions. Zero init.
+    let mut beta_c = vec![0.0; tc * v];
+    let mut beta_c_opt = Adam::new(beta_c.len(), lr, 0.99, 0.0);
+    let mut beta_ci = if interactions && tc > 0 {
+        vec![0.0; k * tc * v]
+    } else {
+        Vec::new()
+    };
+    let mut beta_ci_opt = Adam::new(beta_ci.len(), lr, 0.99, 0.0);
     // Label classifier head: logit_y = wc.theta + bc. Zero init, like the prior
     // weights (diverges from the reference's default nn.Linear Kaiming-uniform init):
     // symmetry breaks on the first step since g_wc = dlogit (x) theta is nonzero, and
@@ -269,7 +340,7 @@ pub fn fit_scholar<R: Rng>(
 
             let batch = Batch {
                 xns: chunk.iter().map(|&di| xn[di].as_slice()).collect(),
-                embs: chunk.iter().map(|&di| pcs[di].as_slice()).collect(),
+                embs: chunk.iter().map(|&di| feats[di].as_slice()).collect(),
                 counts: chunk.iter().map(|&di| bows[di].as_slice()).collect(),
                 totals: chunk.iter().map(|&di| totals[di]).collect(),
                 eps: &eps,
@@ -278,8 +349,30 @@ pub fn fit_scholar<R: Rng>(
                 prior_mus: Some(&prior_mus),
             };
 
+            // Content (topic-covariate) decoder deviation for this batch.
+            let tc_batch: Vec<Vec<f64>> = if tc > 0 {
+                chunk.iter().map(|&di| tcs[di].clone()).collect()
+            } else {
+                Vec::new()
+            };
+            let content_fwd = (tc > 0).then(|| ContentFwd {
+                tc: &tc_batch,
+                beta_c: &beta_c,
+                beta_ci: if interactions { Some(&beta_ci) } else { None },
+                c: tc,
+            });
+
             let (loss, cache, stats) = batch_forward(
-                &w, &bn_mu, &bn_lv, &bn_dec, &prior_mu, &prior_var, &alpha_vec, &opts, &batch,
+                &w,
+                &bn_mu,
+                &bn_lv,
+                &bn_dec,
+                &prior_mu,
+                &prior_var,
+                &alpha_vec,
+                &opts,
+                &batch,
+                content_fwd.as_ref(),
             );
             bn_mu.update_running(&stats[0].0, &stats[0].1);
             bn_lv.update_running(&stats[1].0, &stats[1].1);
@@ -322,6 +415,14 @@ pub fn fit_scholar<R: Rng>(
             } else {
                 None
             };
+            let mut content_grad = ContentGrad {
+                beta_c: vec![0.0; tc * v],
+                beta_ci: if interactions && tc > 0 {
+                    Some(vec![0.0; k * tc * v])
+                } else {
+                    None
+                },
+            };
             batch_backward(
                 &w,
                 &prior_mu,
@@ -333,9 +434,30 @@ pub fn fit_scholar<R: Rng>(
                 &mut g,
                 Some(&mut d_prior_mu),
                 dte,
+                content_fwd.as_ref().map(|cf| (cf, &mut content_grad)),
             );
             g.scale(1.0 / n as f64);
             opt.step(&mut w, &g);
+
+            // Content deviation Adam step: data term batch-mean + a fixed-strength
+            // ridge penalty (l1_content_reg; the reference's adaptive-strength L1
+            // reweighting is simplified to a fixed strength here), un-averaged.
+            if tc > 0 {
+                let inv_n = 1.0 / n as f64;
+                for idx in 0..content_grad.beta_c.len() {
+                    content_grad.beta_c[idx] =
+                        content_grad.beta_c[idx] * inv_n + 2.0 * l1_content_reg * beta_c[idx];
+                }
+                beta_c_opt.step(&mut beta_c, &content_grad.beta_c);
+                if interactions {
+                    if let Some(gci) = content_grad.beta_ci.as_mut() {
+                        for idx in 0..gci.len() {
+                            gci[idx] = gci[idx] * inv_n + 2.0 * l1_content_reg * beta_ci[idx];
+                        }
+                        beta_ci_opt.step(&mut beta_ci, gci);
+                    }
+                }
+            }
 
             // Classifier head Adam step (data term averaged over the batch, like the
             // encoder/decoder grads; no regularization on the head).
@@ -401,7 +523,7 @@ pub fn fit_scholar<R: Rng>(
         bn_mu,
         prior: Prior::Laplace,
     };
-    let doc_topic = base.transform_with_emb(docs, pcs);
+    let doc_topic = base.transform_with_emb(docs, &feats);
     let base = ProdldaModel { doc_topic, ..base };
     ScholarModel {
         base,
@@ -411,6 +533,14 @@ pub fn fit_scholar<R: Rng>(
         wc,
         bc,
         n_labels,
+        beta_c,
+        beta_ci: if interactions && tc > 0 {
+            Some(beta_ci)
+        } else {
+            None
+        },
+        n_topic_covars: tc,
+        interactions: interactions && tc > 0,
     }
 }
 
@@ -419,6 +549,9 @@ mod tests {
     use super::*;
     use rand::SeedableRng;
     use rand_chacha::ChaCha8Rng;
+
+    /// No topic covariates (the prevalence/label-only fit paths).
+    const NO_TC: &[Vec<f64>] = &[];
 
     // Recompute the summed batch loss (including the L2 prior penalty on W) for a
     // given (weights, prior_w), at fixed noise and all-ones dropout. This is the
@@ -447,7 +580,7 @@ mod tests {
         // The shared prior_mu slice is unused when prior_mus is Some; pass zeros.
         let prior_mu = vec![0.0; k];
         let (loss, _, _) = batch_forward(
-            w, &bn_mu, &bn_lv, &bn_dec, &prior_mu, prior_var, alpha, opts, &batch,
+            w, &bn_mu, &bn_lv, &bn_dec, &prior_mu, prior_var, alpha, opts, &batch, None,
         );
         let reg: f64 = prior_w.iter().map(|&x| x * x).sum();
         loss + l2 * reg
@@ -542,7 +675,7 @@ mod tests {
         let bn_dec = BatchNorm::new(v);
         let prior_mu0 = vec![0.0; k];
         let (_, cache, _) = batch_forward(
-            &w, &bn_mu, &bn_lv, &bn_dec, &prior_mu0, &prior_var, &alpha, &opts, &batch,
+            &w, &bn_mu, &bn_lv, &bn_dec, &prior_mu0, &prior_var, &alpha, &opts, &batch, None,
         );
         let mut g = Grad::zeros(&w);
         let mut d_prior_mu = vec![vec![0.0; k]; n];
@@ -556,6 +689,7 @@ mod tests {
             &cache,
             &mut g,
             Some(&mut d_prior_mu),
+            None,
             None,
         );
         // Map to dW (summed over docs, NOT averaged — the loss here is the summed
@@ -641,7 +775,8 @@ mod tests {
         }
 
         let m = fit_scholar(
-            &docs, &pcs, None, 0, k, v, 2, 20, 1.0, 0.2, 120, 40, 0.01, 0.0, 0.0, &mut rng,
+            &docs, &pcs, None, 0, NO_TC, 0, false, 0.0, k, v, 2, 20, 1.0, 0.2, 120, 40, 0.01, 0.0,
+            0.0, &mut rng,
         );
 
         // Topic-word rows are valid distributions.
@@ -690,7 +825,8 @@ mod tests {
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(3);
             fit_scholar(
-                &docs, &pcs, None, 0, 2, 6, 2, 8, 1.0, 0.2, 15, 4, 0.01, 0.01, 0.0, &mut rng,
+                &docs, &pcs, None, 0, NO_TC, 0, false, 0.0, 2, 6, 2, 8, 1.0, 0.2, 15, 4, 0.01,
+                0.01, 0.0, &mut rng,
             )
         };
         let a = run();
@@ -828,6 +964,10 @@ mod tests {
             &pcs,
             Some(&labels),
             n_labels,
+            NO_TC,
+            0,
+            false,
+            0.0,
             k,
             v,
             0,
@@ -843,7 +983,7 @@ mod tests {
         );
 
         // In-sample class accuracy from predict_proba should be well above 1/3.
-        let proba = m.predict_proba(&docs, &pcs);
+        let proba = m.predict_proba(&docs, &pcs, NO_TC);
         let mut correct = 0;
         for (i, p) in proba.iter().enumerate() {
             let pred = (0..n_labels)
@@ -874,6 +1014,10 @@ mod tests {
                 &pcs,
                 Some(&labels),
                 2,
+                NO_TC,
+                0,
+                false,
+                0.0,
                 2,
                 6,
                 0,
@@ -893,6 +1037,260 @@ mod tests {
         assert_eq!(a.topic_word(), b.topic_word());
         assert_eq!(a.wc, b.wc);
         assert_eq!(a.bc, b.bc);
-        assert_eq!(a.predict_proba(&docs, &pcs), b.predict_proba(&docs, &pcs));
+        assert_eq!(
+            a.predict_proba(&docs, &pcs, NO_TC),
+            b.predict_proba(&docs, &pcs, NO_TC)
+        );
+    }
+
+    // FD check of the content-deviation gradients. beta_c and beta_ci are decoder-only,
+    // and the interaction beta_ci*(theta_do (x) TC) makes the loss depend on theta, so
+    // the encoder head w_mu also gets a content contribution — check all three against
+    // the content-active batch loss.
+    #[test]
+    fn content_gradient_matches_fd() {
+        let mut rng = ChaCha8Rng::seed_from_u64(0);
+        let (v, hidden, k, tc) = (7usize, 5usize, 4usize, 2usize);
+        // TC rides the encoder (emb_dim = tc here, pc = 0) and drives decoder deviations.
+        let mut w0 = Weights::new(v, tc, hidden, k, InputMode::BowEmb, &mut rng);
+        let alpha = vec![1.0; k];
+        let (prior_mu, prior_var) = laplace_prior(&alpha);
+        let opts = AvitmOptions {
+            prior: Prior::Laplace,
+            ..AvitmOptions::default()
+        };
+        let docs: Vec<Vec<u32>> = vec![
+            vec![0, 0, 2, 3, 6],
+            vec![1, 4, 4, 5],
+            vec![2, 2, 3, 5, 6, 0],
+        ];
+        let n = docs.len();
+        let tcs: Vec<Vec<f64>> = (0..n)
+            .map(|i| {
+                (0..tc)
+                    .map(|c| 0.5 * (i as f64 + 1.0) - 0.3 * c as f64)
+                    .collect()
+            })
+            .collect();
+        let xns: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| normalized_bow(d)).collect();
+        let bows: Vec<Vec<(usize, f64)>> = docs.iter().map(|d| raw_bow(d)).collect();
+        let totals: Vec<f64> = bows
+            .iter()
+            .map(|b| b.iter().map(|&(_, c)| c).sum())
+            .collect();
+        let eps: Vec<Vec<f64>> = (0..n)
+            .map(|i| {
+                (0..k)
+                    .map(|t| 0.1 * (i as f64 + 1.0) - 0.05 * t as f64)
+                    .collect()
+            })
+            .collect();
+        let masks2 = vec![vec![1.0; hidden]; n];
+        let masks_t = vec![vec![1.0; k]; n];
+
+        let mut beta_c: Vec<f64> = (0..tc * v).map(|i| 0.13 * (i as f64 % 4.0) - 0.2).collect();
+        let mut beta_ci: Vec<f64> = (0..k * tc * v)
+            .map(|i| 0.07 * (i as f64 % 5.0) - 0.15)
+            .collect();
+
+        let build_batch = || Batch {
+            xns: xns.iter().map(|x| x.as_slice()).collect(),
+            embs: tcs.iter().map(|x| x.as_slice()).collect(),
+            counts: bows.iter().map(|b| b.as_slice()).collect(),
+            totals: totals.clone(),
+            eps: &eps,
+            masks2: &masks2,
+            masks_t: &masks_t,
+            prior_mus: None,
+        };
+        let loss = |w: &Weights, beta_c: &[f64], beta_ci: &[f64]| -> f64 {
+            let bn_mu = BatchNorm::new(k);
+            let bn_lv = BatchNorm::new(k);
+            let bn_dec = BatchNorm::new(v);
+            let cf = ContentFwd {
+                tc: &tcs,
+                beta_c,
+                beta_ci: Some(beta_ci),
+                c: tc,
+            };
+            batch_forward(
+                w,
+                &bn_mu,
+                &bn_lv,
+                &bn_dec,
+                &prior_mu,
+                &prior_var,
+                &alpha,
+                &opts,
+                &build_batch(),
+                Some(&cf),
+            )
+            .0
+        };
+
+        // Analytic gradients.
+        let bn_mu = BatchNorm::new(k);
+        let bn_lv = BatchNorm::new(k);
+        let bn_dec = BatchNorm::new(v);
+        let cf = ContentFwd {
+            tc: &tcs,
+            beta_c: &beta_c,
+            beta_ci: Some(&beta_ci),
+            c: tc,
+        };
+        let (_, cache, _) = batch_forward(
+            &w0,
+            &bn_mu,
+            &bn_lv,
+            &bn_dec,
+            &prior_mu,
+            &prior_var,
+            &alpha,
+            &opts,
+            &build_batch(),
+            Some(&cf),
+        );
+        let mut g = Grad::zeros(&w0);
+        let mut cg = ContentGrad {
+            beta_c: vec![0.0; tc * v],
+            beta_ci: Some(vec![0.0; k * tc * v]),
+        };
+        batch_backward(
+            &w0,
+            &prior_mu,
+            &prior_var,
+            &alpha,
+            &opts,
+            &build_batch(),
+            &cache,
+            &mut g,
+            None,
+            None,
+            Some((&cf, &mut cg)),
+        );
+
+        let fd = 1e-6;
+        let check = |name: &str, analytic: f64, num: f64| {
+            assert!(
+                (analytic - num).abs() < 1e-4,
+                "{name}: analytic {analytic} vs numeric {num}"
+            );
+        };
+        for idx in 0..beta_c.len() {
+            let o = beta_c[idx];
+            beta_c[idx] = o + fd;
+            let lp = loss(&w0, &beta_c, &beta_ci);
+            beta_c[idx] = o - fd;
+            let lm = loss(&w0, &beta_c, &beta_ci);
+            beta_c[idx] = o;
+            check("beta_c", cg.beta_c[idx], (lp - lm) / (2.0 * fd));
+        }
+        let gci = cg.beta_ci.as_ref().unwrap();
+        for idx in 0..beta_ci.len() {
+            let o = beta_ci[idx];
+            beta_ci[idx] = o + fd;
+            let lp = loss(&w0, &beta_c, &beta_ci);
+            beta_ci[idx] = o - fd;
+            let lm = loss(&w0, &beta_c, &beta_ci);
+            beta_ci[idx] = o;
+            check("beta_ci", gci[idx], (lp - lm) / (2.0 * fd));
+        }
+        // Encoder head w_mu, with content active: confirms the interaction dtheta path.
+        for idx in 0..w0.w_mu.len() {
+            let o = w0.w_mu[idx];
+            w0.w_mu[idx] = o + fd;
+            let lp = loss(&w0, &beta_c, &beta_ci);
+            w0.w_mu[idx] = o - fd;
+            let lm = loss(&w0, &beta_c, &beta_ci);
+            w0.w_mu[idx] = o;
+            check("w_mu(content)", g.w_mu()[idx], (lp - lm) / (2.0 * fd));
+        }
+    }
+
+    // A content covariate that pushes specific words up/down should be recovered:
+    // documents in group 1 over-use a marker word regardless of topic; beta_c for that
+    // covariate should place its largest positive deviation on the marker word.
+    #[test]
+    fn fit_recovers_content() {
+        let mut rng = ChaCha8Rng::seed_from_u64(9);
+        let (k, v) = (2usize, 10usize);
+        let marker = 9u32; // group-1 marker word
+        let mut docs: Vec<Vec<u32>> = Vec::new();
+        let mut tcs: Vec<Vec<f64>> = Vec::new();
+        for g in 0..2 {
+            for _ in 0..60 {
+                let mut doc = Vec::new();
+                for _ in 0..25 {
+                    // Base content from two topic blocks (words 0-3 / 4-7), plus in group
+                    // 1 a heavy dose of the marker word 9 (word 8 unused base).
+                    if g == 1 && rng.gen::<f64>() < 0.35 {
+                        doc.push(marker);
+                    } else if rng.gen::<f64>() < 0.5 {
+                        doc.push((rng.gen::<f64>() * 4.0) as u32);
+                    } else {
+                        doc.push(4 + (rng.gen::<f64>() * 4.0) as u32);
+                    }
+                }
+                docs.push(doc);
+                tcs.push(if g == 0 {
+                    vec![1.0, 0.0]
+                } else {
+                    vec![0.0, 1.0]
+                });
+            }
+        }
+        let pcs: Vec<Vec<f64>> = vec![Vec::new(); docs.len()];
+        let m = fit_scholar(
+            &docs, &pcs, None, 0, &tcs, 2, false, 0.0, k, v, 0, 20, 1.0, 0.2, 200, 40, 0.01, 0.0,
+            0.0, &mut rng,
+        );
+        let eff = m.content_effects();
+        assert_eq!(eff.len(), 2);
+        assert_eq!(eff[0].len(), v);
+        // Covariate 1 (group 1) should deviate the marker word up relative to covariate 0.
+        assert!(
+            eff[1][marker as usize] > eff[0][marker as usize],
+            "content deviation not recovered: covar1 marker {} !> covar0 marker {}",
+            eff[1][marker as usize],
+            eff[0][marker as usize]
+        );
+        // And the marker is the covariate-1 word with (near) the largest deviation.
+        let argmax = (0..v)
+            .max_by(|&a, &b| eff[1][a].total_cmp(&eff[1][b]))
+            .unwrap();
+        assert_eq!(
+            argmax, marker as usize,
+            "marker word not the top content deviation"
+        );
+    }
+
+    #[test]
+    fn fit_with_interactions_is_deterministic() {
+        let docs: Vec<Vec<u32>> = vec![
+            vec![0, 1, 2, 0, 1],
+            vec![3, 4, 5, 3],
+            vec![0, 2, 4, 1, 5],
+            vec![1, 1, 3, 5, 2],
+        ];
+        let pcs: Vec<Vec<f64>> = vec![Vec::new(); 4];
+        let tcs: Vec<Vec<f64>> = vec![
+            vec![1.0, 0.0],
+            vec![0.0, 1.0],
+            vec![1.0, 0.0],
+            vec![0.0, 1.0],
+        ];
+        let run = || {
+            let mut rng = ChaCha8Rng::seed_from_u64(5);
+            fit_scholar(
+                &docs, &pcs, None, 0, &tcs, 2, true, 0.0, 2, 6, 0, 8, 1.0, 0.2, 15, 4, 0.01, 0.0,
+                0.0, &mut rng,
+            )
+        };
+        let a = run();
+        let b = run();
+        assert_eq!(a.topic_word(), b.topic_word());
+        assert_eq!(a.content_effects(), b.content_effects());
+        assert_eq!(a.beta_ci, b.beta_ci);
+        assert!(a.interactions && a.beta_ci.is_some());
     }
 }

--- a/tests/test_scholar.py
+++ b/tests/test_scholar.py
@@ -241,7 +241,83 @@ def test_missing_covariates_and_labels_raises():
     docs, _ = _corpus()
     m = topica.Scholar(2, seed=1)
     with pytest.raises(ValueError):
-        m.fit(docs, iters=10)  # neither covariates nor labels
+        m.fit(docs, iters=10)  # neither covariates, labels, nor content
+
+
+def _content_corpus(n_per_group=60, dlen=25, seed=0, marker="wMARK", marker_frac=0.35):
+    """Two content groups; group 1 heavily over-uses a marker word regardless of topic.
+    beta_c for group 1 should place its largest deviation on the marker."""
+    rng = np.random.default_rng(seed)
+    docs, TC = [], []
+    for g in range(2):
+        for _ in range(n_per_group):
+            doc = []
+            for _ in range(dlen):
+                if g == 1 and rng.random() < marker_frac:
+                    doc.append(marker)
+                elif rng.random() < 0.5:
+                    doc.append(f"a{int(rng.integers(4))}")
+                else:
+                    doc.append(f"b{int(rng.integers(4))}")
+            docs.append(doc)
+            TC.append([1.0, 0.0] if g == 0 else [0.0, 1.0])
+    return docs, np.array(TC), marker
+
+
+def test_content_recovers_word_deviation():
+    docs, TC, marker = _content_corpus(seed=0)
+    m = topica.Scholar(2, content_names=["g0", "g1"], seed=1)
+    m.fit(docs, content=TC, iters=200)
+    assert m.content_names == ["g0", "g1"]
+    eff = m.content_effects
+    assert eff.shape[0] == 2
+    mi = list(m.vocabulary).index(marker)
+    # Group-1 marker deviation exceeds group 0, and is the top group-1 deviation.
+    assert eff[1][mi] > eff[0][mi]
+    assert int(eff[1].argmax()) == mi
+
+
+def test_content_transform_and_interactions():
+    docs, TC, _ = _content_corpus(seed=1)
+    m = topica.Scholar(2, interactions=True, seed=2)
+    m.fit(docs, content=TC, iters=60)
+    th = m.transform(docs[:5], content=TC[:5])
+    assert th.shape == (5, 2)
+    np.testing.assert_allclose(th.sum(axis=1), 1.0, atol=1e-6)
+
+
+def test_all_three_roles_compose():
+    docs, TC, _ = _content_corpus(seed=2)
+    y = ["c" + str(int(t[1])) for t in TC]
+    m = topica.Scholar(2, seed=3)
+    m.fit(docs, covariates=TC, labels=y, content=TC, iters=200)
+    assert m.covariate_effects.shape == (2, 2)
+    assert m.content_effects.shape[0] == 2
+    assert m.classes == ["c0", "c1"]
+    acc = np.mean([a == b for a, b in zip(m.predict(docs, covariates=TC, content=TC), y)])
+    assert acc > 0.8
+
+
+def test_content_save_load_roundtrip(tmp_path):
+    docs, TC, _ = _content_corpus(seed=3)
+    m = topica.Scholar(2, interactions=True, seed=1)
+    m.fit(docs, content=TC, iters=80)
+    p = tmp_path / "scholar_content.topica"
+    m.save(str(p))
+    m2 = topica.Scholar.load(str(p))
+    assert np.array_equal(m.content_effects, m2.content_effects)
+    assert np.array_equal(m.transform(docs[:4], content=TC[:4]),
+                          m2.transform(docs[:4], content=TC[:4]))
+
+
+def test_content_determinism():
+    docs, TC, _ = _content_corpus(seed=0)
+    a = topica.Scholar(2, seed=7)
+    a.fit(docs, content=TC, iters=60)
+    b = topica.Scholar(2, seed=7)
+    b.fit(docs, content=TC, iters=60)
+    assert np.array_equal(a.content_effects, b.content_effects)
+    assert np.array_equal(a.topic_word, b.topic_word)
 
 
 def test_covariate_row_mismatch_raises():


### PR DESCRIPTION
PR3 of the SCHOLAR port, completing the family (PR1 prevalence #377, PR2 labels #379).

Adds SCHOLAR's **content (topic-covariate)** role to `topica.Scholar`: content covariates that change *how* topics are worded across groups — the neural analog of SAGE.

## What it does

```python
m = topica.Scholar(num_topics=20, content_names=["outlet"], interactions=False, seed=1)
m.fit(docs, content=G)                 # G is (n_docs, n_content), numeric
m.content_effects                      # (n_content, vocab): per-covariate word shifts
m.transform(new_docs, content=G_new)
m.fit(docs, covariates=X, labels=y, content=G)   # all three roles compose
```

Each content covariate gets a per-word deviation added to the decoder logits (`beta_c`); `interactions=True` adds topic×covariate deviations (`beta_ci`); `l1_content_reg` shrinks them. Like the prevalence covariates (and unlike labels), the content covariate is observed at prediction, so it also enters the encoder — no train/test inconsistency.

## Design

Reuses the ProdLDA backbone via one new gated hook on the shared **decoder**: `batch_forward` gains an optional `ContentFwd` (adds `beta_c·TC` [+ `beta_ci·(theta_do⊗TC)`] to the logits before the decoder batchnorm), `batch_backward` an optional `ContentGrad` (accumulates the `beta_c`/`beta_ci` gradients and folds the interaction's gradient back into `theta`). `None` on both leaves the decoder untouched, so **ProdLDA/InfoCTM and the prevalence/label Scholar paths stay bit-for-bit identical** (174 Rust tests unchanged; benchmark bit-identity guard confirmed).

Hand-derived gradients are FD-verified (`content_gradient_matches_fd` checks `beta_c`, `beta_ci`, and the interaction's gradient into the encoder head `w_mu`).

## Validation

Two independent agents, **both faithful, no blockers**:

- **Author-emulation** ("Dallas Card"): decoder deviation, interaction, and all gradients faithful and FD-verified; the two simplifications (fixed-ridge vs adaptive-L1; no content background bias) reduce to the reference at the shipped defaults.
- **Benchmark**: planted content recovery textbook-clean; the reference agrees on the identified between-group contrast for both markers; interactions + compose work; ProdLDA/InfoCTM unregressed by the shared-decoder change.

Because topica has no content background bias, `content_effects` come out **centered** (pure between-group deviations) rather than frequency-shifted like the reference's raw `beta_c` — a cleaner readout of the SAGE contrast. Two documented simplifications: `l1_content_reg` is a fixed-strength ridge (the reference reweights per-weight each epoch to approximate L1 sparsity), and there is no separate content background bias (it lives in the shared decoder batchnorm). Both default off / reduce to the reference.

`tests/test_scholar.py` now 23; full suite 3308 passed. README/docs/stub/registry updated. This closes out the SCHOLAR family.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016LUJQnjFKBPuhFbZUpyu5U