### PR TITLE
feat(manifest): compare two manifests (#394 V2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- **Manifest comparison**: `AnalysisManifest.compare(other)` diffs two manifests
+  directly (no corpus or model needed) and returns a `ManifestDiff` reporting per
+  field `same` / `changed` / `only_in_a` / `only_in_b` / `incomparable` — so you
+  can see whether two runs used the same corpus, model, and inputs, or what
+  changed between them.
 - **Analysis card rendering** for the manifest: `AnalysisManifest.render(path)`
   writes a self-contained HTML card and `.to_markdown()` returns a Markdown
   version (Quarto/notebook). The card renders only what the manifest recorded, so

--- a/docs/api/manifest.md
+++ b/docs/api/manifest.md
@@ -46,6 +46,20 @@ class says it may still replay), or `unverifiable` (nothing recorded to check
 against, a bounded component, or a fingerprint from a spec this build does not
 recognise).
 
+## Comparing two fits
+
+`a.compare(b)` diffs two manifests directly, with no corpus or model needed, and
+reports per field `same` / `changed` / `only_in_a` / `only_in_b` / `incomparable`.
+It answers "did these two runs use the same corpus, model, and inputs, or did
+something change, and what?" — for example, whether a collaborator changed the
+corpus or only the seed.
+
+```python
+a = topica.AnalysisManifest.load("run-a.json")
+b = topica.AnalysisManifest.load("run-b.json")
+print(a.compare(b).summary())
+```
+
 ## The analysis card
 
 `record.render(path)` writes a self-contained HTML **analysis card**, and
@@ -66,6 +80,8 @@ record.render("analysis-card.html", verification=record.verify(corpus, model))
 ::: topica.manifest.AnalysisManifest
 
 ::: topica.manifest.VerifyResult
+
+::: topica.manifest.ManifestDiff
 
 ::: topica.manifest.fingerprint_corpus
 

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -230,6 +230,35 @@ class VerifyResult:
 
 
 @dataclass
+class ManifestDiff:
+    """The outcome of :meth:`AnalysisManifest.compare`, per field.
+
+    Compares two manifests directly (no corpus or model needed), so it answers
+    "did these two runs differ, and where?". ``fields`` maps each field to
+    ``same``, ``changed``, ``only_in_a`` / ``only_in_b`` (recorded in one but not
+    the other), or ``incomparable`` (e.g. fingerprints from different specs, or a
+    keyed digest). ``same`` is a convenience for "every field same"; the summary
+    always shows the breakdown.
+    """
+
+    fields: dict[str, str]
+
+    @property
+    def same(self) -> bool:
+        return all(v == "same" for v in self.fields.values())
+
+    def summary(self) -> str:
+        width = max((len(k) for k in self.fields), default=0)
+        lines = [f"compare: {'identical' if self.same else 'differences found'}"]
+        for name, status in self.fields.items():
+            lines.append(f"  {name.ljust(width)}  {status}")
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return f"ManifestDiff(same={self.same}, fields={self.fields})"
+
+
+@dataclass
 class AnalysisManifest:
     """A versioned, privacy-aware record of one fit. See the module docstring."""
 
@@ -390,6 +419,37 @@ class AnalysisManifest:
                 out[f"model_{name}"] = "artifact_changed"
         return out
 
