### PR TITLE
feat(models): uniform `model.settings` introspection across every model (#400)

### DIFF
--- a/docs/contributing/conventions.md
+++ b/docs/contributing/conventions.md
@@ -42,6 +42,15 @@ being `GDMR`) matches by construction rather than by memory.
 3. The Gibbs-sampler family shares a fixed keyword block, in this order:
    `iters, num_samples, sample_interval, progress, progress_interval,
    keep_theta_draws, num_theta_draws, convergence_tol, check_every`.
+4. **Every model exposes `model.settings`** — its constructor configuration as a
+   JSON-serialisable dict, keyword-named to match `__init__` (issue #400). It
+   reports the *effective* values in force (e.g. `num_threads` after its `max(1)`
+   floor; `sampler`/`init` as the canonical public string, not an internal flag),
+   and omits data/guidance inputs (`keywords`, `seed_words`, covariate arrays,
+   embeddings, LLM backends). `tests/test_model_settings.py` derives the expected
+   keys from each constructor signature, so a new parameter that is not surfaced in
+   `settings` fails the suite — there is no second inventory to maintain. The
+   analysis manifest (`record_fit`) reads this surface directly.
 
 ## Threads and stopping rules
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -232,6 +232,12 @@ class DMR:
     features: alpha_{d,t} = exp(lambda_t . x_d). After fitting, the learned
     weights are in `feature_effects`.
     """
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -410,6 +416,12 @@ class CTM:
     Topics drawn from a logistic-normal prior with full covariance, so they can
     correlate (unlike LDA's Dirichlet). Fit by variational EM (STM's Laplace
     E-step)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -566,6 +578,12 @@ class STM:
     """Structural Topic Model (Roberts, Stewart & Tingley): the correlated-topic
     core (CTM) plus prevalence covariates — the prior topic mean is a regression
     on document covariates (mu_d = X_d gamma)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -779,6 +797,12 @@ class STS:
     plus a per-document, per-topic continuous sentiment-discourse latent that
     modulates the topic-word distribution, with both prevalence and sentiment
     driven by document covariates. Fit by Laplace variational EM."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -924,6 +948,12 @@ class HDP:
     2006): the nonparametric LDA that *infers* the number of topics rather than
     fixing K. Fit by the direct-assignment Gibbs sampler (Chinese Restaurant
     Franchise). The inferred topic count is read from `num_topics` after fit."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -1075,6 +1105,12 @@ class DTM:
     Fit variationally with Kalman smoothing (a port of Blei's C dtm /
     gensim's LdaSeqModel). Query a topic's distribution at a slice with
     topic_word(time) and a word's trajectory with word_evolution(topic, word)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -1177,6 +1213,12 @@ class DETM:
     supply the word embeddings rho like ETM. The headline output is the time-varying
     topic-word tensor beta_over_time (num_times, num_topics, vocab); topic_word is its
     mean over time."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -1312,6 +1354,12 @@ class SupervisedLDA:
     real-valued response y_d ~ N(eta^T zbar_d, sigma^2) regressed on its topic
     usage. Topics are shaped to predict the response; `coefficients` (eta) report
     how each topic moves y. Fit by variational EM; `predict` scores new docs."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -1455,6 +1503,12 @@ class SAGE:
     """Content-covariate topic model (SAGE / the STM content model). Topics are
     shared but each topic's word distribution varies by a document-level group
     covariate, so you can read how a topic is worded differently across groups."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -1606,6 +1660,12 @@ class SAGE:
 class LabeledLDA:
     """Labeled LDA (Ramage et al. 2009): supervised topics constrained to each
     document's label set. The number of topics equals the number of labels."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -1747,6 +1807,12 @@ class LabeledLDA:
 
 class LDA:
     """Sparse LDA topic model (MALLET's algorithm) implemented in Rust."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2057,6 +2123,12 @@ class PT:
     """Pseudo-document Topic model (Zuo et al. 2016) for short texts: aggregates
     documents into `num_pseudo` pseudo-documents so LDA-style mixed membership is
     estimable on short, sparse texts. Fit by collapsed Gibbs."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2152,6 +2224,12 @@ class GSDMM:
     (Yin & Wang 2014): a one-topic-per-document mixture for short texts. You set
     an upper bound K (`num_topics`); empty clusters die out, so the effective
     number of topics is read from `num_topics` after fit."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2233,6 +2311,12 @@ class BTM:
     texts are too sparse to estimate), BTM learns one global topic distribution and
     per-topic word distributions from the corpus's biterms -- unordered word pairs
     co-occurring within a window. `alpha` defaults to 50/num_topics."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2302,6 +2386,12 @@ class PolylingualLDA:
     `beta` the topic-word prior applied to every language (default 0.01); with
     `optimize_alpha` the asymmetric alpha.m prior is re-estimated every
     `optimize_interval` Gibbs iterations after an `optimize_burn_in` warm-up."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2390,6 +2480,12 @@ class DiscLDA:
     (`class_topics`) vs their common ground (`shared_topics`), and gives a
     class-carrying document representation (`transform`/`predict`). Fixed
     block-transform variant (paper section 4.1)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2471,6 +2567,12 @@ class PA:
     """Pachinko Allocation Model (Li & McCallum 2006): a DAG of `num_super`
     super-topics over `num_sub` shared sub-topics over words, capturing topic
     correlations. `super_sub` reports which sub-topics each super-topic groups."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2576,6 +2678,12 @@ class HLDA:
     """Hierarchical LDA (Blei et al.): topics arranged in a `depth`-level tree via
     the nested Chinese Restaurant Process. Each document follows a root-to-leaf
     path; general words sit near the root, specific words near the leaves."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2648,6 +2756,12 @@ class SeededLDA:
     vocabulary and any `residual` unseeded topics are still learned. Seeding
     follows the seededlda package (seed words get a `weight * 100` prior
     pseudocount in their topic, plus seeded initialization)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2766,6 +2880,12 @@ class Top2Vec:
     documents' embeddings and its words are the nearest vocabulary terms. You
     bring the embeddings; the topic count is discovered, not set. No embedder of
     your own? ``topica.llm_embed(texts, model=...)`` builds the matrix."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2866,6 +2986,12 @@ class BERTopic:
     to a target; `doc_topic` is the approximate distribution. You bring the
     document embeddings; the topic count is discovered (before any reduction).
     No embedder of your own? ``topica.llm_embed(texts, model=...)`` builds it."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -2969,6 +3095,12 @@ class ETM:
     autoencoder, which scales to large corpora and maps new documents with a single
     encoder pass. Neither uses PyTorch. No embedder of your own?
     ``topica.llm_embed(vocabulary, model=...)`` builds the word embeddings rho."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3079,6 +3211,12 @@ class InfoCTM:
     term (a masked cross-lingual InfoNCE over topic-word columns) seeded by a
     bilingual ``dictionary`` (optionally densified by per-language ``embeddings``).
     After fitting, topic ``k`` denotes the same theme in both languages."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3147,6 +3285,12 @@ class ProdLDA:
     minibatch Adam on the ELBO; batch normalization and high-momentum Adam guard
     against component collapse. Unlike ETM you bring no embeddings: beta is learned
     directly. New documents transform with a single encoder forward pass."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3243,6 +3387,12 @@ class Scholar:
     is the fitted covariate-by-topic prevalence matrix. Covariates also enter the
     encoder. Built on topica's ProdLDA backbone. Reference implementation:
     dallascard/scholar (Apache-2.0)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3369,6 +3519,12 @@ class CombinedTM:
     reconstructs the bag of words. Bring the embeddings at fit() as a
     (num_docs, E) array, aligned to the documents. Reference implementation:
     contextualized-topic-models (Bianchi et al., MIT)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3470,6 +3626,12 @@ class ZeroShotTM:
     another. Bring the embeddings at fit() as a (num_docs, E) array, aligned to the
     documents. Reference implementation: contextualized-topic-models (Bianchi et
     al., MIT)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3574,6 +3736,12 @@ class NMF:
     scikit-learn's sklearn.decomposition.NMF (BSD-3-Clause). The topic-word matrix
     is each row of H normalized to sum 1; the document-topic matrix is each row of
     W normalized to sum 1."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3651,6 +3819,12 @@ class LSA:
     absolute value). doc_topic (D x K) is U_k Sigma_k (signed document
     coordinates; rows do not sum to 1). singular_values (K) is Sigma_k. A
     deterministic svd_flip sign convention matches scikit-learn's output."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3720,6 +3894,12 @@ class TensorLDA:
     """Online Tensor LDA (TensorLDA) topic model (Kangaslahti et al. 2026).
     Method-of-moments topic modeling using second and third-order cumulants.
     Gated behind `topica.enable_experimental()`."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3794,6 +3974,12 @@ class FASTopic:
     transport costs. Held-out documents are mapped by a distance-softmax over the
     fitted topic embeddings, so `transform` needs only their embeddings. No
     embedder of your own? ``topica.llm_embed(texts, model=...)`` builds it."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -3887,6 +4073,12 @@ class KeyATM:
     a distribution over only that topic's keywords or from its full distribution,
     anchoring keyword topics to their keywords. `num_topics` may exceed the number
     of keyword topics to add regular, no-keyword topics."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -4159,6 +4351,12 @@ class IdealPointTM:
     is parameterized directly over the vocabulary (counts; "Wordfish with topics");
     pass them and it is factored through word embeddings, as in ETM. Both are the
     same model. Gated behind topica.enable_experimental()."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -4296,6 +4494,12 @@ class Wordfish:
     latent position, beta_j the word's discrimination. The word-frequency baseline
     companion to IdealPointTM. The fit is deterministic. Validated against R
     quanteda's textmodel_wordfish (parity/wordfish_r_compare.py)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -4373,6 +4577,12 @@ class IdealPointSentenceTM:
     (e ~ N(mu_k + x_a . V_k, sigma^2)); ||V_k|| is the topic's discrimination. The
     sentence-embedding sibling of IdealPointTM, fit by EM. Gated behind
     topica.enable_experimental()."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -4453,6 +4663,12 @@ class TBIP:
     single-sample SVI, Adam, document minibatching). Recovers ideological scales
     from unlabeled text. Validated by planted-position recovery and a PyTorch
     reference (parity/tbip_parity.py)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:
@@ -4534,6 +4750,12 @@ class PartyEmbeddings:
     Implemented from Mikolov et al. (2013) and Le & Mikolov (2014); validated by
     planted-position recovery and correlation against the gensim reference
     (parity/party_embeddings_compare.py)."""
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict,
+        keyword-named to match ``__init__`` (issue #400)."""
+        ...
+
 
     @property
     def seed(self) -> int:

--- a/python/topica/anchor.py
+++ b/python/topica/anchor.py
@@ -267,6 +267,22 @@ class AnchorLDA:
         self._converged = None
         self._word_counts = None
 
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict, keyword-named
+        to match ``__init__`` (issue #400)."""
+        return {
+            "num_topics": self._k,
+            "recover": self.recover,
+            "min_count": self.min_count,
+            "seed": self.seed,
+            "eta": self.eta,
+            "convergence_tol": self.convergence_tol,
+            "frex_w": self.frex_w,
+            "frequency_temper": self.frequency_temper,
+            "anchor_min_doc_freq": self.anchor_min_doc_freq,
+        }
+
     # -- fitting ------------------------------------------------------------
     def fit(self, data, *, iters=None, min_count=None):
         """Recover topics from ``data`` (a :class:`~topica.Corpus` or a list of

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -329,6 +329,22 @@ class EmbeddingLDA:
             self.seeds, alpha=alpha, beta=beta, weight=weight, seed=seed
         )
 
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict, keyword-named
+        to match ``__init__`` (issue #400). The ``embeddings``/``vocabulary`` inputs
+        are data, not hyperparameters, so they are not reported here."""
+        sub = self._model.settings
+        return {
+            "num_topics": self.num_topics,
+            "top_m": self.top_m,
+            "weight": sub["weight"],
+            "doc_anchor": self.doc_anchor,
+            "alpha": self.alpha,
+            "beta": sub["beta"],
+            "seed": sub["seed"],
+        }
+
     def document_topic_prior(self, doc_embeddings) -> np.ndarray:
         """The per-document Dirichlet prior ``α_{d,k}`` implied by document
         embeddings: ``alpha + doc_anchor * max(cos(doc_d, centroid_k), 0)``,

--- a/python/topica/gdmr.py
+++ b/python/topica/gdmr.py
@@ -632,6 +632,29 @@ class GDMR:
     # ------------------------------------------------------------------
 
     @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict, keyword-named
+        to match ``__init__`` (issue #400)."""
+        return {
+            "num_topics": self._num_topics,
+            "degrees": list(self._degrees),
+            "beta": self._beta,
+            "optimize_interval": self._optimize_interval,
+            "burn_in": self._burn_in,
+            "seed": self._seed,
+            "sigma": self._sigma,
+            "sigma0": self._sigma0,
+            "decay": self._decay,
+            "metadata_range": (
+                [list(t) for t in self._metadata_range]
+                if self._metadata_range is not None
+                else None
+            ),
+            "lbfgs_iters": self._lbfgs_iters,
+            "sampler": self._sampler,
+        }
+
+    @property
     def topic_word(self) -> np.ndarray:
         """Topic-word matrix phi, shape ``(num_topics, num_words)``, rows sum to 1."""
         self._require_fitted()

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -66,14 +66,6 @@ BUNDLE_VERSION = 1
 _DIGEST_SIZE = 32
 _CANONICAL_NAN = 0x7FF8000000000000
 
-# Model settings captured by the per-model adapters (allowlist, not
-# serialize-everything). Everything else is omitted and marked as such.
-_SETTINGS_ALLOWLIST: dict[str, tuple[str, ...]] = {
-    "LDA": ("num_topics", "alpha", "beta"),
-    "STM": ("num_topics", "beta", "sigma_prior"),
-}
-
-
 # --------------------------------------------------------------------------
 # Fingerprint-v1 primitives
 # --------------------------------------------------------------------------
@@ -719,13 +711,14 @@ def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
     if reg is not None and cls in reg.REGISTRY:
         determinism = reg.REGISTRY[cls].determinism
 
+    settings, settings_coverage = _capture_settings(model)
     model_block: dict[str, Any] = {
         "class": cls,
         "determinism": determinism,
         "num_topics": getattr(model, "num_topics", None),
         "seed": getattr(model, "seed", None),  # most models do not expose it -> None
-        "settings": _capture_settings(model, cls),
-        "settings_coverage": f"adapter:{cls}" if cls in _SETTINGS_ALLOWLIST else "generic",
+        "settings": settings,
+        "settings_coverage": settings_coverage,
         "fit_settings": _allowlist_kwargs(fit_settings),
         "output_fingerprints": _output_fingerprints(model),
     }
@@ -777,13 +770,15 @@ def _capture_diagnostic(name: str, model, corpus, n: int) -> dict[str, Any]:
     return entry
 
 
-def _capture_settings(model, cls: str) -> dict[str, Any]:
-    out: dict[str, Any] = {}
-    for name in _SETTINGS_ALLOWLIST.get(cls, ()):
-        val = getattr(model, name, None)
-        if val is not None:
-            out[name] = _jsonable(val)
-    return out
+def _capture_settings(model) -> tuple[dict[str, Any], str]:
+    """The model's constructor configuration via its uniform ``settings`` surface
+    (issue #400), plus a coverage tag. ``full`` when the model reports ``settings``;
+    ``none`` for the rare model that does not (recorded honestly rather than faked).
+    """
+    settings = getattr(model, "settings", None)
+    if not isinstance(settings, dict):
+        return {}, "none"
+    return {k: _jsonable(v) for k, v in settings.items()}, "full"
 
 
 def _output_fingerprints(model) -> dict[str, Any]:

--- a/python/topica/narrative.py
+++ b/python/topica/narrative.py
@@ -71,6 +71,25 @@ class NarrativeTM:
         return self._num_topics
 
     @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict, keyword-named
+        to match ``__init__`` (issue #400)."""
+        return {
+            "num_topics": self._num_topics,
+            "degree": self._degree,
+            "segment_by": self._segment_by,
+            "chunk_size": self._chunk_size,
+            "beta": self._beta,
+            "optimize_interval": self._optimize_interval,
+            "burn_in": self._burn_in,
+            "seed": self._seed,
+            "decay": self._decay,
+            "sigma": self._sigma,
+            "sigma0": self._sigma0,
+            "sampler": self._sampler,
+        }
+
+    @property
     def vocabulary(self) -> list[str]:
         if not self._fitted:
             raise RuntimeError("Model is not fitted")

--- a/python/topica/topicgpt.py
+++ b/python/topica/topicgpt.py
@@ -489,6 +489,22 @@ class TopicGPT:
         self._cache: dict[str, str] = {}
         self._call_count: int = 0
 
+    @property
+    def settings(self) -> dict:
+        """The constructor configuration as a JSON-serialisable dict, keyword-named
+        to match ``__init__`` (issue #400). The ``backend`` callable is data, not a
+        hyperparameter, so it is not reported; ``model`` records the named backend."""
+        return {
+            "model": self._model_name,
+            "hierarchical": self.hierarchical,
+            "assignment": self.assignment,
+            "sample": self.sample,
+            "max_topics": self.max_topics,
+            "temperature": self.temperature,
+            "seed": self.seed,
+            "prompts": dict(self.prompts),
+        }
+
     # -- custom prompts ----------------------------------------------------
 
     def with_prompt(self, stage: str, template: str) -> "TopicGPT":

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2};
+use pyo3::types::PyDict;
 use pyo3::types::PyType;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -95,6 +96,22 @@ impl BTM {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``alpha`` is ``None`` when left at its
+    /// ``50 / num_topics`` default (resolved only at fit).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("iters", self.iters)?;
+        d.set_item("window", self.window)?;
+        d.set_item("background", self.background)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted BTM model. `alpha` defaults to `50 / num_topics`

--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2};
+use pyo3::types::PyDict;
 use pyo3::types::PyType;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -119,6 +120,22 @@ impl DiscLDA {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``alpha`` is ``None`` when left at its
+    /// ``0.1`` default (resolved only at fit).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("k_class", self.k_class)?;
+        d.set_item("k_shared", self.k_shared)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("iters", self.iters)?;
+        d.set_item("infer_sweeps", self.infer_sweeps)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted DiscLDA. `k_class` is the number of class-specific topics

--- a/src/python/embedding_cluster.rs
+++ b/src/python/embedding_cluster.rs
@@ -9,6 +9,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2};
+use pyo3::types::PyDict;
 
 /// Guard `reducer='umap'`: error out on the (non-wheel) build where the `umap`
 /// feature was not compiled in. The in-house UMAP reducer is seeded and fully
@@ -100,6 +101,37 @@ impl Top2Vec {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). Internal flags are reported under
+    /// their public names (``reducer``, ``metric``); values are the effective
+    /// ones actually in force (e.g. ``min_samples`` after its
+    /// ``min_cluster_size`` default).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("n_components", self.n_components)?;
+        d.set_item("min_cluster_size", self.min_cluster_size)?;
+        d.set_item("min_samples", self.min_samples)?;
+        d.set_item("reducer", if self.use_umap { "umap" } else { "pca" })?;
+        d.set_item("n_neighbors", self.n_neighbors)?;
+        d.set_item("clusterer", self.clusterer.as_str())?;
+        d.set_item("num_clusters", self.num_clusters)?;
+        d.set_item("resolution", self.resolution)?;
+        d.set_item("knn_neighbors", self.knn_neighbors)?;
+        d.set_item("diagnostics", self.diagnostics)?;
+        d.set_item("min_dist", self.umap_params.min_dist)?;
+        d.set_item("spread", self.umap_params.spread)?;
+        d.set_item("n_epochs", self.umap_params.n_epochs)?;
+        d.set_item(
+            "negative_sample_rate",
+            self.umap_params.negative_sample_rate,
+        )?;
+        d.set_item("repulsion_strength", self.umap_params.repulsion_strength)?;
+        d.set_item("metric", self.umap_params.metric.as_str())?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `n_components` is the reduced dimensionality
@@ -761,6 +793,42 @@ impl BERTopic {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). Internal flags are reported under
+    /// their public names (``reducer``, ``metric``); values are the effective
+    /// ones actually in force (e.g. ``window``/``stride`` after their ``.max(1)``
+    /// floor, ``min_samples`` after its ``min_cluster_size`` default).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("n_components", self.n_components)?;
+        d.set_item("min_cluster_size", self.min_cluster_size)?;
+        d.set_item("min_samples", self.min_samples)?;
+        d.set_item("nr_topics", self.nr_topics)?;
+        d.set_item("window", self.window)?;
+        d.set_item("stride", self.stride)?;
+        d.set_item("reducer", if self.use_umap { "umap" } else { "pca" })?;
+        d.set_item("n_neighbors", self.n_neighbors)?;
+        d.set_item("bm25", self.bm25)?;
+        d.set_item("reduce_frequent", self.reduce_frequent)?;
+        d.set_item("clusterer", self.clusterer.as_str())?;
+        d.set_item("num_clusters", self.num_clusters)?;
+        d.set_item("resolution", self.resolution)?;
+        d.set_item("knn_neighbors", self.knn_neighbors)?;
+        d.set_item("diagnostics", self.diagnostics)?;
+        d.set_item("min_dist", self.umap_params.min_dist)?;
+        d.set_item("spread", self.umap_params.spread)?;
+        d.set_item("n_epochs", self.umap_params.n_epochs)?;
+        d.set_item(
+            "negative_sample_rate",
+            self.umap_params.negative_sample_rate,
+        )?;
+        d.set_item("repulsion_strength", self.umap_params.repulsion_strength)?;
+        d.set_item("metric", self.umap_params.metric.as_str())?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `nr_topics` (optional) reduces the discovered

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -6,6 +6,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2};
+use pyo3::types::PyDict;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
@@ -92,6 +93,19 @@ impl PA {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_super", self.num_super)?;
+        d.set_item("num_sub", self.num_sub)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted model with `num_super` super-topics and `num_sub`
@@ -497,6 +511,23 @@ impl HLDA {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``beta`` is the effective topic-word
+    /// Dirichlet in force (the internal ``eta`` field, after resolving the
+    /// deprecated ``eta=`` alias); ``eta`` is the deprecated alias and is not
+    /// retained, so it always reports ``None``.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("depth", self.depth)?;
+        d.set_item("gamma", self.gamma)?;
+        d.set_item("beta", self.eta)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("eta", None::<f64>)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `depth` is the (fixed) tree depth; `gamma` is

--- a/src/python/idealpoint.rs
+++ b/src/python/idealpoint.rs
@@ -16,6 +16,8 @@
 //! coherence helpers, save/load, the experimental gate).
 
 use super::*;
+use pyo3::types::PyDict;
+
 use crate::idealpoint::{self, IdealPointModel};
 use crate::idealpoint_lda::{self, IdealPointLdaModel};
 use std::collections::{HashMap, HashSet};
@@ -330,6 +332,25 @@ impl IdealPointTM {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). Values are the effective ones actually
+    /// in force (e.g. ``min_count`` after the ``.max(1)`` floor).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("num_dims", self.num_dims)?;
+        d.set_item("convergence_tol", self.convergence_tol)?;
+        d.set_item("sigma_shrink", self.sigma_shrink)?;
+        d.set_item("prior_variance", self.prior_variance)?;
+        d.set_item("w_prior_variance", self.w_prior_variance)?;
+        d.set_item("x_prior_variance", self.x_prior_variance)?;
+        d.set_item("max_inner", self.max_inner)?;
+        d.set_item("min_count", self.min_count)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `num_topics` is K (>= 2); `num_dims` is the

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1365,6 +1365,43 @@ impl LDA {
         Ok(())
     }
 
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). Internal flags are reported under
+    /// their public names (``sampler``, ``init``); values are the effective ones
+    /// actually in force (e.g. ``num_threads`` after the ``.max(1)`` floor).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha_sum", self.alpha_sum)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("optimize_interval", self.optimize_interval)?;
+        d.set_item("burn_in", self.burn_in)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("num_threads", self.num_threads)?;
+        let sampler = if self.light {
+            "lightlda"
+        } else if self.warp {
+            "warp"
+        } else if self.cvb0 {
+            "cvb0"
+        } else {
+            "sparse"
+        };
+        d.set_item("sampler", sampler)?;
+        d.set_item("mh_steps", self.mh_steps)?;
+        d.set_item("use_symmetric_alpha", self.use_symmetric_alpha)?;
+        d.set_item(
+            "init",
+            if self.init_spectral {
+                "spectral"
+            } else {
+                "random"
+            },
+        )?;
+        Ok(d)
+    }
+
     /// Topic-word probability matrix φ, shape ``(num_topics, num_words)``.
     #[getter]
     fn topic_word<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
@@ -3370,6 +3407,29 @@ impl DMR {
 
 #[pymethods]
 impl DMR {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("optimize_interval", self.optimize_interval)?;
+        d.set_item("burn_in", self.burn_in)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("prior_variance", self.prior_variance)?;
+        d.set_item("lbfgs_iters", self.lbfgs_iters)?;
+        let sampler = if self.warp {
+            "warp"
+        } else if self.cvb0 {
+            "cvb0"
+        } else {
+            "sparse"
+        };
+        d.set_item("sampler", sampler)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -4386,6 +4446,18 @@ impl LabeledLDA {
 
 #[pymethods]
 impl LabeledLDA {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("sampler", if self.cvb0 { "cvb0" } else { "sparse" })?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -5055,6 +5127,21 @@ impl SAGE {
 
 #[pymethods]
 impl SAGE {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("prior_variance", self.prior_variance)?;
+        d.set_item("optimize_interval", self.optimize_interval)?;
+        d.set_item("burn_in", self.burn_in)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("lbfgs_iters", self.lbfgs_iters)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -5878,6 +5965,26 @@ impl CTM {
 
 #[pymethods]
 impl CTM {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("sigma_shrink", self.sigma_shrink)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item(
+            "init",
+            if self.init_spectral {
+                "spectral"
+            } else {
+                "random"
+            },
+        )?;
+        d.set_item("variational", self.variational.as_str())?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -6624,6 +6731,26 @@ impl STM {
 
 #[pymethods]
 impl STM {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("sigma_shrink", self.sigma_shrink)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item(
+            "init",
+            if self.init_spectral {
+                "spectral"
+            } else {
+                "random"
+            },
+        )?;
+        d.set_item("variational", self.variational.as_str())?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -8052,6 +8179,24 @@ impl STS {
 
 #[pymethods]
 impl STS {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item(
+            "init",
+            if self.init_spectral {
+                "spectral"
+            } else {
+                "random"
+            },
+        )?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -8839,6 +8984,21 @@ impl HDP {
 
 #[pymethods]
 impl HDP {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``eta`` is a deprecated alias for
+    /// ``beta``, folded at construction, so it always reports ``None`` here.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("gamma", self.gamma)?;
+        d.set_item("beta", self.eta)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("resample_conc", self.resample_conc)?;
+        d.set_item("eta", None::<f64>)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -9408,6 +9568,27 @@ impl DTM {
 
 #[pymethods]
 impl DTM {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("chain_variance", self.chain_variance)?;
+        d.set_item("obs_variance", self.obs_variance)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item(
+            "init",
+            if self.init_spectral {
+                "spectral"
+            } else {
+                "random"
+            },
+        )?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -9851,6 +10032,17 @@ impl SupervisedLDA {
 
 #[pymethods]
 impl SupervisedLDA {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -10430,6 +10622,19 @@ impl PT {
 
 #[pymethods]
 impl PT {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("num_pseudo", self.num_pseudo)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -10817,6 +11022,18 @@ impl GSDMM {
 
 #[pymethods]
 impl GSDMM {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``num_topics`` is the max-cluster cap.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.k_max)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -11241,6 +11458,28 @@ impl SeededLDA {
 
 #[pymethods]
 impl SeededLDA {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). The ``seed_words`` guidance is data,
+    /// not a hyperparameter, so it is not reported here.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("residual", self.residual)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("weight", self.weight)?;
+        d.set_item("seed", self.seed)?;
+        let sampler = if self.warp {
+            "warp"
+        } else if self.cvb0 {
+            "cvb0"
+        } else {
+            "sparse"
+        };
+        d.set_item("sampler", sampler)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -11993,6 +12232,25 @@ impl FASTopic {
 
 #[pymethods]
 impl FASTopic {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``em_tol`` is a deprecated alias for
+    /// ``convergence_tol``, folded at construction, so it reports ``None`` here.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("lr", self.lr)?;
+        d.set_item("dt_alpha", self.dt_alpha)?;
+        d.set_item("tw_alpha", self.tw_alpha)?;
+        d.set_item("theta_temp", self.theta_temp)?;
+        d.set_item("convergence_tol", self.em_tol)?;
+        d.set_item("sinkhorn_iters", self.sinkhorn_iters)?;
+        d.set_item("sinkhorn_tol", self.sinkhorn_tol)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("em_tol", None::<f64>)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {
@@ -12435,6 +12693,26 @@ impl KeyATM {
 
 #[pymethods]
 impl KeyATM {
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). The ``keywords`` guidance is data,
+    /// not a hyperparameter, so it is not reported here; ``num_topics`` and
+    /// ``alpha`` are the effective values resolved at construction.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("beta_keyword", self.beta_keyword)?;
+        d.set_item("gamma1", self.gamma1)?;
+        d.set_item("gamma2", self.gamma2)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("estimate_alpha", self.estimate_alpha)?;
+        d.set_item("sampler", if self.cvb0 { "cvb0" } else { "sparse" })?;
+        d.set_item("num_threads", self.num_threads)?;
+        Ok(d)
+    }
+
     /// The random seed the model was constructed with.
     #[getter]
     fn seed(&self) -> u64 {

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -10,6 +10,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2};
+use pyo3::types::PyDict;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
@@ -198,6 +199,32 @@ impl ETM {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). `inference`/`prior` are reported under
+    /// their public strings; `convergence_tol` is the effective tolerance in force
+    /// (the deprecated `em_tol` alias is folded into it and reported as ``None``).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("inference", self.inference.as_str())?;
+        d.set_item("convergence_tol", self.em_tol)?;
+        d.set_item("sigma_shrink", self.sigma_shrink)?;
+        d.set_item("prior_variance", self.prior_variance)?;
+        d.set_item("max_inner", self.max_inner)?;
+        d.set_item("hidden_size", self.hidden_size)?;
+        d.set_item("batch_size", self.batch_size)?;
+        d.set_item("lr", self.lr)?;
+        d.set_item("wdecay", self.wdecay)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("prior", self.prior.as_str())?;
+        d.set_item("contrastive", self.contrastive)?;
+        d.set_item("contrastive_weight", self.contrastive_weight)?;
+        d.set_item("contrastive_temp", self.contrastive_temp)?;
+        d.set_item("em_tol", None::<f64>)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `inference` selects the engine: `"em"` (default)
@@ -859,6 +886,25 @@ impl DETM {
         self.seed
     }
 
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``grad_clip`` is ``None`` when unset.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("delta", self.delta)?;
+        d.set_item("hidden_size", self.hidden_size)?;
+        d.set_item("eta_hidden_size", self.eta_hidden_size)?;
+        d.set_item("eta_nlayers", self.eta_nlayers)?;
+        d.set_item("batch_size", self.batch_size)?;
+        d.set_item("lr", self.lr)?;
+        d.set_item("wdecay", self.wdecay)?;
+        d.set_item("grad_clip", self.grad_clip)?;
+        d.set_item("convergence_tol", self.convergence_tol)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
+    }
+
     /// Create an unfitted model. ``delta`` is the random-walk standard-deviation
     /// knob on the topic-embedding and topic-prior trajectories (smaller = smoother
     /// drift; reference default 0.005). ``hidden_size`` is the document encoder
@@ -1460,6 +1506,25 @@ impl InfoCTM {
         self.seed
     }
 
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). `convergence_tol` is the effective
+    /// tolerance in force; `languages` is the normalized ``(a, b)`` pair.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("mi_weight", self.mi_weight)?;
+        d.set_item("mi_temperature", self.mi_temperature)?;
+        d.set_item("pos_threshold", self.pos_threshold)?;
+        d.set_item("hidden_size", self.hidden_size)?;
+        d.set_item("dropout", self.dropout)?;
+        d.set_item("lr", self.lr)?;
+        d.set_item("convergence_tol", self.em_tol)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("languages", self.languages.clone())?;
+        Ok(d)
+    }
+
     /// Create an unfitted model. `mi_weight` scales the alignment term (reference
     /// 30-50); `mi_temperature` is the InfoNCE temperature (0.2); `pos_threshold`
     /// is the cosine cutoff for the embedding-densified positive mask (0.4, used
@@ -1888,6 +1953,29 @@ impl ProdLDA {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). `prior` is reported as its public
+    /// string; `convergence_tol` is the effective tolerance in force (the
+    /// deprecated `em_tol` alias is folded into it and reported as ``None``).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("hidden_size", self.hidden_size)?;
+        d.set_item("dropout", self.dropout)?;
+        d.set_item("batch_size", self.batch_size)?;
+        d.set_item("lr", self.lr)?;
+        d.set_item("convergence_tol", self.em_tol)?;
+        d.set_item("seed", self.seed)?;
+        d.set_item("prior", self.prior.as_str())?;
+        d.set_item("contrastive", self.contrastive)?;
+        d.set_item("contrastive_weight", self.contrastive_weight)?;
+        d.set_item("contrastive_temp", self.contrastive_temp)?;
+        d.set_item("em_tol", None::<f64>)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `alpha` is the symmetric Dirichlet prior
@@ -2438,6 +2526,27 @@ macro_rules! ctm_embedding_model {
             #[getter]
             fn seed(&self) -> u64 {
                 self.seed
+            }
+
+            /// The constructor configuration as a JSON-serialisable dict,
+            /// keyword-named to match ``__init__`` (issue #400). `prior` is
+            /// reported as its public string.
+            #[getter]
+            fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+                let d = PyDict::new_bound(py);
+                d.set_item("num_topics", self.num_topics)?;
+                d.set_item("alpha", self.alpha)?;
+                d.set_item("hidden_size", self.hidden_size)?;
+                d.set_item("dropout", self.dropout)?;
+                d.set_item("batch_size", self.batch_size)?;
+                d.set_item("lr", self.lr)?;
+                d.set_item("convergence_tol", self.convergence_tol)?;
+                d.set_item("seed", self.seed)?;
+                d.set_item("prior", self.prior.as_str())?;
+                d.set_item("contrastive", self.contrastive)?;
+                d.set_item("contrastive_weight", self.contrastive_weight)?;
+                d.set_item("contrastive_temp", self.contrastive_temp)?;
+                Ok(d)
             }
 
             /// Create an unfitted model. `alpha` is the symmetric Dirichlet prior

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -3,6 +3,7 @@
 //! bindings helpers (Corpus, build_corpus_from_docs, save/load, array adapters, …).
 
 use super::*;
+use pyo3::types::PyDict;
 
 /// NMF, non-negative matrix factorization for topic modeling (Lee & Seung 2001;
 /// Boutsidis & Gallopoulos 2008). We factor the non-negative document-term matrix
@@ -95,6 +96,34 @@ impl NMF {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). Enum-ish params are reported under
+    /// their public strings (``beta_loss``, ``init``, ``weighting``).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        let beta_loss = match self.beta_loss {
+            nmf::BetaLoss::Frobenius => "frobenius",
+            nmf::BetaLoss::KullbackLeibler => "kullback-leibler",
+        };
+        d.set_item("beta_loss", beta_loss)?;
+        let init = match self.init {
+            nmf::Init::Nndsvd => "nndsvd",
+            nmf::Init::Random => "random",
+        };
+        d.set_item("init", init)?;
+        let weighting = if self.weighting_tfidf {
+            "tfidf"
+        } else {
+            "count"
+        };
+        d.set_item("weighting", weighting)?;
+        d.set_item("convergence_tol", self.convergence_tol)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `num_topics` is K (2 <= K <= vocabulary size).
@@ -428,6 +457,23 @@ impl LSA {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``weighting`` is reported under its
+    /// public string.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        let weighting = if self.weighting_tfidf {
+            "tfidf"
+        } else {
+            "count"
+        };
+        d.set_item("weighting", weighting)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `num_topics` is K (2 <= K <= min(num_docs,

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -6,6 +6,8 @@
 //! bindings (Corpus, arrays, save/load).
 
 use super::*;
+use pyo3::types::PyDict;
+
 use crate::party_embeddings::{self, PartyEmbeddingsModel, PvdmConfig};
 use std::collections::HashMap;
 
@@ -106,6 +108,23 @@ impl PartyEmbeddings {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). Values are the effective ones actually
+    /// in force (e.g. ``min_count`` after the ``.max(1)`` floor).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_dims", self.num_dims)?;
+        d.set_item("vector_size", self.vector_size)?;
+        d.set_item("window", self.window)?;
+        d.set_item("min_count", self.min_count)?;
+        d.set_item("negative", self.negative)?;
+        d.set_item("sample", self.sample)?;
+        d.set_item("learning_rate", self.learning_rate)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted PartyEmbeddings model. `num_dims` is the number of

--- a/src/python/pltm.rs
+++ b/src/python/pltm.rs
@@ -143,6 +143,23 @@ impl PolylingualLDA {
         self.seed
     }
 
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``alpha`` is ``None`` when left unset
+    /// (the core resolves it to the 0.01 default at fit time).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("beta", self.beta)?;
+        d.set_item("iters", self.iters)?;
+        d.set_item("optimize_alpha", self.optimize_alpha)?;
+        d.set_item("optimize_interval", self.optimize_interval)?;
+        d.set_item("optimize_burn_in", self.optimize_burn_in)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
+    }
+
     /// Create an unfitted PLTM. `alpha` is the per-topic document-topic prior
     /// (default `0.01`, the paper's `0.01·T` total with a uniform base measure).
     /// `beta` is the topic-word prior (default `0.01`); it is applied to every

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -2,7 +2,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2};
-use pyo3::types::PyType;
+use pyo3::types::{PyDict, PyType};
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 
@@ -250,6 +250,29 @@ impl Scholar {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). The numeric data arrays ``covariates``
+    /// and ``content`` are excluded; the config-name lists ``covariate_names`` and
+    /// ``content_names`` (a list of strings, or ``None`` when unset) are kept.
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("covariate_names", self.covariate_names.clone())?;
+        d.set_item("content_names", self.content_names.clone())?;
+        d.set_item("interactions", self.interactions)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("hidden_size", self.hidden_size)?;
+        d.set_item("dropout", self.dropout)?;
+        d.set_item("batch_size", self.batch_size)?;
+        d.set_item("lr", self.lr)?;
+        d.set_item("l2_prior_reg", self.l2_prior_reg)?;
+        d.set_item("l1_content_reg", self.l1_content_reg)?;
+        d.set_item("convergence_tol", self.convergence_tol)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted SCHOLAR. `covariates` (a `(num_docs, n_covars)` numeric

--- a/src/python/sentence_ideal.rs
+++ b/src/python/sentence_ideal.rs
@@ -4,6 +4,8 @@
 //! Experimental, gated. `use super::*` pulls in the shared bindings.
 
 use super::*;
+use pyo3::types::PyDict;
+
 use crate::sentence_ideal::{self, SentenceIdealModel};
 use std::collections::HashMap;
 
@@ -59,6 +61,19 @@ impl IdealPointSentenceTM {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("num_dims", self.num_dims)?;
+        d.set_item("convergence_tol", self.convergence_tol)?;
+        d.set_item("x_prior_variance", self.x_prior_variance)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `num_topics` is K (>= 2); `num_dims` the latent

--- a/src/python/tbip.rs
+++ b/src/python/tbip.rs
@@ -5,6 +5,8 @@
 //! pulls in the shared bindings.
 
 use super::*;
+use pyo3::types::PyDict;
+
 use crate::tbip::{self, TbipConfig, TbipModel, TbipParams};
 use std::collections::{HashMap, HashSet};
 
@@ -71,6 +73,23 @@ impl TBIP {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). Values are the effective ones actually
+    /// in force (e.g. ``batch_size``/``min_count`` after the ``.max(1)`` floor).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("a_gamma", self.a_gamma)?;
+        d.set_item("b_gamma", self.b_gamma)?;
+        d.set_item("iters", self.iters)?;
+        d.set_item("batch_size", self.batch_size)?;
+        d.set_item("learning_rate", self.learning_rate)?;
+        d.set_item("min_count", self.min_count)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted model. `num_topics` is K (>= 2). `a_gamma`/`b_gamma` are

--- a/src/python/tlda.rs
+++ b/src/python/tlda.rs
@@ -2,6 +2,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2};
+use pyo3::types::PyDict;
 use pyo3::types::PyType;
 use std::collections::HashMap;
 
@@ -118,6 +119,26 @@ impl TensorLDA {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). ``n_eigenvec`` is ``None`` when left
+    /// unset (defaults to ``num_topics`` at fit).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("num_topics", self.num_topics)?;
+        d.set_item("alpha_0", self.alpha_0)?;
+        d.set_item("n_iter_train", self.n_iter_train)?;
+        d.set_item("n_iter_test", self.n_iter_test)?;
+        d.set_item("learning_rate", self.learning_rate)?;
+        d.set_item("batch_size", self.batch_size)?;
+        d.set_item("smoothing", self.smoothing)?;
+        d.set_item("theta", self.theta)?;
+        d.set_item("n_eigenvec", self.n_eigenvec)?;
+        d.set_item("pca_batch_size", self.pca_batch_size)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted TensorLDA model.

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -4,6 +4,8 @@
 //! bindings (Corpus, arrays, save/load).
 
 use super::*;
+use pyo3::types::PyDict;
+
 use crate::wordfish::{self, WordfishModel};
 use std::collections::HashMap;
 
@@ -64,6 +66,20 @@ impl Wordfish {
     #[getter]
     fn seed(&self) -> u64 {
         self.seed
+    }
+
+    /// The constructor configuration as a JSON-serialisable dict, keyword-named
+    /// to match ``__init__`` (issue #400). Values are the effective ones actually
+    /// in force (e.g. ``min_count`` after the ``.max(1)`` floor).
+    #[getter]
+    fn settings<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let d = PyDict::new_bound(py);
+        d.set_item("beta_prior_sd", self.beta_prior_sd)?;
+        d.set_item("theta_prior_sd", self.theta_prior_sd)?;
+        d.set_item("min_count", self.min_count)?;
+        d.set_item("convergence_tol", self.convergence_tol)?;
+        d.set_item("seed", self.seed)?;
+        Ok(d)
     }
 
     /// Create an unfitted Wordfish model. `beta_prior_sd` / `theta_prior_sd` are the

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -1,0 +1,176 @@
+"""#400 — uniform ``model.settings`` introspection.
+
+Every public model exposes its constructor configuration as a JSON-serialisable
+dict, keyword-named to match ``__init__``. The expected key set is derived
+directly from the class's ``__text_signature__`` (minus the data-guidance args),
+so this test is the single inventory: adding a constructor parameter without
+surfacing it in ``settings`` fails here, with no second list to maintain.
+"""
+
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+
+import topica
+import topica._topica as _ext
+from topica.registry import REGISTRY
+
+# Several registered models are experimental-gated and refuse to construct
+# otherwise; settings introspection is part of their surface too.
+topica.enable_experimental()
+
+# Constructor parameters that are data / guidance inputs, not hyperparameters,
+# and are therefore intentionally omitted from ``settings`` (recorded elsewhere
+# as corpus/guidance data).
+_DATA_ARGS: dict[str, set[str]] = {
+    "KeyATM": {"keywords"},
+    "SeededLDA": {"seed_words"},
+    "Scholar": {"covariates", "content"},
+    "EmbeddingLDA": {"embeddings", "vocabulary"},
+    "TopicGPT": {"backend"},
+}
+
+# Zero/low-arg factories for every Rust-backed public model. Guidance/label args
+# get minimal placeholders; the values do not matter — settings reports the
+# *construction config*, which is available before fit.
+_FACTORIES: dict[str, object] = {
+    "LDA": lambda: topica.LDA(2),
+    "DMR": lambda: topica.DMR(2),
+    "SAGE": lambda: topica.SAGE(2),
+    "PA": lambda: topica.PA(num_super=2, num_sub=4),
+    "PT": lambda: topica.PT(num_topics=2, num_pseudo=10),
+    "HDP": lambda: topica.HDP(),
+    "HLDA": lambda: topica.HLDA(),
+    "LabeledLDA": lambda: topica.LabeledLDA(),
+    "SupervisedLDA": lambda: topica.SupervisedLDA(num_topics=2),
+    "DTM": lambda: topica.DTM(2),
+    "DiscLDA": lambda: topica.DiscLDA(2, 2),
+    "KeyATM": lambda: topica.KeyATM({"a": ["x"]}, num_topics=2),
+    "SeededLDA": lambda: topica.SeededLDA({"a": ["x"], "b": ["y"]}),
+    "GSDMM": lambda: topica.GSDMM(num_topics=5),
+    "BTM": lambda: topica.BTM(2),
+    "STM": lambda: topica.STM(2),
+    "CTM": lambda: topica.CTM(2),
+    "STS": lambda: topica.STS(2),
+    "ETM": lambda: topica.ETM(2),
+    "DETM": lambda: topica.DETM(2),
+    "ProdLDA": lambda: topica.ProdLDA(2),
+    "CombinedTM": lambda: topica.CombinedTM(2),
+    "ZeroShotTM": lambda: topica.ZeroShotTM(2),
+    "FASTopic": lambda: topica.FASTopic(2),
+    "InfoCTM": lambda: topica.InfoCTM(2),
+    "NMF": lambda: topica.NMF(2),
+    "LSA": lambda: topica.LSA(2),
+    "BERTopic": lambda: topica.BERTopic(min_cluster_size=5),
+    "Top2Vec": lambda: topica.Top2Vec(),
+    "PolylingualLDA": lambda: topica.PolylingualLDA(2),
+    "Scholar": lambda: topica.Scholar(2),
+    "TensorLDA": lambda: topica.TensorLDA(2),
+    "TBIP": lambda: topica.TBIP(2),
+    "IdealPointTM": lambda: topica.IdealPointTM(2),
+    "IdealPointSentenceTM": lambda: topica.IdealPointSentenceTM(2),
+    "Wordfish": lambda: topica.Wordfish(),
+    "PartyEmbeddings": lambda: topica.PartyEmbeddings(),
+    # Pure-Python wrapper models.
+    "GDMR": lambda: topica.GDMR(2, degrees=[2]),
+    "NarrativeTM": lambda: topica.NarrativeTM(2),
+    "AnchorLDA": lambda: topica.AnchorLDA(2),
+    "EmbeddingLDA": lambda: topica.EmbeddingLDA(
+        2, embeddings=[[1.0, 0.0], [0.0, 1.0], [1.0, 1.0]], vocabulary=["a", "b", "c"]
+    ),
+    "TopicGPT": lambda: topica.TopicGPT(backend=lambda p: ""),
+}
+
+# Every public registry model (Rust aliases collapse to one qualname).
+_MODELS = sorted(
+    set({getattr(_ext, n).__qualname__: n for n in REGISTRY if hasattr(_ext, n)}.values())
+    | {n for n in REGISTRY if not hasattr(_ext, n)}
+)
+
+
+def _expected_keys(cls) -> set[str]:
+    """Public keyword/positional constructor parameter names.
+
+    ``inspect.signature`` reads the Rust ``__text_signature__`` and native Python
+    ``__init__`` alike, so this covers both binding kinds. VAR_KEYWORD/VAR_POSITIONAL
+    (``*args``/``**kwargs``) are skipped.
+    """
+    out = set()
+    for p in inspect.signature(cls).parameters.values():
+        if p.kind in (p.VAR_KEYWORD, p.VAR_POSITIONAL):
+            continue
+        out.add(p.name)
+    return out
+
+
+def test_every_registry_model_covered():
+    """No public registry model is missing a factory here."""
+    missing = [n for n in _MODELS if n not in _FACTORIES]
+    assert not missing, f"add factories for: {missing}"
+
+
+@pytest.mark.parametrize("name", _MODELS)
+def test_settings_present_and_json(name):
+    model = _FACTORIES[name]()
+    assert hasattr(model, "settings"), f"{name} has no .settings"
+    s = model.settings
+    assert isinstance(s, dict), f"{name}.settings is {type(s)}, not dict"
+    # strict JSON: no NaN/Inf, no numpy scalars, no Python objects
+    json.dumps(s, allow_nan=False)
+
+
+@pytest.mark.parametrize("name", _MODELS)
+def test_settings_keys_match_constructor(name):
+    cls = getattr(topica, name)
+    expected = _expected_keys(cls) - _DATA_ARGS.get(name, set())
+    got = set(_FACTORIES[name]().settings.keys())
+    assert got == expected, (
+        f"{name}.settings keys mismatch\n"
+        f"  missing: {sorted(expected - got)}\n"
+        f"  extra:   {sorted(got - expected)}"
+    )
+
+
+# Non-default value cases for the reconstruction-prone params: enum-ish strings
+# rebuilt from internal flags/enums, renamed fields, and deprecated aliases.
+# ``settings`` must report the effective public value, not an internal form.
+_VALUE_CASES = [
+    (lambda: topica.LDA(2, sampler="warp"), "sampler", "warp"),
+    (lambda: topica.LDA(2, sampler="lightlda"), "sampler", "lightlda"),
+    (lambda: topica.LDA(2, sampler="cvb0"), "sampler", "cvb0"),
+    (lambda: topica.LDA(2, num_threads=0), "num_threads", 1),  # .max(1) floor
+    (lambda: topica.LDA(2, init="spectral"), "init", "spectral"),
+    (lambda: topica.DMR(2, sampler="warp"), "sampler", "warp"),
+    (lambda: topica.DMR(2, sampler="cvb0"), "sampler", "cvb0"),
+    (lambda: topica.LabeledLDA(sampler="cvb0"), "sampler", "cvb0"),
+    (lambda: topica.SeededLDA({"a": ["x"], "b": ["y"]}, sampler="warp"), "sampler", "warp"),
+    (lambda: topica.KeyATM({"a": ["x"]}, num_topics=2, sampler="cvb0"), "sampler", "cvb0"),
+    (lambda: topica.STM(2, init="random"), "init", "random"),
+    (lambda: topica.STM(2, variational="diagonal"), "variational", "diagonal"),
+    (lambda: topica.CTM(2, init="random"), "init", "random"),
+    (lambda: topica.DTM(2, init="spectral"), "init", "spectral"),
+    (lambda: topica.STS(2, init="random"), "init", "random"),
+    (lambda: topica.NMF(2, beta_loss="kullback-leibler"), "beta_loss", "kullback-leibler"),
+    (lambda: topica.NMF(2, weighting="tfidf"), "weighting", "tfidf"),
+    (lambda: topica.NMF(2, init="random"), "init", "random"),
+    (lambda: topica.LSA(2, weighting="count"), "weighting", "count"),
+    (lambda: topica.ProdLDA(2, prior="dirichlet"), "prior", "dirichlet"),
+    (lambda: topica.ETM(2, prior="laplace"), "prior", "laplace"),
+    (lambda: topica.ETM(2, inference="vae"), "inference", "vae"),
+    (lambda: topica.BERTopic(reducer="umap", min_cluster_size=5), "reducer", "umap"),
+    (lambda: topica.BERTopic(clusterer="kmeans", num_clusters=3, min_cluster_size=5), "clusterer", "kmeans"),
+    (lambda: topica.BERTopic(metric="euclidean", min_cluster_size=5), "metric", "euclidean"),
+    (lambda: topica.HDP(beta=0.5), "beta", 0.5),          # stored in the field named `eta`
+    (lambda: topica.HDP(beta=0.5), "eta", None),          # deprecated alias always None
+    (lambda: topica.GSDMM(num_topics=7), "num_topics", 7),  # stored as `k_max`
+    (lambda: topica.FASTopic(2, convergence_tol=1e-3), "convergence_tol", 1e-3),  # stored in `em_tol`
+    (lambda: topica.FASTopic(2, convergence_tol=1e-3), "em_tol", None),  # deprecated alias always None
+]
+
+
+@pytest.mark.parametrize("factory,key,expected", _VALUE_CASES)
+def test_settings_reconstructed_values(factory, key, expected):
+    assert factory().settings[key] == expected


### PR DESCRIPTION
Closes #400.

## What

Adds a uniform `model.settings` getter to **every** public model — its constructor configuration as a JSON-serialisable dict, keyword-named to match `__init__`. Covers all 37 Rust-backed classes and the 5 Python-wrapper models (GDMR, NarrativeTM, AnchorLDA, EmbeddingLDA, TopicGPT).

```python
topica.LDA(20, sampler="cvb0", init="spectral").settings
# {'num_topics': 20, 'alpha_sum': None, 'beta': 0.01, ..., 'sampler': 'cvb0', 'init': 'spectral'}
```

## Design

- **Effective values, public names.** `num_threads` after its `max(1)` floor; enum-ish params (`sampler`, `init`, `variational`, `prior`, `reducer`, `clusterer`, `metric`, `beta_loss`, `weighting`, `inference`) reconstructed to the canonical public string, not an internal flag/enum.
- **Honest handling of renames/aliases.** GSDMM `num_topics` from `k_max`; HDP `beta` from the field named `eta` (deprecated `eta` arg → `None`); FASTopic/ETM/ProdLDA `convergence_tol` from the folded `em_tol` field (deprecated `em_tol` → `None`).
- **Data omitted.** Guidance/data inputs (`keywords`, `seed_words`, covariate/content arrays, embeddings, LLM backends) are not hyperparameters and are excluded.
- `settings` only — no `get_params()` (house rule: different things, different names).

## Retires the manifest allowlist

`record_fit` previously kept a hand-written `_SETTINGS_ALLOWLIST` (LDA + STM only) and marked everything else `generic`. It now reads `model.settings` directly, so every model records full construction config (`settings_coverage: "full"`). This closes the manifest V2 "per-model settings adapters" backlog item — the fix belongs on the model, not the manifest.

## Tests

`tests/test_model_settings.py` derives the expected key set from each constructor signature, so **the test is the single inventory** — a new constructor parameter not surfaced in `settings` fails the suite. It also pins 30 non-default value cases for the reconstruction-prone params. 115 new assertions; full suite `3489 passed`, `cargo test --lib` `174 passed`, preflight (fmt + clippy + tables + stub) and strict mkdocs all green.

The `.pyi` stub gains `settings` on all 37 classes; `conventions.md` documents it as structural rule #4.

## Notes

Plan reviewed with an independent second-opinion pass (codex) before implementation; the Rust-side sweep was fanned out across the per-family binding files and centrally verified. This is the first of the #400-series follow-ups from the analysis manifest (#394); #401 (config-aware determinism) builds on this surface next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)