### PR TITLE
devex: add a just command runner for the Rust/Python dev loop (#384)

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -17,6 +17,29 @@ maturin develop --release --features python
 Always build with `--release`: the debug build is much slower for the Gibbs and
 EM loops.
 
+## Development loop
+
+The mixed Rust/PyO3 workflow (release-mode rebuilds, the `VIRTUAL_ENV`/`.venv-dev`
+handshake maturin needs, feature-gated tests) is wrapped in a
+[`just`](https://just.systems) command runner so you do not have to reconstruct
+the commands. Install it (`cargo install just`, `brew install just`, or your
+package manager), then:
+
+```bash
+just                 # list every recipe
+just build           # (re)build the extension into the dev venv (--release)
+just lint            # cargo fmt --check + clippy -D warnings (the CI lint gate)
+just test            # Rust core + feature-gated Rust + Python tests
+just docs            # mkdocs build --strict
+just pre-pr          # build + lint + test + docs + preflight — run before a PR
+```
+
+`just --list` shows the rest (`fmt`, `clippy`, `test-rust`, `test-rust-features`,
+`test-py`, `preflight`). The recipes assume a POSIX shell and a dev venv with
+binaries under `bin/` (macOS / Linux); the raw commands each recipe runs are
+below and in the `justfile`, so Windows contributors (or anyone without `just`)
+can run them directly.
+
 ## Tests
 
 ```bash

--- a/justfile
+++ b/justfile
@@ -1,0 +1,90 @@
+# topica development command runner (issue #384).
+#
+# `just` (https://just.systems) wraps the mixed Rust/PyO3 workflow so the
+# release-mode rebuild and the VIRTUAL_ENV/.venv-dev handshake are not something
+# a contributor has to remember. Install it with `cargo install just`,
+# `brew install just`, or your package manager, then run `just` to list recipes.
+#
+# Platform assumption: these recipes assume a POSIX shell and a development
+# virtualenv whose binaries live under `bin/` (macOS / Linux). On Windows, run
+# under Git Bash or invoke the underlying commands directly; see
+# .github/CONTRIBUTING.md for the raw command list.
+
+# The dev virtualenv. maturin needs VIRTUAL_ENV set explicitly because the dev
+# venv is `.venv-dev`, not `.venv`. Honor an already-active venv if there is one,
+# else default to .venv-dev. Exported so every recipe (and maturin) sees it.
+export VIRTUAL_ENV := env_var_or_default("VIRTUAL_ENV", justfile_directory() / ".venv-dev")
+
+py := VIRTUAL_ENV / "bin" / "python"
+maturin := VIRTUAL_ENV / "bin" / "maturin"
+
+# List available recipes (default when you run bare `just`).
+default:
+    @just --list
+
+# --- Format & lint ---------------------------------------------------------
+
+# Rewrite Rust source to rustfmt's canonical form.
+fmt:
+    cargo fmt --all
+
+# Check formatting without rewriting (the CI gate).
+fmt-check:
+    cargo fmt --all --check
+
+# Clippy with warnings-as-errors, all targets, all features (the CI gate).
+clippy:
+    cargo clippy --workspace --all-targets --all-features -- -D warnings
+
+# The full CI lint job: formatting check + clippy.
+lint: fmt-check clippy
+
+# --- Tests -----------------------------------------------------------------
+
+# No `python` feature: pyo3 extension-module mode won't link a standalone test
+# binary. `--workspace` so topica-core is covered too.
+#
+# Rust unit tests (core + topica-core).
+test-rust:
+    cargo test --workspace --lib
+
+# The embeddings/umap/tsne cfg gates, which `test-rust` skips (issue #383). Not
+# `--all-features`: that enables `python` and breaks linking.
+#
+# Rust tests behind the feature gates.
+test-rust-features:
+    cargo test --workspace --lib --features embeddings,umap,tsne
+
+# Python test suite (needs a current dev build; run `just build` first).
+test-py:
+    {{py}} -m pytest tests/ -q
+
+# Every test surface: Rust core, feature-gated Rust, and Python.
+test: test-rust test-rust-features test-py
+
+# --- Build & docs ----------------------------------------------------------
+
+# Always --release: debug Gibbs/EM loops are an order of magnitude slower. Run
+# after any Rust change.
+#
+# (Re)build the extension into the dev venv.
+build:
+    {{maturin}} develop --release --features python
+
+# Strict docs build — a broken nav entry or cross-reference fails.
+docs:
+    {{py}} -m mkdocs build --strict
+
+# --- Aggregate gates -------------------------------------------------------
+
+# fmt + clippy + model-table + .pyi stub sync; also wired as the pre-push hook.
+#
+# Generated-file + lint preflight.
+preflight:
+    ./scripts/preflight.sh
+
+# Rebuild, then lint + all tests + strict docs + preflight. Mirrors what CI
+# enforces, in cheapest-useful order.
+#
+# Full pre-PR gate — run before opening a PR.
+pre-pr: build lint test docs preflight


### PR DESCRIPTION
Closes #384. Third item in the 381–386 devex batch.

## What
A `justfile` command runner ([just.systems](https://just.systems)) wrapping the mixed Rust/PyO3 dev loop, so contributors don't reconstruct the `VIRTUAL_ENV`/`.venv-dev` handshake, the `--release` rebuild, or the feature-gated test command by hand.

```
just                 # list recipes
just build           # maturin develop --release --features python (into the dev venv)
just fmt / lint      # cargo fmt + clippy -D warnings (the CI lint gate)
just test-rust       # cargo test --workspace --lib
just test-rust-features   # + --features embeddings,umap,tsne (the gates cargo test skips, #383)
just test-py         # pytest tests/ -q
just test            # all three test surfaces
just docs            # mkdocs build --strict
just preflight       # the generated-file + lint pre-push gate
just pre-pr          # build + lint + test + docs + preflight — the full pre-PR gate
```

## Design
- **Preserves release-mode rebuild.** `build` runs `maturin develop --release --features python`.
- **Handles the venv dance.** Recipes honor an already-active `VIRTUAL_ENV`, else default to `.venv-dev`, and route python/maturin through that venv's `bin/` — the thing that's easy to get wrong.
- **`pre-pr` mirrors CI** in cheapest-useful order, so one command is the standard pre-PR check.
- **Platform assumption stated** (justfile header + guide): POSIX shell, dev-venv binaries under `bin/` (macOS / Linux). The raw commands each recipe runs are documented as the Windows / no-`just` fallback.

## Docs
`.github/CONTRIBUTING.md` gains a **Development loop** section presenting `just` as the primary loop, keeping the raw-command Tests block as the fallback.

## Acceptance criteria
- [x] Contributor guide uses the runner as the primary development loop.
- [x] Commands preserve current release-mode rebuild behavior.
- [x] A contributor can run the standard pre-PR checks without reconstructing shell/virtualenv commands.
- [x] Cross-platform assumptions clearly stated.

## Verification
- `just --list` renders clean one-line docs for every recipe.
- `just --dry-run pre-pr` expands the full chain with venv paths resolved correctly.
- `just fmt-check` and `just test-py` run green through the venv wiring (**3308 passed, 30 skipped**).
- Pre-push `preflight` (fmt + clippy + model-tables + stub sync) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)