### PR TITLE
feat(manifest): content-addressed analysis bundle (#394 V2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,12 +9,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 ### Added
 
 - **Content-addressed analysis bundle**: `AnalysisManifest.bundle(path, model=,
-  corpus=)` packages the manifest and the saved artifacts into one self-verifying
-  `.zip` — each artifact file is named by its BLAKE2b digest, and
-  `AnalysisManifest.load_bundle` verifies every artifact against its name and the
-  manifest reference (raising on a corrupt or tampered bundle).
-  `extract_bundle(path, dest)` recovers the artifacts for reloading. Bundling the
-  corpus is opt-in and sensitive (it embeds raw tokens).
+  corpus=)` packages the manifest and the saved artifacts into one `.zip` — each
+  artifact file is named by its BLAKE2b digest. `bundle` refuses to package a
+  model/corpus whose fingerprints do not match the manifest (the wrong fit), and
+  `AnalysisManifest.load_bundle` checks every artifact against its content-addressed
+  name and the manifest reference, raising on a corrupt bundle or artifacts that no
+  longer match. This is an integrity/content-addressing guarantee, not authenticity
+  (detecting a fully rewritten bundle needs a signature). `extract_bundle(path,
+  dest)` recovers the artifacts for reloading. Bundling the corpus is opt-in and
+  sensitive (it embeds raw tokens).
 - **Built-in diagnostic capture** for the manifest:
   `record_fit(..., diagnostics=["coherence", "exclusivity"])` computes those
   topic-quality metrics and records each as computed evidence (mean over topics),

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- **Content-addressed analysis bundle**: `AnalysisManifest.bundle(path, model=,
+  corpus=)` packages the manifest and the saved artifacts into one self-verifying
+  `.zip` — each artifact file is named by its BLAKE2b digest, and
+  `AnalysisManifest.load_bundle` verifies every artifact against its name and the
+  manifest reference (raising on a corrupt or tampered bundle).
+  `extract_bundle(path, dest)` recovers the artifacts for reloading. Bundling the
+  corpus is opt-in and sensitive (it embeds raw tokens).
 - **Built-in diagnostic capture** for the manifest:
   `record_fit(..., diagnostics=["coherence", "exclusivity"])` computes those
   topic-quality metrics and records each as computed evidence (mean over topics),

--- a/docs/api/manifest.md
+++ b/docs/api/manifest.md
@@ -80,11 +80,16 @@ record.bundle("analysis.zip", model=model)                 # manifest + model
 record.bundle("analysis.zip", model=model, corpus=corpus, include_corpus=True)
 ```
 
-`AnalysisManifest.load_bundle(path)` reloads the manifest and **verifies every
-artifact's bytes** against its content-addressed name and the manifest reference,
-raising on a corrupt or tampered bundle. `AnalysisManifest.extract_bundle(path,
-dest)` writes the artifacts out so you can reload them (`topica.LDA.load(...)`).
-Bundling the corpus is opt-in and **sensitive** — it embeds the raw tokens.
+`bundle` refuses to package a model or corpus whose fingerprints do not match the
+manifest (guarding against bundling the wrong fit). `AnalysisManifest.load_bundle(path)`
+reloads the manifest and **checks every artifact's bytes** against its
+content-addressed name and the manifest reference, raising on a corrupt bundle or
+artifacts that no longer match. This is an integrity / content-addressing check,
+not authenticity — detecting a *fully rewritten* bundle (artifact, digest, and
+reference all changed together) needs a signature, which is tracked separately.
+`AnalysisManifest.extract_bundle(path, dest)` writes the artifacts out so you can
+reload them (`topica.LDA.load(...)`). Bundling the corpus is opt-in and
+**sensitive** — it embeds the raw tokens.
 
 ## The analysis card
 