+    # -- comparison (V2): two manifests, no corpus/model needed ------------
+
+    def compare(self, other: "AnalysisManifest") -> ManifestDiff:
+        """Compare this manifest with ``other`` field by field.
+
+        Uses only what each manifest recorded (fingerprints, counts, settings),
+        so it needs neither corpus nor model. Answers "did these two runs use the
+        same corpus / model / inputs, or did something change, and what?".
+        """
+        f: dict[str, str] = {}
+        f["environment"] = _cmp_value(self.environment, other.environment)
+        f["model_class"] = _cmp_value(self.model.get("class"), other.model.get("class"))
+        f["num_topics"] = _cmp_value(self.model.get("num_topics"), other.model.get("num_topics"))
+        f["model_settings"] = _cmp_value(self.model.get("settings"), other.model.get("settings"))
+        f["fit_settings"] = _cmp_value(self.model.get("fit_settings"), other.model.get("fit_settings"))
+
+        a_out = self.model.get("output_fingerprints", {})
+        b_out = other.model.get("output_fingerprints", {})
+        for name in sorted(set(a_out) | set(b_out)):
+            f[f"model_{name}"] = _cmp_fp(a_out.get(name), b_out.get(name))
+
+        f["corpus_counts"] = _cmp_value(
+            (self.corpus.get("num_docs"), self.corpus.get("total_tokens")),
+            (other.corpus.get("num_docs"), other.corpus.get("total_tokens")))
+        f["corpus_fingerprint"] = _cmp_fp(
+            self.corpus.get("fingerprint"), other.corpus.get("fingerprint"))
+
+        for name in sorted(set(self.inputs) | set(other.inputs)):
+            f[f"input_{name}"] = _cmp_fp(self.inputs.get(name), other.inputs.get(name))
+        return ManifestDiff(f)
+
     # -- rendering (V2): a human-facing "analysis card" ---------------------
 
     def render(self, path: str | None = None, *, title: str | None = None,
@@ -419,6 +479,36 @@ class AnalysisManifest:
                 f"privacy={self.corpus.get('privacy')!r}, "
                 f"decisions={len(self.decisions)}, "
                 f"diagnostics={len(self.diagnostics)})")
