### PR TITLE
docs+ci: fix stale src/python.rs refs, test feature-gated Rust code (#382, #383)

### DIFF
--- a/.github/CONTRIBUTING-MODELS.md
+++ b/.github/CONTRIBUTING-MODELS.md
@@ -21,7 +21,15 @@ with a thin Python layer on top.
 
 ```
 src/<model>.rs        pure-Rust algorithm (sampler/EM), no Python types. Unit-testable.
-src/python.rs         the PyO3 bindings: one #[pyclass] per model, plus free functions.
+src/python/mod.rs     the PyO3 binding hub: many #[pyclass]es plus free functions, and
+                      the single #[pymodule] registration fn (`m.add_class::<...>()`) at
+                      the bottom. Large models are extracted into their own module:
+src/python/<model>.rs a per-model binding module (btm.rs, disclda.rs, scholar.rs, ...).
+                      Defines `pub struct <Model>`; mod.rs pulls it in with
+                      `use <model>::<Model>;` and registers it in the #[pymodule] fn.
+src/python/{arrays,error,py_corpus,save}.rs   shared binding helpers.
+topica-core/          vendorable crate holding the shared CTM/STM variational math.
+                      The root crate re-exports it; touch it for CTM/STM-family changes.
 src/model.rs          shared TopicModel state used by the MALLET-family samplers.
 src/{sampler,optimize,coherence,corpus,linalg,spectral,reduce,represent}.rs
                       shared machinery (Gibbs sweep, hyperparameter optimization,
@@ -36,9 +44,12 @@ tests/                pytest. parity/ statistical checks vs R/MALLET. docs/ mkdo
 ```
 
 The split that matters: **algorithms live in `src/<model>.rs` and know nothing
-about Python; `src/python.rs` is the only place that touches PyO3.** Keep that
-boundary. The algorithm crate is where your unit tests and finite-difference
-checks run; the binding is plumbing.
+about Python; the `src/python/` modules are the only place that touches PyO3.**
+Keep that boundary. The algorithm crate is where your unit tests and
+finite-difference checks run; the binding is plumbing. Small models add their
+`#[pyclass]` directly in `src/python/mod.rs`; larger ones get their own
+`src/python/<model>.rs` module (see the extraction pattern above) that mod.rs
+declares with `mod <model>;` and registers in the `#[pymodule]` fn.
 
 ## Invariants you must not break
 
@@ -194,7 +205,8 @@ Example shape: add a `min_cluster_weight` knob, or a new `weights=` mode.
    pure-Rust function takes and uses it. Add or extend a `#[cfg(test)]` unit test
    that exercises the new behavior (planted data where the parameter changes the
    recovered result in a predictable direction).
-2. **Binding.** In `src/python.rs`, add the argument to the relevant
+2. **Binding.** In the model's binding (`src/python/mod.rs`, or its
+   `src/python/<model>.rs` module if extracted), add the argument to the relevant
    `#[pyo3(signature = (...))]`. It must be **keyword-only** (after the `*`) with
    a default that preserves current behavior. Validate it in the body and raise
    `PyValueError` on bad input, matching the existing messages. Pass it into the
@@ -261,7 +273,7 @@ and needs no rebuild.
 
 ## Part B: adding a new model
 
-Use `GSDMM` (`src/gsdmm.rs` + the `GSDMM` block in `src/python.rs`) as the
+Use `GSDMM` (`src/gsdmm.rs` + the `GSDMM` block in `src/python/mod.rs`) as the
 reference template. It is small, self-contained, and exercises the whole
 contract. Work in this order.
 
@@ -336,7 +348,11 @@ Tier-0 method is structurally undefined (a time-sliced or tree model has no flat
 `doc_topic`), return an empty value and record the exemption in that row — do not
 fake a value.
 
