### PR TITLE
feat(manifest): capture built-in diagnostics in record_fit (#394 V2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- **Built-in diagnostic capture** for the manifest:
+  `record_fit(..., diagnostics=["coherence", "exclusivity"])` computes those
+  topic-quality metrics and records each as computed evidence (mean over topics),
+  or `value=None` with a note when the metric is not defined for the model.
 - **Manifest comparison**: `AnalysisManifest.compare(other)` diffs two manifests
   directly (no corpus or model needed) and returns a `ManifestDiff` reporting per
   field `same` / `changed` / `only_in_a` / `only_in_b` / `incomparable` — so you

--- a/docs/api/manifest.md
+++ b/docs/api/manifest.md
@@ -46,6 +46,15 @@ class says it may still replay), or `unverifiable` (nothing recorded to check
 against, a bounded component, or a fingerprint from a spec this build does not
 recognise).
 
+## Recording evidence
+
+`record_fit(..., diagnostics=["coherence", "exclusivity"])` computes those
+built-in topic-quality metrics and records each as *computed evidence* (its mean
+over topics), or `value=None` with a note when a metric is not defined for the
+model. You can also attach your own with `record.add_diagnostic(name, value)` and
+interpretive notes with `record.add_decision(key, note)`; both are stored as
+visibly researcher-authored, never as tool-verified conclusions.
+
 ## Comparing two fits
 
 `a.compare(b)` diffs two manifests directly, with no corpus or model needed, and

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -519,6 +519,7 @@ def _cmp_fp(a: dict | None, b: dict | None) -> str:
 def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
                privacy: str = "minimal", content_fingerprint: bool = False,
                fingerprint_key: bytes | None = None, thread_count: int | None = None,
