### PR TITLE
feat(models): expose model `seed` and `Corpus.preprocessing` for provenance (#399)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- **`model.seed` and `Corpus.preprocessing` getters** (#399): every model now
+  exposes the `seed` it was constructed with, and a `Corpus` exposes the
+  vocabulary-filtering parameters Topica applied — `min_doc_freq`,
+  `max_doc_fraction`, `min_cf`, `rm_top` — as a dict (`None` for a corpus loaded
+  from disk, where they are not persisted). The analysis manifest now records both
+  the seed and the preprocessing, which it previously could not read back.
+
 - **Content-addressed analysis bundle**: `AnalysisManifest.bundle(path, model=,
   corpus=)` packages the manifest and the saved artifacts into one `.zip` — each
   artifact file is named by its BLAKE2b digest. `bundle` refuses to package a

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -111,6 +111,12 @@ def window_cooccurrence(
 class Corpus:
     """A preprocessed token corpus for LDA training."""
 
+    @property
+    def preprocessing(self) -> dict | None:
+        """The vocabulary-filtering parameters Topica applied when this corpus
+        was built (min_doc_freq/max_doc_fraction/min_cf/rm_top), or None after load."""
+        ...
+
     @staticmethod
     def from_documents(
         documents: list[list[str]],
@@ -226,6 +232,11 @@ class DMR:
     features: alpha_{d,t} = exp(lambda_t . x_d). After fitting, the learned
     weights are in `feature_effects`.
     """
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -400,6 +411,11 @@ class CTM:
     correlate (unlike LDA's Dirichlet). Fit by variational EM (STM's Laplace
     E-step)."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -550,6 +566,11 @@ class STM:
     """Structural Topic Model (Roberts, Stewart & Tingley): the correlated-topic
     core (CTM) plus prevalence covariates — the prior topic mean is a regression
     on document covariates (mu_d = X_d gamma)."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -759,6 +780,11 @@ class STS:
     modulates the topic-word distribution, with both prevalence and sentiment
     driven by document covariates. Fit by Laplace variational EM."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -898,6 +924,11 @@ class HDP:
     2006): the nonparametric LDA that *infers* the number of topics rather than
     fixing K. Fit by the direct-assignment Gibbs sampler (Chinese Restaurant
     Franchise). The inferred topic count is read from `num_topics` after fit."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -1045,6 +1076,11 @@ class DTM:
     gensim's LdaSeqModel). Query a topic's distribution at a slice with
     topic_word(time) and a word's trajectory with word_evolution(topic, word)."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -1141,6 +1177,11 @@ class DETM:
     supply the word embeddings rho like ETM. The headline output is the time-varying
     topic-word tensor beta_over_time (num_times, num_topics, vocab); topic_word is its
     mean over time."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -1271,6 +1312,11 @@ class SupervisedLDA:
     real-valued response y_d ~ N(eta^T zbar_d, sigma^2) regressed on its topic
     usage. Topics are shaped to predict the response; `coefficients` (eta) report
     how each topic moves y. Fit by variational EM; `predict` scores new docs."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(self, num_topics: int, *, alpha: float = 0.1, seed: int = 42) -> None:
         """num_topics >= 2. alpha is the Dirichlet concentration on doc-topic
@@ -1409,6 +1455,11 @@ class SAGE:
     """Content-covariate topic model (SAGE / the STM content model). Topics are
     shared but each topic's word distribution varies by a document-level group
     covariate, so you can read how a topic is worded differently across groups."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -1556,6 +1607,11 @@ class LabeledLDA:
     """Labeled LDA (Ramage et al. 2009): supervised topics constrained to each
     document's label set. The number of topics equals the number of labels."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self, *, alpha: float = 0.1, beta: float = 0.01, seed: int = 42,
         sampler: str = "sparse",
@@ -1691,6 +1747,11 @@ class LabeledLDA:
 
 class LDA:
     """Sparse LDA topic model (MALLET's algorithm) implemented in Rust."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -1997,6 +2058,11 @@ class PT:
     documents into `num_pseudo` pseudo-documents so LDA-style mixed membership is
     estimable on short, sparse texts. Fit by collapsed Gibbs."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -2087,6 +2153,11 @@ class GSDMM:
     an upper bound K (`num_topics`); empty clusters die out, so the effective
     number of topics is read from `num_topics` after fit."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -2163,6 +2234,11 @@ class BTM:
     per-topic word distributions from the corpus's biterms -- unordered word pairs
     co-occurring within a window. `alpha` defaults to 50/num_topics."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -2226,6 +2302,11 @@ class PolylingualLDA:
     `beta` the topic-word prior applied to every language (default 0.01); with
     `optimize_alpha` the asymmetric alpha.m prior is re-estimated every
     `optimize_interval` Gibbs iterations after an `optimize_burn_in` warm-up."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -2310,6 +2391,11 @@ class DiscLDA:
     class-carrying document representation (`transform`/`predict`). Fixed
     block-transform variant (paper section 4.1)."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         k_class: int,
@@ -2385,6 +2471,11 @@ class PA:
     """Pachinko Allocation Model (Li & McCallum 2006): a DAG of `num_super`
     super-topics over `num_sub` shared sub-topics over words, capturing topic
     correlations. `super_sub` reports which sub-topics each super-topic groups."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -2486,6 +2577,11 @@ class HLDA:
     the nested Chinese Restaurant Process. Each document follows a root-to-leaf
     path; general words sit near the root, specific words near the leaves."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         *,
@@ -2552,6 +2648,11 @@ class SeededLDA:
     vocabulary and any `residual` unseeded topics are still learned. Seeding
     follows the seededlda package (seed words get a `weight * 100` prior
     pseudocount in their topic, plus seeded initialization)."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -2666,6 +2767,11 @@ class Top2Vec:
     bring the embeddings; the topic count is discovered, not set. No embedder of
     your own? ``topica.llm_embed(texts, model=...)`` builds the matrix."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         *,
@@ -2760,6 +2866,11 @@ class BERTopic:
     to a target; `doc_topic` is the approximate distribution. You bring the
     document embeddings; the topic count is discovered (before any reduction).
     No embedder of your own? ``topica.llm_embed(texts, model=...)`` builds it."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -2858,6 +2969,11 @@ class ETM:
     autoencoder, which scales to large corpora and maps new documents with a single
     encoder pass. Neither uses PyTorch. No embedder of your own?
     ``topica.llm_embed(vocabulary, model=...)`` builds the word embeddings rho."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -2964,6 +3080,11 @@ class InfoCTM:
     bilingual ``dictionary`` (optionally densified by per-language ``embeddings``).
     After fitting, topic ``k`` denotes the same theme in both languages."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -3026,6 +3147,11 @@ class ProdLDA:
     minibatch Adam on the ELBO; batch normalization and high-momentum Adam guard
     against component collapse. Unlike ETM you bring no embeddings: beta is learned
     directly. New documents transform with a single encoder forward pass."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -3117,6 +3243,11 @@ class Scholar:
     is the fitted covariate-by-topic prevalence matrix. Covariates also enter the
     encoder. Built on topica's ProdLDA backbone. Reference implementation:
     dallascard/scholar (Apache-2.0)."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -3239,6 +3370,11 @@ class CombinedTM:
     (num_docs, E) array, aligned to the documents. Reference implementation:
     contextualized-topic-models (Bianchi et al., MIT)."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -3334,6 +3470,11 @@ class ZeroShotTM:
     another. Bring the embeddings at fit() as a (num_docs, E) array, aligned to the
     documents. Reference implementation: contextualized-topic-models (Bianchi et
     al., MIT)."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -3434,6 +3575,11 @@ class NMF:
     is each row of H normalized to sum 1; the document-topic matrix is each row of
     W normalized to sum 1."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -3506,6 +3652,11 @@ class LSA:
     coordinates; rows do not sum to 1). singular_values (K) is Sigma_k. A
     deterministic svd_flip sign convention matches scikit-learn's output."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -3569,6 +3720,11 @@ class TensorLDA:
     """Online Tensor LDA (TensorLDA) topic model (Kangaslahti et al. 2026).
     Method-of-moments topic modeling using second and third-order cumulants.
     Gated behind `topica.enable_experimental()`."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -3638,6 +3794,11 @@ class FASTopic:
     transport costs. Held-out documents are mapped by a distance-softmax over the
     fitted topic embeddings, so `transform` needs only their embeddings. No
     embedder of your own? ``topica.llm_embed(texts, model=...)`` builds it."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -3726,6 +3887,11 @@ class KeyATM:
     a distribution over only that topic's keywords or from its full distribution,
     anchoring keyword topics to their keywords. `num_topics` may exceed the number
     of keyword topics to add regular, no-keyword topics."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -3994,6 +4160,11 @@ class IdealPointTM:
     pass them and it is factored through word embeddings, as in ETM. Both are the
     same model. Gated behind topica.enable_experimental()."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -4126,6 +4297,11 @@ class Wordfish:
     companion to IdealPointTM. The fit is deterministic. Validated against R
     quanteda's textmodel_wordfish (parity/wordfish_r_compare.py)."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         *,
@@ -4197,6 +4373,11 @@ class IdealPointSentenceTM:
     (e ~ N(mu_k + x_a . V_k, sigma^2)); ||V_k|| is the topic's discrimination. The
     sentence-embedding sibling of IdealPointTM, fit by EM. Gated behind
     topica.enable_experimental()."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,
@@ -4273,6 +4454,11 @@ class TBIP:
     from unlabeled text. Validated by planted-position recovery and a PyTorch
     reference (parity/tbip_parity.py)."""
 
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
+
     def __init__(
         self,
         num_topics: int,
@@ -4348,6 +4534,11 @@ class PartyEmbeddings:
     Implemented from Mikolov et al. (2013) and Le & Mikolov (2014); validated by
     planted-position recovery and correlation against the gensim reference
     (parity/party_embeddings_compare.py)."""
+
+    @property
+    def seed(self) -> int:
+        """The random seed the model was constructed with."""
+        ...
 
     def __init__(
         self,

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -826,15 +826,12 @@ def _length_summary(lengths: np.ndarray) -> dict[str, Any]:
 
 
 def _preprocessing(corpus) -> dict[str, Any]:
-    # Only parameters Topica itself applied and can observe. Preprocessing done
-    # outside Topica is not visible here (a fingerprint proves identity, not
-    # provenance).
-    out: dict[str, Any] = {}
-    for name in ("min_doc_freq", "max_doc_fraction", "min_cf", "rm_top"):
-        val = getattr(corpus, name, None)
-        if val is not None:
-            out[name] = _jsonable(val)
-    return out
+    # Only the parameters Topica itself applied and recorded on the corpus
+    # (min_doc_freq/max_doc_fraction/min_cf/rm_top); None for a corpus loaded from
+    # disk. Preprocessing done outside Topica is not visible here (a fingerprint
+    # proves identity, not provenance).
+    prep = getattr(corpus, "preprocessing", None)
+    return {k: _jsonable(v) for k, v in prep.items()} if prep else {}
 
 
 # --------------------------------------------------------------------------

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -91,6 +91,12 @@ fn map_to_vocab(corpus: &corpus::Corpus, data: &Bound<'_, PyAny>) -> PyResult<Ve
 
 #[pymethods]
 impl BTM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted BTM model. `alpha` defaults to `50 / num_topics`
     /// (the reference default), `beta` to `0.01`, `window` to 15.
     #[new]

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -9,10 +9,22 @@ use std::path::Path;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
+use pyo3::types::PyDict;
 
 use super::build_corpus_from_docs;
 use super::error::io_err;
 use crate::corpus::{self, InputFormat, LoadOptions};
+
+/// The vocabulary-filtering parameters Topica applied when building a corpus.
+/// Recorded so a fitted corpus can report how it was preprocessed (issue #399).
+/// `None` on a corpus loaded from disk, where the parameters were not persisted.
+#[derive(Clone)]
+pub(crate) struct PrepInfo {
+    pub min_doc_freq: u32,
+    pub max_doc_fraction: f64,
+    pub min_cf: u32,
+    pub rm_top: usize,
+}
 
 /// A preprocessed, integer-encoded document collection.
 ///
@@ -29,6 +41,8 @@ pub struct Corpus {
     // Optional per-document metadata (e.g. a pandas DataFrame), already filtered
     // to the surviving rows. Round-tripped as a plain Python object.
     metadata: Option<PyObject>,
+    // The preprocessing parameters Topica applied, when known (None after load).
+    preprocessing: Option<PrepInfo>,
 }
 
 // Manual Clone: PyObject needs the GIL to bump its refcount, so it can't derive.
@@ -38,6 +52,7 @@ impl Clone for Corpus {
             inner: self.inner.clone(),
             kept_indices: self.kept_indices.clone(),
             metadata: self.metadata.as_ref().map(|m| m.clone_ref(py)),
+            preprocessing: self.preprocessing.clone(),
         })
     }
 }
@@ -89,6 +104,12 @@ impl Corpus {
             inner,
             kept_indices,
             metadata: None,
+            preprocessing: Some(PrepInfo {
+                min_doc_freq,
+                max_doc_fraction,
+                min_cf,
+                rm_top,
+            }),
         })
     }
 