-### B2. The PyO3 binding in `src/python.rs`
+### B2. The PyO3 binding in `src/python/`
+
+Add the binding in `src/python/mod.rs` next to the other model blocks, or, for a
+larger model, in its own `src/python/<model>.rs` module (declared with
+`mod <model>;` in mod.rs and pulled in with `use <model>::<Model>;`).
 
 Add a `#[pyclass(module = "topica")]` struct holding the hyperparameters, a
 `fitted: bool`, the fitted state (`phi`/`theta` as `Option<Array2<f64>>`), and
@@ -482,7 +498,9 @@ falls back to the bootstrap.
 
 ### B4. Register the class
 
-In the `#[pymodule]` function at the bottom of `src/python.rs`:
+In the `#[pymodule]` function at the bottom of `src/python/mod.rs` (if you put
+the binding in its own module, also add `mod <model>;` and `use <model>::<Model>;`
+near the top of mod.rs first):
 
 ```rust
 m.add_class::<MyModel>()?;
@@ -532,7 +550,7 @@ the topics on a real corpus.
 
 - [ ] Algorithm in `src/<model>.rs` with `#[cfg(test)]` recovery + determinism tests; `mod` added to `src/lib.rs`.
 - [ ] `Estimator` (and the family trait, where it applies) implemented on the fitted struct, a `*_conforms` test added, and a `RUST_ESTIMATORS` row in `src/conformance.rs`.
-- [ ] `#[pyclass]` binding in `src/python.rs` exposing the four required analysis-surface attributes plus `top_words`, `coherence`, `save`/`load`, `__repr__`.
+- [ ] `#[pyclass]` binding in `src/python/` (mod.rs or a per-model `src/python/<model>.rs` module) exposing the four required analysis-surface attributes plus `top_words`, `coherence`, `save`/`load`, `__repr__`.
 - [ ] Keyword-only new params with behavior-preserving defaults; clear `PyValueError`/`RuntimeError` messages; GIL released during fit; RNG seeded from `self.seed`.
 - [ ] Registered in `#[pymodule]`; re-exported in `__init__.py` (+ `__all__`); `.pyi` stub updated to match.
 - [ ] `tests/test_<model>.py` passes; `parity/` check added where a reference exists.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -20,10 +20,17 @@ EM loops.
 ## Tests
 
 ```bash
-cargo test --lib                 # Rust unit tests
+cargo test --workspace --lib                              # Rust unit tests
+cargo test --workspace --lib --features embeddings,umap,tsne  # feature-gated tests
 python -m pytest tests/ -q       # Python tests
 mkdocs build --strict            # docs must build clean
 ```
