### PR TITLE
devex: scaffold the standard touchpoints for a new topic model (#386)

### DIFF
--- a/.claude/skills/add-topic-model/SKILL.md
+++ b/.claude/skills/add-topic-model/SKILL.md
@@ -80,7 +80,15 @@ deterministic.
 
 Follow `references/conventions.md` closely. In short:
 
-1. Add `src/<model>.rs` with the fit/inference loop. Preserve topica's
+0. **Scaffold the touchpoints first.** Run `just new-model <ModelName>` (or
+   `python scripts/new_model.py --name <ModelName>`) to generate `src/<model>.rs`,
+   `src/python/<model>.rs`, and `tests/test_<model>.py` from templates, each
+   stamped with a `SCAFFOLD(<ModelName>)` marker, plus a printed checklist of the
+   wiring steps. It wires nothing in (an un-finished model stays inert), and
+   `tests/test_scaffold_guard.py` fails once the model is registered if any
+   `SCAFFOLD` marker survives — so you can't ship a half-filled placeholder. Fill
+   in the templates below; the steps that follow are that checklist in prose.
+1. Implement `src/<model>.rs` with the fit/inference loop. Preserve topica's
    **bit-for-bit determinism**: a fixed seed (and thread count, for samplers) must
    reproduce exactly; parallel reductions must sum in a fixed (document) order.
 2. Wire the PyO3 binding in `src/python/` (a directory module, not a single file):
@@ -91,10 +99,16 @@ Follow `references/conventions.md` closely. In short:
    `fit(docs, …)`, then `topic_word`, `doc_topic`, `top_words(n)`, `save`/`load`.
 3. Apply the naming contract: canonical argument names, reference-package aliases
    where helpful, `iters` for the iteration count, `seed=`, no deprecation cycles.
-4. Build and gate after every change:
+4. Build and gate after every change. The `just` runner wraps the release rebuild
+   and the `VIRTUAL_ENV`/`.venv-dev` handshake:
+   ```bash
+   just build          # maturin develop --release --features python
+   just test           # cargo test (core + feature-gated) + pytest
+   ```
+   The raw commands still work if `just` is unavailable:
    ```bash
    VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/maturin develop --release --features python
-   cargo test --lib
+   cargo test --workspace --lib                                   # add --features embeddings,umap,tsne for an embedding model
    VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/python -m pytest tests/ -q
    ```
    Add a Rust unit test and a `tests/test_<model>.py`. The new model must pass
@@ -153,14 +167,18 @@ Read `references/pr-and-docs.md` for the checklist. In short:
 2. Open a **PR** from the feature branch (squash-merge, delete branch on merge, per
    `CLAUDE.md`). The PR body summarizes the method, the parity result, and both
    agents' verdicts.
-3. **Update the docs as part of the same PR.** The README/docs roster *tables* are
-   **registry-generated** (`scripts/gen_model_tables.py`, enforced by
-   `test_registry.py`) — register the model there and regenerate; do NOT hand-edit a
-   table row (it fights the generator). Your hand-written work is the per-model prose
-   section (in `docs/guides/models.md`), a validation/replication note where the
-   existing models keep theirs, and the README acknowledgement. (Updating the paper
-   is out of scope — that is the maintainer's, not a contributor's, job.)
-4. Confirm all gates green (`cargo test --lib`, `pytest`, `mkdocs build --strict`)
+3. **Update the docs as part of the same PR.** Both generated tables come from the
+   registry (`python/topica/registry.py`), enforced by `test_registry.py`: add a
+   `ModelInfo` to `REGISTRY` (drives the README/docs roster) **and** an `ImplInfo`
+   to `IMPL` (drives the contributor `docs/contributing/model-map.md` — source
+   file, binding, feature, parity tests; its paths are existence-checked in CI).
+   Then run `scripts/gen_model_tables.py` (or `just gen-tables`) to regenerate both;
+   do NOT hand-edit a generated table (it fights the generator). Your hand-written
+   work is the per-model prose section (in `docs/guides/models.md`), a
+   validation/replication note where the existing models keep theirs, and the
+   README acknowledgement. (Updating the paper is out of scope — that is the
+   maintainer's, not a contributor's, job.)
+4. Confirm all gates green (`just test`, `mkdocs build --strict`)
    before requesting merge.
 
 ## Bundled references

--- a/.claude/skills/add-topic-model/references/conventions.md
+++ b/.claude/skills/add-topic-model/references/conventions.md
@@ -57,11 +57,16 @@ compare `topic_word`/`doc_topic` with `numpy.array_equal` (exact, not `allclose`
 
 ## Build and test gates (run after every change)
 
+The `just` runner wraps the rebuild + venv handshake (`just build`, `just test`,
+`just docs`, or `just pre-pr` for all gates). The raw commands, if `just` is
+unavailable:
+
 ```bash
 # Build the extension into the dev venv (note: .venv-dev, and VIRTUAL_ENV must be set).
 VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/maturin develop --release --features python
 
-cargo test --lib                                                  # Rust unit tests
+cargo test --workspace --lib                                      # Rust unit tests (core + topica-core)
+cargo test --workspace --lib --features embeddings,umap,tsne      # feature-gated tests (embedding models)
 VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/python -m pytest tests/ -q
 VIRTUAL_ENV="$PWD/.venv-dev" .venv-dev/bin/mkdocs build --strict   # docs must build clean
 ```
@@ -72,6 +77,10 @@ least one Rust `#[test]` in `src/<model>.rs`. Write scratch/benchmark files to
 `/private/tmp`, never into the repo or `/tmp`.
 
 ## File layout
+
+`just new-model <ModelName>` (or `python scripts/new_model.py --name <ModelName>`)
+scaffolds the first three files below from templates; the rest are shared files you
+wire the model into (see the checklist it prints).
 
 - `src/<model>.rs` — one file per model; the fit/inference loop and its unit tests.
   (The CTM/STM/SAGE structural-variational cluster and shared numeric kernels live

--- a/.claude/skills/add-topic-model/references/evaluation-agents.md
+++ b/.claude/skills/add-topic-model/references/evaluation-agents.md
@@ -86,7 +86,7 @@ Prompt template (fill the `<…>` slots):
 >    realistic-density inputs — a toy or all-sparse matrix can hide the gap (NMF was
 >    ~1.3x on sparse text but ~1.6x on near-dense X). If the bar is missed, a
 >    perf-optimization iteration is a normal, expected sub-phase — flag it, don't ship.
-> 5. **Gates.** Run `cargo test --lib` and `pytest tests/ -q`; report pass/fail.
+> 5. **Gates.** Run `cargo test --workspace --lib` and `pytest tests/ -q`; report pass/fail.
 >
 > Deliverable (your final message, a raw report): the parity table with the noise
 > floor, the determinism result, the speed table, gate results, and a clear verdict

--- a/.claude/skills/add-topic-model/references/pr-and-docs.md
+++ b/.claude/skills/add-topic-model/references/pr-and-docs.md
@@ -24,8 +24,8 @@ Open a tracking issue with `gh issue create` that states:
     reviewer verdicts and how any blockers were resolved.
   - **Conventions**: confirm `tests/test_naming_conventions.py` passes and note any
     reference-package aliases added.
-  - **Gates**: `cargo test --lib`, `pytest tests/ -q`, `mkdocs build --strict` all
-    green.
+  - **Gates**: `just test` (Rust core + feature-gated + pytest) and
+    `mkdocs build --strict` all green.
   - End the PR body with the repo's standard generated-with trailer if the repo uses
     one (check recent merged PRs).
 - Merge with `gh pr merge <n> --squash --delete-branch`, then sync and prune local
@@ -37,10 +37,14 @@ Open a tracking issue with `gh issue create` that states:
 
 These ship WITH the model, not in a follow-up:
 
-1. **README model table.** Add a row for the new model in the appropriate section
-   (count-based, structural/covariate, embedding-based, …), matching the existing
-   rows' one-line description style. If the model is validated against a named
-   reference, note it the way the other validated models do.
+1. **Registry entry (drives the generated tables).** Do NOT hand-edit the README
+   or docs roster tables — they are generated from `python/topica/registry.py`
+   (enforced by `test_registry.py`). Add a `ModelInfo` to `REGISTRY` (group,
+   brings, inference, determinism, one-line summary) AND an `ImplInfo` to `IMPL`
+   (source file, binding, shared machinery, Cargo feature, parity tests — its
+   paths are existence-checked in CI), then run `scripts/gen_model_tables.py` (or
+   `just gen-tables`) to regenerate the README roster and the contributor model
+   map (`docs/contributing/model-map.md`).
 2. **README acknowledgements.** If you read a permissively-licensed reference to
    match details, credit it in the acknowledgements list alongside the existing
    references.
@@ -62,9 +66,11 @@ User-facing prose follows the project's academic register: no em dashes, agent-l
 
 ## Final check before requesting merge
 
-- `cargo test --lib` — green (includes the new model's Rust test).
-- `pytest tests/ -q` — green (includes `tests/test_<model>.py` and the conventions
-  test).
+- `cargo test --workspace --lib` — green (includes the new model's Rust test; add
+  `--features embeddings,umap,tsne` for an embedding model).
+- `pytest tests/ -q` — green (includes `tests/test_<model>.py`, the conventions
+  test, and — once the model is registered — the scaffold-guard check that no
+  `SCAFFOLD` marker remains).
 - `mkdocs build --strict` — clean (the docs edits build).
 - The parity check under `parity/` passes when the reference is present and skips
   cleanly when it is not.

--- a/.github/CONTRIBUTING-MODELS.md
+++ b/.github/CONTRIBUTING-MODELS.md
@@ -283,6 +283,30 @@ Use `GSDMM` (`src/gsdmm.rs` + the `GSDMM` block in `src/python/mod.rs`) as the
 reference template. It is small, self-contained, and exercises the whole
 contract. Work in this order.
 
+### Scaffold the touchpoints first
+
+To avoid missing one of the coordinated edits below, generate the standard files
+from a template:
+
+```bash
+just new-model MyModel          # or: python scripts/new_model.py --name MyModel
+```
+
+This writes `src/<snake>.rs` (algorithm + `Estimator` trait + `#[cfg(test)]`
+stubs), `src/python/<snake>.rs` (the binding, following the GSDMM/BTM shape), and
+`tests/test_<snake>.py` (a pytest skeleton), each stamped with a
+`SCAFFOLD(<Name>)` marker, and prints the wiring checklist filled in for your
+model. It deliberately **wires nothing** into the shared files (`lib.rs`,
+`src/python/mod.rs`, `__init__.py`, the registry, …), so an un-finished model is
+inert — not compiled, not exported, not registered, and so unable to ship or
+fake-pass conformance. Work through B0–B8 to implement and wire it in. The
+generated files compile as-is (`fit` is a `todo!()`), so build early and often.
+
+`tests/test_scaffold_guard.py` is the backstop: once your model is in the
+registry, it fails if any `SCAFFOLD(<Name>)` marker still remains in its files, so
+you cannot land a half-finished placeholder. Search for leftovers with
+`grep -rn 'SCAFFOLD(MyModel)' src tests`.
+
 ### B0. Decide the family and what you can reuse
 
 - **Count-based (Gibbs or variational EM)** over a `Corpus`: lean on

--- a/justfile
+++ b/justfile
@@ -75,10 +75,18 @@ build:
 docs:
     {{py}} -m mkdocs build --strict
 
-# Regenerate the model roster (README + docs) and the contributor model map from
-# python/topica/registry.py.
+# Renders python/topica/registry.py into the README roster and the model map.
+#
+# Regenerate the model roster + contributor model map.
 gen-tables:
     {{py}} scripts/gen_model_tables.py
+
+# Writes src/<snake>.rs, the binding, and a pytest skeleton; wires nothing in and
+# prints the checklist. Usage: `just new-model MyModel`.
+#
+# Scaffold the standard touchpoints for a new model.
+new-model name:
+    {{py}} scripts/new_model.py --name {{name}}
 
 # --- Aggregate gates -------------------------------------------------------
 

--- a/scripts/new_model.py
+++ b/scripts/new_model.py
@@ -1,0 +1,398 @@
+#!/usr/bin/env python
+"""Scaffold the standard touchpoints for a new topic model (issue #386).
+
+Generates three self-contained template files, each stamped with a greppable
+``SCAFFOLD(<Name>)`` sentinel:
+
+    src/<snake>.rs           the Rust algorithm crate (fit loop + Estimator trait
+                             + #[cfg(test)] recovery/determinism stubs)
+    src/python/<snake>.rs    the PyO3 binding (pyclass + the analysis surface)
+    tests/test_<snake>.py    the pytest skeleton (skipped until you implement)
+
+It deliberately wires **nothing** into the shared registration files. An
+un-wired model is inert: it is not compiled (`src/lib.rs` has no `pub mod`), not
+exported, and not in the registry, so it cannot silently ship or fake-pass
+conformance. When you are ready, follow the checklist this script prints (it is
+the "Definition of done" from CONTRIBUTING-MODELS.md, filled in for your model).
+
+The sentinel is the safety net: ``tests/test_scaffold_guard.py`` fails if any
+model that IS registered still carries a ``SCAFFOLD`` marker in its files — so
+you cannot ship a half-finished placeholder.
+
+    python scripts/new_model.py --name MyModel
+    python scripts/new_model.py --name MyModel --snake my_model --family gibbs
+
+Run ``--help`` for options. Follows the naming and estimator-contract conventions
+in .github/CONTRIBUTING-MODELS.md; supply the algorithm, invariants, and
+validation yourself.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+SENTINEL = "SCAFFOLD"
+
+
+def to_snake(name: str) -> str:
+    """PascalCase / CamelCase -> snake_case (MyModel -> my_model, GSDMM -> gsdmm)."""
+    s = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", name)
+    s = re.sub(r"(?<=[A-Z])(?=[A-Z][a-z])", "_", s)
+    return s.lower()
+
+
+RUST_ALGO = r'''//! __NAME__: <one-line description of the model and its reference>.
+//!
+//! SCAFFOLD(__NAME__): implement the algorithm below, then delete this line and
+//! every other `SCAFFOLD(__NAME__)` marker in this file. Pure Rust, no PyO3.
+//! See .github/CONTRIBUTING-MODELS.md section B1.
+//!
+//! Note: the fitted state stores the topic-word and doc-topic matrices as
+//! `Vec<Vec<f64>>` (not `ndarray::Array2`) — `ndarray` is behind the `embeddings`
+//! feature, so a default-build model file must not depend on it. The binding
+//! converts to numpy arrays with the shared `vecs_to_arr2` helper.
+
+use crate::corpus::Corpus;
+use crate::estimator::{Estimator, ModelFamily};
+use rand::Rng;
+
+/// Fitted state for [`fit`]: whatever the PyO3 binding reads back.
+pub struct __NAME__Model {
+    pub num_topics: usize,
+    pub topic_word: Vec<Vec<f64>>, // K rows of length V
+    pub doc_topic: Vec<Vec<f64>>,  // D rows of length K (each sums to 1)
+    pub fit_history: Vec<(usize, f64)>,
+    pub converged: bool,
+}
+
+/// Fit the model. Takes the corpus, hyperparameters, and a seeded RNG; returns
+/// the fitted state. Seed every random draw from `rng` (a `ChaCha8Rng` the
+/// binding seeds from `self.seed`) so a fixed seed reproduces bit-for-bit.
+pub fn fit<R: Rng>(
+    _corpus: &Corpus,
+    num_topics: usize,
+    _iters: usize,
+    _rng: &mut R,
+) -> __NAME__Model {
+    // SCAFFOLD(__NAME__): implement the fit/inference loop. Fill topic_word
+    // (K x V) and doc_topic (D x K, each row summing to 1). Record
+    // (iter, objective) in fit_history if the model has a per-iteration
+    // objective; leave it empty otherwise.
+    let _ = num_topics;
+    todo!("implement __NAME__::fit")
+}
+
+impl Estimator for __NAME__Model {
+    fn num_topics(&self) -> usize {
+        self.num_topics
+    }
+    fn topic_word(&self) -> Vec<Vec<f64>> {
+        self.topic_word.clone()
+    }
+    fn doc_topic(&self) -> Vec<Vec<f64>> {
+        self.doc_topic.clone()
+    }
+    fn fit_history(&self) -> Vec<(usize, f64)> {
+        self.fit_history.clone()
+    }
+    fn converged(&self) -> Option<bool> {
+        Some(self.converged)
+    }
+    fn model_family(&self) -> ModelFamily {
+        // SCAFFOLD(__NAME__): Dirichlet (collapsed-Gibbs), LogisticNormal (STM/CTM),
+        // or None_ (embedding/cluster). Also implement DirichletModel /
+        // LogisticNormalModel if applicable (see B1).
+        ModelFamily::None_
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use rand_chacha::rand_core::SeedableRng;
+    use rand_chacha::ChaCha8Rng;
+
+    // SCAFFOLD(__NAME__): build a planted-topic corpus, fit, and assert the
+    // recovered topics match (cosine or top-word overlap above a threshold).
+    #[test]
+    #[ignore = "SCAFFOLD(__NAME__): write the planted-data recovery test"]
+    fn __SNAKE___recovers_planted_topics() {
+        todo!("planted-data recovery")
+    }
+
+    // Same seed => identical output. Required for every model.
+    #[test]
+    #[ignore = "SCAFFOLD(__NAME__): write the determinism test"]
+    fn __SNAKE___is_deterministic() {
+        let mut _rng = ChaCha8Rng::seed_from_u64(42);
+        todo!("assert two fits with the same seed are identical")
+    }
+
+    // The fitted struct satisfies the estimator contract.
+    #[test]
+    #[ignore = "SCAFFOLD(__NAME__): fit a tiny instance and check conformance"]
+    fn __SNAKE___conforms() {
+        // let m = fit(&tiny_corpus, 2, 20, &mut ChaCha8Rng::seed_from_u64(0));
+        // assert!(crate::conformance::check_conformance(&m).is_empty());
+        todo!("conformance")
+    }
+}
+'''
+
+RUST_BINDING = r'''//! Python bindings for __NAME__.
+//!
+//! SCAFFOLD(__NAME__): flesh out the binding, then delete every
+//! `SCAFFOLD(__NAME__)` marker in this file. Mirrors the GSDMM/BTM pattern; see
+//! .github/CONTRIBUTING-MODELS.md section B2.
+
+use super::*;
+use numpy::{PyArray1, PyArray2};
+use rand_chacha::rand_core::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+
+/// __NAME__: <user-facing docstring — what it does and when to choose it>.
+#[pyclass(module = "topica")]
+pub struct __NAME__ {
+    num_topics: usize,
+    // SCAFFOLD(__NAME__): add hyperparameter fields here.
+    seed: u64,
+    fitted: bool,
+    model: Option<crate::__SNAKE__::__NAME__Model>,
+    corpus: Option<corpus::Corpus>,
+}
+
+impl __NAME__ {
+    fn fitted_model(&self) -> PyResult<&crate::__SNAKE__::__NAME__Model> {
+        self.model
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("model is not fitted yet; call fit() first"))
+    }
+}
+
+#[pymethods]
+impl __NAME__ {
+    #[new]
+    #[pyo3(signature = (num_topics, *, seed=42))]
+    fn new(
+        #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
+        // SCAFFOLD(__NAME__): add keyword-only hyperparameters with defaults.
+        seed: u64,
+    ) -> PyResult<Self> {
+        if num_topics < 1 {
+            return Err(PyValueError::new_err("num_topics must be >= 1"));
+        }
+        Ok(__NAME__ {
+            num_topics,
+            seed,
+            fitted: false,
+            model: None,
+            corpus: None,
+        })
+    }
+
+    #[pyo3(signature = (data, *, iters=1000))]
+    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>, iters: usize) -> PyResult<()> {
+        let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
+            c.inner
+        } else {
+            let docs: Vec<Vec<String>> = data.extract().map_err(|_| {
+                PyValueError::new_err("fit() expects a Corpus or a list of token lists")
+            })?;
+            build_corpus_from_docs(docs, None, None, std::collections::HashSet::new(), 1, 1.0, 0, 0)?.0
+        };
+        if corpus.num_docs() == 0 {
+            return Err(PyValueError::new_err("corpus contains no documents"));
+        }
+        let num_topics = self.num_topics;
+        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let (model, corpus) = py.allow_threads(move || {
+            let model = crate::__SNAKE__::fit(&corpus, num_topics, iters, &mut rng);
+            (model, corpus)
+        });
+        self.model = Some(model);
+        self.corpus = Some(corpus);
+        self.fitted = true;
+        Ok(())
+    }
+
+    // --- Required analysis surface (B3) ---
+    #[getter]
+    fn topic_word<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        Ok(vecs_to_arr2(&self.fitted_model()?.topic_word).to_pyarray_bound(py))
+    }
+    #[getter]
+    fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        Ok(vecs_to_arr2(&self.fitted_model()?.doc_topic).to_pyarray_bound(py))
+    }
+    #[getter]
+    fn num_topics(&self) -> usize {
+        self.num_topics
+    }
+    #[getter]
+    fn vocabulary(&self) -> PyResult<Vec<String>> {
+        self.fitted_model()?;
+        Ok(self.corpus.as_ref().unwrap().id_to_word.clone())
+    }
+
+    // --- Conventional extras ---
+    #[pyo3(signature = (n=10, *, topic=None))]
+    fn top_words<'py>(
+        &self,
+        py: Python<'py>,
+        n: usize,
+        topic: Option<usize>,
+    ) -> PyResult<Bound<'py, PyAny>> {
+        let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
+        topic_words_helper(
+            py,
+            &phi,
+            &self.corpus.as_ref().unwrap().id_to_word,
+            self.num_topics,
+            n,
+            topic,
+        )
+    }
+    #[pyo3(signature = (n=10))]
+    fn coherence<'py>(&self, py: Python<'py>, n: usize) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
+        let tops = top_word_ids_phi(&phi, self.num_topics, n);
+        Ok(Array1::from(umass_coherence(self.corpus.as_ref().unwrap(), &tops)).to_pyarray_bound(py))
+    }
+
+    // SCAFFOLD(__NAME__): add save/load via a serde *State struct (see BtmState).
+
+    fn __repr__(&self) -> String {
+        format!("__NAME__(num_topics={}, fitted={})", self.num_topics, self.fitted)
+    }
+}
+'''
+
+PYTEST = r'''"""Tests for __NAME__ (issue: <link>).
+
+SCAFFOLD(__NAME__): implement the model, then remove the module-level skip below
+and write the tests. Follows the four idioms in CONTRIBUTING-MODELS.md
+(shapes/normalization, planted-data recovery, determinism, save-load + bad-params)
+plus an analysis-surface check and edge cases.
+"""
+import numpy as np
+import pytest
+
+import topica
+
+pytest.skip(
+    "SCAFFOLD(__NAME__): not implemented yet; remove this skip once __NAME__ ships",
+    allow_module_level=True,
+)
+
+
+def _toy_docs():
+    return [["a", "b", "c"], ["a", "b", "b"], ["c", "c", "d"], ["d", "e", "f"]]
+
+
+def test_shapes_and_normalization():
+    m = topica.__NAME__(2, seed=0).fit(_toy_docs(), iters=20)
+    assert m.topic_word.shape == (2, len(m.vocabulary))
+    assert np.allclose(m.doc_topic.sum(axis=1), 1.0)
+
+
+def test_determinism():
+    a = topica.__NAME__(2, seed=1).fit(_toy_docs(), iters=20)
+    b = topica.__NAME__(2, seed=1).fit(_toy_docs(), iters=20)
+    assert np.array_equal(a.topic_word, b.topic_word)
+
+
+def test_recovers_planted_topics():
+    # SCAFFOLD(__NAME__): build a corpus with known topics and assert recovery.
+    raise NotImplementedError
+
+
+def test_rejects_empty_corpus():
+    with pytest.raises((ValueError, RuntimeError)):
+        topica.__NAME__(2).fit([])
+'''
+
+
+def render(tpl: str, name: str, snake: str) -> str:
+    return (
+        tpl.replace("__NAME__", name)
+        .replace("__SNAKE__", snake)
+    )
+
+
+def checklist(name: str, snake: str) -> str:
+    return f"""
+Scaffolded {name}. Nothing is wired in yet, so the model is inert (excluded from
+the build and the registry). Implement it, then complete these steps — this is the
+"Definition of done" from CONTRIBUTING-MODELS.md, filled in for {name}:
+
+  ALGORITHM
+  [ ] Implement src/{snake}.rs: the fit loop, the Estimator trait, and the
+      #[cfg(test)] recovery + determinism tests (remove their #[ignore]).
+  [ ] Add `pub mod {snake};` to src/lib.rs (alphabetical with the others).
+  [ ] Add a row to RUST_ESTIMATORS in src/conformance.rs (name, family, exemptions).
+
+  BINDING
+  [ ] Implement src/python/{snake}.rs (hyperparameters, fit, save/load).
+  [ ] In src/python/mod.rs: add `mod {snake};`, `use {snake}::{name};`, and
+      `m.add_class::<{name}>()?;` in the #[pymodule] fn.
+
+  PYTHON SURFACE
+  [ ] python/topica/__init__.py: add {name} to the _topica import block and __all__.
+  [ ] python/topica/_topica.pyi: add `class {name}` matching the binding exactly.
+  [ ] python/topica/registry.py: add a ModelInfo to REGISTRY AND an ImplInfo to
+      IMPL (source/binding/core/feature/validation), then run
+      `python scripts/gen_model_tables.py` to regenerate the roster + model map.
+  [ ] python/topica/conformance.py: add {name} to REGISTRY there if it needs a
+      non-default factory.
+
+  TESTS + DOCS
+  [ ] tests/test_{snake}.py: remove the module-level skip and implement the tests.
+  [ ] parity/{snake}_compare.py if a reference implementation exists.
+  [ ] docs/guides/models.md + docs/api/models.md prose; CHANGELOG.md `### Added` line.
+
+  GATES (all green before the PR)
+  [ ] just build && just test && just docs   (or the raw commands)
+  [ ] No SCAFFOLD({name}) markers remain — `grep -rn 'SCAFFOLD({name})' src tests`
+      must be empty. tests/test_scaffold_guard.py enforces this once {name} is
+      registered.
+"""
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    p.add_argument("--name", required=True, help="canonical class name, PascalCase (e.g. MyModel)")
+    p.add_argument("--snake", help="file stem override (default: snake_case of --name)")
+    p.add_argument("--force", action="store_true", help="overwrite existing scaffold files")
+    args = p.parse_args()
+
+    name = args.name
+    if not re.fullmatch(r"[A-Za-z][A-Za-z0-9]*", name):
+        p.error("--name must be a bare PascalCase identifier (letters/digits, no spaces)")
+    snake = args.snake or to_snake(name)
+
+    targets = {
+        ROOT / "src" / f"{snake}.rs": render(RUST_ALGO, name, snake),
+        ROOT / "src" / "python" / f"{snake}.rs": render(RUST_BINDING, name, snake),
+        ROOT / "tests" / f"test_{snake}.py": render(PYTEST, name, snake),
+    }
+
+    existing = [t for t in targets if t.exists()]
+    if existing and not args.force:
+        print("refusing to overwrite (use --force):", file=sys.stderr)
+        for t in existing:
+            print(f"  {t.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    for path, content in targets.items():
+        path.write_text(content, encoding="utf-8")
+        print(f"wrote {path.relative_to(ROOT)}")
+
+    print(checklist(name, snake))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_new_model.py
+++ b/tests/test_new_model.py
@@ -1,0 +1,49 @@
+"""The new-model scaffold generator (scripts/new_model.py, issue #386)."""
+import importlib.util
+import pathlib
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "new_model",
+    pathlib.Path(__file__).resolve().parent.parent / "scripts" / "new_model.py",
+)
+new_model = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(new_model)
+
+
+@pytest.mark.parametrize(
+    "name,snake",
+    [
+        ("MyModel", "my_model"),
+        ("FooBarTM", "foo_bar_tm"),
+        ("GSDMM", "gsdmm"),
+        ("ETM", "etm"),
+        ("Wordfish", "wordfish"),
+    ],
+)
+def test_to_snake(name, snake):
+    assert new_model.to_snake(name) == snake
+
+
+def test_rendered_templates_carry_name_and_sentinel():
+    for tpl in (new_model.RUST_ALGO, new_model.RUST_BINDING, new_model.PYTEST):
+        out = new_model.render(tpl, "MyModel", "my_model")
+        assert "MyModel" in out
+        assert "SCAFFOLD(MyModel)" in out
+        assert "__NAME__" not in out and "__SNAKE__" not in out
+
+
+def test_algo_template_is_ndarray_free():
+    # ndarray is behind the `embeddings` feature; a default-build model file must
+    # not import it. The binding converts via vecs_to_arr2 instead.
+    out = new_model.render(new_model.RUST_ALGO, "MyModel", "my_model")
+    assert "use ndarray" not in out
+    assert "Vec<Vec<f64>>" in out
+
+
+def test_checklist_names_the_wiring_steps():
+    text = new_model.checklist("MyModel", "my_model")
+    for needle in ("src/lib.rs", "src/python/mod.rs", "__init__.py", "registry.py",
+                   "conformance.py", "test_scaffold_guard.py"):
+        assert needle in text

--- a/tests/test_scaffold_guard.py
+++ b/tests/test_scaffold_guard.py
@@ -1,0 +1,43 @@
+"""A registered model may not carry a scaffold placeholder (issue #386).
+
+`scripts/new_model.py` stamps every generated template file with a
+``SCAFFOLD(<Name>)`` sentinel and wires nothing in, so an un-finished model is
+inert (not compiled, not exported, not registered). This guard is the other
+half of that contract: once a model IS registered, none of the files that
+implement it may still contain the sentinel. So you cannot ship a half-finished
+placeholder — the moment a scaffolded model enters the registry, CI fails until
+every SCAFFOLD marker is gone.
+
+It reads the implementation map (`topica.registry.IMPL`, issue #381) to know
+which files belong to each registered model, so it needs no separate list.
+"""
+import pathlib
+
+from topica.registry import IMPL
+
+SENTINEL = "SCAFFOLD"
+ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+
+def _files_for(info) -> list[str]:
+    paths = [info.source]
+    if info.binding:
+        paths.append(info.binding)
+    paths += [p.strip() for p in info.validation.split(",")]
+    return paths
+
+
+def test_no_registered_model_has_a_scaffold_sentinel():
+    offenders = []
+    for name, info in IMPL.items():
+        for rel in _files_for(info):
+            path = ROOT / rel
+            if not path.exists():
+                continue  # existence is checked by test_registry.py
+            text = path.read_text(encoding="utf-8")
+            if SENTINEL in text:
+                offenders.append(f"{name}: {rel} still contains a {SENTINEL} marker")
+    assert not offenders, (
+        "registered models with unfinished scaffold placeholders:\n  "
+        + "\n  ".join(offenders)
+    )


### PR DESCRIPTION
Closes #386. Last item in the 381–386 devex batch.

## What
`scripts/new_model.py` (and `just new-model MyModel`) generates the standard files for a new model so none of the coordinated edits get missed. Three self-contained templates, each stamped with a greppable `SCAFFOLD(<Name>)` sentinel:

- **`src/<snake>.rs`** — algorithm + `Estimator` trait + `#[cfg(test)]` recovery/determinism/conformance stubs.
- **`src/python/<snake>.rs`** — the PyO3 binding (GSDMM/BTM shape, the four required getters + `top_words`/`coherence`/`__repr__`).
- **`tests/test_<snake>.py`** — a pytest skeleton, module-skipped until implemented.

It **wires nothing** into shared files — instead it prints the wiring checklist (the "Definition of done" from CONTRIBUTING-MODELS.md, filled in for your model).

## How it satisfies "no silently shipped model" — both ways
- **Clearly excluded** before registration: nothing references the generated files, so an un-finished model is inert (not compiled, not exported, not registered) and can't ship or fake-pass conformance.
- **Fails checks** at registration: `tests/test_scaffold_guard.py` reads the #381 `IMPL` map and fails if any *registered* model's files still contain a `SCAFFOLD` marker. So the moment you wire a model in, CI forces every placeholder to be gone. (Verified the negative case — injecting a `SCAFFOLD(LDA)` marker into `src/model.rs` fails the guard.)

## Templates actually compile
A subtle trap avoided: `ndarray` is behind the `embeddings` feature, so a default-build model file can't use `Array2`. The algo template stores `Vec<Vec<f64>>` and the binding converts via the shared `vecs_to_arr2` (the BTM pattern). I verified a scaffolded model compiles wired-in under both `cargo check` (default) and `cargo check --features python`, and is clippy-clean — so an implementer starts from a green base (`fit` is a `todo!()`).

## Also
- `tests/test_new_model.py` — snake-casing (`FooBarTM`→`foo_bar_tm`, `GSDMM`→`gsdmm`) + template rendering + the ndarray-free invariant + checklist completeness.
- `.github/CONTRIBUTING-MODELS.md` — a "Scaffold the touchpoints first" subsection in Part B.
- `justfile` — the `new-model` recipe (and tidied the `gen-tables`/`new-model` `--list` doc lines).

## Acceptance criteria
- [x] No silently shipped model — unfinished placeholders are excluded until wired, then fail checks.
- [x] Follows the naming + estimator-contract conventions (templates mirror GSDMM/BTM and the B1–B3 shapes).
- [x] The playbook documents when and how to use it.

## Verification
- `just new-model FooBarTM` → 3 files; wired-in `cargo check` (default + python) and clippy clean; scaffolded pytest collects-and-skips.
- `tests/test_new_model.py` + `tests/test_scaffold_guard.py` → 9 passed; guard negative case confirmed.
- Pre-push `preflight` (fmt + clippy + tables + stub) passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)