@@ -146,6 +167,12 @@ impl Corpus {
             inner,
             kept_indices,
             metadata: None,
+            preprocessing: Some(PrepInfo {
+                min_doc_freq,
+                max_doc_fraction,
+                min_cf: 0,
+                rm_top: 0,
+            }),
         })
     }
 
@@ -159,6 +186,8 @@ impl Corpus {
             inner,
             kept_indices,
             metadata: None,
+            // Not persisted in the corpus save format; unknown after load.
+            preprocessing: None,
         })
     }
 
@@ -244,6 +273,24 @@ impl Corpus {
     #[setter]
     fn set_metadata(&mut self, value: Option<PyObject>) {
         self.metadata = value;
+    }
+
+    /// The vocabulary-filtering parameters Topica applied when this corpus was
+    /// built (``min_doc_freq``, ``max_doc_fraction``, ``min_cf``, ``rm_top``), as
+    /// a dict. ``None`` for a corpus loaded from disk, where they are not stored.
+    #[getter]
+    fn preprocessing<'py>(&self, py: Python<'py>) -> PyResult<Option<Bound<'py, PyDict>>> {
+        match &self.preprocessing {
+            None => Ok(None),
+            Some(p) => {
+                let d = PyDict::new_bound(py);
+                d.set_item("min_doc_freq", p.min_doc_freq)?;
+                d.set_item("max_doc_fraction", p.max_doc_fraction)?;
+                d.set_item("min_cf", p.min_cf)?;
+                d.set_item("rm_top", p.rm_top)?;
+                Ok(Some(d))
+            }
+        }
     }
 
     #[getter]

