### PR TITLE
feat(manifest): privacy-preserving analysis manifest / flight recorder (#394)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Added
+
+- **Analysis manifest** (`topica.record_fit`, `topica.AnalysisManifest`): a
+  portable, privacy-aware JSON record of one fit. It captures the model settings,
+  environment, fit arguments, researcher decisions, and canonical fingerprints of
+  the corpus, design matrix, and model outputs, then `verify(corpus, model)`
+  reports per field whether the fit's identity and replay conditions still hold
+  (`exact` / `input_changed` / `artifact_changed` / `environment_changed` /
+  `unverifiable`), never a single pass/fail. Privacy-by-default: `privacy="minimal"`
+  records only coarse corpus counts, with an aggregate description and a sensitive
+  content fingerprint as explicit opt-ins. The manifest composes with
+  `Corpus.save` / `model.save` rather than replacing them.
+
 ### Removed
 
 - **ECTM** (the Evolving Content Topic Model) is removed. Its one interpretive

--- a/docs/api/manifest.md
+++ b/docs/api/manifest.md
@@ -1,0 +1,61 @@
+# Analysis manifest
+
+A portable, privacy-aware record of one fit: the inputs and decisions needed to
+inspect or replay it, plus a verifier that reports what actually holds rather than
+a single pass/fail. The manifest is not a second model format. It composes with
+`Corpus.save` and `model.save`, and records fingerprints and settings, not raw
+content.
+
+We write the manifest with an explicit `record_fit` call. The explicit boundary
+is deliberate: a call cannot honestly see preprocessing performed before it, so it
+records only what it observes and marks the rest.
+
+```python
+import topica
+
+corpus = topica.Corpus.from_documents(tokens)
+model = topica.STM(num_topics=20, seed=42)
+model.fit(corpus, prevalence=X, iters=1000)
+
+record = topica.record_fit(model, corpus, prevalence=X, prevalence_names=names, iters=1000)
+record.add_decision("K", "Chose 20 after inspecting 15/20/25.")
+record.save("analysis.topica.json")
+
+# On another machine or session:
+record = topica.AnalysisManifest.load("analysis.topica.json")
+print(record.verify(corpus, model).summary())
+```
+
+## Privacy
+
+The default `privacy="minimal"` records the model, the environment, and coarse
+corpus counts (document count, total tokens) only. It carries no length
+distribution, vocabulary size, preprocessing detail, or raw content.
+`privacy="aggregate"` opts those descriptive fields in. A content fingerprint,
+which lets `verify` prove corpus identity, is a separate opt-in
+(`content_fingerprint=True`) and is **sensitive**: a hash is not anonymisation,
+and a small or public corpus can be brute-forced. `privacy="full"` (raw values)
+is intentionally not part of this version.
+
+## What `verify` reports
+
+`verify` re-derives fingerprints from the supplied corpus and model and reports a
+status per field, never collapsing them into one flag: `exact`, `input_changed`,
+`artifact_changed`, `environment_changed` (differs, but the model's determinism
+class says it may still replay), or `unverifiable` (nothing recorded to check
+against, a bounded component, or a fingerprint from a spec this build does not
+recognise).
+
+## Reference
+
+::: topica.record_fit
+
+::: topica.manifest.AnalysisManifest
+
+::: topica.manifest.VerifyResult
+
+::: topica.manifest.fingerprint_corpus
+
+::: topica.manifest.fingerprint_array
+
+::: topica.manifest.fingerprint_design

--- a/docs/publishing/reporting.md
+++ b/docs/publishing/reporting.md
@@ -97,6 +97,13 @@ model.save("model.tt")                                    # full state, reloadab
 - **Share the model.** `model.save(path)` writes the complete fitted state;
   `Model.load(path)` brings it back, so reviewers can reproduce every number
   without refitting.
+- **Record the analysis, not just the model.** `topica.record_fit(model, corpus,
+  ...)` writes an [analysis manifest](../api/manifest.md): a small, privacy-aware
+  JSON record of the fit's inputs, settings, environment, and your interpretive
+  decisions, plus fingerprints that let `record.verify(corpus, model)` report
+  later whether the same corpus and model still reproduce it. It records
+  fingerprints and coarse counts, not raw text, and defaults to the most private
+  setting.
 
 !!! success "You're done"
     A corpus you can defend, a `K` you can justify, topics you've validated,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -122,6 +122,7 @@ nav:
       - Models: api/models.md
       - Embedding models: api/embedding.md
       - Diagnostics: api/diagnostics.md
+      - Analysis manifest: api/manifest.md
       - Content-covariate diagnostics: api/content.md
       - Visualization: api/viz.md
       - STM toolkit: api/stm.md

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -162,6 +162,8 @@ from . import validation  # noqa: E402  (post-hoc topic diagnostics surface)
 from . import content  # noqa: E402  (content-covariate diagnostics: STM/STS/SAGE)
 from . import conformance  # noqa: E402  (estimator contract and registry)
 from .conformance import check_conformance  # noqa: E402
+from . import manifest  # noqa: E402  (analysis manifest / provenance record)
+from .manifest import AnalysisManifest, record_fit  # noqa: E402
 from .effects import (  # noqa: E402  general, work on any model's theta
     estimate_effect,
     by_strata,
@@ -461,6 +463,8 @@ __all__ = [
     "keywords",
     "conformance",
     "check_conformance",
+    "AnalysisManifest",
+    "record_fit",
     "preprocess",
     "learn_phrases",
     "apply_phrases",

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -1,0 +1,563 @@
+"""Analysis manifest (issue #394): a portable, privacy-aware record of one fit.
+
+An :class:`AnalysisManifest` records the inputs and decisions needed to inspect
+or replay a single fit, plus a verifier that reports *what actually holds* rather
+than a single green check. It is deliberately **not** a second model
+serialization: it composes with ``Corpus.save`` / ``model.save`` and references
+them by path + digest rather than embedding them.
+
+    record = topica.record_fit(model, corpus, prevalence=X, iters=1000)
+    record.add_decision("K", "Chose 20 after inspecting 15/20/25.")
+    record.save("analysis.topica.json")
+
+    later = topica.AnalysisManifest.load("analysis.topica.json")
+    print(later.verify(corpus, model).summary())
+
+V1 scope (narrow on purpose): the manifest, the fingerprint-v1 contract below,
+``record_fit`` for the count-based and structural models, and ``verify`` with a
+textual report. No HTML rendering, no generic diagnostic auto-capture.
+
+Fingerprint-v1 contract ("fp1")
+-------------------------------
+A fingerprint is ``{"spec": "fp1", "algo": "blake2b-256", "digest": <hex>, ...}``.
+The contract is frozen: a manifest carries ``spec`` forever, and a verifier that
+does not recognise the spec reports ``unverifiable`` -- it never silently
+reinterprets it.
+
+- **Algorithm**: BLAKE2b, 32-byte digest, optional ``key`` for keyed/salted
+  private verification (a keyed digest is NOT portable and is marked as such).
+- **Encoding**: every field is domain-tagged and length-prefixed (u64
+  little-endian counts), so no two distinct inputs share an encoding. Integers and
+  array bytes are little-endian regardless of host.
+- **Arrays**: cast to ``float64``, C-contiguous, little-endian; ``-0.0`` is
+  normalised to ``0.0`` and every ``NaN`` to the canonical quiet-NaN
+  ``0x7ff8000000000000`` before hashing (bit patterns must not leak).
+- **Corpus**: hashed as token *strings* in document order (robust to vocabulary
+  re-indexing). This is the sensitive content fingerprint -- opt-in only.
+
+Privacy
+-------
+Default ``privacy="minimal"``: model + environment + coarse corpus counts
+(document count, total tokens) only -- no length distribution, vocabulary size,
+or preprocessing detail. ``privacy="aggregate"`` opts those in. A content
+fingerprint is a separate opt-in (``content_fingerprint=True``) and is documented
+as sensitive: a hash is not anonymisation, and a small or public corpus can be
+brute-forced. ``privacy="full"`` (raw values) is intentionally not in V1.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import platform
+import struct
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+SCHEMA = "topica.manifest"
+SCHEMA_VERSION = 1
+FINGERPRINT_SPEC = "fp1"
+HASH_ALGORITHM = "blake2b-256"
+_DIGEST_SIZE = 32
+_CANONICAL_NAN = 0x7FF8000000000000
+
+# Model settings captured by the per-model adapters (allowlist, not
+# serialize-everything). Everything else is omitted and marked as such.
+_SETTINGS_ALLOWLIST: dict[str, tuple[str, ...]] = {
+    "LDA": ("num_topics", "alpha", "beta"),
+    "STM": ("num_topics", "beta", "sigma_prior"),
+}
+
+
+# --------------------------------------------------------------------------
+# Fingerprint-v1 primitives
+# --------------------------------------------------------------------------
+
+
+class _Canon:
+    """Incremental BLAKE2b over a length-prefixed, domain-tagged byte stream."""
+
+    def __init__(self, key: bytes | None = None):
+        self._h = hashlib.blake2b(digest_size=_DIGEST_SIZE, key=key or b"")
+
+    def tag(self, name: bytes) -> "_Canon":
+        self._h.update(name + b"\x00")
+        return self
+
+    def u64(self, n: int) -> "_Canon":
+        self._h.update(struct.pack("<Q", n))
+        return self
+
+    def blob(self, b: bytes) -> "_Canon":
+        self._h.update(struct.pack("<Q", len(b)))
+        self._h.update(b)
+        return self
+
+    def text(self, s: str) -> "_Canon":
+        return self.blob(s.encode("utf-8"))
+
+    def hexdigest(self) -> str:
+        return self._h.hexdigest()
+
+
+def _canonical_array_bytes(arr: np.ndarray) -> bytes:
+    """float64, C-contiguous, little-endian, with -0.0 and NaN normalised."""
+    a = np.ascontiguousarray(arr, dtype="<f8").copy()
+    # Normalise -0.0 -> 0.0 without touching other values.
+    a[a == 0.0] = 0.0
+    if a.size:
+        nan_mask = np.isnan(a)
+        if nan_mask.any():
+            canon = np.frombuffer(struct.pack("<Q", _CANONICAL_NAN), dtype="<f8")[0]
+            a[nan_mask] = canon
+    return a.tobytes(order="C")
+
+
+def _fp(digest: str, *, keyed: bool, **extra: Any) -> dict[str, Any]:
+    fp = {"spec": FINGERPRINT_SPEC, "algo": HASH_ALGORITHM, "digest": digest}
+    if keyed:
+        # A keyed digest verifies only against the same key; it does not support
+        # public replay. Flag it so a consumer never mistakes it for portable.
+        fp["keyed"] = True
+    fp.update(extra)
+    return fp
+
+
+def fingerprint_array(arr, *, key: bytes | None = None) -> dict[str, Any]:
+    """Order-sensitive fingerprint of a numeric array (embeddings, vectors)."""
+    a = np.asarray(arr)
+    c = _Canon(key).tag(b"ndarray").u64(a.ndim)
+    for dim in a.shape:
+        c.u64(int(dim))
+    c.blob(_canonical_array_bytes(a))
+    return _fp(c.hexdigest(), keyed=key is not None, shape=list(a.shape))
+
+
+def fingerprint_design(matrix, names=None, *, key: bytes | None = None) -> dict[str, Any]:
+    """Fingerprint of a numeric design matrix, binding column names to values."""
+    a = np.asarray(matrix)
+    if a.ndim != 2:
+        a = a.reshape(a.shape[0], -1)
+    cols = list(names) if names is not None else [f"x{i}" for i in range(a.shape[1])]
+    c = _Canon(key).tag(b"design").u64(a.shape[0]).u64(a.shape[1])
+    for name in cols:
+        c.text(str(name))
+    c.blob(_canonical_array_bytes(a))
+    return _fp(
+        c.hexdigest(), keyed=key is not None, n_rows=a.shape[0], columns=cols
+    )
+
+
+def fingerprint_corpus(corpus, *, key: bytes | None = None) -> dict[str, Any]:
+    """Sensitive, order-sensitive fingerprint of a corpus's token content.
+
+    Hashes token strings in document order, so it survives a vocabulary
+    re-indexing but changes if any document's tokens or the document order
+    change. A hash is not anonymisation; treat this as sensitive.
+    """
+    docs = corpus.documents()
+    c = _Canon(key).tag(b"corpus").u64(len(docs))
+    for doc in docs:
+        c.u64(len(doc))
+        for tok in doc:
+            c.text(tok)
+    return _fp(c.hexdigest(), keyed=key is not None, num_docs=len(docs))
+
+
+# --------------------------------------------------------------------------
+# Environment (shared notion with the paper's provenance report)
+# --------------------------------------------------------------------------
+
+
+def _environment(thread_count: int | None = None) -> dict[str, Any]:
+    import topica
+
+    return {
+        "topica_version": getattr(topica, "__version__", None),
+        "python_version": platform.python_version(),
+        "platform": platform.platform(),
+        "architecture": platform.machine(),
+        "cpu_count": _cpu_count(),
+        "thread_count": thread_count,
+    }
+
+
+def _cpu_count() -> int | None:
+    import os
+
+    try:
+        return os.cpu_count()
+    except Exception:  # pragma: no cover - platform dependent
+        return None
+
+
+# --------------------------------------------------------------------------
+# The manifest
+# --------------------------------------------------------------------------
+
+
+@dataclass
+class VerifyResult:
+    """The outcome of :meth:`AnalysisManifest.verify`, per field.
+
+    ``fields`` maps each checked field to one of: ``exact`` (recomputed value
+    matches), ``input_changed``, ``artifact_changed``, ``environment_changed``
+    (differs but the model's determinism class says it may still replay),
+    ``unverifiable`` (nothing to check against, or a bounded/unknown component).
+    ``ok`` is a convenience for "every field exact"; the summary always shows the
+    full breakdown -- the statuses are never collapsed into one flag.
+    """
+
+    fields: dict[str, str]
+
+    @property
+    def ok(self) -> bool:
+        return all(v == "exact" for v in self.fields.values())
+
+    def summary(self) -> str:
+        width = max((len(k) for k in self.fields), default=0)
+        lines = [f"verify: {'all exact' if self.ok else 'differences found'}"]
+        for name, status in self.fields.items():
+            lines.append(f"  {name.ljust(width)}  {status}")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return f"VerifyResult(ok={self.ok}, fields={self.fields})"
+
+
+@dataclass
+class AnalysisManifest:
+    """A versioned, privacy-aware record of one fit. See the module docstring."""
+
+    topica_version: str
+    environment: dict[str, Any]
+    model: dict[str, Any]
+    corpus: dict[str, Any]
+    inputs: dict[str, Any] = field(default_factory=dict)
+    diagnostics: list[dict[str, Any]] = field(default_factory=list)
+    decisions: list[dict[str, Any]] = field(default_factory=list)
+    schema_version: int = SCHEMA_VERSION
+    created: str | None = None
+
+    # -- authoring ---------------------------------------------------------
+
+    def add_decision(self, key: str, note: str, *, author: str | None = None,
+                     time: str | None = None) -> "AnalysisManifest":
+        """Record a researcher-authored decision (K choice, labels, …).
+
+        Always stored as visibly researcher-authored, never as a substantive
+        conclusion the tool is vouching for.
+        """
+        self.decisions.append(
+            {"key": key, "note": note, "author": author, "time": time})
+        return self
+
+    def add_diagnostic(self, name: str, value: Any) -> "AnalysisManifest":
+        """Record a diagnostic as computed *evidence* (not a conclusion)."""
+        self.diagnostics.append(
+            {"name": name, "value": _jsonable(value), "kind": "computed_evidence"})
+        return self
+
+    # -- serialization -----------------------------------------------------
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema": SCHEMA,
+            "schema_version": self.schema_version,
+            "created": self.created,
+            "topica_version": self.topica_version,
+            "fingerprint_spec": FINGERPRINT_SPEC,
+            "hash_algorithm": HASH_ALGORITHM,
+            "environment": self.environment,
+            "model": self.model,
+            "corpus": self.corpus,
+            "inputs": self.inputs,
+            "diagnostics": self.diagnostics,
+            "decisions": self.decisions,
+        }
+
+    def to_json(self) -> str:
+        # sort_keys => deterministic bytes for a given manifest.
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True,
+                          ensure_ascii=False)
+
+    def save(self, path: str) -> None:
+        from pathlib import Path
+
+        Path(path).write_text(self.to_json(), encoding="utf-8")
+
+    @classmethod
+    def from_dict(cls, d: dict[str, Any]) -> "AnalysisManifest":
+        if d.get("schema") != SCHEMA:
+            raise ValueError(f"not a topica manifest (schema={d.get('schema')!r})")
+        ver = d.get("schema_version")
+        if ver != SCHEMA_VERSION:
+            raise ValueError(
+                f"unsupported manifest schema_version {ver!r} "
+                f"(this build reads {SCHEMA_VERSION}); upgrade topica or migrate")
+        return cls(
+            topica_version=d["topica_version"],
+            environment=d["environment"],
+            model=d["model"],
+            corpus=d["corpus"],
+            inputs=d.get("inputs", {}),
+            diagnostics=d.get("diagnostics", []),
+            decisions=d.get("decisions", []),
+            schema_version=ver,
+            created=d.get("created"),
+        )
+
+    @classmethod
+    def load(cls, path: str) -> "AnalysisManifest":
+        from pathlib import Path
+
+        return cls.from_dict(json.loads(Path(path).read_text(encoding="utf-8")))
+
+    # -- verification ------------------------------------------------------
+
+    def verify(self, corpus=None, model=None) -> VerifyResult:
+        """Re-derive fingerprints from the supplied corpus/model and report,
+        per field, whether the fit's identity and replay conditions still hold.
+
+        Never collapses the fields into one boolean. Uses the recorded
+        determinism class to decide whether an environment difference is
+        potentially replayable rather than a mismatch.
+        """
+        fields: dict[str, str] = {}
+        fields["environment"] = self._verify_environment()
+        if corpus is not None:
+            fields.update(self._verify_corpus(corpus))
+        if model is not None:
+            fields.update(self._verify_model(model))
+        return VerifyResult(fields)
+
+    def _verify_environment(self) -> str:
+        now = _environment(self.environment.get("thread_count"))
+        if now == self.environment:
+            return "exact"
+        determinism = self.model.get("determinism")
+        threads_match = now.get("thread_count") == self.environment.get("thread_count")
+        if determinism == "bit-exact":
+            return "environment_changed"  # bit-exact: env change should not matter
+        if determinism == "seed-reproducible" and threads_match:
+            return "environment_changed"  # replayable under the same thread count
+        return "unverifiable"
+
+    def _verify_corpus(self, corpus) -> dict[str, str]:
+        rec = self.corpus
+        # Coarse counts are always present.
+        counts_ok = (rec.get("num_docs") == corpus.num_docs
+                     and rec.get("total_tokens") == corpus.total_tokens)
+        out = {"corpus_counts": "exact" if counts_ok else "input_changed"}
+        stored = rec.get("fingerprint")
+        if stored is None:
+            out["corpus_fingerprint"] = "unverifiable"  # not recorded (privacy)
+        elif stored.get("spec") != FINGERPRINT_SPEC:
+            out["corpus_fingerprint"] = "unverifiable"  # unknown spec, do not reinterpret
+        else:
+            key = None  # keyed fingerprints require the caller's key; unsupported here
+            if stored.get("keyed"):
+                out["corpus_fingerprint"] = "unverifiable"
+            else:
+                now = fingerprint_corpus(corpus, key=key)
+                out["corpus_fingerprint"] = (
+                    "exact" if now["digest"] == stored["digest"] else "input_changed")
+        return out
+
+    def _verify_model(self, model) -> dict[str, str]:
+        stored = self.model.get("output_fingerprints", {})
+        determinism = self.model.get("determinism")
+        out: dict[str, str] = {}
+        for name in ("topic_word", "doc_topic"):
+            want = stored.get(name)
+            have = getattr(model, name, None)
+            if want is None or have is None:
+                out[f"model_{name}"] = "unverifiable"
+                continue
+            if want.get("spec") != FINGERPRINT_SPEC:
+                out[f"model_{name}"] = "unverifiable"
+                continue
+            now = fingerprint_array(have)
+            if now["digest"] == want["digest"]:
+                out[f"model_{name}"] = "exact"
+            elif determinism == "llm-bounded":
+                out[f"model_{name}"] = "unverifiable"  # bounded nondeterminism
+            else:
+                out[f"model_{name}"] = "artifact_changed"
+        return out
+
+    def __repr__(self) -> str:
+        return (f"AnalysisManifest(model={self.model.get('class')!r}, "
+                f"privacy={self.corpus.get('privacy')!r}, "
+                f"decisions={len(self.decisions)}, "
+                f"diagnostics={len(self.diagnostics)})")
+
+
+# --------------------------------------------------------------------------
+# record_fit
+# --------------------------------------------------------------------------
+
+
+def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
+               privacy: str = "minimal", content_fingerprint: bool = False,
+               fingerprint_key: bytes | None = None, thread_count: int | None = None,
+               **fit_settings) -> AnalysisManifest:
+    """Record a fitted ``model`` on ``corpus`` as an :class:`AnalysisManifest`.
+
+    The explicit call is deliberate: it cannot honestly see preprocessing done
+    before it, so it records only what it can observe and marks the rest.
+
+    Parameters
+    ----------
+    privacy : ``"minimal"`` (default) or ``"aggregate"``. ``"full"`` is not in V1.
+    content_fingerprint : opt-in, **sensitive**. Adds an order-sensitive hash of
+        the corpus tokens so ``verify`` can prove corpus identity. A hash is not
+        anonymisation.
+    fingerprint_key : optional key for keyed/salted fingerprints (private
+        verification only; keyed digests are marked non-portable).
+    fit_settings : the fit arguments you passed (``iters=``, …), recorded as
+        provenance. Only JSON-serialisable values are kept; others are dropped
+        with a note.
+    """
+    if privacy not in ("minimal", "aggregate"):
+        raise ValueError(
+            f"privacy must be 'minimal' or 'aggregate' (got {privacy!r}); "
+            f"'full' (raw values) is intentionally not available in V1")
+
+    import topica
+
+    cls = type(model).__name__
+    determinism = None
+    reg = getattr(topica, "registry", None)
+    if reg is not None and cls in reg.REGISTRY:
+        determinism = reg.REGISTRY[cls].determinism
+
+    model_block: dict[str, Any] = {
+        "class": cls,
+        "determinism": determinism,
+        "num_topics": getattr(model, "num_topics", None),
+        "seed": getattr(model, "seed", None),  # most models do not expose it -> None
+        "settings": _capture_settings(model, cls),
+        "settings_coverage": f"adapter:{cls}" if cls in _SETTINGS_ALLOWLIST else "generic",
+        "fit_settings": _allowlist_kwargs(fit_settings),
+        "output_fingerprints": _output_fingerprints(model),
+    }
+
+    corpus_block = _corpus_block(corpus, privacy, content_fingerprint, fingerprint_key)
+
+    inputs: dict[str, Any] = {}
+    if prevalence is not None:
+        inputs["prevalence"] = {
+            "kind": "design_matrix",
+            **fingerprint_design(prevalence, prevalence_names, key=fingerprint_key),
+        }
+
+    return AnalysisManifest(
+        topica_version=getattr(topica, "__version__", None),
+        environment=_environment(thread_count),
+        model=model_block,
+        corpus=corpus_block,
+        inputs=inputs,
+    )
+
+
+def _capture_settings(model, cls: str) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for name in _SETTINGS_ALLOWLIST.get(cls, ()):
+        val = getattr(model, name, None)
+        if val is not None:
+            out[name] = _jsonable(val)
+    return out
+
+
+def _output_fingerprints(model) -> dict[str, Any]:
+    out: dict[str, Any] = {}
+    for name in ("topic_word", "doc_topic"):
+        arr = getattr(model, name, None)
+        if arr is not None:
+            out[name] = fingerprint_array(arr)
+    return out
+
+
+def _corpus_block(corpus, privacy, content_fingerprint, key) -> dict[str, Any]:
+    block: dict[str, Any] = {
+        "privacy": privacy,
+        "num_docs": corpus.num_docs,
+        "total_tokens": corpus.total_tokens,
+    }
+    if privacy == "aggregate":
+        lengths = np.asarray(corpus.doc_lengths, dtype=float)
+        block["description"] = {
+            "vocab_size": corpus.num_words,
+            "doc_length_summary": _length_summary(lengths),
+            "preprocessing": _preprocessing(corpus),
+        }
+    if content_fingerprint:
+        block["fingerprint"] = fingerprint_corpus(corpus, key=key)
+    return block
+
+
+def _length_summary(lengths: np.ndarray) -> dict[str, Any]:
+    if lengths.size == 0:
+        return {"count": 0}
+    return {
+        "count": int(lengths.size),
+        "min": int(lengths.min()),
+        "max": int(lengths.max()),
+        "mean": float(lengths.mean()),
+        "median": float(np.median(lengths)),
+    }
+
+
+def _preprocessing(corpus) -> dict[str, Any]:
+    # Only parameters Topica itself applied and can observe. Preprocessing done
+    # outside Topica is not visible here (a fingerprint proves identity, not
+    # provenance).
+    out: dict[str, Any] = {}
+    for name in ("min_doc_freq", "max_doc_fraction", "min_cf", "rm_top"):
+        val = getattr(corpus, name, None)
+        if val is not None:
+            out[name] = _jsonable(val)
+    return out
+
+
+# --------------------------------------------------------------------------
+# helpers
+# --------------------------------------------------------------------------
+
+_JSON_SCALARS = (str, int, float, bool, type(None))
+
+
+def _allowlist_kwargs(kwargs: dict[str, Any]) -> dict[str, Any]:
+    """Keep JSON-serialisable fit settings; drop the rest with a marker."""
+    out: dict[str, Any] = {}
+    dropped: list[str] = []
+    for k, v in kwargs.items():
+        j = _jsonable(v, _allow_containers=False)
+        if j is _UNSERIALISABLE:
+            dropped.append(k)
+        else:
+            out[k] = j
+    if dropped:
+        out["_dropped"] = sorted(dropped)
+    return out
+
+
+_UNSERIALISABLE = object()
+
+
+def _jsonable(value: Any, _allow_containers: bool = True):
+    if isinstance(value, _JSON_SCALARS):
+        return value
+    if isinstance(value, np.integer):
+        return int(value)
+    if isinstance(value, np.floating):
+        return float(value)
+    if isinstance(value, np.ndarray):
+        return value.tolist() if _allow_containers else _UNSERIALISABLE
+    if _allow_containers and isinstance(value, (list, tuple)):
+        return [_jsonable(v) for v in value]
+    if _allow_containers and isinstance(value, dict):
+        return {str(k): _jsonable(v) for k, v in value.items()}
+    return _UNSERIALISABLE if not _allow_containers else str(value)

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -56,15 +56,20 @@ def test_minimal_default_leaks_no_content(fitted):
         assert token not in js
     for leaked in ("description", "vocab_size", "doc_length_summary", "fingerprint"):
         assert f'"{leaked}"' not in js
-    # A design matrix is fingerprinted, not embedded: no raw value strings.
-    assert "0.5" not in js and "0.2" not in js
+    # A design matrix is fingerprinted, not embedded: the prevalence entry is a
+    # fingerprint dict (spec/algo/digest/columns/…), never the raw values.
+    prev = rec.inputs["prevalence"]
+    assert prev["spec"] == FINGERPRINT_SPEC and prev["digest"]
+    assert set(prev) <= {"spec", "algo", "digest", "keyed", "kind", "n_rows", "columns"}
 
 
 def test_no_raw_document_ids_or_metadata(fitted):
     corpus, model = fitted
     rec = record_fit(model, corpus, iters=50)
-    js = rec.to_json()
-    assert "metadata" not in js.lower() or '"metadata"' not in js
+    # V1 records no metadata values, document IDs, or paths at any privacy level.
+    assert "metadata" not in rec.corpus
+    for block in (rec.corpus, rec.model, rec.inputs):
+        assert "path" not in block and "doc_names" not in block
 
 
 def test_aggregate_opts_in_description_but_still_no_tokens(fitted):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -1,0 +1,233 @@
+"""Analysis manifest / provenance record (issue #394).
+
+Covers the privacy contract (no leakage), deterministic serialization, the
+fingerprint-v1 canonicalization, change detection in verify(), and schema
+forward-compatibility.
+"""
+import json
+
+import numpy as np
+import pytest
+
+import topica
+from topica.manifest import (
+    FINGERPRINT_SPEC,
+    SCHEMA,
+    SCHEMA_VERSION,
+    AnalysisManifest,
+    fingerprint_array,
+    fingerprint_corpus,
+    record_fit,
+)
+
+# Distinctive tokens that cannot collide with hyperparameter names (alpha/beta/…)
+# recorded as legitimate model settings.
+DOCS = [
+    ["wordone", "wordtwo", "wordthree", "wordone"],
+    ["wordone", "wordtwo", "wordtwo", "wordfour"],
+    ["wordthree", "wordthree", "wordfour", "wordfive"],
+    ["wordfour", "wordfive", "wordone", "wordtwo"],
+    ["wordfive", "wordsix", "wordone", "wordthree"],
+    ["wordtwo", "wordthree", "wordfour", "wordfive"],
+]
+X = np.array([[1.0, 0.0], [1.0, 1.0], [0.0, 1.0], [1.0, 0.5], [0.0, 0.0], [1.0, 0.2]])
+
+
+@pytest.fixture
+def fitted():
+    corpus = topica.Corpus.from_documents(DOCS)
+    model = topica.LDA(3, seed=7)
+    model.fit(corpus, iters=50)
+    return corpus, model
+
+
+# -- privacy / leakage -----------------------------------------------------
+
+
+def test_minimal_default_leaks_no_content(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, prevalence=X, prevalence_names=["a", "b"], iters=50)
+    js = rec.to_json()
+    assert rec.corpus["privacy"] == "minimal"
+    # Coarse counts only; no vocabulary, length distribution, preprocessing,
+    # content fingerprint, or any raw token.
+    assert set(rec.corpus) == {"privacy", "num_docs", "total_tokens"}
+    for token in {t for doc in DOCS for t in doc}:
+        assert token not in js
+    for leaked in ("description", "vocab_size", "doc_length_summary", "fingerprint"):
+        assert f'"{leaked}"' not in js
+    # A design matrix is fingerprinted, not embedded: no raw value strings.
+    assert "0.5" not in js and "0.2" not in js
+
+
+def test_no_raw_document_ids_or_metadata(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, iters=50)
+    js = rec.to_json()
+    assert "metadata" not in js.lower() or '"metadata"' not in js
+
+
+def test_aggregate_opts_in_description_but_still_no_tokens(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, privacy="aggregate", iters=50)
+    desc = rec.corpus["description"]
+    assert desc["vocab_size"] == corpus.num_words
+    assert desc["doc_length_summary"]["count"] == corpus.num_docs
+    js = rec.to_json()
+    for token in {t for doc in DOCS for t in doc}:
+        assert token not in js
+
+
+def test_full_privacy_rejected(fitted):
+    corpus, model = fitted
+    with pytest.raises(ValueError, match="not available in V1|minimal"):
+        record_fit(model, corpus, privacy="full")
+
+
+def test_content_fingerprint_is_opt_in(fitted):
+    corpus, model = fitted
+    assert record_fit(model, corpus).corpus.get("fingerprint") is None
+    rec = record_fit(model, corpus, content_fingerprint=True)
+    assert rec.corpus["fingerprint"]["spec"] == FINGERPRINT_SPEC
+
+
+# -- deterministic serialization + round trip ------------------------------
+
+
+def test_serialization_is_deterministic(fitted):
+    corpus, model = fitted
+    a = record_fit(model, corpus, iters=50).to_json()
+    b = record_fit(model, corpus, iters=50).to_json()
+    assert a == b  # no wall-clock, sorted keys
+
+
+def test_round_trip(tmp_path, fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, prevalence=X, iters=50)
+    rec.add_decision("K", "chose 3")
+    rec.add_diagnostic("coh", float(np.mean(model.coherence(5))))
+    p = tmp_path / "a.topica.json"
+    rec.save(str(p))
+    back = AnalysisManifest.load(str(p))
+    assert back.to_json() == rec.to_json()
+    assert back.decisions[0]["key"] == "K"
+    assert back.diagnostics[0]["kind"] == "computed_evidence"
+
+
+# -- fingerprint-v1 canonicalization ---------------------------------------
+
+
+def test_fingerprint_array_order_sensitive():
+    a = fingerprint_array(np.array([1.0, 2.0, 3.0]))
+    b = fingerprint_array(np.array([3.0, 2.0, 1.0]))
+    assert a["digest"] != b["digest"]
+    assert a["spec"] == FINGERPRINT_SPEC and a["shape"] == [3]
+
+
+def test_fingerprint_normalises_negative_zero_and_nan():
+    assert (fingerprint_array(np.array([0.0, 1.0]))["digest"]
+            == fingerprint_array(np.array([-0.0, 1.0]))["digest"])
+    # Distinct NaN bit patterns must hash identically (no bit-pattern leak).
+    n1 = np.array([np.nan], dtype="<f8")
+    n2 = np.frombuffer(np.uint64(0x7FF8000000000001).tobytes(), dtype="<f8").copy()
+    assert (fingerprint_array(n1)["digest"] == fingerprint_array(n2)["digest"])
+
+
+def test_corpus_fingerprint_survives_reindex_changes_on_edit():
+    c1 = topica.Corpus.from_documents(DOCS)
+    c2 = topica.Corpus.from_documents(DOCS)  # same content
+    assert fingerprint_corpus(c1)["digest"] == fingerprint_corpus(c2)["digest"]
+    reordered = [DOCS[0][::-1]] + DOCS[1:]   # change one document's token order
+    c3 = topica.Corpus.from_documents(reordered)
+    assert fingerprint_corpus(c3)["digest"] != fingerprint_corpus(c1)["digest"]
+
+
+def test_keyed_fingerprint_is_flagged_and_differs():
+    plain = fingerprint_array(X)
+    keyed = fingerprint_array(X, key=b"secret")
+    assert "keyed" not in plain
+    assert keyed["keyed"] is True
+    assert keyed["digest"] != plain["digest"]
+
+
+# -- verify: graded outcomes, change detection -----------------------------
+
+
+def test_verify_same_inputs_matches(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, content_fingerprint=True, iters=50)
+    res = rec.verify(corpus, model)
+    assert res.fields["corpus_counts"] == "exact"
+    assert res.fields["corpus_fingerprint"] == "exact"
+    assert res.fields["model_topic_word"] == "exact"
+    assert res.fields["model_doc_topic"] == "exact"
+
+
+def test_verify_detects_changed_corpus(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, content_fingerprint=True, iters=50)
+    changed = topica.Corpus.from_documents([DOCS[0][::-1]] + DOCS[1:])
+    res = rec.verify(changed, model)
+    assert res.fields["corpus_fingerprint"] == "input_changed"
+    assert not res.ok
+
+
+def test_verify_detects_changed_model(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, iters=50)
+    other = topica.LDA(3, seed=999)
+    other.fit(corpus, iters=50)
+    res = rec.verify(corpus, other)
+    assert res.fields["model_topic_word"] == "artifact_changed"
+
+
+def test_verify_unrecorded_fingerprint_is_unverifiable_not_pass(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, iters=50)  # no content fingerprint
+    res = rec.verify(corpus, model)
+    # Absence of a recorded fingerprint must never read as a pass.
+    assert res.fields["corpus_fingerprint"] == "unverifiable"
+
+
+def test_verify_result_never_a_bare_bool(fitted):
+    corpus, model = fitted
+    res = record_fit(model, corpus, iters=50).verify(corpus, model)
+    assert isinstance(res.fields, dict) and len(res.fields) >= 3
+    assert "exact" in res.summary()
+
+
+# -- schema + fingerprint-spec forward compatibility -----------------------
+
+
+def test_unknown_schema_version_rejected(fitted):
+    corpus, model = fitted
+    d = record_fit(model, corpus).to_dict()
+    d["schema_version"] = 999
+    with pytest.raises(ValueError, match="schema_version"):
+        AnalysisManifest.from_dict(d)
+
+
+def test_non_topica_manifest_rejected():
+    with pytest.raises(ValueError, match="not a topica manifest"):
+        AnalysisManifest.from_dict({"schema": "something.else"})
+
+
+def test_unknown_fingerprint_spec_is_unverifiable_not_reinterpreted(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, content_fingerprint=True, iters=50)
+    rec.corpus["fingerprint"]["spec"] = "fp99"  # a future spec this build can't read
+    res = rec.verify(corpus, model)
+    assert res.fields["corpus_fingerprint"] == "unverifiable"
+
+
+def test_schema_constants_are_stable():
+    # These are the durable contract; changing them is a breaking change.
+    assert SCHEMA == "topica.manifest"
+    assert SCHEMA_VERSION == 1
+    assert FINGERPRINT_SPEC == "fp1"
+
+
+def test_manifest_is_valid_json(fitted):
+    corpus, model = fitted
+    d = json.loads(record_fit(model, corpus, iters=50).to_json())
+    assert d["schema"] == SCHEMA and d["fingerprint_spec"] == FINGERPRINT_SPEC


### PR DESCRIPTION
Closes #394. V1 of the analysis manifest, implemented per the issue and your four refinements. Lands on `main`, **unreleased** — it can't disturb the submitted paper, and it's visible to anyone browsing the repo.

## What it is
`topica.record_fit(model, corpus, ...)` writes an `AnalysisManifest`: a portable, privacy-aware JSON record of one fit (settings, environment, fit args, researcher decisions, and canonical fingerprints), and `record.verify(corpus, model)` later reports **per field** whether the fit's identity and replay conditions still hold. It's not a second model format — it composes with `Corpus.save`/`model.save` and records fingerprints, not raw content.

```python
record = topica.record_fit(model, corpus, prevalence=X, prevalence_names=names, iters=1000)
record.add_decision("K", "Chose 20 after inspecting 15/20/25.")
record.save("analysis.topica.json")
topica.AnalysisManifest.load("analysis.topica.json").verify(corpus, model).summary()
```

## Your four refinements, all in
1. **Fingerprint-v1 as a frozen, standalone contract** (`"fp1"`, documented in the module docstring): BLAKE2b-256; length-prefixed + domain-tagged encoding so no two inputs collide; arrays cast to float64/C-order/little-endian with `-0.0` and **every NaN bit pattern** normalized to a canonical quiet-NaN (no bit-pattern leak); corpus hashed as token strings in document order (survives vocab reindexing). Optional keyed/salted mode, flagged non-portable. **A verifier that meets an unknown spec reports `unverifiable`, never reinterprets.**
2. **`privacy="minimal"` default** — coarse corpus counts only (doc count, total tokens); no length distribution, vocab size, or preprocessing. `aggregate` opts those in; the content fingerprint is a *separate* opt-in and documented sensitive; `full` is rejected in V1.
3. **Reconciled with the paper's provenance report** — the environment block mirrors the report's fields (topica version, platform, arch, cores) so the two share one notion and can converge later. No change to the frozen paper code.
4. **Narrow V1** — `AnalysisManifest` + fingerprint spec + `record_fit` (LDA/STM adapters + generic) + `verify` with a textual report. No HTML, no generic diagnostic auto-capture.

## `verify` is honest by construction
Returns a `VerifyResult` mapping each field to `exact` / `input_changed` / `artifact_changed` / `environment_changed` / `unverifiable` — never a single pass/fail. It uses the determinism taxonomy (`registry` `bit-exact`/`seed-reproducible`/`llm-bounded`) to decide whether an environment difference is potentially replayable, and an *unrecorded* fingerprint reads as `unverifiable`, never as a pass.

## Tests (21, `tests/test_manifest.py`)
Leakage (minimal + aggregate carry no raw tokens), deterministic serialization (no wall-clock), canonicalization (NaN / `-0.0` / order sensitivity / keyed), change detection (reordered corpus → `input_changed`, different model → `artifact_changed`), and schema + fingerprint-spec forward-compatibility (unknown schema_version rejected; unknown fp spec → `unverifiable`).

## Scope / notes
- Pure Python (`python/topica/manifest.py`); no Rust, no `.pyi`.
- `seed` is not exposed by the model objects, so it's captured best-effort (`None` when unavailable) and honestly labeled; the **verifiable core is the model output fingerprints**.
- Docs: `docs/api/manifest.md` (+ nav), a section in the reproducibility guide, CHANGELOG `### Added`.

## Gates
- Full pytest suite: **3342 passed, 30 skipped**.
- `mkdocs build --strict` clean (new API page renders via mkdocstrings).
- preflight (fmt + clippy + tables + stub) green.

Deferred to V2 (unchanged from the issue): registry adapters for every model family, `add_diagnostic` adapters for built-ins, HTML/Quarto rendering, manifest comparison, signed/bundled artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)