### PR TITLE
devex: generate a CI-validated model implementation map (#381)

### DIFF
--- a/docs/contributing/model-map.md
+++ b/docs/contributing/model-map.md
@@ -1,0 +1,119 @@
+# Model implementation map
+
+This page maps every shipped model to the files a change touches: its core
+algorithm, its PyO3 binding, the shared machinery it builds on, the Cargo feature
+it needs, and where its reference-parity tests live. Use it to find the surfaces
+for a model without searching the tree.
+
+It is **generated from the registry**, not hand-maintained here. The source of
+truth is the `IMPL` map in
+[`python/topica/registry.py`](https://github.com/nealcaren/topica/blob/main/python/topica/registry.py);
+`scripts/gen_model_tables.py` renders it into the block below, and
+`tests/test_registry.py` fails CI if the block is stale, if `IMPL` and the model
+registry cover different models, or if any path or Cargo feature it names does
+not exist. So this map cannot silently drift from the code.
+
+To change a row, edit `registry.py` and run `python scripts/gen_model_tables.py`
+(the `preflight` hook and CI reject a stale block); do not edit the generated
+block directly.
+
+Column meanings:
+
+- **Source** — the core algorithm file. A Rust `src/*.rs` (or `topica-core/`)
+  file, or a `python/topica/*.py` module for the pure-Python models.
+- **Binding** — the PyO3 binding: `src/python/mod.rs`, an extracted
+  `src/python/<model>.rs` module, or `—` for a pure-Python model.
+- **Core / family** — the shared machinery the model builds on (the collapsed
+  Gibbs core in `model.rs`/`sampler.rs`, the CTM/STM variational core in
+  `topica-core`, the ProdLDA VAE, and so on).
+- **Feature** — the Cargo feature required beyond the default build. `default`
+  builds with a plain `cargo build`; `embeddings` is the clustering-model gate
+  (`cargo test --features embeddings,umap,tsne` covers it).
+- **Validation** — the reference-parity / gold artifacts for the model. Every
+  registered model is additionally covered by the conformance suite
+  (`tests/test_conformance.py`).
+
+<!-- BEGIN MODEL MAP (generated from topica.registry IMPL; edit registry.py, not this block) -->
+
+### General-purpose
+
+| Model | Source | Binding | Core / family | Feature | Validation |
+|---|---|---|---|---|---|
+| `LDA` | `src/model.rs` | `src/python/mod.rs` | SparseLDA collapsed Gibbs (model.rs, sampler.rs) | default | `parity/lda_gold.py`, `parity/mallet_parity.py` |
+| `CTM` | `topica-core/src/ctm.rs` | `src/python/mod.rs` | CTM/STM variational core (topica-core) | default | `parity/ctm_gold.py`, `parity/ctm_r_compare.py` |
+| `ProdLDA` | `src/prodlda.rs` | `src/python/mod.rs` | hand-coded batched VAE (prodlda.rs) | default | `parity/prodlda_gold.py`, `parity/prodlda_compare.py` |
+| `HDP` | `src/hdp.rs` | `src/python/mod.rs` | collapsed Gibbs (model.rs, sampler.rs) | default | `parity/hdp_gold.py` |
+| `NMF` | `src/nmf.rs` | `src/python/nmf_lsa.rs` | multiplicative-update matrix factorization | default | `parity/nmf_vs_sklearn.py` |
+| `LSA` | `src/lsa.rs` | `src/python/nmf_lsa.rs` | truncated SVD (linalg) | default | `parity/lsa_vs_sklearn.py` |
+| `AnchorLDA` | `python/topica/anchor.py` | — _(Python)_ | spectral anchor-word recovery (Python over Rust primitives) | default | `tests/test_anchor.py` |
+| `TensorLDA` | `src/tlda.rs` | `src/python/tlda.rs` | method-of-moments cumulants (linalg, spectral) | default | `parity/tlda_gold.py`, `parity/tlda_compare.py` |
+| `PolylingualLDA` | `src/pltm.rs` | `src/python/pltm.rs` | collapsed Gibbs (model.rs, sampler.rs) | default | `parity/pltm_compare.py` |
+
+### Covariates & structure
+
+| Model | Source | Binding | Core / family | Feature | Validation |
+|---|---|---|---|---|---|
+| `STM` | `src/sts.rs` | `src/python/mod.rs` | CTM/STM variational core (topica-core) | default | `parity/stm_gold.py`, `parity/stm_r_compare.py` |
+| `STS` | `src/sts.rs` | `src/python/mod.rs` | CTM/STM variational core (topica-core) | default | `parity/sts_gold.py`, `parity/sts_r_compare.py` |
+| `SAGE` | `src/sage.rs` | `src/python/mod.rs` | collapsed Gibbs + SAGE deviations | default | `parity/sage_gold.py` |
+| `DMR` | `src/dmr.rs` | `src/python/mod.rs` | collapsed Gibbs + DMR prior (optimize.rs) | default | `parity/dmr_gold.py` |
+| `GDMR` | `src/dmr.rs` | `src/python/mod.rs` | collapsed Gibbs + DMR prior (optimize.rs) | default | `parity/gdmr_gold.py`, `parity/test_gdmr_tomotopy.py` |
+| `Scholar` | `src/scholar.rs` | `src/python/scholar.rs` | ProdLDA VAE + covariate prior (prodlda.rs) | default | `tests/test_scholar.py` |
+| `NarrativeTM` | `python/topica/narrative.py` | — _(Python)_ | intra-document trajectory over Gibbs core (Python) | default | `tests/test_content_trajectory.py` |
+
+### Guided & supervised
+
+| Model | Source | Binding | Core / family | Feature | Validation |
+|---|---|---|---|---|---|
+| `KeyATM` | `src/keyatm.rs` | `src/python/mod.rs` | collapsed Gibbs + keyword index | default | `parity/keyatm_gold.py`, `parity/keyatm_r_compare.py` |
+| `SeededLDA` | `src/seeded.rs` | `src/python/mod.rs` | collapsed Gibbs (model.rs, sampler.rs) | default | `parity/seededlda_gold.py` |
+| `LabeledLDA` | `src/labeled.rs` | `src/python/mod.rs` | collapsed Gibbs (model.rs, sampler.rs) | default | `parity/labeledlda_gold.py` |
+| `SupervisedLDA` | `src/slda.rs` | `src/python/mod.rs` | collapsed Gibbs + response head | default | `parity/supervisedlda_gold.py` |
+| `DiscLDA` | `src/disclda.rs` | `src/python/disclda.rs` | collapsed Gibbs + class transform | default | `parity/disclda_20ng.py`, `tests/test_disclda.py` |
+
+### Short text
+
+| Model | Source | Binding | Core / family | Feature | Validation |
+|---|---|---|---|---|---|
+| `GSDMM` | `src/gsdmm.rs` | `src/python/mod.rs` | collapsed Gibbs mixture (one topic/doc) | default | `parity/gsdmm_gold.py` |
+| `PT` | `src/pt.rs` | `src/python/mod.rs` | collapsed Gibbs over pseudo-documents | default | `parity/pt_gold.py` |
+| `BTM` | `src/btm.rs` | `src/python/btm.rs` | collapsed Gibbs over biterms | default | `parity/btm_compare.py`, `tests/test_btm.py` |
+
+### Dynamic & hierarchical
+
+| Model | Source | Binding | Core / family | Feature | Validation |
+|---|---|---|---|---|---|
+| `DTM` | `src/dtm.rs` | `src/python/mod.rs` | variational Kalman over time slices | default | `parity/dtm_gold.py` |
+| `DETM` | `src/detm.rs` | `src/python/mod.rs` | embedding VAE + LSTM q(eta) (etm_vae.rs) | default | `parity/detm_gold.py` |
+| `HLDA` | `src/hlda.rs` | `src/python/mod.rs` | nested-CRP collapsed Gibbs | default | `parity/hlda_gold.py` |
+| `PA` | `src/pa.rs` | `src/python/mod.rs` | collapsed Gibbs over a topic DAG | default | `parity/pa_gold.py` |
+
+### Embedding-based
+
+| Model | Source | Binding | Core / family | Feature | Validation |
+|---|---|---|---|---|---|
+| `BERTopic` | `src/bertopic.rs` | `src/python/mod.rs` | embedding clustering (cluster.rs, reduce.rs, represent.rs) | `embeddings` | `parity/bertopic_gold.py` |
+| `Top2Vec` | `src/top2vec.rs` | `src/python/mod.rs` | embedding clustering (cluster.rs, reduce.rs) | `embeddings` | `parity/top2vec_gold.py`, `parity/top2vec_compare.py` |
+| `ETM` | `src/etm.rs` | `src/python/mod.rs` | variational EM over word embeddings (ctm.rs) | default | `parity/etm_gold.py` |
+| `IdealPointTM` | `src/idealpoint.rs` | `src/python/idealpoint.rs` | variational EM + ideal-point head | default | `tests/test_idealpoint.py`, `tests/test_idealpoint_counts.py` |
+| `IdealPointSentenceTM` | `src/sentence_ideal.rs` | `src/python/sentence_ideal.rs` | Gaussian-cluster EM over embeddings | default | `tests/test_sentence_ideal.py` |
+| `FASTopic` | `src/fastopic.rs` | `src/python/mod.rs` | reverse-mode Sinkhorn optimal transport | default | `parity/fastopic_gold.py`, `parity/fastopic_compare.py` |
+| `EmbeddingLDA` | `python/topica/embedding.py` | — _(Python)_ | seeded Gibbs + embedding NN expansion (Python) | default | `parity/embeddinglda_gold.py`, `tests/test_embedding_lda.py` |
+| `CombinedTM` | `src/prodlda.rs` | `src/python/mod.rs` | contextualized ProdLDA VAE (prodlda.rs) | default | `parity/combinedtm_gold.py`, `parity/combinedtm_compare.py` |
+| `ZeroShotTM` | `src/prodlda.rs` | `src/python/mod.rs` | contextualized ProdLDA VAE (prodlda.rs) | default | `parity/zeroshot_gold.py`, `parity/zeroshot_compare.py` |
+| `InfoCTM` | `src/infoctm.rs` | `src/python/mod.rs` | two ProdLDA VAEs + TAMI alignment (prodlda.rs) | default | `parity/infoctm_gold.py`, `parity/infoctm_compare.py` |
+
+### Ideal point
+
+| Model | Source | Binding | Core / family | Feature | Validation |
+|---|---|---|---|---|---|
+| `Wordfish` | `src/wordfish.rs` | `src/python/wordfish.rs` | Poisson-scaling EM | default | `parity/wordfish_r_compare.py`, `tests/test_wordfish.py` |
+| `TBIP` | `src/tbip.rs` | `src/python/tbip.rs` | Poisson-factorization mean-field SVI | default | `parity/tbip_parity.py`, `tests/test_tbip.py` |
+| `PartyEmbeddings` | `src/party_embeddings.rs` | `src/python/party_embeddings.rs` | PV-DM paragraph vectors (negative sampling) | default | `parity/party_embeddings_compare.py`, `tests/test_party_embeddings.py` |
+
+### LLM-based
+
+| Model | Source | Binding | Core / family | Feature | Validation |
+|---|---|---|---|---|---|
+| `TopicGPT` | `python/topica/llm.py` | — _(Python)_ | LLM prompting pipeline (Python) | default | `tests/test_topicgpt.py` |
+<!-- END MODEL MAP -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -130,5 +130,6 @@ nav:
   - Contributing:
       - API conventions: contributing/conventions.md
       - Estimator contract: contributing/estimator-contract.md
+      - Model implementation map: contributing/model-map.md
       - Release checklist: contributing/release-checklist.md
   - Citing: citing.md

--- a/python/topica/registry.py
+++ b/python/topica/registry.py
@@ -211,6 +211,93 @@ REGISTRY: dict[str, ModelInfo] = {
 }
 
 
+@dataclass(frozen=True)
+class ImplInfo:
+    """Where a model lives in the source tree and how it is validated (#381).
+
+    The companion to :class:`ModelInfo`: that one is the user-facing taxonomy,
+    this one is the contributor's map from a model name to the files a change
+    touches. Keyed by the same model name, so a model cannot appear in one and
+    not the other (``tests/test_registry.py`` asserts ``IMPL`` and ``REGISTRY``
+    cover exactly the same set). Every path is checked to exist and every Cargo
+    feature checked to be real by the same test, so this map cannot silently rot
+    into a stale inventory.
+
+    Attributes
+    ----------
+    source : the core algorithm file — a Rust ``src/*.rs`` / ``topica-core/``
+        file, or a ``python/topica/*.py`` module for the pure-Python models.
+    binding : the PyO3 binding location (``src/python/mod.rs`` or an extracted
+        ``src/python/<model>.rs`` module); ``""`` for pure-Python models with no
+        binding of their own.
+    core : the shared machinery / family the model builds on (free text).
+    feature : the Cargo feature required beyond the default build (``""`` builds
+        with a plain ``cargo build``; ``"embeddings"`` for the clustering models).
+    validation : reference-parity / gold / test artifacts, as comma-separated
+        repo-relative paths. Every registered model is additionally covered by
+        the conformance suite (``tests/test_conformance.py``).
+    """
+
+    source: str
+    binding: str
+    core: str
+    feature: str
+    validation: str
+
+
+def _i(source: str, binding: str, core: str, feature: str, validation: str) -> ImplInfo:
+    return ImplInfo(source, binding, core, feature, validation)
+
+
+# name -> where it lives + how it is validated. Curated, but path- and
+# feature-validated in CI (tests/test_registry.py), and required to cover exactly
+# the same models as REGISTRY. Add a model here when you add it to REGISTRY.
+IMPL: dict[str, ImplInfo] = {
+    "LDA": _i("src/model.rs", "src/python/mod.rs", "SparseLDA collapsed Gibbs (model.rs, sampler.rs)", "", "parity/lda_gold.py, parity/mallet_parity.py"),
+    "CTM": _i("topica-core/src/ctm.rs", "src/python/mod.rs", "CTM/STM variational core (topica-core)", "", "parity/ctm_gold.py, parity/ctm_r_compare.py"),
+    "ProdLDA": _i("src/prodlda.rs", "src/python/mod.rs", "hand-coded batched VAE (prodlda.rs)", "", "parity/prodlda_gold.py, parity/prodlda_compare.py"),
+    "HDP": _i("src/hdp.rs", "src/python/mod.rs", "collapsed Gibbs (model.rs, sampler.rs)", "", "parity/hdp_gold.py"),
+    "NMF": _i("src/nmf.rs", "src/python/nmf_lsa.rs", "multiplicative-update matrix factorization", "", "parity/nmf_vs_sklearn.py"),
+    "LSA": _i("src/lsa.rs", "src/python/nmf_lsa.rs", "truncated SVD (linalg)", "", "parity/lsa_vs_sklearn.py"),
+    "AnchorLDA": _i("python/topica/anchor.py", "", "spectral anchor-word recovery (Python over Rust primitives)", "", "tests/test_anchor.py"),
+    "TensorLDA": _i("src/tlda.rs", "src/python/tlda.rs", "method-of-moments cumulants (linalg, spectral)", "", "parity/tlda_gold.py, parity/tlda_compare.py"),
+    "PolylingualLDA": _i("src/pltm.rs", "src/python/pltm.rs", "collapsed Gibbs (model.rs, sampler.rs)", "", "parity/pltm_compare.py"),
+    "STM": _i("src/sts.rs", "src/python/mod.rs", "CTM/STM variational core (topica-core)", "", "parity/stm_gold.py, parity/stm_r_compare.py"),
+    "STS": _i("src/sts.rs", "src/python/mod.rs", "CTM/STM variational core (topica-core)", "", "parity/sts_gold.py, parity/sts_r_compare.py"),
+    "SAGE": _i("src/sage.rs", "src/python/mod.rs", "collapsed Gibbs + SAGE deviations", "", "parity/sage_gold.py"),
+    "DMR": _i("src/dmr.rs", "src/python/mod.rs", "collapsed Gibbs + DMR prior (optimize.rs)", "", "parity/dmr_gold.py"),
+    "GDMR": _i("src/dmr.rs", "src/python/mod.rs", "collapsed Gibbs + DMR prior (optimize.rs)", "", "parity/gdmr_gold.py, parity/test_gdmr_tomotopy.py"),
+    "Scholar": _i("src/scholar.rs", "src/python/scholar.rs", "ProdLDA VAE + covariate prior (prodlda.rs)", "", "tests/test_scholar.py"),
+    "NarrativeTM": _i("python/topica/narrative.py", "", "intra-document trajectory over Gibbs core (Python)", "", "tests/test_content_trajectory.py"),
+    "KeyATM": _i("src/keyatm.rs", "src/python/mod.rs", "collapsed Gibbs + keyword index", "", "parity/keyatm_gold.py, parity/keyatm_r_compare.py"),
+    "SeededLDA": _i("src/seeded.rs", "src/python/mod.rs", "collapsed Gibbs (model.rs, sampler.rs)", "", "parity/seededlda_gold.py"),
+    "LabeledLDA": _i("src/labeled.rs", "src/python/mod.rs", "collapsed Gibbs (model.rs, sampler.rs)", "", "parity/labeledlda_gold.py"),
+    "SupervisedLDA": _i("src/slda.rs", "src/python/mod.rs", "collapsed Gibbs + response head", "", "parity/supervisedlda_gold.py"),
+    "DiscLDA": _i("src/disclda.rs", "src/python/disclda.rs", "collapsed Gibbs + class transform", "", "parity/disclda_20ng.py, tests/test_disclda.py"),
+    "GSDMM": _i("src/gsdmm.rs", "src/python/mod.rs", "collapsed Gibbs mixture (one topic/doc)", "", "parity/gsdmm_gold.py"),
+    "PT": _i("src/pt.rs", "src/python/mod.rs", "collapsed Gibbs over pseudo-documents", "", "parity/pt_gold.py"),
+    "BTM": _i("src/btm.rs", "src/python/btm.rs", "collapsed Gibbs over biterms", "", "parity/btm_compare.py, tests/test_btm.py"),
+    "DTM": _i("src/dtm.rs", "src/python/mod.rs", "variational Kalman over time slices", "", "parity/dtm_gold.py"),
+    "DETM": _i("src/detm.rs", "src/python/mod.rs", "embedding VAE + LSTM q(eta) (etm_vae.rs)", "", "parity/detm_gold.py"),
+    "HLDA": _i("src/hlda.rs", "src/python/mod.rs", "nested-CRP collapsed Gibbs", "", "parity/hlda_gold.py"),
+    "PA": _i("src/pa.rs", "src/python/mod.rs", "collapsed Gibbs over a topic DAG", "", "parity/pa_gold.py"),
+    "BERTopic": _i("src/bertopic.rs", "src/python/mod.rs", "embedding clustering (cluster.rs, reduce.rs, represent.rs)", "embeddings", "parity/bertopic_gold.py"),
+    "Top2Vec": _i("src/top2vec.rs", "src/python/mod.rs", "embedding clustering (cluster.rs, reduce.rs)", "embeddings", "parity/top2vec_gold.py, parity/top2vec_compare.py"),
+    "ETM": _i("src/etm.rs", "src/python/mod.rs", "variational EM over word embeddings (ctm.rs)", "", "parity/etm_gold.py"),
+    "IdealPointTM": _i("src/idealpoint.rs", "src/python/idealpoint.rs", "variational EM + ideal-point head", "", "tests/test_idealpoint.py, tests/test_idealpoint_counts.py"),
+    "Wordfish": _i("src/wordfish.rs", "src/python/wordfish.rs", "Poisson-scaling EM", "", "parity/wordfish_r_compare.py, tests/test_wordfish.py"),
+    "IdealPointSentenceTM": _i("src/sentence_ideal.rs", "src/python/sentence_ideal.rs", "Gaussian-cluster EM over embeddings", "", "tests/test_sentence_ideal.py"),
+    "TBIP": _i("src/tbip.rs", "src/python/tbip.rs", "Poisson-factorization mean-field SVI", "", "parity/tbip_parity.py, tests/test_tbip.py"),
+    "PartyEmbeddings": _i("src/party_embeddings.rs", "src/python/party_embeddings.rs", "PV-DM paragraph vectors (negative sampling)", "", "parity/party_embeddings_compare.py, tests/test_party_embeddings.py"),
+    "FASTopic": _i("src/fastopic.rs", "src/python/mod.rs", "reverse-mode Sinkhorn optimal transport", "", "parity/fastopic_gold.py, parity/fastopic_compare.py"),
+    "EmbeddingLDA": _i("python/topica/embedding.py", "", "seeded Gibbs + embedding NN expansion (Python)", "", "parity/embeddinglda_gold.py, tests/test_embedding_lda.py"),
+    "CombinedTM": _i("src/prodlda.rs", "src/python/mod.rs", "contextualized ProdLDA VAE (prodlda.rs)", "", "parity/combinedtm_gold.py, parity/combinedtm_compare.py"),
+    "ZeroShotTM": _i("src/prodlda.rs", "src/python/mod.rs", "contextualized ProdLDA VAE (prodlda.rs)", "", "parity/zeroshot_gold.py, parity/zeroshot_compare.py"),
+    "InfoCTM": _i("src/infoctm.rs", "src/python/mod.rs", "two ProdLDA VAEs + TAMI alignment (prodlda.rs)", "", "parity/infoctm_gold.py, parity/infoctm_compare.py"),
+    "TopicGPT": _i("python/topica/llm.py", "", "LLM prompting pipeline (Python)", "", "tests/test_topicgpt.py"),
+}
+
+
 def list_models(
     *,
     group: str | None = None,
@@ -311,3 +398,79 @@ def markdown_table(by_group: bool = True) -> str:
                 f"{m.determinism} | {m.summary} |"
             )
     return "\n".join(lines)
+
+
+def impl_markdown_table(by_group: bool = True) -> str:
+    """Render the implementation map (:data:`IMPL`) as a Markdown table.
+
+    One row per model: where its algorithm lives, where its PyO3 binding lives,
+    the shared machinery it builds on, the Cargo feature it needs, and where its
+    reference-parity / gold tests live. Grouped by purpose to match the roster.
+    Used to (re)generate ``docs/contributing/model-map.md`` so the map cannot
+    drift from the source tree.
+    """
+    header = ("| Model | Source | Binding | Core / family | Feature | Validation |",
+              "|---|---|---|---|---|---|")
+
+    def _cell_paths(csv: str) -> str:
+        return ", ".join(f"`{p.strip()}`" for p in csv.split(","))
+
+    def _rows(models: list[ModelInfo]) -> list[str]:
+        rows = list(header)
+        for m in models:
+            im = IMPL[m.name]
+            binding = f"`{im.binding}`" if im.binding else "— _(Python)_"
+            feature = f"`{im.feature}`" if im.feature else "default"
+            rows.append(
+                f"| `{m.name}` | `{im.source}` | {binding} | {im.core} | "
+                f"{feature} | {_cell_paths(im.validation)} |"
+            )
+        return rows
+
+    lines: list[str] = []
+    if by_group:
+        for key, label in GROUPS.items():
+            models = [m for m in REGISTRY.values() if m.group == key]
+            if not models:
+                continue
+            lines.append(f"### {label}\n")
+            lines += _rows(models)
+            lines.append("")
+    else:
+        lines += _rows(list(REGISTRY.values()))
+    return "\n".join(lines).rstrip()
+
+
+def validate_impl() -> list[str]:
+    """Return a list of problems with :data:`IMPL` (empty when it is sound).
+
+    Checks that (1) IMPL covers exactly the registry, (2) every ``source`` /
+    ``binding`` / ``validation`` path exists, and (3) every ``feature`` is a real
+    Cargo feature. The anti-staleness guard the contributor map depends on;
+    ``tests/test_registry.py`` fails on any returned problem.
+    """
+    import pathlib
+    import re
+
+    root = pathlib.Path(__file__).resolve().parent.parent.parent
+    problems: list[str] = []
+
+    missing = set(REGISTRY) - set(IMPL)
+    extra = set(IMPL) - set(REGISTRY)
+    if missing:
+        problems.append(f"IMPL is missing models: {sorted(missing)}")
+    if extra:
+        problems.append(f"IMPL has non-registry models: {sorted(extra)}")
+
+    cargo = (root / "Cargo.toml").read_text(encoding="utf-8")
+    features = set(re.findall(r"^([\w-]+)\s*=\s*\[", cargo, re.M))
+
+    for name, im in IMPL.items():
+        paths = [im.source] + ([im.binding] if im.binding else [])
+        paths += [p.strip() for p in im.validation.split(",")]
+        for p in paths:
+            if not (root / p).exists():
+                problems.append(f"{name}: path does not exist: {p}")
+        if im.feature and im.feature not in features:
+            problems.append(f"{name}: unknown Cargo feature {im.feature!r}")
+    return problems

--- a/scripts/gen_model_tables.py
+++ b/scripts/gen_model_tables.py
@@ -18,30 +18,50 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(ROOT / "python"))
 
-from topica.registry import markdown_table  # noqa: E402
+from topica.registry import impl_markdown_table, markdown_table  # noqa: E402
 
 BEGIN = "<!-- BEGIN MODEL TABLE (generated from topica.registry; edit registry.py, not this block) -->"
 END = "<!-- END MODEL TABLE -->"
 TARGETS = [ROOT / "README.md", ROOT / "docs" / "guides" / "models.md"]
+
+# The contributor implementation map (issue #381): the same registry, rendered
+# with the source/binding/feature/validation columns instead of the user-facing
+# taxonomy. Injected into its own docs page with its own marker pair.
+MAP_BEGIN = "<!-- BEGIN MODEL MAP (generated from topica.registry IMPL; edit registry.py, not this block) -->"
+MAP_END = "<!-- END MODEL MAP -->"
+MAP_TARGET = ROOT / "docs" / "contributing" / "model-map.md"
 
 
 def _rendered_block() -> str:
     return f"{BEGIN}\n\n{markdown_table(by_group=True)}\n{END}"
 
 
-def inject(text: str) -> str:
-    i, j = text.find(BEGIN), text.find(END)
+def _rendered_map_block() -> str:
+    return f"{MAP_BEGIN}\n\n{impl_markdown_table(by_group=True)}\n{MAP_END}"
+
+
+def _inject(text: str, begin: str, end: str, block: str) -> str:
+    i, j = text.find(begin), text.find(end)
     if i == -1 or j == -1:
         raise SystemExit("marker comments not found in target")
-    return text[:i] + _rendered_block() + text[j + len(END):]
+    return text[:i] + block + text[j + len(end):]
+
+
+def inject(text: str) -> str:
+    return _inject(text, BEGIN, END, _rendered_block())
+
+
+def inject_map(text: str) -> str:
+    return _inject(text, MAP_BEGIN, MAP_END, _rendered_map_block())
 
 
 def main() -> None:
     check = "--check" in sys.argv
     stale = []
-    for path in TARGETS:
+    jobs = [(path, inject) for path in TARGETS] + [(MAP_TARGET, inject_map)]
+    for path, injector in jobs:
         old = path.read_text(encoding="utf-8")
-        new = inject(old)
+        new = injector(old)
         if old != new:
             stale.append(path.name)
             if not check:
@@ -49,7 +69,8 @@ def main() -> None:
     if check and stale:
         print(f"stale (run scripts/gen_model_tables.py): {stale}")
         raise SystemExit(1)
-    print("up to date" if check else f"wrote {[t.name for t in TARGETS]}")
+    names = [t.name for t, _ in jobs]
+    print("up to date" if check else f"wrote {names}")
 
 
 if __name__ == "__main__":

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -5,7 +5,16 @@ import inspect
 import pytest
 
 import topica
-from topica.registry import GROUPS, REGISTRY, ModelInfo, list_models, markdown_table
+from topica.registry import (
+    GROUPS,
+    IMPL,
+    REGISTRY,
+    ModelInfo,
+    impl_markdown_table,
+    list_models,
+    markdown_table,
+    validate_impl,
+)
 
 # Exported classes that are NOT topic models (so not in the registry).
 _NON_MODEL_CLASSES = {"Heldout", "HeldoutResult", "Corpus", "ModelInfo"}
@@ -68,6 +77,45 @@ def test_markdown_table_renders_all_models():
     table = markdown_table(by_group=True)
     for name in REGISTRY:
         assert f"`{name}`" in table
+
+
+def test_impl_map_covers_registry_and_paths_exist():
+    # The contributor implementation map (#381): IMPL must cover exactly the
+    # registry, and every source/binding/validation path it names and every Cargo
+    # feature it names must exist. validate_impl() returns a list of problems.
+    problems = validate_impl()
+    assert not problems, "IMPL problems:\n  " + "\n  ".join(problems)
+
+
+def test_impl_map_covers_registry_one_to_one():
+    assert set(IMPL) == set(REGISTRY), (
+        f"IMPL vs REGISTRY differ: "
+        f"only in IMPL={sorted(set(IMPL) - set(REGISTRY))}, "
+        f"only in REGISTRY={sorted(set(REGISTRY) - set(IMPL))}"
+    )
+
+
+def test_impl_markdown_table_renders_all_models():
+    table = impl_markdown_table(by_group=True)
+    for name in REGISTRY:
+        assert f"`{name}`" in table
+
+
+def test_model_map_page_in_sync_with_registry():
+    # The generated block in docs/contributing/model-map.md must match the IMPL
+    # render; regenerate with scripts/gen_model_tables.py if this fails.
+    import pathlib
+
+    BEGIN = ("<!-- BEGIN MODEL MAP (generated from topica.registry IMPL; "
+             "edit registry.py, not this block) -->")
+    END = "<!-- END MODEL MAP -->"
+    expected = f"{BEGIN}\n\n{impl_markdown_table(by_group=True)}\n{END}"
+    root = pathlib.Path(__file__).resolve().parent.parent
+    text = (root / "docs/contributing/model-map.md").read_text(encoding="utf-8")
+    i, j = text.find(BEGIN), text.find(END)
+    assert i != -1 and j != -1, "model-map.md marker comments missing"
+    assert text[i:j + len(END)] == expected, (
+        "docs/contributing/model-map.md is stale; run scripts/gen_model_tables.py")
 
 
 def test_readme_and_docs_roster_in_sync_with_registry():


### PR DESCRIPTION
Closes #381. Fourth item in the 381–386 devex batch. Based on `main`, independent of #387/#388.

## What
A contributor-facing **implementation map**: for every shipped model, where its algorithm lives, where its PyO3 binding lives, the shared machinery it builds on, the Cargo feature it needs, and where its reference-parity tests are. Generated from the registry, published at **docs → Contributing → Model implementation map**.

## Design — a companion to the registry, not a new stale inventory
The acceptance criteria hinge on *not* hand-maintaining a drifting list. So instead of a standalone doc:

- `python/topica/registry.py` gains an `ImplInfo` dataclass + `IMPL` map (`source` / `binding` / `core` / `feature` / `validation`), keyed by the **same model names** as the existing user-facing `REGISTRY`, plus `impl_markdown_table()` and `validate_impl()`.
- `scripts/gen_model_tables.py` renders `IMPL` into `docs/contributing/model-map.md` (its own marker pair), alongside the existing README/roster generation. The `preflight` hook's `--check` now covers it automatically.
- `tests/test_registry.py` asserts: `IMPL` and `REGISTRY` cover **exactly** the same models; every `source`/`binding`/`validation` path **exists**; every Cargo `feature` is **real**; and the generated page is **in sync**.

That last test is the anti-staleness guarantee — the map cannot drift from the source tree without failing CI. (Verified the negative case: a bogus path and a bogus feature are both caught.)

## Why curated, not scraped
Auto-derivation was unreliable here: some models are pure-Python (`anchor.py`, `narrative.py`, `embedding.py`, `llm.py`), some are Rust mode-variants sharing another model's file (GDMR↔DMR, CombinedTM/ZeroShotTM↔`prodlda.rs`), some macro'd. Curated-once-then-path-validated is accurate and still can't rot.

## Coverage highlights (all 42 models)
- Only **BERTopic** and **Top2Vec** require `--features embeddings`; everything else builds default (traced through `lib.rs` module gates).
- Pure-Python models render binding as `— _(Python)_`.
- Shared cores surfaced: SparseLDA Gibbs (`model.rs`/`sampler.rs`), CTM/STM variational core (`topica-core`), the ProdLDA VAE, etc.

## Acceptance criteria
- [x] Covers all shipped models (42/42, enforced == REGISTRY).
- [x] Not an independently-maintained stale inventory (single registry keying + CI path/feature/sync validation).
- [x] Contributors can locate implementation, binding, and validation surfaces per model.

## Verification
- `scripts/gen_model_tables.py --check` → up to date; `tests/test_registry.py` → 11 passed.
- `mkdocs build --strict` clean (new nav page).
- Pre-push `preflight` (fmt + clippy + tables + stub) passed.

## Deferred (waiting on the batch merges, per the current hold)
- A one-line link to this page from `.github/CONTRIBUTING-MODELS.md` — that file is edited by #387, so I'll add the link after #387 lands.
- A `just gen-tables` recipe — belongs to the #388 justfile; I'll add it once #388 merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)