+               diagnostics=None, diagnostics_n: int = 10,
                **fit_settings) -> AnalysisManifest:
     """Record a fitted ``model`` on ``corpus`` as an :class:`AnalysisManifest`.
 
@@ -533,6 +534,11 @@ def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
         anonymisation.
     fingerprint_key : optional key for keyed/salted fingerprints (private
         verification only; keyed digests are marked non-portable).
+    diagnostics : optional list of built-in diagnostics to compute and record as
+        evidence: any of :data:`BUILTIN_DIAGNOSTICS` (``"coherence"``,
+        ``"exclusivity"``). Each is recorded as computed evidence (its mean over
+        topics), or ``value=None`` with a note if it is not defined for this model.
+    diagnostics_n : the top-N words each diagnostic uses (default 10).
     fit_settings : the fit arguments you passed (``iters=``, …), recorded as
         provenance. Only JSON-serialisable values are kept; others are dropped
         with a note.
@@ -541,6 +547,10 @@ def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
         raise ValueError(
             f"privacy must be 'minimal' or 'aggregate' (got {privacy!r}); "
             f"'full' (raw values) is intentionally not available in V1")
+    for name in diagnostics or ():
+        if name not in BUILTIN_DIAGNOSTICS:
+            raise ValueError(
+                f"unknown diagnostic {name!r}; choose from {sorted(BUILTIN_DIAGNOSTICS)}")
 
     import topica
 
@@ -570,13 +580,42 @@ def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
             **fingerprint_design(prevalence, prevalence_names, key=fingerprint_key),
         }
 
-    return AnalysisManifest(
+    manifest = AnalysisManifest(
         topica_version=getattr(topica, "__version__", None),
         environment=_environment(thread_count),
         model=model_block,
         corpus=corpus_block,
         inputs=inputs,
     )
+    for name in diagnostics or ():
+        manifest.diagnostics.append(_capture_diagnostic(name, model, corpus, diagnostics_n))
+    return manifest
+
+
+# Built-in diagnostics record_fit can compute from the model alone (mean over
+# topics). Both are the classic STM-style topic-quality metrics.
+BUILTIN_DIAGNOSTICS = ("coherence", "exclusivity")
+
+
+def _capture_diagnostic(name: str, model, corpus, n: int) -> dict[str, Any]:
+    import numpy as _np
+    import topica
+
+    entry = {"name": name, "kind": "computed_evidence", "params": {"n": n}}
+    try:
+        if name == "coherence":
+            value = float(_np.mean(model.coherence(n)))
+        elif name == "exclusivity":
+            value = float(_np.mean(topica.exclusivity(model, n=n)))
+        else:  # pragma: no cover - guarded by BUILTIN_DIAGNOSTICS
+            raise KeyError(name)
+        entry["value"] = value
+    except Exception as exc:
+        # Honestly record the attempt and why it could not be computed rather
+        # than silently dropping it (e.g. coherence on a cluster/neural model).
+        entry["value"] = None
+        entry["note"] = f"unavailable for this model: {type(exc).__name__}"
+    return entry
 
 
 def _capture_settings(model, cls: str) -> dict[str, Any]:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -11,6 +11,7 @@ import pytest
 
 import topica
 from topica.manifest import (
+    BUILTIN_DIAGNOSTICS,
     FINGERPRINT_SPEC,
     SCHEMA,
     SCHEMA_VERSION,
@@ -237,6 +238,58 @@ def test_manifest_is_valid_json(fitted):
     corpus, model = fitted
     d = json.loads(record_fit(model, corpus, iters=50).to_json())
     assert d["schema"] == SCHEMA and d["fingerprint_spec"] == FINGERPRINT_SPEC
+
+
+# -- built-in diagnostic capture (V2) --------------------------------------
+
+
+def test_record_fit_captures_builtin_diagnostics(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, diagnostics=["coherence", "exclusivity"],
+                     diagnostics_n=5, iters=50)
+    names = {d["name"]: d for d in rec.diagnostics}
+    assert set(names) == {"coherence", "exclusivity"}
+    for d in rec.diagnostics:
+        assert d["kind"] == "computed_evidence"
+        assert d["params"] == {"n": 5}
+        assert isinstance(d["value"], float)
+
+
+def test_unknown_diagnostic_rejected(fitted):
+    corpus, model = fitted
+    with pytest.raises(ValueError, match="unknown diagnostic"):
+        record_fit(model, corpus, diagnostics=["not_a_diagnostic"])
+
+
+def test_builtin_diagnostics_is_stable():
+    assert BUILTIN_DIAGNOSTICS == ("coherence", "exclusivity")
+
+
+def test_diagnostic_unavailable_is_recorded_not_dropped(fitted):
+    corpus, model = fitted
+
+    class _NoCoherence:
+        # A stand-in whose coherence() raises, like a cluster/neural model.
+        num_topics = 3
+        topic_word = model.topic_word
+        doc_topic = model.doc_topic
+
+        def coherence(self, n):
+            raise NotImplementedError("no coherence for this model")
+
+    rec = record_fit(_NoCoherence(), corpus, diagnostics=["coherence"], iters=50)
+    entry = rec.diagnostics[0]
+    assert entry["name"] == "coherence"
+    assert entry["value"] is None
+    assert "unavailable for this model" in entry["note"]
+
+
+def test_manual_add_diagnostic_still_works(fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, iters=50)
+    rec.add_diagnostic("custom", 0.42)
+    assert rec.diagnostics[-1] == {"name": "custom", "value": 0.42,
+                                   "kind": "computed_evidence"}
 
 
 # -- comparison: two manifests (V2) ----------------------------------------


### PR DESCRIPTION
Next V2 increment (after V1 #395, render #396, compare #397).

## What
`record_fit(..., diagnostics=["coherence", "exclusivity"])` computes those topic-quality metrics from the fitted model and records each as **computed evidence** (mean over topics, with the top-N used). `diagnostics_n=` sets N (default 10).

```python
rec = topica.record_fit(model, corpus, diagnostics=["coherence", "exclusivity"], iters=1000)
```

## Honest by construction
- An **unknown name** raises with the allowed set (`BUILTIN_DIAGNOSTICS`, the frozen supported set).
- A metric **not defined for the model** (e.g. coherence on a cluster/neural model) is recorded as `value=None` with a note (`"unavailable for this model: …"`), not silently dropped — the same honest-omission discipline as the rest of the manifest.
- Everything is stamped `kind: "computed_evidence"`, so the card never presents it as a substantive conclusion.
- Manual `add_diagnostic(name, value)` (V1) is unchanged.

## Scope
Started with the two model-only STM-style metrics (`coherence`, `exclusivity`). Metrics needing extra inputs (perplexity → held-out, semantic_coherence → texts) are deliberately left out of the built-in set for now.

## Tests (`+5`, 44 total)
Capture + params, unknown-name rejection, frozen set, the unavailable→`None`+note path (via a stand-in whose `coherence()` raises), and that manual `add_diagnostic` still works.

## Gates
- Full pytest suite: **3360 passed, 30 skipped**.
- `mkdocs build --strict` clean; preflight green. Pure Python.

## Remaining V2 (lower value / more speculative)
Per-model-family `record_fit` settings adapters, and signed / content-addressed artifact bundles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)