+
+The second command exercises the Rust tests behind the `embeddings`/`umap`/`tsne`
+`#[cfg(feature = ...)]` gates, which a plain `cargo test` skips. CI runs both
+(issue #383). It does not use `--all-features`, because that also enables
+`python`, and pyo3's extension-module mode does not link libpython into a
+standalone test binary.
 
 The `parity/` directory holds cross-implementation checks against R (`stm`,
 `keyATM`) and Java MALLET. They skip cleanly when Rscript or the package is not
@@ -32,9 +39,11 @@ installed, so they are optional locally but run when the tooling is present.
 ## Conventions
 
 - The house import is `import topica`, with no alias.
-- One Rust file per model under `src/` (`keyatm.rs`, `stm.rs`, …); `python.rs`
-  holds the PyO3 bindings. Keep the `python/topica/_topica.pyi` type stub in sync
-  when you change a binding's signature.
+- One Rust file per model under `src/` (`keyatm.rs`, `stm.rs`, …); the PyO3
+  bindings live under `src/python/` — most in the `src/python/mod.rs` hub, larger
+  models in their own `src/python/<model>.rs` module. Keep the
+  `python/topica/_topica.pyi` type stub in sync when you change a binding's
+  signature.
 - New gradients or samplers should ship with a test that checks them (finite
   differences for gradients, planted-data recovery for samplers), and where a
   reference implementation exists, a statistical-parity check under `parity/`.

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -48,8 +48,8 @@ jobs:
           test "$tag" = "$cargo_version"
 
   # Rust hygiene gate, run once (OS-independent): the whole workspace must be
-  # rustfmt-clean and clippy-clean (-D warnings, all features so python.rs is
-  # linted too). Catches drift without relying on reviewer discipline.
+  # rustfmt-clean and clippy-clean (-D warnings, all features so the src/python/
+  # bindings are linted too). Catches drift without relying on reviewer discipline.
   lint:
     name: lint (fmt + clippy)
     runs-on: ubuntu-latest
@@ -110,6 +110,16 @@ jobs:
       # in CONTRIBUTING.md, so it gates PRs here too.
       - name: cargo test
         run: cargo test --workspace --lib
+
+      # Feature-gated Rust tests (issue #383). The bare run above does not compile
+      # the `embeddings`/`umap`/`tsne` code, so tests behind those `#[cfg(feature
+      # = ...)]` gates never run. Enable them explicitly. NOT `--all-features`:
+      # that would also turn on `python`, and pyo3's extension-module mode does
+      # not link libpython into a standalone test binary (see above). This set
+      # covers every feature gate except `python`, which has no unit-testable
+      # code. Also in CONTRIBUTING.md as `cargo test --features embeddings,umap,tsne`.
+      - name: cargo test (feature-gated models)
+        run: cargo test --workspace --lib --features embeddings,umap,tsne
 
       - name: Build extension and run tests
         shell: bash

--- a/docs/contributing/estimator-contract.md
+++ b/docs/contributing/estimator-contract.md
@@ -216,8 +216,9 @@ open a pull request.
 
 ## Adding a new estimator
 
-1. Implement the model in `src/<name>.rs` with PyO3 bindings in `src/python.rs`
-   (or in pure Python in `python/topica/`).
+1. Implement the model in `src/<name>.rs` with PyO3 bindings under `src/python/`
+   (in the `src/python/mod.rs` hub, or a per-model `src/python/<name>.rs` module),
+   or in pure Python in `python/topica/`.
 2. Export it from `python/topica/__init__.py`.
 3. Add it to `REGISTRY` in `python/topica/conformance.py` with a zero-arg
    factory lambda and the correct `model_family` string.


### PR DESCRIPTION
Closes #382, closes #383. Two small contributor-experience fixes from the 381–386 devex batch; no model math or public API touched.

## #382 — refresh the Rust/PyO3 contributor map
The bindings moved from a single `src/python.rs` to `src/python/mod.rs` plus per-model `src/python/<model>.rs` modules. The contributor guides still pointed at the nonexistent `src/python.rs` in 10 places.

- `CONTRIBUTING-MODELS.md`: rewrote the architecture block to show the hub + extracted-module pattern (`pub struct <Model>` in `src/python/<model>.rs`, pulled into mod.rs with `use <model>::<Model>;`, registered in the single `#[pymodule]` fn), added `topica-core/` for shared CTM/STM math, and fixed the binding/registration/checklist references.
- `CONTRIBUTING.md`, `docs/contributing/estimator-contract.md`, and the CI lint comment: same correction.
- No remaining `src/python.rs` references anywhere in `.github/` or `docs/`.

## #383 — run feature-gated Rust tests in CI
CI ran only `cargo test --workspace --lib`, which never compiles the code behind the `embeddings`/`umap`/`tsne` `#[cfg(feature = ...)]` gates (11 gated sites; locally the gated run adds tests the bare run skips — 224+29 pass).

- Added a second CI step: `cargo test --workspace --lib --features embeddings,umap,tsne`.
- **Not** `--all-features`: that also enables `python`, and pyo3's extension-module mode doesn't link libpython into a standalone test binary (the same reason the existing bare run omits it). The `python` gate has no unit-testable code.
- Documented the local command in `CONTRIBUTING.md`.

## Checks
- `mkdocs build --strict` clean
- CI.yml validates as YAML
- Feature-gated Rust tests pass locally: `224 passed; 1 ignored` + `29 passed`

🤖 Generated with [Claude Code](https://claude.com/claude-code)