+
+
+# --------------------------------------------------------------------------
+# comparison helpers
+# --------------------------------------------------------------------------
+
+
+def _cmp_value(a, b) -> str:
+    a_has, b_has = a is not None, b is not None
+    if not a_has and not b_has:
+        return "same"
+    if a_has and not b_has:
+        return "only_in_a"
+    if b_has and not a_has:
+        return "only_in_b"
+    return "same" if a == b else "changed"
+
+
+def _cmp_fp(a: dict | None, b: dict | None) -> str:
+    if a is None and b is None:
+        return "same"
+    if a is None:
+        return "only_in_b"
+    if b is None:
+        return "only_in_a"
+    # Different fingerprint specs, or a keyed digest, cannot be compared for
+    # equality of content -- do not guess.
+    if a.get("spec") != b.get("spec") or a.get("keyed") or b.get("keyed"):
+        return "incomparable"
+    return "same" if a.get("digest") == b.get("digest") else "changed"
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -15,6 +15,7 @@ from topica.manifest import (
     SCHEMA,
     SCHEMA_VERSION,
     AnalysisManifest,
+    ManifestDiff,
     fingerprint_array,
     fingerprint_corpus,
     record_fit,
@@ -236,6 +237,73 @@ def test_manifest_is_valid_json(fitted):
     corpus, model = fitted
     d = json.loads(record_fit(model, corpus, iters=50).to_json())
     assert d["schema"] == SCHEMA and d["fingerprint_spec"] == FINGERPRINT_SPEC
+
+
+# -- comparison: two manifests (V2) ----------------------------------------
+
+
+def test_compare_identical_runs(fitted):
+    corpus, model = fitted
+    a = record_fit(model, corpus, prevalence=X, content_fingerprint=True, iters=50)
+    b = record_fit(model, corpus, prevalence=X, content_fingerprint=True, iters=50)
+    diff = a.compare(b)
+    assert isinstance(diff, ManifestDiff)
+    assert diff.same
+    assert all(v == "same" for v in diff.fields.values())
+
+
+def test_compare_localizes_a_changed_model(fitted):
+    corpus, model = fitted
+    a = record_fit(model, corpus, iters=50)
+    other = topica.LDA(4, seed=7)   # different K
+    other.fit(corpus, iters=50)
+    b = record_fit(other, corpus, iters=50)
+    diff = a.compare(b)
+    assert not diff.same
+    assert diff.fields["num_topics"] == "changed"
+    assert diff.fields["model_topic_word"] == "changed"
+    assert diff.fields["corpus_counts"] == "same"     # same corpus
+
+
+def test_compare_localizes_a_changed_input(fitted):
+    corpus, model = fitted
+    a = record_fit(model, corpus, prevalence=X, iters=50)
+    b = record_fit(model, corpus, prevalence=X * 2 + 1, iters=50)  # different design matrix
+    diff = a.compare(b)
+    assert diff.fields["input_prevalence"] == "changed"
+    assert diff.fields["model_topic_word"] == "same"
+
+
+def test_compare_only_in_one(fitted):
+    corpus, model = fitted
+    with_fp = record_fit(model, corpus, content_fingerprint=True, iters=50)
+    without = record_fit(model, corpus, iters=50)
+    assert with_fp.compare(without).fields["corpus_fingerprint"] == "only_in_a"
+    assert without.compare(with_fp).fields["corpus_fingerprint"] == "only_in_b"
+
+
+def test_compare_incomparable_across_specs(fitted):
+    corpus, model = fitted
+    a = record_fit(model, corpus, content_fingerprint=True, iters=50)
+    b = record_fit(model, corpus, content_fingerprint=True, iters=50)
+    b.corpus["fingerprint"]["spec"] = "fp99"   # a future spec
+    assert a.compare(b).fields["corpus_fingerprint"] == "incomparable"
+
+
+def test_compare_survives_round_trip(tmp_path, fitted):
+    corpus, model = fitted
+    a = record_fit(model, corpus, prevalence=X, content_fingerprint=True, iters=50)
+    p = tmp_path / "a.json"
+    a.save(str(p))
+    reloaded = AnalysisManifest.load(str(p))
+    assert a.compare(reloaded).same
+
+
+def test_compare_summary_is_not_a_bare_bool(fitted):
+    corpus, model = fitted
+    a = record_fit(model, corpus, iters=50)
+    diff = a.compare(a)
+    assert isinstance(diff.fields, dict) and "same" in diff.summary()
 
 
 # -- rendering: the analysis card (V2) -------------------------------------


### PR DESCRIPTION
Next V2 increment (after #395 V1 and #396 render). Manifest-vs-manifest comparison completes the audit story: `verify` checks a manifest against a *live* corpus/model; `compare` checks it against *another recorded fit*, needing no data at all.

## What
`AnalysisManifest.compare(other) -> ManifestDiff` diffs two manifests directly and reports **per field**: `same` / `changed` / `only_in_a` / `only_in_b` / `incomparable`.

It compares environment, model class / K / settings / fit-settings, output fingerprints, corpus counts + content fingerprint, and design-matrix fingerprints — using only what each manifest recorded. Fingerprints from different specs, or keyed digests, are `incomparable` rather than guessed. Same ergonomics as `verify`: `.fields`, `.same`, `.summary()`.

```python
a = topica.AnalysisManifest.load("run-a.json")
b = topica.AnalysisManifest.load("run-b.json")
print(a.compare(b).summary())
```

## It localizes the difference
- **Different K** → `num_topics` + `model_settings` + `model_topic_word`/`doc_topic` `changed`; `corpus_counts` `same`.
- **Different prevalence covariate, same fit** → only `input_prevalence` `changed`.
- **A run that recorded a content fingerprint vs. one that didn't** → `corpus_fingerprint` `only_in_a`.

So it answers "did my collaborator change the corpus, or just the seed?" from the recorded fingerprints alone.

## Tests (`+7`, 34 total in the file)
Identical runs, changed model, changed input, only-in-one, incomparable-across-specs, save/load round-trip, and that the diff is never a bare bool.

## Gates
- Full pytest suite: **3355 passed, 30 skipped**.
- `mkdocs build --strict` clean; preflight green. Pure Python.

## Remaining V2 (future PRs)
Per-model-family `record_fit` adapters, `add_diagnostic` adapters for built-in diagnostics/effects, signed/bundled artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)