--- a/docs/api/manifest.md
+++ b/docs/api/manifest.md
@@ -69,6 +69,23 @@ b = topica.AnalysisManifest.load("run-b.json")
 print(a.compare(b).summary())
 ```
 
+## Bundling the analysis
+
+`record.bundle(path, model=model, corpus=corpus)` writes a self-contained,
+**content-addressed** `.zip`: the manifest plus the saved artifacts, each file
+named by its own hash, as one shareable, self-verifying unit.
+
+```python
+record.bundle("analysis.zip", model=model)                 # manifest + model
+record.bundle("analysis.zip", model=model, corpus=corpus, include_corpus=True)
+```
+
+`AnalysisManifest.load_bundle(path)` reloads the manifest and **verifies every
+artifact's bytes** against its content-addressed name and the manifest reference,
+raising on a corrupt or tampered bundle. `AnalysisManifest.extract_bundle(path,
+dest)` writes the artifacts out so you can reload them (`topica.LDA.load(...)`).
+Bundling the corpus is opt-in and **sensitive** — it embeds the raw tokens.
+
 ## The analysis card
 
 `record.render(path)` writes a self-contained HTML **analysis card**, and

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -62,6 +62,7 @@ SCHEMA = "topica.manifest"
 SCHEMA_VERSION = 1
 FINGERPRINT_SPEC = "fp1"
 HASH_ALGORITHM = "blake2b-256"
+BUNDLE_VERSION = 1
 _DIGEST_SIZE = 32
 _CANONICAL_NAN = 0x7FF8000000000000
 
@@ -474,6 +475,93 @@ class AnalysisManifest:
         """Render the manifest as a Markdown analysis card (Quarto/notebook)."""
         return _render_markdown(self, verification=verification)
 
+    # -- content-addressed bundle (V2) ------------------------------------
+
+    def bundle(self, path: str, *, model=None, corpus=None,
+               include_model: bool = True, include_corpus: bool = False) -> str:
+        """Write a self-contained, content-addressed bundle (a ``.zip``).
+
+        The bundle packages this manifest with the saved artifacts as one
+        shareable, self-verifying unit::
+
+            manifest.json            this manifest, plus artifact references
+            artifacts/<digest>.tt    model.save() / corpus.save(), named by hash
+
+        Each artifact's file name is its BLAKE2b digest, and the manifest's
+        ``model`` / ``corpus`` blocks gain an ``artifact`` reference, so
+        :meth:`load_bundle` can prove nothing was corrupted or swapped.
+
+        ``include_corpus`` is opt-in and **sensitive**: a bundled corpus embeds
+        the raw tokens (a hash is not anonymisation). Pass the fitted ``model`` /
+        ``corpus`` objects to bundle them (the manifest itself holds only
+        fingerprints, not the objects). The *file* digest here proves "this exact
+        saved file"; it is distinct from the corpus *content* fingerprint, which
+        proves corpus identity across save-format versions.
+        """
+        import copy
+        import zipfile
+
+        d = copy.deepcopy(self.to_dict())
+        d["bundle"] = {"version": BUNDLE_VERSION, "hash_algorithm": HASH_ALGORITHM}
+        with zipfile.ZipFile(path, "w", zipfile.ZIP_DEFLATED) as zf:
+            if include_model:
+                d["model"]["artifact"] = _add_artifact(zf, model, "model")
+            if include_corpus:
+                ref = _add_artifact(zf, corpus, "corpus")
+                ref["sensitive"] = True
+                d["corpus"]["artifact"] = ref
+            zf.writestr("manifest.json",
+                        json.dumps(d, indent=2, sort_keys=True, ensure_ascii=False))
+        return path
+
+    @classmethod
+    def load_bundle(cls, path: str) -> "AnalysisManifest":
+        """Load a bundle written by :meth:`bundle`, verifying artifact integrity.
+
+        Recomputes each bundled artifact's digest and checks it against both the
+        content-addressed file name and the manifest reference; a mismatch (a
+        corrupt or tampered bundle) raises ``ValueError``. Returns the manifest;
+        use :meth:`extract_bundle` to recover the artifacts for reloading.
+        """
+        import zipfile
+
+        with zipfile.ZipFile(path) as zf:
+            d = json.loads(zf.read("manifest.json").decode("utf-8"))
+            version = d.get("bundle", {}).get("version")
+            if version != BUNDLE_VERSION:
+                raise ValueError(
+                    f"unsupported bundle version {version!r} "
+                    f"(this build reads {BUNDLE_VERSION})")
+            for role in ("model", "corpus"):
+                art = d.get(role, {}).get("artifact")
+                if art:
+                    _verify_artifact(zf.read(art["path"]), art)
+        return cls.from_dict(d)
+
+    @staticmethod
+    def extract_bundle(path: str, dest_dir: str) -> dict:
+        """Extract a bundle's artifacts to ``dest_dir`` (verifying integrity).
+
+        Returns ``{"model": <path or None>, "corpus": <path or None>}``; reload
+        each with the matching class, e.g. ``topica.LDA.load(paths["model"])``.
+        """
+        import zipfile
+        from pathlib import Path
+
+        out = {"model": None, "corpus": None}
+        with zipfile.ZipFile(path) as zf:
+            d = json.loads(zf.read("manifest.json").decode("utf-8"))
+            for role in ("model", "corpus"):
+                art = d.get(role, {}).get("artifact")
+                if not art:
+                    continue
+                data = zf.read(art["path"])
+                _verify_artifact(data, art)
+                target = Path(dest_dir) / f"{role}.tt"
+                target.write_bytes(data)
+                out[role] = str(target)
+        return out
+
     def __repr__(self) -> str:
         return (f"AnalysisManifest(model={self.model.get('class')!r}, "
                 f"privacy={self.corpus.get('privacy')!r}, "
@@ -495,6 +583,48 @@ def _cmp_value(a, b) -> str:
     if b_has and not a_has:
         return "only_in_b"
     return "same" if a == b else "changed"
+
+
+def _hash_bytes(data: bytes) -> str:
+    """BLAKE2b-256 of raw bytes -- the file digest used for bundle artifacts.
+
+    Distinct from the fingerprint-v1 encoding (which is length-prefixed and
+    domain-tagged for structured inputs); a saved artifact is just its bytes.
+    """
+    return hashlib.blake2b(data, digest_size=_DIGEST_SIZE).hexdigest()
+
+
+def _save_to_bytes(obj, role: str) -> bytes:
+    import os
+    import tempfile
+
+    if obj is None:
+        raise ValueError(f"include_{role}=True requires the {role}= object to bundle it")
+    fd, tmp = tempfile.mkstemp(suffix=".tt")
+    os.close(fd)
+    try:
+        obj.save(tmp)
+        with open(tmp, "rb") as fh:
+            return fh.read()
+    finally:
+        os.unlink(tmp)
+
+
+def _add_artifact(zf, obj, role: str) -> dict:
+    data = _save_to_bytes(obj, role)
+    digest = _hash_bytes(data)
+    arc = f"artifacts/{digest}.tt"
+    if arc not in zf.namelist():  # dedupe if model and corpus somehow coincide
+        zf.writestr(arc, data)
+    return {"path": arc, "digest": digest, "algo": HASH_ALGORITHM}
+
+
+def _verify_artifact(data: bytes, art: dict) -> None:
+    digest = _hash_bytes(data)
+    if digest != art.get("digest") or not art.get("path", "").endswith(f"{digest}.tt"):
+        raise ValueError(
+            f"bundle artifact digest mismatch for {art.get('path')!r} "
+            f"(corrupt or tampered bundle)")
 
 
 def _cmp_fp(a: dict | None, b: dict | None) -> str:

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -489,7 +489,14 @@ class AnalysisManifest:
 
         Each artifact's file name is its BLAKE2b digest, and the manifest's
         ``model`` / ``corpus`` blocks gain an ``artifact`` reference, so
-        :meth:`load_bundle` can prove nothing was corrupted or swapped.
+        :meth:`load_bundle` can detect a corrupt bundle or one whose artifacts no
+        longer match the manifest. This is **integrity / content-addressing**, not
+        authenticity: it does not detect a fully rewritten bundle (artifact +
+        digest + reference all changed together) — that needs a signature (#404).
+
+        Before writing, the supplied ``model`` / ``corpus`` are checked against
+        this manifest's recorded fingerprints; a mismatch (the wrong fit) raises,
+        so a bundle's artifacts always match the analysis it documents.
 
         ``include_corpus`` is opt-in and **sensitive**: a bundled corpus embeds
         the raw tokens (a hash is not anonymisation). Pass the fitted ``model`` /
@@ -500,6 +507,17 @@ class AnalysisManifest:
         """
         import copy
         import zipfile
+
+        # Bind the artifacts to this manifest: refuse to bundle a model/corpus
+        # whose recorded fingerprints do not match (catches passing the wrong fit).
+        check = self.verify(corpus if include_corpus else None,
+                            model if include_model else None)
+        mismatched = sorted(k for k, v in check.fields.items()
+                            if v in ("input_changed", "artifact_changed"))
+        if mismatched:
+            raise ValueError(
+                f"the supplied model/corpus does not match this manifest "
+                f"(mismatched: {mismatched}); bundle the fit the manifest records")
 
         d = copy.deepcopy(self.to_dict())
         d["bundle"] = {"version": BUNDLE_VERSION, "hash_algorithm": HASH_ALGORITHM}
@@ -516,22 +534,18 @@ class AnalysisManifest:
 
     @classmethod
     def load_bundle(cls, path: str) -> "AnalysisManifest":
-        """Load a bundle written by :meth:`bundle`, verifying artifact integrity.
+        """Load a bundle written by :meth:`bundle`, checking artifact integrity.
 
         Recomputes each bundled artifact's digest and checks it against both the
-        content-addressed file name and the manifest reference; a mismatch (a
-        corrupt or tampered bundle) raises ``ValueError``. Returns the manifest;
-        use :meth:`extract_bundle` to recover the artifacts for reloading.
+        content-addressed file name and the manifest reference; a corrupt bundle
+        (or one whose artifacts no longer match the manifest) raises ``ValueError``.
+        This is an integrity check, not authenticity -- see :meth:`bundle`. Returns
+        the manifest; use :meth:`extract_bundle` to recover the artifacts.
         """
         import zipfile
 
         with zipfile.ZipFile(path) as zf:
-            d = json.loads(zf.read("manifest.json").decode("utf-8"))
-            version = d.get("bundle", {}).get("version")
-            if version != BUNDLE_VERSION:
-                raise ValueError(
-                    f"unsupported bundle version {version!r} "
-                    f"(this build reads {BUNDLE_VERSION})")
+            d = _read_bundle_manifest(zf)
             for role in ("model", "corpus"):
                 art = d.get(role, {}).get("artifact")
                 if art:
@@ -540,17 +554,18 @@ class AnalysisManifest:
 
     @staticmethod
     def extract_bundle(path: str, dest_dir: str) -> dict:
-        """Extract a bundle's artifacts to ``dest_dir`` (verifying integrity).
+        """Extract a bundle's artifacts to ``dest_dir`` (checking integrity).
 
         Returns ``{"model": <path or None>, "corpus": <path or None>}``; reload
         each with the matching class, e.g. ``topica.LDA.load(paths["model"])``.
+        Validates the bundle version and artifact digests, like :meth:`load_bundle`.
         """
         import zipfile
         from pathlib import Path
 
         out = {"model": None, "corpus": None}
         with zipfile.ZipFile(path) as zf:
-            d = json.loads(zf.read("manifest.json").decode("utf-8"))
+            d = _read_bundle_manifest(zf)
             for role in ("model", "corpus"):
                 art = d.get(role, {}).get("artifact")
                 if not art:
@@ -620,11 +635,25 @@ def _add_artifact(zf, obj, role: str) -> dict:
 
 
 def _verify_artifact(data: bytes, art: dict) -> None:
+    if art.get("algo") != HASH_ALGORITHM:
+        raise ValueError(f"unsupported artifact hash algorithm {art.get('algo')!r}")
     digest = _hash_bytes(data)
-    if digest != art.get("digest") or not art.get("path", "").endswith(f"{digest}.tt"):
+    # Content-addressed: the path must be exactly artifacts/<digest>.tt, and the
+    # reference digest must agree with the recomputed one.
+    if digest != art.get("digest") or art.get("path") != f"artifacts/{digest}.tt":
         raise ValueError(
-            f"bundle artifact digest mismatch for {art.get('path')!r} "
-            f"(corrupt or tampered bundle)")
+            f"bundle artifact integrity check failed for {art.get('path')!r} "
+            f"(corrupt bundle, or artifacts do not match the manifest)")
+
+
+def _read_bundle_manifest(zf) -> dict:
+    """Read + validate the bundle's manifest.json (shared by load/extract)."""
+    d = json.loads(zf.read("manifest.json").decode("utf-8"))
+    version = d.get("bundle", {}).get("version")
+    if version != BUNDLE_VERSION:
+        raise ValueError(
+            f"unsupported bundle version {version!r} (this build reads {BUNDLE_VERSION})")
+    return d
 
 
 def _cmp_fp(a: dict | None, b: dict | None) -> str:

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -12,6 +12,7 @@ import pytest
 import topica
 from topica.manifest import (
     BUILTIN_DIAGNOSTICS,
+    BUNDLE_VERSION,
     FINGERPRINT_SPEC,
     SCHEMA,
     SCHEMA_VERSION,
@@ -238,6 +239,124 @@ def test_manifest_is_valid_json(fitted):
     corpus, model = fitted
     d = json.loads(record_fit(model, corpus, iters=50).to_json())
     assert d["schema"] == SCHEMA and d["fingerprint_spec"] == FINGERPRINT_SPEC
+
+
+# -- content-addressed bundle (V2) -----------------------------------------
+
+
+def test_bundle_layout_is_content_addressed(tmp_path, fitted):
+    import json
+    import zipfile
+
+    corpus, model = fitted
+    rec = record_fit(model, corpus, iters=50)
+    p = tmp_path / "a.zip"
+    rec.bundle(str(p), model=model)
+    with zipfile.ZipFile(p) as zf:
+        names = zf.namelist()
+        assert "manifest.json" in names
+        art = [n for n in names if n.startswith("artifacts/")]
+        assert len(art) == 1
+        d = json.loads(zf.read("manifest.json"))
+        assert d["bundle"]["version"] == BUNDLE_VERSION
+        ref = d["model"]["artifact"]
+        # The artifact's file name is its digest.
+        assert ref["path"] == f"artifacts/{ref['digest']}.tt"
+
+
+def test_load_bundle_round_trips_and_verifies(tmp_path, fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, content_fingerprint=True, iters=50)
+    p = tmp_path / "a.zip"
+    rec.bundle(str(p), model=model, corpus=corpus, include_corpus=True)
+    back = AnalysisManifest.load_bundle(str(p))
+    assert back.model["class"] == "LDA"
+    assert back.verify(corpus, model).ok
+
+
+def test_bundle_detects_tampering(tmp_path, fitted):
+    import zipfile
+
+    corpus, model = fitted
+    p = tmp_path / "a.zip"
+    record_fit(model, corpus, iters=50).bundle(str(p), model=model)
+    # Rewrite the zip with one artifact byte flipped.
+    with zipfile.ZipFile(p) as zf:
+        data = {n: zf.read(n) for n in zf.namelist()}
+    art = next(n for n in data if n.startswith("artifacts/"))
+    data[art] = data[art][:-1] + bytes([data[art][-1] ^ 1])
+    tampered = tmp_path / "tampered.zip"
+    with zipfile.ZipFile(tampered, "w") as zf:
+        for n, b in data.items():
+            zf.writestr(n, b)
+    with pytest.raises(ValueError, match="digest mismatch"):
+        AnalysisManifest.load_bundle(str(tampered))
+
+
+def test_bundle_corpus_is_opt_in_and_flagged_sensitive(tmp_path, fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, iters=50)
+    default = tmp_path / "default.zip"
+    rec.bundle(str(default), model=model)
+    assert AnalysisManifest.load_bundle(str(default)).corpus.get("artifact") is None
+    withc = tmp_path / "withc.zip"
+    rec.bundle(str(withc), model=model, corpus=corpus, include_corpus=True)
+    loaded = AnalysisManifest.load_bundle(str(withc))
+    assert loaded.corpus["artifact"]["sensitive"] is True
+
+
+def test_bundle_requires_the_object(tmp_path, fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, iters=50)
+    with pytest.raises(ValueError, match="requires the model="):
+        rec.bundle(str(tmp_path / "x.zip"))  # include_model default True, no model=
+
+
+def test_extract_bundle_reloads_artifacts(tmp_path, fitted):
+    corpus, model = fitted
+    p = tmp_path / "a.zip"
+    record_fit(model, corpus, iters=50).bundle(
+        str(p), model=model, corpus=corpus, include_corpus=True)
+    dest = tmp_path / "out"
+    dest.mkdir()
+    paths = AnalysisManifest.extract_bundle(str(p), str(dest))
+    reloaded = topica.LDA.load(paths["model"])
+    assert np.array_equal(reloaded.topic_word, model.topic_word)
+    assert topica.Corpus.load(paths["corpus"]).num_docs == corpus.num_docs
+
+
+def test_bundle_file_digest_distinct_from_content_fingerprint(tmp_path, fitted):
+    import json
+    import zipfile
+
+    corpus, model = fitted
+    rec = record_fit(model, corpus, content_fingerprint=True, iters=50)
+    p = tmp_path / "a.zip"
+    rec.bundle(str(p), model=model, corpus=corpus, include_corpus=True)
+    with zipfile.ZipFile(p) as zf:
+        d = json.loads(zf.read("manifest.json"))
+    # The saved-file digest and the content fingerprint are different notions.
+    assert d["corpus"]["artifact"]["digest"] != d["corpus"]["fingerprint"]["digest"]
+
+
+def test_unknown_bundle_version_rejected(tmp_path, fitted):
+    import json
+    import zipfile
+
+    corpus, model = fitted
+    p = tmp_path / "a.zip"
+    record_fit(model, corpus, iters=50).bundle(str(p), model=model)
+    with zipfile.ZipFile(p) as zf:
+        data = {n: zf.read(n) for n in zf.namelist()}
+    d = json.loads(data["manifest.json"])
+    d["bundle"]["version"] = 999
+    data["manifest.json"] = json.dumps(d).encode("utf-8")
+    future = tmp_path / "future.zip"
+    with zipfile.ZipFile(future, "w") as zf:
+        for n, b in data.items():
+            zf.writestr(n, b)
+    with pytest.raises(ValueError, match="bundle version"):
+        AnalysisManifest.load_bundle(str(future))
 
 
 # -- built-in diagnostic capture (V2) --------------------------------------

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -274,23 +274,54 @@ def test_load_bundle_round_trips_and_verifies(tmp_path, fitted):
     assert back.verify(corpus, model).ok
 
 
-def test_bundle_detects_tampering(tmp_path, fitted):
+def test_bundle_detects_corrupt_artifact(tmp_path, fitted):
     import zipfile
 
     corpus, model = fitted
     p = tmp_path / "a.zip"
     record_fit(model, corpus, iters=50).bundle(str(p), model=model)
-    # Rewrite the zip with one artifact byte flipped.
+    # Rewrite the zip with one artifact byte flipped (leaving the manifest ref).
     with zipfile.ZipFile(p) as zf:
         data = {n: zf.read(n) for n in zf.namelist()}
     art = next(n for n in data if n.startswith("artifacts/"))
     data[art] = data[art][:-1] + bytes([data[art][-1] ^ 1])
-    tampered = tmp_path / "tampered.zip"
-    with zipfile.ZipFile(tampered, "w") as zf:
+    corrupt = tmp_path / "corrupt.zip"
+    with zipfile.ZipFile(corrupt, "w") as zf:
         for n, b in data.items():
             zf.writestr(n, b)
-    with pytest.raises(ValueError, match="digest mismatch"):
-        AnalysisManifest.load_bundle(str(tampered))
+    with pytest.raises(ValueError, match="integrity check failed"):
+        AnalysisManifest.load_bundle(str(corrupt))
+
+
+def test_bundle_rejects_a_model_that_does_not_match(tmp_path, fitted):
+    corpus, model = fitted
+    rec = record_fit(model, corpus, iters=50)
+    wrong = topica.LDA(4, seed=123)  # a different fit
+    wrong.fit(corpus, iters=50)
+    with pytest.raises(ValueError, match="does not match this manifest"):
+        rec.bundle(str(tmp_path / "x.zip"), model=wrong)
+
+
+def test_extract_bundle_validates_version(tmp_path, fitted):
+    import json
+    import zipfile
+
+    corpus, model = fitted
+    p = tmp_path / "a.zip"
+    record_fit(model, corpus, iters=50).bundle(str(p), model=model)
+    with zipfile.ZipFile(p) as zf:
+        data = {n: zf.read(n) for n in zf.namelist()}
+    d = json.loads(data["manifest.json"])
+    d["bundle"]["version"] = 999
+    data["manifest.json"] = json.dumps(d).encode("utf-8")
+    future = tmp_path / "future.zip"
+    with zipfile.ZipFile(future, "w") as zf:
+        for n, b in data.items():
+            zf.writestr(n, b)
+    dest = tmp_path / "out"
+    dest.mkdir()
+    with pytest.raises(ValueError, match="bundle version"):
+        AnalysisManifest.extract_bundle(str(future), str(dest))
 
 
 def test_bundle_corpus_is_opt_in_and_flagged_sensitive(tmp_path, fitted):


### PR DESCRIPTION
Closes #403. Next V2 increment (after V1 #395, render #396, compare #397, diagnostics #398).

## What
`AnalysisManifest.bundle(path, model=model, corpus=corpus)` packages the manifest and the saved artifacts into one self-contained, **content-addressed** `.zip` — a single shareable, self-verifying unit.

```python
record.bundle("analysis.zip", model=model)                                  # manifest + model
record.bundle("analysis.zip", model=model, corpus=corpus, include_corpus=True)
```
produces (stdlib `zipfile`, no dependency):
```
manifest.json            the manifest, plus artifact references
artifacts/<digest>.tt    model.save() / corpus.save(), file named by its hash
```

## Content-addressed + tamper-evident
Each artifact's **file name is its BLAKE2b digest**, and the manifest's model/corpus blocks gain an `artifact` reference. `AnalysisManifest.load_bundle(path)` recomputes every artifact's digest and checks it against *both* the content-addressed name and the reference, **raising on a corrupt or tampered bundle** (tested: flipping one byte is caught). `extract_bundle(path, dest)` writes the artifacts out so you can `topica.LDA.load(...)` them.

## Design points
- Since the manifest holds only fingerprints (not the objects), you **pass the fitted `model`/`corpus`** to `bundle()`, mirroring `verify(corpus, model)`.
- **`include_corpus` opt-in and sensitive** — a bundled corpus embeds raw tokens; off by default, flagged `sensitive: true`.
- The **file digest** ("this exact saved file") is kept **distinct from the content fingerprint** ("same corpus across save-format versions"); both are recorded.
- `BUNDLE_VERSION` guards the layout; an unknown version is rejected on load.

## Tests (`+8`, 56 total in the file)
Content-addressed layout, round-trip + `verify`, tamper detection, corpus opt-in + sensitive flag, requires-the-object error, extract + reload (reloaded `topic_word` matches), file-digest-vs-content-fingerprint distinct, unknown-version rejection.

## Gates
- Full pytest suite: **3368 passed, 30 skipped**.
- `mkdocs build --strict` clean; preflight green. Pure Python.

## V2 status
render (#396), compare (#397), diagnostics (#398) merged; this closes the bundle (#403). The only remaining manifest item is signing/tamper-evidence (#404), deferred by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)