--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -115,6 +115,12 @@ fn map_to_vocab(corpus: &corpus::Corpus, data: &Bound<'_, PyAny>) -> PyResult<Ve
 
 #[pymethods]
 impl DiscLDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted DiscLDA. `k_class` is the number of class-specific topics
     /// per class, `k_shared` the number of shared topics; the total topic count is
     /// `num_classes * k_class + k_shared`, with `num_classes` taken from the labels

--- a/src/python/embedding_cluster.rs
+++ b/src/python/embedding_cluster.rs
@@ -96,6 +96,12 @@ impl Top2Vec {
 
 #[pymethods]
 impl Top2Vec {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `n_components` is the reduced dimensionality
     /// before clustering. `clusterer` is `"hdbscan"` (default; discovers the topic
     /// count, leaves a `-1` noise bucket — `min_cluster_size`/`min_samples` are
@@ -751,6 +757,12 @@ impl BERTopic {
 
 #[pymethods]
 impl BERTopic {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `nr_topics` (optional) reduces the discovered
     /// topics to that many by merging the most c-TF-IDF-similar; `window`/`stride`
     /// parameterize the soft `doc_topic` distribution.

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -88,6 +88,12 @@ impl PA {
 
 #[pymethods]
 impl PA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model with `num_super` super-topics and `num_sub`
     /// sub-topics (the sub-topics are the word-level topics).
     /// `alpha` is the symmetric Dirichlet prior on each document's distribution
@@ -487,6 +493,12 @@ impl HLDA {
 
 #[pymethods]
 impl HLDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `depth` is the (fixed) tree depth; `gamma` is
     /// the nested-CRP concentration (larger => more child topics); `beta` the
     /// topic-word Dirichlet; `alpha` the per-document level distribution.

--- a/src/python/idealpoint.rs
+++ b/src/python/idealpoint.rs
@@ -326,6 +326,12 @@ impl IdealPointTM {
 
 #[pymethods]
 impl IdealPointTM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `num_topics` is K (>= 2); `num_dims` is the
     /// dimensionality d of the latent ideal point (default 1). `prior_variance` is
     /// the Gaussian prior on the topic profiles (weak by default, as ETM);

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -857,6 +857,12 @@ impl LDA {
 
 #[pymethods]
 impl LDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model.
     ///
     /// `alpha_sum` is the total document-topic Dirichlet mass (default:
@@ -3364,6 +3370,12 @@ impl DMR {
 
 #[pymethods]
 impl DMR {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted DMR model. `prior_variance` is the Gaussian prior
     /// variance σ² on the feature weights λ (smaller = stronger shrinkage);
     /// `lbfgs_iters` caps the L-BFGS steps per optimization round.
@@ -4374,6 +4386,12 @@ impl LabeledLDA {
 
 #[pymethods]
 impl LabeledLDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `alpha` is the (symmetric) per-topic prior
     /// over a document's allowed topics.
     /// `beta` is the topic-word Dirichlet smoothing; `seed` seeds the Gibbs RNG.
@@ -5037,6 +5055,12 @@ impl SAGE {
 
 #[pymethods]
 impl SAGE {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `alpha` is the symmetric document-topic prior;
     /// `prior_variance` is the Gaussian prior on the κ content deviations.
     /// `num_topics` is the number of topics K; `seed` seeds the Gibbs RNG. The κ
@@ -5854,6 +5878,12 @@ impl CTM {
 
 #[pymethods]
 impl CTM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `sigma_shrink` ∈ [0,1] shrinks the topic
     /// covariance toward its diagonal each M-step (stabilizes Σ). `init` is
     /// ``"spectral"`` (default; deterministic anchor-word init, matching STM's
@@ -6594,6 +6624,12 @@ impl STM {
 
 #[pymethods]
 impl STM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `sigma_shrink` ∈ [0,1] shrinks Σ toward its
     /// diagonal each M-step. `init` is ``"spectral"`` (default; deterministic
     /// anchor-word init, matching STM's default — `seed` is then irrelevant for
@@ -8016,6 +8052,12 @@ impl STS {
 
 #[pymethods]
 impl STS {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `init` is ``"spectral"`` (default; deterministic
     /// anchor-word β init) or ``"random"`` (seeded).
     /// `num_topics` is the number of topics K; `seed` seeds the RNG.
@@ -8797,6 +8839,12 @@ impl HDP {
 
 #[pymethods]
 impl HDP {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `alpha`/`gamma` are the document- and
     /// corpus-level DP concentrations; `eta` is the topic-word Dirichlet (base
     /// measure). `gamma` is the dominant lever on the inferred topic count:
@@ -9360,6 +9408,12 @@ impl DTM {
 
 #[pymethods]
 impl DTM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `chain_variance` controls how much a topic may
     /// drift between adjacent slices (larger = freer to change; gensim's default
     /// is 0.005). `obs_variance` is the observation noise; `alpha` the Dirichlet
@@ -9797,6 +9851,12 @@ impl SupervisedLDA {
 
 #[pymethods]
 impl SupervisedLDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `alpha` is the symmetric Dirichlet
     /// concentration on document-topic proportions.
     /// `num_topics` is the number of topics K; `seed` seeds the RNG.
@@ -10370,6 +10430,12 @@ impl PT {
 
 #[pymethods]
 impl PT {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `num_pseudo` is the number of pseudo-documents
     /// short texts are aggregated into (more = finer, fewer = more aggregation).
     /// `num_topics` is the number of topics K; `alpha` is the document-topic
@@ -10751,6 +10817,12 @@ impl GSDMM {
 
 #[pymethods]
 impl GSDMM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `num_topics` is the *maximum* number of clusters
     /// `K`; the number actually used (non-empty after fitting) is reported by the
     /// `num_topics` getter and is usually smaller. `alpha` controls the pull
@@ -11169,6 +11241,12 @@ impl SeededLDA {
 
 #[pymethods]
 impl SeededLDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `seed_words` is ``{topic_name: [words]}``;
     /// `residual` adds that many extra unseeded topics. `weight` (default 0.01,
     /// matching the seededlda package) scales the seed prior. `alpha` is the
@@ -11915,6 +11993,12 @@ impl FASTopic {
 
 #[pymethods]
 impl FASTopic {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `lr` drives the full-batch Adam optimizer;
     /// `dt_alpha`/`tw_alpha` are the inverse entropic regularizations for the
     /// doc-topic and topic-word transport (reference defaults 3.0 and 2.0);
@@ -12351,6 +12435,12 @@ impl KeyATM {
 
 #[pymethods]
 impl KeyATM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `keywords` is ``{topic_name: [words]}`` (the
     /// keyword topics, in order). `num_topics` (default = number of keyword
     /// topics) may be larger to add regular, no-keyword topics. `alpha` is the

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -194,6 +194,12 @@ impl ETM {
 
 #[pymethods]
 impl ETM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `inference` selects the engine: `"em"` (default)
     /// is per-document variational EM, accurate but not minibatched; `"vae"` is the
     /// reference's amortized autoencoder, which scales to large corpora and maps new
@@ -847,6 +853,12 @@ impl DETM {
 
 #[pymethods]
 impl DETM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. ``delta`` is the random-walk standard-deviation
     /// knob on the topic-embedding and topic-prior trajectories (smaller = smoother
     /// drift; reference default 0.005). ``hidden_size`` is the document encoder
@@ -1442,6 +1454,12 @@ impl InfoCTM {
 
 #[pymethods]
 impl InfoCTM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `mi_weight` scales the alignment term (reference
     /// 30-50); `mi_temperature` is the InfoNCE temperature (0.2); `pos_threshold`
     /// is the cosine cutoff for the embedding-densified positive mask (0.4, used
@@ -1866,6 +1884,12 @@ impl ProdLDA {
 
 #[pymethods]
 impl ProdLDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `alpha` is the symmetric Dirichlet prior
     /// concentration (reference 1.0); `hidden_size` is the encoder width (reference
     /// 100); `dropout` is the dropout rate on the hidden layer and on `theta`;
@@ -2410,6 +2434,12 @@ macro_rules! ctm_embedding_model {
 
         #[pymethods]
         impl $name {
+            /// The random seed the model was constructed with.
+            #[getter]
+            fn seed(&self) -> u64 {
+                self.seed
+            }
+
             /// Create an unfitted model. `alpha` is the symmetric Dirichlet prior
             /// concentration (reference 1.0); `hidden_size` is the encoder width
             /// (reference 100); `dropout` is the dropout rate on the hidden layer

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -91,6 +91,12 @@ impl NMF {
 
 #[pymethods]
 impl NMF {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `num_topics` is K (2 <= K <= vocabulary size).
     /// `beta_loss` is `"frobenius"` (default) or `"kullback-leibler"` (alias
     /// `"kl"`). `init` is `"nndsvd"` (default, deterministic SVD-based init) or
@@ -418,6 +424,12 @@ impl LSA {
 
 #[pymethods]
 impl LSA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `num_topics` is K (2 <= K <= min(num_docs,
     /// vocabulary size)). `weighting` is `"tfidf"` (default, classic LSI) or
     /// `"count"` (raw term counts). `seed` seeds the randomized-SVD sketch.

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -102,6 +102,12 @@ fn standardize_columns(rows: &mut [Vec<f64>]) {
 
 #[pymethods]
 impl PartyEmbeddings {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted PartyEmbeddings model. `num_dims` is the number of
     /// placement dimensions returned in `author_positions` (the leading principal
     /// components of the party vectors; the first is the left-right scale).

--- a/src/python/pltm.rs
+++ b/src/python/pltm.rs
@@ -137,6 +137,12 @@ fn extract_languages(data: &Bound<'_, PyAny>) -> PyResult<(Vec<String>, Vec<Vec<
 
 #[pymethods]
 impl PolylingualLDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted PLTM. `alpha` is the per-topic document-topic prior
     /// (default `0.01`, the paper's `0.01·T` total with a uniform base measure).
     /// `beta` is the topic-word prior (default `0.01`); it is applied to every

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -246,6 +246,12 @@ impl Scholar {
 
 #[pymethods]
 impl Scholar {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted SCHOLAR. `covariates` (a `(num_docs, n_covars)` numeric
     /// matrix — numpy array, list of lists, or a numeric pandas/Polars frame) may be
     /// given here or at :meth:`fit`. `covariate_names` labels the covariate columns.

--- a/src/python/sentence_ideal.rs
+++ b/src/python/sentence_ideal.rs
@@ -55,6 +55,12 @@ impl IdealPointSentenceTM {
 
 #[pymethods]
 impl IdealPointSentenceTM {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `num_topics` is K (>= 2); `num_dims` the latent
     /// ideal-point dimensionality (default 1). `x_prior_variance` is the Gaussian
     /// prior on the positions (1.0 matches the unit-variance standardization).

--- a/src/python/tbip.rs
+++ b/src/python/tbip.rs
@@ -67,6 +67,12 @@ impl TBIP {
 
 #[pymethods]
 impl TBIP {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted model. `num_topics` is K (>= 2). `a_gamma`/`b_gamma` are
     /// the sparse-Gamma prior hyperparameters on theta and beta (default 0.3 each,
     /// as in the paper). `iters` is the number of SVI steps; `batch_size` the

--- a/src/python/tlda.rs
+++ b/src/python/tlda.rs
@@ -114,6 +114,12 @@ fn map_heldout(corpus: &corpus::Corpus, data: &Bound<'_, PyAny>) -> PyResult<Vec
 
 #[pymethods]
 impl TensorLDA {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted TensorLDA model.
     #[new]
     #[pyo3(signature = (num_topics, *, alpha_0=1.0, n_iter_train=100, n_iter_test=30,

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -60,6 +60,12 @@ impl Wordfish {
 
 #[pymethods]
 impl Wordfish {
+    /// The random seed the model was constructed with.
+    #[getter]
+    fn seed(&self) -> u64 {
+        self.seed
+    }
+
     /// Create an unfitted Wordfish model. `beta_prior_sd` / `theta_prior_sd` are the
     /// standard deviations of the weak Gaussian priors regularizing the word
     /// discriminations and the positions (pass `inf` for none); `min_count` drops

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -247,3 +247,25 @@ class TestRepr:
         docs = [["cat"]]
         c = Corpus.from_documents(docs)
         assert "Corpus" in repr(c)
+
+
+# ---------------------------------------------------------------------------
+# preprocessing parameters (issue #399)
+# ---------------------------------------------------------------------------
+
+class TestPreprocessingGetter:
+    def test_records_the_params_applied(self):
+        c = Corpus.from_documents(
+            [["a", "b", "c"], ["b", "c", "d"]],
+            min_doc_freq=1, max_doc_fraction=1.0, min_cf=0, rm_top=2)
+        assert c.preprocessing == {
+            "min_doc_freq": 1, "max_doc_fraction": 1.0, "min_cf": 0, "rm_top": 2}
+
+    def test_none_after_load(self, tmp_path):
+        c = Corpus.from_documents([["a", "b"], ["b", "c", "a"]])
+        assert c.preprocessing is not None
+        p = tmp_path / "c.tt"
+        c.save(str(p))
+        # The save format does not carry the params, so a loaded corpus is honest
+        # about not knowing them.
+        assert Corpus.load(str(p)).preprocessing is None

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -66,6 +66,24 @@ def test_minimal_default_leaks_no_content(fitted):
     assert set(prev) <= {"spec", "algo", "digest", "keyed", "kind", "n_rows", "columns"}
 
 
+def test_captures_seed_and_preprocessing(fitted):
+    # #399: models now expose `seed` and corpora expose `preprocessing`, so the
+    # manifest records both (they were previously null / empty).
+    corpus = topica.Corpus.from_documents(DOCS, min_doc_freq=1, rm_top=1)
+    model = topica.LDA(3, seed=99)
+    model.fit(corpus, iters=50)
+    rec = record_fit(model, corpus, privacy="aggregate", iters=50)
+    assert rec.model["seed"] == 99
+    assert rec.corpus["description"]["preprocessing"] == {
+        "min_doc_freq": 1, "max_doc_fraction": 1.0, "min_cf": 0, "rm_top": 1}
+
+
+def test_models_expose_seed(fitted):
+    for m in (topica.LDA(3, seed=11), topica.NMF(3, seed=11), topica.CTM(3, seed=11),
+              topica.CombinedTM(3, seed=11)):
+        assert m.seed == 11
+
+
 def test_no_raw_document_ids_or_metadata(fitted):
     corpus, model = fitted
     rec = record_fit(model, corpus, iters=50)


### PR DESCRIPTION
Closes #399. First of the model-side follow-ups from the analysis-manifest work, and Codex's recommended starting point.

## Why
Two of the most basic reproducibility inputs were *stored* but not *readable* off the objects, so the manifest could only record them as absent (`seed: null`, empty preprocessing).

## What
- **`model.seed` getter** on every model that takes a seed — all **37 seed-bearing pyclasses** (35 directly; CombinedTM/ZeroShotTM via their shared `ctm_embedding_model!` macro). `model.seed` now returns the constructed seed (was an AttributeError).
- **`Corpus.preprocessing`** — the `Corpus` now **retains** the vocabulary-filter params it applied (`min_doc_freq`/`max_doc_fraction`/`min_cf`/`rm_top`) and exposes them as a dict. `None` for a corpus loaded from disk (the save format doesn't carry them) — honest, not fabricated.
- **Manifest wiring** — `record_fit` now records the real seed and the preprocessing, closing the two gaps that motivated the issue.

## Design notes
- **No build change.** I evaluated pyo3's `multiple-pymethods` (would allow a one-line macro per model) but rejected it: it's a global build feature pulling in `inventory`'s linker-section tricks — exactly the kind of thing that bites Windows wheels. The getters live in the existing `#[pymethods]` blocks instead; the compiler verifies all 37.
- Stub synced across all 38 classes (`seed` + Corpus `preprocessing`).

## Tests
Corpus preprocessing getter (including `None`-after-load), manifest seed+preprocessing capture (the payoff: `seed: 99` where it was `null`), and seed exposure across a sample of models.

## Gates
- Full pytest suite: **3374 passed, 30 skipped**.
- clippy `-D warnings`, `cargo fmt`, preflight (incl. stub-sync), `mkdocs --strict` — all green.

Next in Codex's recommended order: **#400** (uniform `get_params()`), where the macro/trait single-source design from its review applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)