### PR TITLE
fix(api): `fit()` returns self so calls chain (#402)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -286,7 +286,7 @@ class DMR:
         convergence_tol: float = 0.0,
         check_every: int = 10,
         covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
-    ) -> None:
+    ) -> "DMR":
         """Fit by collapsed Gibbs with the per-document Dirichlet prior
         alpha_{d,t} = exp(lambda_t . x_d). `features` (or `covariates`, a
         symmetric alias) is required: an (num_docs, F) covariate matrix (no
@@ -459,7 +459,7 @@ class CTM:
         em_tol: Optional[float] = None,
         keep_eta_cov: bool = True,
         num_threads: Optional[int] = None,
-    ) -> None:
+    ) -> "CTM":
         """EM stops once the relative change in the variational bound falls below
         convergence_tol or after iters iterations, whichever comes first. Pass
         convergence_tol=0 to always run iters steps. Check converged and bound
@@ -627,7 +627,7 @@ class STM:
         covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
         keep_eta_cov: bool = True,
         num_threads: Optional[int] = None,
-    ) -> None:
+    ) -> "STM":
         """Fit. prevalence (or covariates, a symmetric alias) is (num_docs, F)
         covariates driving topic proportions (mu_d = X_d gamma; intercept
         prepended). content is one group label per document, making topic-word
@@ -834,7 +834,7 @@ class STS:
         em_tol: Optional[float] = None,
         covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
         keep_eta_cov: bool = True,
-    ) -> None:
+    ) -> "STS":
         """Fit. sentiment_seed (required, one value per document) defines the
         aggregation groups for the topic-word (kappa) Poisson M-step and seeds the
         initial sentiment — e.g. a star rating the sentiment should track.
@@ -990,7 +990,7 @@ class HDP:
         keep_theta_draws: bool = True,
         num_theta_draws: int = 25,
         report_interval: Optional[int] = None,
-    ) -> None:
+    ) -> "HDP":
         """Fit by `iters` Gibbs sweeps. The inferred K is then `num_topics`.
 
         progress_interval controls the discovery/convergence trace
@@ -1141,7 +1141,7 @@ class DTM:
         times: Sequence[int],
         *,
         iters: int = 20,
-    ) -> None:
+    ) -> "DTM":
         """Fit by variational EM. `times` is each document's integer time-slice
         index (0-based, contiguous); the slice count is max(times)+1."""
         ...
@@ -1263,7 +1263,7 @@ class DETM:
         timestamps: Sequence[int] | None = None,
         iters: int = 100,
         convergence_tol: float | None = None,
-    ) -> None:
+    ) -> "DETM":
         """Fit on `data` with `word_embeddings` (len(vocabulary), L) aligned to
         `vocabulary`. `times` is each document's integer time-slice index (0-based,
         contiguous; `timestamps` is the accepted alias). `iters` is the epoch count."""
@@ -1382,7 +1382,7 @@ class SupervisedLDA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 1,
-    ) -> None:
+    ) -> "SupervisedLDA":
         """Fit by variational EM. `y` is the per-document response (length =
         number of documents)."""
         ...
@@ -1542,7 +1542,7 @@ class SAGE:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
-    ) -> None:
+    ) -> "SAGE":
         """Fit. groups is one group label per document (strings or ints);
         group_names fixes group order (default: sorted union)."""
         ...
@@ -1702,7 +1702,7 @@ class LabeledLDA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
-    ) -> None:
+    ) -> "LabeledLDA":
         """Fit the model. labels is one label-list per document; the topic set is
         the union of all labels (or label_names, which fixes topic order). An
         empty label list leaves that document unconstrained (all topics)."""
@@ -1885,7 +1885,7 @@ class LDA:
         check_every: int = 10,
         num_threads: Optional[int] = None,
         turbo_merge_every: int = 1,
-    ) -> None:
+    ) -> "LDA":
         """Run Gibbs sampling to fit the model on data.
 
         With ``keep_theta_draws`` (default on), the last ``num_theta_draws``
@@ -2153,7 +2153,7 @@ class PT:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
-    ) -> None: ...
+    ) -> "PT": ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
@@ -2251,7 +2251,7 @@ class GSDMM:
         iters: int = 30,
         progress_interval: int = 0,
         report_interval: Optional[int] = None,
-    ) -> None:
+    ) -> "GSDMM":
         """Fit by the Movie Group Process. progress_interval controls the
         cluster-discovery trace (0 = auto ~50 points).
 
@@ -2336,7 +2336,7 @@ class BTM:
     ) -> None: ...
     def fit(
         self, data: Corpus | Sequence[Sequence[str]], *, iters: int | None = None
-    ) -> None: ...
+    ) -> "BTM": ...
     def transform(
         self, data: Corpus | Sequence[Sequence[str]]
     ) -> numpy.typing.NDArray[numpy.float64]:
@@ -2416,7 +2416,7 @@ class PolylingualLDA:
         | Sequence[Corpus | Sequence[Sequence[str]]],
         *,
         iters: int | None = None,
-    ) -> None:
+    ) -> "PolylingualLDA":
         """Fit on aligned document tuples: a dict {language: docs} (preferred) or a
         list of per-language corpora. Every language must have the same number of
         tuples, aligned by index."""
@@ -2509,7 +2509,7 @@ class DiscLDA:
         y: Sequence[str] | Sequence[int],
         *,
         iters: int | None = None,
-    ) -> None:
+    ) -> "DiscLDA":
         """Fit on documents with one class label `y` per document (str or int)."""
         ...
     def transform(
@@ -2597,7 +2597,7 @@ class PA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
-    ) -> None: ...
+    ) -> "PA": ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]:
         """Sub-topic word matrix, shape (num_sub, num_words); rows sum to 1."""
@@ -2706,7 +2706,7 @@ class HLDA:
 
         eta is a deprecated alias for beta."""
         ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 500) -> None: ...
+    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 500) -> "HLDA": ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]:
         """Node-word matrix, shape (num_nodes, num_words); rows sum to 1."""
@@ -2798,7 +2798,7 @@ class SeededLDA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
-    ) -> None:
+    ) -> "SeededLDA":
         """Fit the seeded model. `convergence_tol` (default 0.0, disabled) enables
         opt-in log-likelihood early stopping on the default ("sparse") sampler,
         recording the `fit_history` trace every `check_every` sweeps; the "cvb0"
@@ -2920,7 +2920,7 @@ class Top2Vec:
         *,
         word_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]] | None = None,
         vocabulary: Sequence[str] | None = None,
-    ) -> None:
+    ) -> "Top2Vec":
         """Fit on token documents plus one `doc_embeddings` row per document.
         Pass `word_embeddings` with the aligned `vocabulary` (same space) to
         enable `topic_neighbors`; they are realigned to topica's vocabulary."""
@@ -3028,7 +3028,7 @@ class BERTopic:
         self,
         data: Corpus | Sequence[Sequence[str]],
         doc_embeddings: numpy.typing.NDArray[numpy.float64] | Sequence[Sequence[float]],
-    ) -> None:
+    ) -> "BERTopic":
         """Fit on token documents plus one `doc_embeddings` row per document."""
         ...
     @property
@@ -3142,7 +3142,7 @@ class ETM:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
-    ) -> None:
+    ) -> "ETM":
         """Fit on token documents plus word embeddings (len(vocabulary) x E) and
         the aligned vocabulary, which defines the word ids. `iters` sets the number
         of training iterations (EM iterations or VAE epochs).
@@ -3253,7 +3253,7 @@ class InfoCTM:
         embeddings_b: dict[str, Sequence[float]] | None = None,
         iters: int | None = None,
         batch_size: int = 128,
-    ) -> None:
+    ) -> "InfoCTM":
         """Fit both languages jointly. ``dictionary`` is an iterable of
         ``(word_a, word_b)`` pairs; ``embeddings_*`` are optional ``{word: vector}``
         maps that densify the alignment mask. ``iters`` is the epoch count (500)."""
@@ -3330,7 +3330,7 @@ class ProdLDA:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
-    ) -> None:
+    ) -> "ProdLDA":
         """Fit on a Corpus or a list of token lists. `iters` sets the number of epochs.
 
         convergence_tol overrides the constructor's convergence_tol for this fit
@@ -3432,7 +3432,7 @@ class Scholar:
         content: object | None = None,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
-    ) -> None:
+    ) -> "Scholar":
         """Fit on a Corpus or list of token lists with prior ``covariates``, supervised
         ``labels`` (str/int, one per document), and/or topic-covariate ``content``. At
         least one of covariates, labels, or content must be given."""
@@ -3563,7 +3563,7 @@ class CombinedTM:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
-    ) -> None:
+    ) -> "CombinedTM":
         """Fit on token documents plus per-document embeddings (num_docs x E,
         in corpus order). `iters` sets the number of training epochs.
 
@@ -3670,7 +3670,7 @@ class ZeroShotTM:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
-    ) -> None:
+    ) -> "ZeroShotTM":
         """Fit on token documents plus per-document embeddings (num_docs x E,
         in corpus order). The encoder uses the embeddings alone. `iters` sets the
         number of training epochs.
@@ -3768,7 +3768,7 @@ class NMF:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
-    ) -> None:
+    ) -> "NMF":
         """Fit on a Corpus or a list of token lists. `iters` is the maximum number
         of multiplicative-update iterations (default 200). convergence_tol
         overrides the constructor value for this fit call only."""
@@ -3841,7 +3841,7 @@ class LSA:
         """weighting is 'tfidf' (default, classic LSI) or 'count'. seed seeds the
         randomized-SVD sketch."""
         ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]]) -> None:
+    def fit(self, data: Corpus | Sequence[Sequence[str]]) -> "LSA":
         """Fit on a Corpus or a list of token lists. The SVD is a direct solve, so
         there is no iters argument."""
         ...
@@ -3921,7 +3921,7 @@ class TensorLDA:
         pca_batch_size: int = 128,
         seed: int = 42,
     ) -> None: ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int | None = None) -> None: ...
+    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int | None = None) -> "TensorLDA": ...
     def partial_fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -4009,7 +4009,7 @@ class FASTopic:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
-    ) -> None:
+    ) -> "FASTopic":
         """Fit on token documents plus frozen document embeddings (num_docs x E).
         The vocabulary is taken from the corpus; the word embeddings are learned.
         `iters` sets the number of training epochs.
@@ -4152,7 +4152,7 @@ class KeyATM:
         convergence_tol: float = 0.0,
         report_interval: Optional[int] = None,
         turbo_alpha_stride: int = 1,
-    ) -> None:
+    ) -> "KeyATM":
         """Fit by collapsed Gibbs. Pass `covariates` (num_docs x F) for the
         covariate keyATM: the document-topic prior becomes a DMR,
         alpha_{d,k} = exp(x_d . lambda_k) (an intercept is prepended), and the
@@ -4395,7 +4395,7 @@ class IdealPointTM:
         anchors: dict[str, float] | None = None,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
-    ) -> None:
+    ) -> "IdealPointTM":
         """Fit on token documents. Omit `word_embeddings` for the count
         representation (the vocabulary is built from the corpus by min_count; do not
         pass `vocabulary`). Pass `word_embeddings` (len(vocabulary) x E) with the
@@ -4529,7 +4529,7 @@ class Wordfish:
         anchors: dict[str, float] | None = None,
         iters: int | None = None,
         convergence_tol: float | None = None,
-    ) -> None:
+    ) -> "Wordfish":
         """group pools documents sharing a label into one unit with one position;
         control is an optional categorical confound (constant within each author)
         whose level-specific word usage is absorbed into per-level offsets so it does
@@ -4606,7 +4606,7 @@ class IdealPointSentenceTM:
         anchors: dict[str, float] | None = None,
         iters: int | None = None,
         convergence_tol: float | None = None,
-    ) -> None:
+    ) -> "IdealPointSentenceTM":
         """embeddings is an (N, D) array of per-observation sentence/document
         embeddings; group (length N) gives the author of each observation."""
         ...
@@ -4695,7 +4695,7 @@ class TBIP:
         iters: int | None = None,
         batch_size: int | None = None,
         learning_rate: float | None = None,
-    ) -> None:
+    ) -> "TBIP":
         """data is a Corpus or list of token lists; group (length num_docs) gives the
         author of each document (documents sharing a label share one ideal point)."""
         ...
@@ -4790,7 +4790,7 @@ class PartyEmbeddings:
         control: Sequence[str] | None = None,
         anchors: dict[str, float] | None = None,
         iters: int = 5,
-    ) -> None:
+    ) -> "PartyEmbeddings":
         """data is a Corpus or list of token lists; group (length num_docs) is the
         party-period label of each document. control is an optional second
         per-document metadata tag (estimated but not placed); anchors

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -166,11 +166,11 @@ impl BTM {
     /// Fit the model on a corpus or list of token lists.
     #[pyo3(signature = (data, *, iters=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -190,19 +190,19 @@ impl BTM {
             .0
         };
         let num_types = corpus.num_types();
-        if num_types < self.num_topics {
+        if num_types < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
         }
-        let iters = iters.unwrap_or(self.iters);
-        let alpha = self.alpha.unwrap_or(50.0 / self.num_topics as f64);
+        let iters = iters.unwrap_or(slf.iters);
+        let alpha = slf.alpha.unwrap_or(50.0 / slf.num_topics as f64);
         let (k, beta, window, background, seed) = (
-            self.num_topics,
-            self.beta,
-            self.window,
-            self.background,
-            self.seed,
+            slf.num_topics,
+            slf.beta,
+            slf.window,
+            slf.background,
+            slf.seed,
         );
 
         let (model, corpus) = py.allow_threads(move || {
@@ -220,11 +220,11 @@ impl BTM {
             );
             (m, corpus)
         });
-        self.model = Some(model);
-        self.corpus = Some(corpus);
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpus = Some(corpus);
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Infer document-topic distributions for new documents (the `sum_b` scheme).

--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -194,12 +194,12 @@ impl DiscLDA {
     /// document). Classes are sorted to a fixed order.
     #[pyo3(signature = (data, y, *, iters=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         y: &Bound<'_, PyAny>,
         iters: Option<usize>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let labels_str = extract_labels(y)?;
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -242,15 +242,15 @@ impl DiscLDA {
 
         let num_types = corpus.num_types();
         let num_classes = classes.len();
-        let l = num_classes * self.k_class + self.k_shared;
+        let l = num_classes * slf.k_class + slf.k_shared;
         if num_types < l {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_classes*k_class + k_shared words",
             ));
         }
-        let iters = iters.unwrap_or(self.iters);
-        let alpha = self.alpha.unwrap_or(0.1);
-        let (k_class, k_shared, beta, seed) = (self.k_class, self.k_shared, self.beta, self.seed);
+        let iters = iters.unwrap_or(slf.iters);
+        let alpha = slf.alpha.unwrap_or(0.1);
+        let (k_class, k_shared, beta, seed) = (slf.k_class, slf.k_shared, slf.beta, slf.seed);
 
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
@@ -268,12 +268,12 @@ impl DiscLDA {
             );
             (m, corpus)
         });
-        self.model = Some(model);
-        self.corpus = Some(corpus);
-        self.classes = classes;
-        self.topic_names = self.build_topic_names();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpus = Some(corpus);
+        slf.classes = classes;
+        slf.topic_names = slf.build_topic_names();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// The class-marginalized discriminative representation Σ_c p(c|w)·θ_c for new

--- a/src/python/embedding_cluster.rs
+++ b/src/python/embedding_cluster.rs
@@ -227,13 +227,13 @@ impl Top2Vec {
     /// `topic_neighbors`; the word embeddings are realigned to topica's vocabulary.
     #[pyo3(signature = (data, doc_embeddings, *, word_embeddings=None, vocabulary=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         doc_embeddings: &Bound<'_, PyAny>,
         word_embeddings: Option<&Bound<'_, PyAny>>,
         vocabulary: Option<Vec<String>>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -299,23 +299,23 @@ impl Top2Vec {
             }
             None => Vec::new(),
         };
-        self.has_word_vectors = !word_vecs.is_empty();
-        self.id_to_word = corpus.id_to_word.clone();
-        self.docs = corpus.docs.clone();
+        slf.has_word_vectors = !word_vecs.is_empty();
+        slf.id_to_word = corpus.id_to_word.clone();
+        slf.docs = corpus.docs.clone();
 
-        umap_notice(py, self.use_umap)?;
+        umap_notice(py, slf.use_umap)?;
         let (nc, uu, nn, mcs, ms, seed) = (
-            self.n_components,
-            self.use_umap,
-            self.n_neighbors,
-            self.min_cluster_size,
-            self.min_samples,
-            self.seed,
+            slf.n_components,
+            slf.use_umap,
+            slf.n_neighbors,
+            slf.min_cluster_size,
+            slf.min_samples,
+            slf.seed,
         );
-        let clusterer = self.clusterer.clone();
-        let num_clusters = self.num_clusters;
-        let (resolution, knn_neighbors) = (self.resolution, self.knn_neighbors);
-        let umap_params = self.umap_params.clone();
+        let clusterer = slf.clusterer.clone();
+        let num_clusters = slf.num_clusters;
+        let (resolution, knn_neighbors) = (slf.resolution, slf.knn_neighbors);
+        let umap_params = slf.umap_params.clone();
         let model = py.allow_threads(move || {
             top2vec::fit_top2vec(
                 &corpus.docs,
@@ -344,20 +344,20 @@ impl Top2Vec {
                  min_cluster_size, add data, or check the scale of your embeddings.",
                 ),
             )?;
-        } else if self.diagnostics {
+        } else if slf.diagnostics {
             emit_cluster_diagnostics(
                 py,
                 "Top2Vec",
-                &self.clusterer,
+                &slf.clusterer,
                 model.num_topics,
                 &model.labels,
             )?;
         }
         let k = model.num_topics;
-        self.model = Some(model);
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Number of topics discovered (HDBSCAN clusters found).
@@ -580,15 +580,15 @@ impl Top2Vec {
     /// word strings aligned to the rows of `word_embeddings`.
     #[pyo3(signature = (data, doc_embeddings, *, word_embeddings=None, vocabulary=None))]
     fn fit_transform<'py>(
-        &mut self,
+        slf: PyRefMut<'_, Self>,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
         doc_embeddings: &Bound<'py, PyAny>,
         word_embeddings: Option<&Bound<'py, PyAny>>,
         vocabulary: Option<Vec<String>>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        self.fit(py, data, doc_embeddings, word_embeddings, vocabulary)?;
-        Ok(vecs_to_arr2(&self.fitted_model()?.doc_topic).to_pyarray_bound(py))
+        let fitted = Self::fit(slf, py, data, doc_embeddings, word_embeddings, vocabulary)?;
+        Ok(vecs_to_arr2(&fitted.bind(py).borrow().fitted_model()?.doc_topic).to_pyarray_bound(py))
     }
 
     /// Merge groups of topics into single topics, e.g. ``[[3, 7], [1, 2]]``. The
@@ -932,11 +932,11 @@ impl BERTopic {
     /// (`(num_docs, E)`), one row per document. No word embeddings are needed.
     #[pyo3(signature = (data, doc_embeddings))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         doc_embeddings: &Bound<'_, PyAny>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -968,26 +968,26 @@ impl BERTopic {
         }
         check_all_finite_2d("doc_embeddings", &doc_emb)?;
         let num_types = corpus.num_types();
-        self.id_to_word = corpus.id_to_word.clone();
-        self.docs = corpus.docs.clone();
-        umap_notice(py, self.use_umap)?;
+        slf.id_to_word = corpus.id_to_word.clone();
+        slf.docs = corpus.docs.clone();
+        umap_notice(py, slf.use_umap)?;
         let (nc, uu, nn, mcs, ms, nr, win, st, b25, rf, seed) = (
-            self.n_components,
-            self.use_umap,
-            self.n_neighbors,
-            self.min_cluster_size,
-            self.min_samples,
-            self.nr_topics,
-            self.window,
-            self.stride,
-            self.bm25,
-            self.reduce_frequent,
-            self.seed,
+            slf.n_components,
+            slf.use_umap,
+            slf.n_neighbors,
+            slf.min_cluster_size,
+            slf.min_samples,
+            slf.nr_topics,
+            slf.window,
+            slf.stride,
+            slf.bm25,
+            slf.reduce_frequent,
+            slf.seed,
         );
-        let clusterer = self.clusterer.clone();
-        let num_clusters = self.num_clusters;
-        let (resolution, knn_neighbors) = (self.resolution, self.knn_neighbors);
-        let umap_params = self.umap_params.clone();
+        let clusterer = slf.clusterer.clone();
+        let num_clusters = slf.num_clusters;
+        let (resolution, knn_neighbors) = (slf.resolution, slf.knn_neighbors);
+        let umap_params = slf.umap_params.clone();
         let model = py.allow_threads(move || {
             bertopic::fit_bertopic(
                 &corpus.docs,
@@ -1020,20 +1020,20 @@ impl BERTopic {
                  min_cluster_size, add data, or check the scale of your embeddings.",
                 ),
             )?;
-        } else if self.diagnostics {
+        } else if slf.diagnostics {
             emit_cluster_diagnostics(
                 py,
                 "BERTopic",
-                &self.clusterer,
+                &slf.clusterer,
                 model.num_topics,
                 &model.labels,
             )?;
         }
         let k = model.num_topics;
-        self.model = Some(model);
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -1201,13 +1201,13 @@ impl BERTopic {
     /// one row per document in corpus order.
     #[pyo3(signature = (data, doc_embeddings))]
     fn fit_transform<'py>(
-        &mut self,
+        slf: PyRefMut<'_, Self>,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
         doc_embeddings: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        self.fit(py, data, doc_embeddings)?;
-        Ok(vecs_to_arr2(&self.fitted_model()?.doc_topic).to_pyarray_bound(py))
+        let fitted = Self::fit(slf, py, data, doc_embeddings)?;
+        Ok(vecs_to_arr2(&fitted.bind(py).borrow().fitted_model()?.doc_topic).to_pyarray_bound(py))
     }
 
     /// Merge groups of topics into single topics, e.g. ``[[3, 7], [1, 2]]``,

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -165,7 +165,7 @@ impl PA {
     #[pyo3(signature = (data, *, iters=1000, keep_theta_draws=true, num_theta_draws=25,
                         convergence_tol=0.0_f64, check_every=10_usize))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
@@ -173,7 +173,7 @@ impl PA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -197,12 +197,12 @@ impl PA {
         }
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
-        let (s, k, a, b) = (self.num_super, self.num_sub, self.alpha, self.beta);
+        let (s, k, a, b) = (slf.num_super, slf.num_sub, slf.alpha, slf.beta);
 
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
             let (m, hist, conv) = pa::fit_pam_with_draws(
                 &corpus.docs,
@@ -219,16 +219,16 @@ impl PA {
             );
             (m, hist, conv, corpus)
         });
-        self.theta_draws = draws_to_array3(&model.theta_draws, num_docs, k, None);
-        self.phi = Some(vecs_to_arr2(&model.topic_word()));
-        self.theta = Some(vecs_to_arr2(&model.doc_topic()));
-        self.super_sub = Some(vecs_to_arr2(&model.super_sub()));
-        self.topic_names = (0..self.num_sub).map(|i| format!("topic_{i}")).collect();
-        self.log_likelihood_history = ll_history;
-        self.converged = converged_flag;
-        self.corpus = Some(corpus);
-        self.fitted = true;
-        Ok(())
+        slf.theta_draws = draws_to_array3(&model.theta_draws, num_docs, k, None);
+        slf.phi = Some(vecs_to_arr2(&model.topic_word()));
+        slf.theta = Some(vecs_to_arr2(&model.doc_topic()));
+        slf.super_sub = Some(vecs_to_arr2(&model.super_sub()));
+        slf.topic_names = (0..slf.num_sub).map(|i| format!("topic_{i}")).collect();
+        slf.log_likelihood_history = ll_history;
+        slf.converged = converged_flag;
+        slf.corpus = Some(corpus);
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Sub-topic word distributions, shape ``(num_sub, num_words)``.
@@ -589,7 +589,12 @@ impl HLDA {
 
     /// Fit by nested-CRP collapsed Gibbs sampling for `iters` sweeps.
     #[pyo3(signature = (data, *, iters=500))]
-    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>, iters: usize) -> PyResult<()> {
+    fn fit(
+        mut slf: PyRefMut<'_, Self>,
+        py: Python<'_>,
+        data: &Bound<'_, PyAny>,
+        iters: usize,
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -612,8 +617,8 @@ impl HLDA {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
         let num_types = corpus.num_types();
-        let (depth, gamma, eta, alpha) = (self.depth, self.gamma, self.eta, self.alpha);
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let (depth, gamma, eta, alpha) = (slf.depth, slf.gamma, slf.eta, slf.alpha);
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
         let (model, corpus) = py.allow_threads(move || {
             let m = hlda::fit_hlda(
                 &corpus.docs,
@@ -635,17 +640,17 @@ impl HLDA {
                 tw[[i, w]] = val;
             }
         }
-        self.num_nodes = nn;
-        self.topic_names = (0..nn).map(|i| format!("topic_{i}")).collect();
-        self.node_topic_word = Some(tw);
-        self.node_levels = (0..nn).map(|i| model.node_level(i)).collect();
-        self.node_parents = (0..nn)
+        slf.num_nodes = nn;
+        slf.topic_names = (0..nn).map(|i| format!("topic_{i}")).collect();
+        slf.node_topic_word = Some(tw);
+        slf.node_levels = (0..nn).map(|i| model.node_level(i)).collect();
+        slf.node_parents = (0..nn)
             .map(|i| model.node_parent(i).map(|p| p as i64).unwrap_or(-1))
             .collect();
-        self.doc_paths = (0..corpus.num_docs()).map(|d| model.doc_path(d)).collect();
-        self.corpus = Some(corpus);
-        self.fitted = true;
-        Ok(())
+        slf.doc_paths = (0..corpus.num_docs()).map(|d| model.doc_path(d)).collect();
+        slf.corpus = Some(corpus);
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// The number of topic nodes in the inferred tree.

--- a/src/python/idealpoint.rs
+++ b/src/python/idealpoint.rs
@@ -432,7 +432,7 @@ impl IdealPointTM {
                         anchors=None, iters=None, convergence_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         word_embeddings: Option<&Bound<'_, PyAny>>,
@@ -441,11 +441,11 @@ impl IdealPointTM {
         anchors: Option<HashMap<String, f64>>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
-        let tol = convergence_tol.unwrap_or(self.convergence_tol);
+    ) -> PyResult<Py<Self>> {
+        let tol = convergence_tol.unwrap_or(slf.convergence_tol);
         let it = iters.unwrap_or(50);
         match word_embeddings {
-            Some(emb) => self.fit_embedded(py, data, emb, vocabulary, group, anchors, it, tol),
+            Some(emb) => slf.fit_embedded(py, data, emb, vocabulary, group, anchors, it, tol)?,
             None => {
                 if vocabulary.is_some() {
                     return Err(PyValueError::new_err(
@@ -453,9 +453,10 @@ impl IdealPointTM {
                          representation (the vocabulary is built from the corpus by min_count)",
                     ));
                 }
-                self.fit_counts(py, data, group, anchors, it, tol)
+                slf.fit_counts(py, data, group, anchors, it, tol)?
             }
         }
+        Ok(slf.into())
     }
 
     #[getter]

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1006,7 +1006,7 @@ impl LDA {
                         turbo_merge_every=1_usize))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
@@ -1020,7 +1020,7 @@ impl LDA {
         check_every: usize,
         num_threads: Option<usize>,
         turbo_merge_every: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         // Accept either a Corpus or a list[list[str]].
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -1037,10 +1037,10 @@ impl LDA {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
 
-        let num_topics = self.num_topics;
+        let num_topics = slf.num_topics;
         let num_types = corpus.num_types();
         let num_docs = corpus.num_docs();
-        let alpha_sum = self.alpha_sum.unwrap_or(num_topics as f64);
+        let alpha_sum = slf.alpha_sum.unwrap_or(num_topics as f64);
         let total_tokens = corpus.total_tokens().max(1) as f64;
 
         // When check_every=0 the caller explicitly disabled trace recording.
@@ -1062,11 +1062,11 @@ impl LDA {
         let draw_thin = theta_draw_thin(iters, draw_cap);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, num_topics)?;
 
-        let mut model = TopicModel::new(num_topics, alpha_sum, self.beta, num_types);
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let mut model = TopicModel::new(num_topics, alpha_sum, slf.beta, num_types);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         // Spectral anchor-word init is opt-in; it falls back to the random draw
         // when the corpus is too small for anchor recovery (spectral_init -> None).
-        if self.init_spectral {
+        if slf.init_spectral {
             match spectral::spectral_init(&corpus.docs, num_topics, num_types) {
                 Some(beta) => model.initialize_spectral(&corpus, &beta, &mut rng),
                 None => model.initialize(&corpus, &mut rng),
@@ -1075,10 +1075,10 @@ impl LDA {
             model.initialize(&corpus, &mut rng);
         }
 
-        let optimize_interval = self.optimize_interval;
-        let burn_in = self.burn_in;
+        let optimize_interval = slf.optimize_interval;
+        let burn_in = slf.burn_in;
         // num_threads from fit() overrides the constructor default for this run.
-        let num_threads = num_threads.unwrap_or(self.num_threads).max(1);
+        let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
         // turbo_merge_every (default 1): in the approximate-parallel (num_threads
         // > 1) path, defer the per-sweep count-table reconciliation, merging once
         // every this-many sweeps instead. 1 keeps the exact per-sweep path
@@ -1088,13 +1088,13 @@ impl LDA {
             return Err(PyValueError::new_err("turbo_merge_every must be >= 1"));
         }
         let merge_every = turbo_merge_every.max(1);
-        let seed_base = self.seed;
-        let light = self.light;
-        let warp = self.warp;
-        let cvb0_flag = self.cvb0;
-        let mh_steps = self.mh_steps;
-        let beta = self.beta;
-        let use_symmetric_alpha = self.use_symmetric_alpha;
+        let seed_base = slf.seed;
+        let light = slf.light;
+        let warp = slf.warp;
+        let cvb0_flag = slf.cvb0;
+        let mh_steps = slf.mh_steps;
+        let beta = slf.beta;
+        let use_symmetric_alpha = slf.use_symmetric_alpha;
 
         // CVB0 path: deterministic collapsed-variational inference. No MCMC, so
         // no θ-draws; convergence_tol early-stops on the mean |Δγ| per sweep.
@@ -1132,12 +1132,12 @@ impl LDA {
                     let model = cv.to_topic_model(&corpus);
                     (acc_phi, acc_theta, ll_history, converged, model, corpus)
                 });
-            self.theta_draws = None;
-            self.finalize_fit(
+            slf.theta_draws = None;
+            slf.finalize_fit(
                 num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus, ll_history,
                 converged,
             );
-            return Ok(());
+            return Ok(slf.into());
         }
 
         // Metropolis-Hastings backends (WarpLDA, LightLDA): each owns its dense
@@ -1196,8 +1196,8 @@ impl LDA {
                     )
                 }
             });
-            self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
-            self.finalize_fit(
+            slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
+            slf.finalize_fit(
                 num_topics,
                 num_types,
                 num_docs,
@@ -1208,7 +1208,7 @@ impl LDA {
                 Vec::new(),
                 false,
             );
-            return Ok(());
+            return Ok(slf.into());
         }
 
         // Heavy loop runs with the GIL released; the progress callback briefly
@@ -1357,12 +1357,12 @@ impl LDA {
                 )
             });
         let (model, corpus) = model;
-        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
-        self.finalize_fit(
+        slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
+        slf.finalize_fit(
             num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus, ll_history,
             converged,
         );
-        Ok(())
+        Ok(slf.into())
     }
 
     /// The constructor configuration as a JSON-serialisable dict, keyword-named
@@ -3533,7 +3533,7 @@ impl DMR {
                         convergence_tol=0.0_f64, check_every=10_usize, covariates=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         features: Option<&Bound<'_, PyAny>>,
@@ -3548,7 +3548,7 @@ impl DMR {
         convergence_tol: f64,
         check_every: usize,
         covariates: Option<&Bound<'_, PyAny>>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         // covariates= is a no-deprecation alias for features=
         let features: &Bound<'_, PyAny> = match (features, covariates) {
             (Some(_), Some(_)) => {
@@ -3627,28 +3627,28 @@ impl DMR {
             feature_names.unwrap_or_else(|| (0..f_in).map(|i| format!("feature_{}", i)).collect()),
         );
 
-        let k = self.num_topics;
+        let k = slf.num_topics;
         let num_types = corpus.num_types();
         let num_docs = corpus.num_docs();
         let total_tokens = corpus.total_tokens().max(1) as f64;
 
         // λ starts at zero -> α ≡ 1 (symmetric) before optimization kicks in.
         let mut lambda = vec![vec![0.0f64; nf]; k];
-        let mut model = TopicModel::new(k, k as f64, self.beta, num_types);
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let mut model = TopicModel::new(k, k as f64, slf.beta, num_types);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         // The sparse path initializes `model` inside its branch below; the warp
         // path builds its own WarpLda state, so the shared init is deferred.
 
-        let optimize_interval = self.optimize_interval;
-        let burn_in = self.burn_in;
-        let prior_variance = self.prior_variance;
-        let lbfgs_iters = self.lbfgs_iters;
+        let optimize_interval = slf.optimize_interval;
+        let burn_in = slf.burn_in;
+        let prior_variance = slf.prior_variance;
+        let lbfgs_iters = slf.lbfgs_iters;
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        let beta = self.beta;
-        let warp = self.warp;
-        let cvb0_flag = self.cvb0;
+        let beta = slf.beta;
+        let warp = slf.warp;
+        let cvb0_flag = slf.cvb0;
         let (
             acc_phi,
             acc_theta,
@@ -4017,18 +4017,18 @@ impl DMR {
             }
         }
 
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.phi = Some(phi);
-        self.theta = Some(theta);
-        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
-        self.feature_effects = Some(fe);
-        self.feature_effect_se = Some(fe_se);
-        self.feature_names = names;
-        self.log_likelihood_history = ll_history;
-        self.converged = converged_flag;
-        self.corpus = Some(corpus);
-        self.fitted = true;
-        Ok(())
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.phi = Some(phi);
+        slf.theta = Some(theta);
+        slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
+        slf.feature_effects = Some(fe);
+        slf.feature_effect_se = Some(fe_se);
+        slf.feature_names = names;
+        slf.log_likelihood_history = ll_history;
+        slf.converged = converged_flag;
+        slf.corpus = Some(corpus);
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Topic-word matrix φ, shape ``(num_topics, num_words)``.
@@ -4529,7 +4529,7 @@ impl LabeledLDA {
                         convergence_tol=0.0_f64, check_every=10_usize))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         labels: Vec<Vec<String>>,
@@ -4543,7 +4543,7 @@ impl LabeledLDA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -4616,9 +4616,9 @@ impl LabeledLDA {
 
         let num_types = corpus.num_types();
         let total_tokens = corpus.total_tokens().max(1) as f64;
-        let alpha_sum = self.alpha * k as f64;
-        let mut model = TopicModel::new(k, alpha_sum, self.beta, num_types);
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let alpha_sum = slf.alpha * k as f64;
+        let mut model = TopicModel::new(k, alpha_sum, slf.beta, num_types);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         labeled::initialize_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
 
         let check_every_labeled = if check_every == 0 {
@@ -4631,12 +4631,12 @@ impl LabeledLDA {
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        if self.cvb0 {
+        if slf.cvb0 {
             // CVB0 LabeledLDA: deterministic; the per-document label set masks the
             // responsibilities (γ is zero off the allowed topics — free in CVB0,
             // unlike a sampler's proposal rejection). No MCMC, so no θ-draws.
-            let beta = self.beta;
-            let alpha = self.alpha;
+            let beta = slf.beta;
+            let alpha = slf.alpha;
             let (acc_phi, acc_theta, model, corpus) = py.allow_threads(move || {
                 let alpha0 = vec![alpha; k];
                 let mut cv = cvb0::Cvb0::new(&corpus, k, &alpha0, beta, &mut rng);
@@ -4659,17 +4659,17 @@ impl LabeledLDA {
                 }
             }
             let theta = vecs_to_arr2(&acc_theta);
-            self.num_topics = k;
-            self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-            self.label_vocab = label_vocab;
-            self.phi = Some(phi);
-            self.theta = Some(theta);
-            self.theta_draws = None;
-            self.corpus = Some(corpus);
-            self.log_likelihood_history = Vec::new();
-            self.converged = false;
-            self.fitted = true;
-            return Ok(());
+            slf.num_topics = k;
+            slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+            slf.label_vocab = label_vocab;
+            slf.phi = Some(phi);
+            slf.theta = Some(theta);
+            slf.theta_draws = None;
+            slf.corpus = Some(corpus);
+            slf.log_likelihood_history = Vec::new();
+            slf.converged = false;
+            slf.fitted = true;
+            return Ok(slf.into());
         }
 
         let (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, model, corpus) = py
@@ -4783,17 +4783,17 @@ impl LabeledLDA {
             }
         }
 
-        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
-        self.num_topics = k;
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.phi = Some(phi);
-        self.theta = Some(theta);
-        self.label_vocab = label_vocab;
-        self.corpus = Some(corpus);
-        self.log_likelihood_history = ll_history;
-        self.converged = converged;
-        self.fitted = true;
-        Ok(())
+        slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
+        slf.num_topics = k;
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.phi = Some(phi);
+        slf.theta = Some(theta);
+        slf.label_vocab = label_vocab;
+        slf.corpus = Some(corpus);
+        slf.log_likelihood_history = ll_history;
+        slf.converged = converged;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Topic-word matrix φ, shape ``(num_topics, num_words)``.
@@ -5221,7 +5221,7 @@ impl SAGE {
                         convergence_tol=0.0_f64, check_every=10_usize))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         groups: &Bound<'_, PyAny>,
@@ -5235,7 +5235,7 @@ impl SAGE {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -5291,21 +5291,21 @@ impl SAGE {
             })
             .collect::<PyResult<_>>()?;
 
-        let k = self.num_topics;
+        let k = slf.num_topics;
         let group_n = group_vocab.len();
         let num_types = corpus.num_types();
-        let alpha = self.alpha;
+        let alpha = slf.alpha;
         let alpha_sum = alpha * k as f64;
         let total_tokens = corpus.total_tokens().max(1) as f64;
 
-        let mut model = sage::SageModel::new(k, group_n, num_types, alpha, self.prior_variance);
+        let mut model = sage::SageModel::new(k, group_n, num_types, alpha, slf.prior_variance);
         model.set_background(&corpus.docs);
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         model.initialize(&corpus.docs, &groups_idx, &mut rng);
 
-        let optimize_interval = self.optimize_interval;
-        let burn_in = self.burn_in;
-        let lbfgs_iters = self.lbfgs_iters;
+        let optimize_interval = slf.optimize_interval;
+        let burn_in = slf.burn_in;
+        let lbfgs_iters = slf.lbfgs_iters;
 
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
@@ -5407,17 +5407,17 @@ impl SAGE {
             }
         }
 
-        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.num_groups = group_n;
-        self.beta = beta;
-        self.theta = Some(theta);
-        self.group_names = group_vocab;
-        self.corpus = Some(corpus);
-        self.log_likelihood_history = ll_history;
-        self.converged = converged_flag;
-        self.fitted = true;
-        Ok(())
+        slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.num_groups = group_n;
+        slf.beta = beta;
+        slf.theta = Some(theta);
+        slf.group_names = group_vocab;
+        slf.corpus = Some(corpus);
+        slf.log_likelihood_history = ll_history;
+        slf.converged = converged_flag;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Topic-word distributions per group, shape ``(num_topics, num_groups, num_words)``.
@@ -6077,7 +6077,7 @@ impl CTM {
                         keep_eta_cov=true, num_threads=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
@@ -6090,7 +6090,7 @@ impl CTM {
         em_tol: Option<f64>,
         keep_eta_cov: bool,
         num_threads: Option<usize>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
             warnings.call_method1(
@@ -6141,12 +6141,12 @@ impl CTM {
             }
         };
 
-        let k = self.num_topics;
+        let k = slf.num_topics;
         let num_types = corpus.num_types();
-        let shrink = self.sigma_shrink;
-        let spectral = self.init_spectral;
-        let diagonal = self.variational == "diagonal";
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let shrink = slf.sigma_shrink;
+        let spectral = slf.init_spectral;
+        let diagonal = slf.variational == "diagonal";
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
         let init_beta = parse_init_beta(beta_init, k, num_types, svi)?;
 
@@ -6253,26 +6253,26 @@ impl CTM {
             arr
         };
 
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.beta = Some(beta);
-        self.theta = Some(theta);
-        self.corr = Some(corr);
-        self.eta_mean = Some(eta_mean_arr);
-        self.eta_cov = stored_eta_cov;
-        self.mu = model.mu.clone();
-        self.sigma = model.sigma.clone();
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.beta = Some(beta);
+        slf.theta = Some(theta);
+        slf.corr = Some(corr);
+        slf.eta_mean = Some(eta_mean_arr);
+        slf.eta_cov = stored_eta_cov;
+        slf.mu = model.mu.clone();
+        slf.sigma = model.sigma.clone();
         // Retain the E-step snapshots only when eta_cov was NOT kept, so the
         // default path carries no extra state (recompute uses the stored eta_cov).
         if !keep_eta_cov {
-            self.sigma_estep = model.sigma_estep.clone();
-            self.beta_estep = Some(beta_estep_arr);
+            slf.sigma_estep = model.sigma_estep.clone();
+            slf.beta_estep = Some(beta_estep_arr);
         }
-        self.corpus = Some(corpus);
-        self.bound = model.bound;
-        self.bound_history = model.bound_history.clone();
-        self.converged = model.converged;
-        self.fitted = true;
-        Ok(())
+        slf.corpus = Some(corpus);
+        slf.bound = model.bound;
+        slf.bound_history = model.bound_history.clone();
+        slf.converged = model.converged;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Topic-word matrix β, shape ``(num_topics, num_words)``.
@@ -6885,7 +6885,7 @@ impl STM {
                         covariates=None, keep_eta_cov=true, num_threads=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         prevalence: Option<&Bound<'_, PyAny>>,
@@ -6905,7 +6905,7 @@ impl STM {
         covariates: Option<&Bound<'_, PyAny>>,
         keep_eta_cov: bool,
         num_threads: Option<usize>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
             warnings.call_method1(
@@ -7140,12 +7140,12 @@ impl STM {
             }
         };
 
-        let k = self.num_topics;
+        let k = slf.num_topics;
         let num_types = corpus.num_types();
-        let shrink = self.sigma_shrink;
-        let spectral = self.init_spectral;
-        let diagonal = self.variational == "diagonal";
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let shrink = slf.sigma_shrink;
+        let spectral = slf.init_spectral;
+        let diagonal = slf.variational == "diagonal";
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
         let init_beta = parse_init_beta(beta_init, k, num_types, false)?;
 
@@ -7196,7 +7196,7 @@ impl STM {
                 corr[[i, j]] = corr_v[i][j];
             }
         }
-        self.gamma = model.gamma.as_ref().map(|g| {
+        slf.gamma = model.gamma.as_ref().map(|g| {
             let nf = g.len();
             let mut arr = Array2::<f64>::zeros((nf, k - 1));
             for ff in 0..nf {
@@ -7246,34 +7246,34 @@ impl STM {
             arr
         };
 
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.beta = Some(beta);
-        self.theta = Some(theta);
-        self.corr = Some(corr);
-        self.eta_mean = Some(eta_mean_arr);
-        self.eta_cov = stored_eta_cov;
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.beta = Some(beta);
+        slf.theta = Some(theta);
+        slf.corr = Some(corr);
+        slf.eta_mean = Some(eta_mean_arr);
+        slf.eta_cov = stored_eta_cov;
         // E-step β snapshot: retained only when eta_cov was NOT kept (see below).
         if !keep_eta_cov {
-            self.beta_estep = Some(beta_estep_arr);
+            slf.beta_estep = Some(beta_estep_arr);
         }
-        self.feature_names = feat_names;
-        self.content_beta = model.content_beta;
-        self.content_kappa = model.content_kappa;
-        self.group_names = group_vocab;
-        self.num_base_groups = num_base_groups;
-        self.num_time_periods = num_time_periods;
-        self.mu = model.mu.clone();
-        self.sigma = model.sigma.clone();
+        slf.feature_names = feat_names;
+        slf.content_beta = model.content_beta;
+        slf.content_kappa = model.content_kappa;
+        slf.group_names = group_vocab;
+        slf.num_base_groups = num_base_groups;
+        slf.num_time_periods = num_time_periods;
+        slf.mu = model.mu.clone();
+        slf.sigma = model.sigma.clone();
         // E-step Σ snapshot: retained only when eta_cov was NOT kept.
         if !keep_eta_cov {
-            self.sigma_estep = model.sigma_estep.clone();
+            slf.sigma_estep = model.sigma_estep.clone();
         }
-        self.corpus = Some(corpus);
-        self.bound = model.bound;
-        self.bound_history = model.bound_history.clone();
-        self.converged = model.converged;
-        self.fitted = true;
-        Ok(())
+        slf.corpus = Some(corpus);
+        slf.bound = model.bound;
+        slf.bound_history = model.bound_history.clone();
+        slf.converged = model.converged;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Topic-word matrix β, shape ``(num_topics, num_words)``.
@@ -8276,7 +8276,7 @@ impl STS {
                         keep_eta_cov=true))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         sentiment_seed: Vec<f64>,
@@ -8289,7 +8289,7 @@ impl STS {
         em_tol: Option<f64>,
         covariates: Option<&Bound<'_, PyAny>>,
         keep_eta_cov: bool,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
             warnings.call_method1(
@@ -8405,10 +8405,10 @@ impl STS {
             prevalence_x = Some(x);
         }
 
-        let k = self.num_topics;
+        let k = slf.num_topics;
         let num_types = corpus.num_types();
-        let spectral = self.init_spectral;
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let spectral = slf.init_spectral;
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
         let (model, corpus) = py.allow_threads(move || {
             let prev_ref = prevalence_x.as_deref();
@@ -8445,7 +8445,7 @@ impl STS {
                 sentiment[[di, t]] = val;
             }
         }
-        self.gamma = model.gamma.as_ref().map(|g| {
+        slf.gamma = model.gamma.as_ref().map(|g| {
             let nf = g.len();
             let mut arr = Array2::<f64>::zeros((nf, n));
             for ff in 0..nf {
@@ -8480,31 +8480,31 @@ impl STS {
         } else {
             None
         };
-        self.eta_mean = Some(eta_mean_arr);
-        self.eta_cov = stored_eta_cov;
+        slf.eta_mean = Some(eta_mean_arr);
+        slf.eta_cov = stored_eta_cov;
         // Retain the E-step snapshots only when eta_cov was NOT kept, so the
         // default path carries no extra state; they let _recompute_eta_cov
         // reproduce ν exactly. When kept, the stored eta_cov is used directly.
         if !keep_eta_cov {
-            self.sigma_estep = model.sigma_estep.clone();
-            self.kappa_t_estep = model.kappa_t_estep.clone();
-            self.kappa_s_estep = model.kappa_s_estep.clone();
+            slf.sigma_estep = model.sigma_estep.clone();
+            slf.kappa_t_estep = model.kappa_t_estep.clone();
+            slf.kappa_s_estep = model.kappa_s_estep.clone();
         }
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.beta = Some(beta);
-        self.theta = Some(theta);
-        self.sentiment = Some(sentiment);
-        self.feature_names = feat_names;
-        self.kappa_t = model.kappa_t;
-        self.kappa_s = model.kappa_s;
-        self.mv = model.mv;
-        self.sigma = model.sigma;
-        self.corpus = Some(corpus);
-        self.bound = model.bound_history.last().copied().unwrap_or(f64::NAN);
-        self.bound_history = model.bound_history;
-        self.converged = model.converged;
-        self.fitted = true;
-        Ok(())
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.beta = Some(beta);
+        slf.theta = Some(theta);
+        slf.sentiment = Some(sentiment);
+        slf.feature_names = feat_names;
+        slf.kappa_t = model.kappa_t;
+        slf.kappa_s = model.kappa_s;
+        slf.mv = model.mv;
+        slf.sigma = model.sigma;
+        slf.corpus = Some(corpus);
+        slf.bound = model.bound_history.last().copied().unwrap_or(f64::NAN);
+        slf.bound_history = model.bound_history;
+        slf.converged = model.converged;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Baseline topic-word matrix β at neutral sentiment, shape ``(num_topics,
@@ -9086,7 +9086,7 @@ impl HDP {
     #[pyo3(signature = (data, *, iters=150, progress_interval=0,
                         keep_theta_draws=true, num_theta_draws=25, report_interval=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
@@ -9094,7 +9094,7 @@ impl HDP {
         keep_theta_draws: bool,
         num_theta_draws: usize,
         report_interval: Option<usize>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let progress_interval = if let Some(old_val) = report_interval {
             let warnings = py.import_bound("warnings")?;
             warnings.call_method1(
@@ -9138,8 +9138,8 @@ impl HDP {
 
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
-        let (alpha, gamma, eta, conc) = (self.alpha, self.gamma, self.eta, self.resample_conc);
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let (alpha, gamma, eta, conc) = (slf.alpha, slf.gamma, slf.eta, slf.resample_conc);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         // 0 = auto: ~50 evenly spaced trace points across the run.
         let ll_interval = if progress_interval == 0 {
             (iters / 50).max(1)
@@ -9187,7 +9187,7 @@ impl HDP {
         // Draw from Dirichlet(njk[d] + alpha*beta[k]) for each draw request.
         let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
         if draw_cap > 0 {
-            let mut draw_rng = Pcg64Mcg::seed_from_u64(self.seed.wrapping_add(1));
+            let mut draw_rng = Pcg64Mcg::seed_from_u64(slf.seed.wrapping_add(1));
             for _ in 0..draw_cap {
                 let snap: Vec<Vec<f32>> = model
                     .njk
@@ -9212,17 +9212,17 @@ impl HDP {
             }
         }
 
-        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
-        self.num_topics = k;
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.learned_alpha = model.alpha;
-        self.learned_gamma = model.gamma;
-        self.beta = Some(beta);
-        self.theta = Some(theta);
-        self.corpus = Some(corpus);
-        self.trace = model.trace.clone();
-        self.fitted = true;
-        Ok(())
+        slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
+        slf.num_topics = k;
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.learned_alpha = model.alpha;
+        slf.learned_gamma = model.gamma;
+        slf.beta = Some(beta);
+        slf.theta = Some(theta);
+        slf.corpus = Some(corpus);
+        slf.trace = model.trace.clone();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Topic-word matrix β, shape ``(num_topics, num_words)``.
@@ -9651,12 +9651,12 @@ impl DTM {
     /// `iters` is the number of variational-EM iterations.
     #[pyo3(signature = (data, times, *, iters=20))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         times: Vec<i64>,
         iters: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -9702,10 +9702,10 @@ impl DTM {
         }
 
         let num_types = corpus.num_types();
-        let k = self.num_topics;
-        let (alpha, cv, ov) = (self.alpha, self.chain_variance, self.obs_variance);
-        let init_spectral = self.init_spectral;
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let k = slf.num_topics;
+        let (alpha, cv, ov) = (slf.alpha, slf.chain_variance, slf.obs_variance);
+        let init_spectral = slf.init_spectral;
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
         let (model, corpus) = py.allow_threads(move || {
             let m = dtm::fit_dtm(
@@ -9727,13 +9727,13 @@ impl DTM {
         // Precompute p(word | topic, time) for every slice.
         let tw: Vec<Vec<Vec<f64>>> = (0..num_times).map(|t| model.topic_word_matrix(t)).collect();
 
-        self.num_times = num_times;
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.bound = model.bound;
-        self.topic_words = Some(tw);
-        self.corpus = Some(corpus);
-        self.fitted = true;
-        Ok(())
+        slf.num_times = num_times;
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.bound = model.bound;
+        slf.topic_words = Some(tw);
+        slf.corpus = Some(corpus);
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Topic-word matrix at time slice `time`, shape ``(num_topics, num_words)``;
@@ -10106,7 +10106,7 @@ impl SupervisedLDA {
                         keep_theta_draws=true, num_theta_draws=25,
                         convergence_tol=0.0_f64, check_every=1_usize))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         y: Vec<f64>,
@@ -10116,7 +10116,7 @@ impl SupervisedLDA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -10148,12 +10148,12 @@ impl SupervisedLDA {
 
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
-        let (k, alpha) = (self.num_topics, self.alpha);
+        let (k, alpha) = (slf.num_topics, slf.alpha);
 
         let draw_cap = if keep_theta_draws { num_theta_draws } else { 0 };
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
             let (m, hist, conv) = slda::fit_slda(
@@ -10189,7 +10189,7 @@ impl SupervisedLDA {
         // Draw from Dirichlet(gamma_d) for each requested draw.
         let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
         if draw_cap > 0 {
-            let mut draw_rng = ChaCha8Rng::seed_from_u64(self.seed.wrapping_add(1));
+            let mut draw_rng = ChaCha8Rng::seed_from_u64(slf.seed.wrapping_add(1));
             for _ in 0..draw_cap {
                 let snap: Vec<Vec<f32>> = model
                     .gamma
@@ -10211,20 +10211,20 @@ impl SupervisedLDA {
                 theta_draw_buf.push(snap);
             }
         }
-        self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
+        slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
 
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.sigma2 = model.sigma2;
-        self.eta = Some(Array1::from(model.eta.clone()));
-        self.m_mat = Some(model.m_mat.clone());
-        self.beta = Some(beta);
-        self.theta = Some(theta);
-        self.log_beta = Some(model.log_beta.clone());
-        self.corpus = Some(corpus);
-        self.log_likelihood_history = ll_history;
-        self.converged = converged_flag;
-        self.fitted = true;
-        Ok(())
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.sigma2 = model.sigma2;
+        slf.eta = Some(Array1::from(model.eta.clone()));
+        slf.m_mat = Some(model.m_mat.clone());
+        slf.beta = Some(beta);
+        slf.theta = Some(theta);
+        slf.log_beta = Some(model.log_beta.clone());
+        slf.corpus = Some(corpus);
+        slf.log_likelihood_history = ll_history;
+        slf.converged = converged_flag;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Predict the response ŷ for new documents (`list[list[str]]` or a
@@ -10698,7 +10698,7 @@ impl PT {
     #[pyo3(signature = (data, *, iters=1000, keep_theta_draws=true, num_theta_draws=25,
                         convergence_tol=0.0_f64, check_every=10_usize))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
@@ -10706,7 +10706,7 @@ impl PT {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -10730,12 +10730,12 @@ impl PT {
         }
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
-        let (k, p, a, b) = (self.num_topics, self.num_pseudo, self.alpha, self.beta);
+        let (k, p, a, b) = (slf.num_topics, slf.num_pseudo, slf.alpha, slf.beta);
 
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
             let (m, hist, conv) = pt::fit_ptm_with_draws(
                 &corpus.docs,
@@ -10752,15 +10752,15 @@ impl PT {
             );
             (m, hist, conv, corpus)
         });
-        self.theta_draws = draws_to_array3(&model.theta_draws, num_docs, k, None);
-        self.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
-        self.phi = Some(vecs_to_arr2(&model.topic_word()));
-        self.theta = Some(vecs_to_arr2(&model.doc_topic()));
-        self.log_likelihood_history = ll_history;
-        self.converged = converged_flag;
-        self.corpus = Some(corpus);
-        self.fitted = true;
-        Ok(())
+        slf.theta_draws = draws_to_array3(&model.theta_draws, num_docs, k, None);
+        slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.phi = Some(vecs_to_arr2(&model.topic_word()));
+        slf.theta = Some(vecs_to_arr2(&model.doc_topic()));
+        slf.log_likelihood_history = ll_history;
+        slf.converged = converged_flag;
+        slf.corpus = Some(corpus);
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -11084,13 +11084,13 @@ impl GSDMM {
     /// `report_interval` is a deprecated alias for `progress_interval`.
     #[pyo3(signature = (data, *, iters=30, progress_interval=0, report_interval=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
         progress_interval: usize,
         report_interval: Option<usize>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let progress_interval = if let Some(old_val) = report_interval {
             let warnings = py.import_bound("warnings")?;
             warnings.call_method1(
@@ -11131,8 +11131,8 @@ impl GSDMM {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
         let num_types = corpus.num_types();
-        let (k, a, b) = (self.k_max, self.alpha, self.beta);
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let (k, a, b) = (slf.k_max, slf.alpha, slf.beta);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         let ll_interval = if progress_interval == 0 {
             (iters / 50).max(1)
         } else {
@@ -11154,14 +11154,14 @@ impl GSDMM {
 
         // Keep only non-empty clusters; remap their ids to a dense 0..num_used.
         let used = model.used_clusters();
-        let mut remap = vec![usize::MAX; self.k_max];
+        let mut remap = vec![usize::MAX; slf.k_max];
         for (new_i, &old) in used.iter().enumerate() {
             remap[old] = new_i;
         }
         let num_used = used.len();
 
         let phi_rows: Vec<Vec<f64>> = used.iter().map(|&k| model.cluster_word(k)).collect();
-        self.phi = Some(vecs_to_arr2(&phi_rows));
+        slf.phi = Some(vecs_to_arr2(&phi_rows));
 
         // Soft per-doc distribution restricted to the used clusters, renormalized.
         let dist = model.doc_cluster_dist(&corpus.docs);
@@ -11177,14 +11177,14 @@ impl GSDMM {
                 theta[[di, ni]] = row[old] / s;
             }
         }
-        self.theta = Some(theta);
-        self.doc_cluster = model.doc_cluster().iter().map(|&c| remap[c]).collect();
-        self.num_used = num_used;
-        self.topic_names = (0..num_used).map(|i| format!("topic_{i}")).collect();
-        self.corpus = Some(corpus);
-        self.trace = model.trace.clone();
-        self.fitted = true;
-        Ok(())
+        slf.theta = Some(theta);
+        slf.doc_cluster = model.doc_cluster().iter().map(|&c| remap[c]).collect();
+        slf.num_used = num_used;
+        slf.topic_names = (0..num_used).map(|i| format!("topic_{i}")).collect();
+        slf.corpus = Some(corpus);
+        slf.trace = model.trace.clone();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Topic-word matrix β, shape ``(num_topics, num_words)`` (used clusters only).
@@ -11566,7 +11566,7 @@ impl SeededLDA {
                         keep_theta_draws=true, num_theta_draws=25,
                         convergence_tol=0.0_f64, check_every=10_usize))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
@@ -11575,7 +11575,7 @@ impl SeededLDA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -11597,10 +11597,10 @@ impl SeededLDA {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        let num_topics = self.num_topics_val();
+        let num_topics = slf.num_topics_val();
         let num_types = corpus.num_types();
-        let seeds = seed_word_ids(&self.seed_words, &corpus.id_to_word, num_topics);
-        let (alpha, beta, seed_weight) = (self.alpha, self.beta, self.weight * 100.0);
+        let seeds = seed_word_ids(&slf.seed_words, &corpus.id_to_word, num_topics);
+        let (alpha, beta, seed_weight) = (slf.alpha, slf.beta, slf.weight * 100.0);
 
         let doc_alpha: Option<Vec<Vec<f64>>> = match doc_topic_prior {
             Some(p) => {
@@ -11640,9 +11640,9 @@ impl SeededLDA {
             corpus.num_docs(),
             num_topics,
         )?;
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
 
-        if self.cvb0 {
+        if slf.cvb0 {
             // CVB0 seeded path: deterministic, asymmetric β via set_seeds. The
             // per-document prior is not threaded through CVB0's θ output yet.
             if doc_alpha.is_some() {
@@ -11659,22 +11659,22 @@ impl SeededLDA {
                 }
                 (cv.topic_word(), cv.doc_topic(), corpus)
             });
-            self.phi = Some(vecs_to_arr2(&phi_tw));
-            self.theta = Some(vecs_to_arr2(&theta_dk));
-            self.theta_draws = None;
-            let mut names = self.seed_names.clone();
-            for i in 0..self.residual {
+            slf.phi = Some(vecs_to_arr2(&phi_tw));
+            slf.theta = Some(vecs_to_arr2(&theta_dk));
+            slf.theta_draws = None;
+            let mut names = slf.seed_names.clone();
+            for i in 0..slf.residual {
                 names.push(format!("residual_{}", i + 1));
             }
-            self.topic_names = names;
-            self.corpus = Some(corpus);
-            self.log_likelihood_history = Vec::new();
-            self.converged = false;
-            self.fitted = true;
-            return Ok(());
+            slf.topic_names = names;
+            slf.corpus = Some(corpus);
+            slf.log_likelihood_history = Vec::new();
+            slf.converged = false;
+            slf.fitted = true;
+            return Ok(slf.into());
         }
 
-        if self.warp {
+        if slf.warp {
             // WarpLDA seeded path. The per-document prior (doc_topic_prior) is not
             // yet wired through the warp θ output, so require the symmetric case.
             if doc_alpha.is_some() {
@@ -11705,19 +11705,19 @@ impl SeededLDA {
                 ws.theta_into(&corpus, &mut theta_dk);
                 (phi_tw, theta_dk, theta_draw_buf, corpus)
             });
-            self.phi = Some(vecs_to_arr2(&phi_tw));
-            self.theta = Some(vecs_to_arr2(&theta_dk));
-            self.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
-            let mut names = self.seed_names.clone();
-            for i in 0..self.residual {
+            slf.phi = Some(vecs_to_arr2(&phi_tw));
+            slf.theta = Some(vecs_to_arr2(&theta_dk));
+            slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
+            let mut names = slf.seed_names.clone();
+            for i in 0..slf.residual {
                 names.push(format!("residual_{}", i + 1));
             }
-            self.topic_names = names;
-            self.corpus = Some(corpus);
-            self.log_likelihood_history = Vec::new();
-            self.converged = false;
-            self.fitted = true;
-            return Ok(());
+            slf.topic_names = names;
+            slf.corpus = Some(corpus);
+            slf.log_likelihood_history = Vec::new();
+            slf.converged = false;
+            slf.fitted = true;
+            return Ok(slf.into());
         }
 
         let (model, ll_history, converged, corpus) = py.allow_threads(move || {
@@ -11738,19 +11738,19 @@ impl SeededLDA {
             );
             (m, ll, conv, corpus)
         });
-        self.phi = Some(vecs_to_arr2(&model.topic_word_all()));
-        self.theta = Some(vecs_to_arr2(&model.doc_topic()));
-        self.theta_draws = draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
-        let mut names = self.seed_names.clone();
-        for i in 0..self.residual {
+        slf.phi = Some(vecs_to_arr2(&model.topic_word_all()));
+        slf.theta = Some(vecs_to_arr2(&model.doc_topic()));
+        slf.theta_draws = draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
+        let mut names = slf.seed_names.clone();
+        for i in 0..slf.residual {
             names.push(format!("residual_{}", i + 1));
         }
-        self.topic_names = names;
-        self.corpus = Some(corpus);
-        self.log_likelihood_history = ll_history;
-        self.converged = converged;
-        self.fitted = true;
-        Ok(())
+        slf.topic_names = names;
+        slf.corpus = Some(corpus);
+        slf.log_likelihood_history = ll_history;
+        slf.converged = converged;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -12332,14 +12332,14 @@ impl FASTopic {
     /// `convergence_tol` overrides the constructor value for this run (when given).
     #[pyo3(signature = (data, doc_embeddings, *, iters=None, convergence_tol=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         doc_embeddings: &Bound<'_, PyAny>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
-        let tol = convergence_tol.unwrap_or(self.em_tol);
+    ) -> PyResult<Py<Self>> {
+        let tol = convergence_tol.unwrap_or(slf.em_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -12371,36 +12371,36 @@ impl FASTopic {
         }
         check_all_finite_2d("doc_embeddings", &doc_emb)?;
         let num_types = corpus.num_types();
-        if num_types < self.num_topics {
+        if num_types < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
         }
-        self.id_to_word = corpus.id_to_word.clone();
+        slf.id_to_word = corpus.id_to_word.clone();
         let docs_ids = corpus.docs.clone();
         let ep = iters.unwrap_or(200);
 
         let (k, lr, dta, twa, tt, et, si, st) = (
-            self.num_topics,
-            self.lr,
-            self.dt_alpha,
-            self.tw_alpha,
-            self.theta_temp,
+            slf.num_topics,
+            slf.lr,
+            slf.dt_alpha,
+            slf.tw_alpha,
+            slf.theta_temp,
             tol,
-            self.sinkhorn_iters,
-            self.sinkhorn_tol,
+            slf.sinkhorn_iters,
+            slf.sinkhorn_tol,
         );
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
         let model = py.allow_threads(move || {
             fastopic::fit_fastopic(
                 &docs_ids, &doc_emb, k, num_types, ep, lr, dta, twa, tt, et, si, st, &mut rng,
             )
         });
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.model = Some(model);
-        self.corpus = Some(corpus);
-        self.fitted = true;
-        Ok(())
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.model = Some(model);
+        slf.corpus = Some(corpus);
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -12529,13 +12529,13 @@ impl FASTopic {
     /// itself.
     #[pyo3(signature = (data, doc_embeddings))]
     fn fit_transform<'py>(
-        &mut self,
+        slf: PyRefMut<'_, Self>,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
         doc_embeddings: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        self.fit(py, data, doc_embeddings, None, None)?;
-        Ok(vecs_to_arr2(&self.fitted_model()?.doc_topic).to_pyarray_bound(py))
+        let fitted = Self::fit(slf, py, data, doc_embeddings, None, None)?;
+        Ok(vecs_to_arr2(&fitted.bind(py).borrow().fitted_model()?.doc_topic).to_pyarray_bound(py))
     }
 
     /// Save the fitted model to `path` (topica's binary format).
@@ -12928,7 +12928,7 @@ impl KeyATM {
                         report_interval=None, turbo_alpha_stride=1))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
@@ -12950,7 +12950,7 @@ impl KeyATM {
         convergence_tol: f64,
         report_interval: Option<usize>,
         turbo_alpha_stride: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         if turbo_alpha_stride < 1 {
             return Err(PyValueError::new_err(
                 "turbo_alpha_stride must be >= 1 (1 = exact; >1 = approximate, subsample documents in the alpha sampler)",
@@ -12984,7 +12984,7 @@ impl KeyATM {
                 progress_interval
             };
         // num_threads: fit()-level value overrides the constructor default.
-        let nthreads_fit = num_threads.unwrap_or(self.num_threads).max(1);
+        let nthreads_fit = num_threads.unwrap_or(slf.num_threads).max(1);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -13006,7 +13006,7 @@ impl KeyATM {
         if corpus.num_docs() == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
-        let num_topics = self.num_topics;
+        let num_topics = slf.num_topics;
         let num_types = corpus.num_types();
         // Thinned θ-draw retention schedule (issue #31), shared by all three fits.
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
@@ -13024,7 +13024,7 @@ impl KeyATM {
         {
             let vocab: HashSet<&str> = corpus.id_to_word.iter().map(|s| s.as_str()).collect();
             let mut notes: Vec<String> = Vec::new();
-            for (name, words) in self.key_names.iter().zip(self.keywords.iter()) {
+            for (name, words) in slf.key_names.iter().zip(slf.keywords.iter()) {
                 let oov: Vec<&str> = words
                     .iter()
                     .map(|w| w.as_str())
@@ -13051,16 +13051,16 @@ impl KeyATM {
                 )?;
             }
         }
-        let keys = seed_word_ids(&self.keywords, &corpus.id_to_word, num_topics);
+        let keys = seed_word_ids(&slf.keywords, &corpus.id_to_word, num_topics);
         let (alpha, beta, beta_key, g1, g2) = (
-            self.alpha,
-            self.beta,
-            self.beta_keyword,
-            self.gamma1,
-            self.gamma2,
+            slf.alpha,
+            slf.beta,
+            slf.beta_keyword,
+            slf.gamma1,
+            slf.gamma2,
         );
-        let estimate_alpha = self.estimate_alpha;
-        let mut rng = Pcg64Mcg::seed_from_u64(self.seed);
+        let estimate_alpha = slf.estimate_alpha;
+        let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         let nthreads = nthreads_fit;
         let weight_scheme = match weights {
             "information-theory" | "info" => keyatm::WeightScheme::InfoTheory,
@@ -13081,7 +13081,7 @@ impl KeyATM {
         };
 
         // The CVB0 backend covers only the base model.
-        if self.cvb0 && (timestamps.is_some() || covariates.is_some() || prior_offset.is_some()) {
+        if slf.cvb0 && (timestamps.is_some() || covariates.is_some() || prior_offset.is_some()) {
             return Err(PyValueError::new_err(
                 "sampler=\"cvb0\" supports only the base keyATM (no timestamps, covariates, or prior_offset)",
             ));
@@ -13094,7 +13094,7 @@ impl KeyATM {
                 "turbo_alpha_stride > 1 applies only to the base keyATM (not the covariate or dynamic model)",
             ));
         }
-        let cvb0 = self.cvb0;
+        let cvb0 = slf.cvb0;
 
         // --- Dynamic model: timestamps drive a change-point HMM on prevalence. ---
         if let Some(ts) = timestamps {
@@ -13157,36 +13157,36 @@ impl KeyATM {
             for (i, &d) in order.iter().enumerate() {
                 theta[d] = theta_sorted[i].clone();
             }
-            self.theta = Some(vecs_to_arr2(&theta));
+            slf.theta = Some(vecs_to_arr2(&theta));
             // θ draws are also sorted; unsort their rows via `order` to match θ.
-            self.theta_draws = draws_to_array3(
+            slf.theta_draws = draws_to_array3(
                 &model.theta_draws,
                 corpus.num_docs(),
                 num_topics,
                 Some(&order),
             );
-            self.phi = Some(vecs_to_arr2(&model.topic_word_all()));
-            self.keyword_rate = model.keyword_rate();
-            self.time_prevalence = model.time_prevalence().map(|tp| vecs_to_arr2(&tp));
+            slf.phi = Some(vecs_to_arr2(&model.topic_word_all()));
+            slf.keyword_rate = model.keyword_rate();
+            slf.time_prevalence = model.time_prevalence().map(|tp| vecs_to_arr2(&tp));
             if let Some(d) = &model.dynamic {
-                self.time_state = d.r_est.clone();
-                self.transition_matrix = Some(vecs_to_arr2(&d.p_est));
+                slf.time_state = d.r_est.clone();
+                slf.transition_matrix = Some(vecs_to_arr2(&d.p_est));
             }
-            self.log_likelihood_history = model.log_likelihood_history.clone();
-            self.converged = model.converged;
-            self.alpha_history = model.alpha_history.clone();
-            self.pi_history = model.pi_history.clone();
-            self.alpha_vec = model.alpha_vec.clone();
-            self.time_labels = labels;
+            slf.log_likelihood_history = model.log_likelihood_history.clone();
+            slf.converged = model.converged;
+            slf.alpha_history = model.alpha_history.clone();
+            slf.pi_history = model.pi_history.clone();
+            slf.alpha_vec = model.alpha_vec.clone();
+            slf.time_labels = labels;
 
-            let mut names = self.key_names.clone();
-            for i in self.key_names.len()..num_topics {
+            let mut names = slf.key_names.clone();
+            for i in slf.key_names.len()..num_topics {
                 names.push(format!("topic_{}", i));
             }
-            self.topic_names = names;
-            self.corpus = Some(corpus);
-            self.fitted = true;
-            return Ok(());
+            slf.topic_names = names;
+            slf.corpus = Some(corpus);
+            slf.fitted = true;
+            return Ok(slf.into());
         }
 
         // Build the (intercept-prepended) feature matrix if covariates were given.
@@ -13330,28 +13330,28 @@ impl KeyATM {
             };
             (m, corpus)
         });
-        self.phi = Some(vecs_to_arr2(&model.topic_word_all()));
-        self.theta = Some(vecs_to_arr2(&model.doc_topic()));
-        self.theta_draws = draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
-        self.keyword_rate = model.keyword_rate();
-        self.log_likelihood_history = model.log_likelihood_history.clone();
-        self.converged = model.converged;
-        self.alpha_history = model.alpha_history.clone();
-        self.pi_history = model.pi_history.clone();
-        self.alpha_vec = model.alpha_vec.clone();
+        slf.phi = Some(vecs_to_arr2(&model.topic_word_all()));
+        slf.theta = Some(vecs_to_arr2(&model.doc_topic()));
+        slf.theta_draws = draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
+        slf.keyword_rate = model.keyword_rate();
+        slf.log_likelihood_history = model.log_likelihood_history.clone();
+        slf.converged = model.converged;
+        slf.alpha_history = model.alpha_history.clone();
+        slf.pi_history = model.pi_history.clone();
+        slf.alpha_vec = model.alpha_vec.clone();
         if let Some(lam) = &model.lambda {
-            self.feature_effects = Some(vecs_to_arr2(lam));
-            self.feature_effect_se = model.lambda_se.as_ref().map(|se| vecs_to_arr2(se));
-            self.feature_names = cov_names;
+            slf.feature_effects = Some(vecs_to_arr2(lam));
+            slf.feature_effect_se = model.lambda_se.as_ref().map(|se| vecs_to_arr2(se));
+            slf.feature_names = cov_names;
         }
-        let mut names = self.key_names.clone();
-        for i in self.key_names.len()..num_topics {
+        let mut names = slf.key_names.clone();
+        for i in slf.key_names.len()..num_topics {
             names.push(format!("topic_{}", i));
         }
-        self.topic_names = names;
-        self.corpus = Some(corpus);
-        self.fitted = true;
-        Ok(())
+        slf.topic_names = names;
+        slf.corpus = Some(corpus);
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Covariate model: learned DMR coefficients λ, shape ``(num_topics, F+1)``;

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -330,16 +330,16 @@ impl ETM {
     /// `convergence_tol` overrides the constructor value for this run (when given).
     #[pyo3(signature = (data, word_embeddings, vocabulary, *, iters=None, convergence_tol=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         word_embeddings: &Bound<'_, PyAny>,
         vocabulary: Vec<String>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         // Use fit()-level convergence_tol if given, else fall back to constructor value.
-        let tol = convergence_tol.unwrap_or(self.em_tol);
+        let tol = convergence_tol.unwrap_or(slf.em_tol);
         let (docs_str, corpus_opt): (Vec<Vec<String>>, Option<corpus::Corpus>) =
             if let Ok(c) = data.extract::<Corpus>() {
                 let strings = c
@@ -368,7 +368,7 @@ impl ETM {
             )));
         }
         check_all_finite_2d("word_embeddings", &rho)?;
-        if vocabulary.len() < self.num_topics {
+        if vocabulary.len() < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
@@ -392,23 +392,23 @@ impl ETM {
             ));
         }
         let num_types = vocabulary.len();
-        self.id_to_word = vocabulary.clone();
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        slf.id_to_word = vocabulary.clone();
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
-        if self.inference == "vae" {
+        if slf.inference == "vae" {
             let ep = iters.unwrap_or(150);
             let opts = build_avitm_options(
-                &self.prior,
-                self.contrastive,
-                self.contrastive_weight,
-                self.contrastive_temp,
+                &slf.prior,
+                slf.contrastive,
+                slf.contrastive_weight,
+                slf.contrastive_temp,
             )?;
             let (k, h, bs, lr, wd, et) = (
-                self.num_topics,
-                self.hidden_size,
-                self.batch_size,
-                self.lr,
-                self.wdecay,
+                slf.num_topics,
+                slf.hidden_size,
+                slf.batch_size,
+                slf.lr,
+                slf.wdecay,
                 tol,
             );
             let m = py.allow_threads(move || {
@@ -416,25 +416,25 @@ impl ETM {
                     &docs_ids, k, num_types, &rho, h, ep, bs, lr, wd, et, opts, &mut rng,
                 )
             });
-            self.vae = Some(m);
-            self.model = None;
+            slf.vae = Some(m);
+            slf.model = None;
         } else {
             let ei = iters.unwrap_or(100);
             let (k, et, ss, pv, mi) = (
-                self.num_topics,
+                slf.num_topics,
                 tol,
-                self.sigma_shrink,
-                self.prior_variance,
-                self.max_inner,
+                slf.sigma_shrink,
+                slf.prior_variance,
+                slf.max_inner,
             );
             let model = py.allow_threads(move || {
                 etm::fit_etm(&docs_ids, k, num_types, &rho, ei, et, ss, pv, mi, &mut rng)
             });
-            self.model = Some(model);
-            self.vae = None;
+            slf.model = Some(model);
+            slf.vae = None;
         }
         // Retain the corpus for coherence/doc_names; build a minimal one if raw docs were given.
-        self.corpus = Some(corpus_opt.unwrap_or_else(|| {
+        slf.corpus = Some(corpus_opt.unwrap_or_else(|| {
             let n = docs_str.len();
             let vocab_clone = vocabulary.clone();
             let v = vocab_clone.len();
@@ -465,9 +465,9 @@ impl ETM {
                 total_freqs: tf,
             }
         }));
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -781,15 +781,15 @@ impl ETM {
     /// epochs).
     #[pyo3(signature = (data, word_embeddings, vocabulary, *, iters=None))]
     fn fit_transform<'py>(
-        &mut self,
+        slf: PyRefMut<'_, Self>,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
         word_embeddings: &Bound<'py, PyAny>,
         vocabulary: Vec<String>,
         iters: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        self.fit(py, data, word_embeddings, vocabulary, iters, None)?;
-        Ok(vecs_to_arr2(&self.surf_doc_topic()?).to_pyarray_bound(py))
+        let fitted = Self::fit(slf, py, data, word_embeddings, vocabulary, iters, None)?;
+        Ok(vecs_to_arr2(&fitted.bind(py).borrow().surf_doc_topic()?).to_pyarray_bound(py))
     }
 
     fn __repr__(&self) -> String {
@@ -989,7 +989,7 @@ impl DETM {
                         iters=100, convergence_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         word_embeddings: &Bound<'_, PyAny>,
@@ -998,7 +998,7 @@ impl DETM {
         timestamps: Option<Vec<i64>>,
         iters: usize,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         // times is canonical; timestamps is the accepted alias.
         let times = match (times, timestamps) {
             (Some(t), None) => t,
@@ -1014,7 +1014,7 @@ impl DETM {
                 ))
             }
         };
-        let tol = convergence_tol.unwrap_or(self.convergence_tol);
+        let tol = convergence_tol.unwrap_or(slf.convergence_tol);
 
         let (docs_str, corpus_opt): (Vec<Vec<String>>, Option<corpus::Corpus>) =
             if let Ok(c) = data.extract::<Corpus>() {
@@ -1069,7 +1069,7 @@ impl DETM {
             )));
         }
         check_all_finite_2d("word_embeddings", &rho)?;
-        if vocabulary.len() < self.num_topics {
+        if vocabulary.len() < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
@@ -1100,19 +1100,19 @@ impl DETM {
         }
 
         let num_types = vocabulary.len();
-        self.id_to_word = vocabulary.clone();
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        slf.id_to_word = vocabulary.clone();
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
         let (k, delta, h, eh, enl, bs, lr, wd, gc) = (
-            self.num_topics,
-            self.delta,
-            self.hidden_size,
-            self.eta_hidden_size,
-            self.eta_nlayers,
-            self.batch_size,
-            self.lr,
-            self.wdecay,
-            self.grad_clip,
+            slf.num_topics,
+            slf.delta,
+            slf.hidden_size,
+            slf.eta_hidden_size,
+            slf.eta_nlayers,
+            slf.batch_size,
+            slf.lr,
+            slf.wdecay,
+            slf.grad_clip,
         );
         let model = py.allow_threads(move || {
             detm::fit_detm(
@@ -1121,10 +1121,10 @@ impl DETM {
             )
         });
 
-        self.num_times = num_times;
-        self.model = Some(model);
+        slf.num_times = num_times;
+        slf.model = Some(model);
         // Retain a corpus for coherence/doc_names; build a minimal one if raw docs were given.
-        self.corpus = Some(corpus_opt.unwrap_or_else(|| {
+        slf.corpus = Some(corpus_opt.unwrap_or_else(|| {
             let n = docs_str.len();
             let v = num_types;
             let mut df = vec![0u32; v];
@@ -1154,9 +1154,9 @@ impl DETM {
                 total_freqs: tf,
             }
         }));
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -1590,7 +1590,7 @@ impl InfoCTM {
                         embeddings_b=None, iters=None, batch_size=128))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data_a: &Bound<'_, PyAny>,
         data_b: &Bound<'_, PyAny>,
@@ -1599,7 +1599,7 @@ impl InfoCTM {
         embeddings_b: Option<std::collections::HashMap<String, Vec<f64>>>,
         iters: Option<usize>,
         batch_size: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let to_corpus = |data: &Bound<'_, PyAny>| -> PyResult<corpus::Corpus> {
             if let Ok(c) = data.extract::<Corpus>() {
                 Ok(c.inner)
@@ -1626,7 +1626,7 @@ impl InfoCTM {
         if corpus_a.num_docs() == 0 || corpus_b.num_docs() == 0 {
             return Err(PyValueError::new_err("both corpora must contain documents"));
         }
-        if va < self.num_topics || vb < self.num_topics {
+        if va < slf.num_topics || vb < slf.num_topics {
             return Err(PyValueError::new_err(
                 "each vocabulary must have at least num_topics words",
             ));
@@ -1669,14 +1669,14 @@ impl InfoCTM {
 
         let ep = iters.unwrap_or(500);
         let (k, h, dp, lr, et) = (
-            self.num_topics,
-            self.hidden_size,
-            self.dropout,
-            self.lr,
-            self.em_tol,
+            slf.num_topics,
+            slf.hidden_size,
+            slf.dropout,
+            slf.lr,
+            slf.em_tol,
         );
-        let (mw, mt, pt) = (self.mi_weight, self.mi_temperature, self.pos_threshold);
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let (mw, mt, pt) = (slf.mi_weight, slf.mi_temperature, slf.pos_threshold);
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
         let docs_a = corpus_a.docs.clone();
         let docs_b = corpus_b.docs.clone();
@@ -1702,11 +1702,11 @@ impl InfoCTM {
                 &mut rng,
             )
         });
-        self.model = Some(model);
-        self.corpus_a = Some(corpus_a);
-        self.corpus_b = Some(corpus_b);
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpus_a = Some(corpus_a);
+        slf.corpus_b = Some(corpus_b);
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -2066,13 +2066,13 @@ impl ProdLDA {
     /// `convergence_tol` overrides the constructor value for this run (when given).
     #[pyo3(signature = (data, *, iters=None, convergence_tol=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
-        let tol = convergence_tol.unwrap_or(self.em_tol);
+    ) -> PyResult<Py<Self>> {
+        let tol = convergence_tol.unwrap_or(slf.em_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -2095,28 +2095,28 @@ impl ProdLDA {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
         let num_types = corpus.num_types();
-        if num_types < self.num_topics {
+        if num_types < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
         }
         let ep = iters.unwrap_or(200);
         let opts = build_avitm_options(
-            &self.prior,
-            self.contrastive,
-            self.contrastive_weight,
-            self.contrastive_temp,
+            &slf.prior,
+            slf.contrastive,
+            slf.contrastive_weight,
+            slf.contrastive_temp,
         )?;
         let (k, h, a, dp, bs, lr, et) = (
-            self.num_topics,
-            self.hidden_size,
-            self.alpha,
-            self.dropout,
-            self.batch_size,
-            self.lr,
+            slf.num_topics,
+            slf.hidden_size,
+            slf.alpha,
+            slf.dropout,
+            slf.batch_size,
+            slf.lr,
             tol,
         );
-        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
         let empty: Vec<Vec<f64>> = vec![Vec::new(); corpus.docs.len()];
         let (model, corpus) = py.allow_threads(move || {
             let m = prodlda::fit_avitm(
@@ -2138,11 +2138,11 @@ impl ProdLDA {
             );
             (m, corpus)
         });
-        self.model = Some(model);
-        self.corpus = Some(corpus);
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpus = Some(corpus);
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -2265,12 +2265,12 @@ impl ProdLDA {
     /// Fit, then return the document-topic proportions (`fit_transform`).
     #[pyo3(signature = (data))]
     fn fit_transform<'py>(
-        &mut self,
+        slf: PyRefMut<'_, Self>,
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        self.fit(py, data, None, None)?;
-        Ok(vecs_to_arr2(&self.fitted_model()?.doc_topic).to_pyarray_bound(py))
+        let fitted = Self::fit(slf, py, data, None, None)?;
+        Ok(vecs_to_arr2(&fitted.bind(py).borrow().fitted_model()?.doc_topic).to_pyarray_bound(py))
     }
 
     /// Save the fitted model to `path` (topica's binary format).
@@ -2620,14 +2620,14 @@ macro_rules! ctm_embedding_model {
             /// for this run (when given).
             #[pyo3(signature = (data, doc_embeddings, *, iters=None, convergence_tol=None))]
             fn fit(
-                &mut self,
+                mut slf: PyRefMut<'_, Self>,
                 py: Python<'_>,
                 data: &Bound<'_, PyAny>,
                 doc_embeddings: &Bound<'_, PyAny>,
                 iters: Option<usize>,
                 convergence_tol: Option<f64>,
-            ) -> PyResult<()> {
-                let tol = convergence_tol.unwrap_or(self.convergence_tol);
+            ) -> PyResult<Py<Self>> {
+                let tol = convergence_tol.unwrap_or(slf.convergence_tol);
                 let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
                     c.inner
                 } else {
@@ -2650,7 +2650,7 @@ macro_rules! ctm_embedding_model {
                     return Err(PyValueError::new_err("corpus contains no documents"));
                 }
                 let num_types = corpus.num_types();
-                if num_types < self.num_topics {
+                if num_types < slf.num_topics {
                     return Err(PyValueError::new_err(
                         "vocabulary must have at least num_topics words",
                     ));
@@ -2662,23 +2662,23 @@ macro_rules! ctm_embedding_model {
                         "doc_embeddings must have at least one column",
                     ));
                 }
-                self.emb_dim = emb_dim;
+                slf.emb_dim = emb_dim;
                 let ep = iters.unwrap_or(200);
                 let opts = build_avitm_options(
-                    &self.prior,
-                    self.contrastive,
-                    self.contrastive_weight,
-                    self.contrastive_temp,
+                    &slf.prior,
+                    slf.contrastive,
+                    slf.contrastive_weight,
+                    slf.contrastive_temp,
                 )?;
                 let (k, h, a, dp, bs, lr) = (
-                    self.num_topics,
-                    self.hidden_size,
-                    self.alpha,
-                    self.dropout,
-                    self.batch_size,
-                    self.lr,
+                    slf.num_topics,
+                    slf.hidden_size,
+                    slf.alpha,
+                    slf.dropout,
+                    slf.batch_size,
+                    slf.lr,
                 );
-                let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+                let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
                 let (model, corpus) = py.allow_threads(move || {
                     let m = prodlda::fit_avitm(
                         &corpus.docs,
@@ -2699,11 +2699,11 @@ macro_rules! ctm_embedding_model {
                     );
                     (m, corpus)
                 });
-                self.model = Some(model);
-                self.corpus = Some(corpus);
-                self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-                self.fitted = true;
-                Ok(())
+                slf.model = Some(model);
+                slf.corpus = Some(corpus);
+                slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+                slf.fitted = true;
+                Ok(slf.into())
             }
 
             #[getter]
@@ -2839,14 +2839,15 @@ macro_rules! ctm_embedding_model {
             /// per document in corpus order. `iters` is the number of training epochs.
             #[pyo3(signature = (data, doc_embeddings, *, iters=None))]
             fn fit_transform<'py>(
-                &mut self,
+                slf: PyRefMut<'_, Self>,
                 py: Python<'py>,
                 data: &Bound<'py, PyAny>,
                 doc_embeddings: &Bound<'py, PyAny>,
                 iters: Option<usize>,
             ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-                self.fit(py, data, doc_embeddings, iters, None)?;
-                Ok(vecs_to_arr2(&self.fitted_model()?.doc_topic).to_pyarray_bound(py))
+                let fitted = Self::fit(slf, py, data, doc_embeddings, iters, None)?;
+                Ok(vecs_to_arr2(&fitted.bind(py).borrow().fitted_model()?.doc_topic)
+                    .to_pyarray_bound(py))
             }
 
             /// Save the fitted model to `path` (topica's binary format).

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -165,13 +165,13 @@ impl NMF {
     /// overrides the constructor value for this run (when given).
     #[pyo3(signature = (data, *, iters=None, convergence_tol=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
-        let tol = convergence_tol.unwrap_or(self.convergence_tol);
+    ) -> PyResult<Py<Self>> {
+        let tol = convergence_tol.unwrap_or(slf.convergence_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -194,28 +194,28 @@ impl NMF {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
         let num_types = corpus.num_types();
-        if num_types < self.num_topics {
+        if num_types < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
         }
         let it = iters.unwrap_or(200);
         let (k, bl, ini, tfidf, seed) = (
-            self.num_topics,
-            self.beta_loss,
-            self.init,
-            self.weighting_tfidf,
-            self.seed,
+            slf.num_topics,
+            slf.beta_loss,
+            slf.init,
+            slf.weighting_tfidf,
+            slf.seed,
         );
         let (model, corpus) = py.allow_threads(move || {
             let m = nmf::fit_nmf(&corpus.docs, k, num_types, bl, ini, tfidf, it, tol, seed);
             (m, corpus)
         });
-        self.model = Some(model);
-        self.corpus = Some(corpus);
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpus = Some(corpus);
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]
@@ -502,7 +502,11 @@ impl LSA {
 
     /// Fit on `data` (a Corpus or list of token lists). The SVD is a direct solve,
     /// so there is no `iters` argument.
-    fn fit(&mut self, py: Python<'_>, data: &Bound<'_, PyAny>) -> PyResult<()> {
+    fn fit(
+        mut slf: PyRefMut<'_, Self>,
+        py: Python<'_>,
+        data: &Bound<'_, PyAny>,
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -528,22 +532,22 @@ impl LSA {
         // K must not exceed min(num_docs, vocabulary size): the truncated SVD has
         // at most min(D, V) nonzero singular triplets.
         let max_k = corpus.num_docs().min(num_types);
-        if self.num_topics > max_k {
+        if slf.num_topics > max_k {
             return Err(PyValueError::new_err(format!(
                 "num_topics ({}) must be <= min(num_docs, vocab) = {}",
-                self.num_topics, max_k
+                slf.num_topics, max_k
             )));
         }
-        let (k, tfidf, seed) = (self.num_topics, self.weighting_tfidf, self.seed);
+        let (k, tfidf, seed) = (slf.num_topics, slf.weighting_tfidf, slf.seed);
         let (model, corpus) = py.allow_threads(move || {
             let m = lsa::fit_lsa(&corpus.docs, k, num_types, tfidf, seed);
             (m, corpus)
         });
-        self.model = Some(model);
-        self.corpus = Some(corpus);
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpus = Some(corpus);
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -192,14 +192,14 @@ impl PartyEmbeddings {
     /// epochs (default 5).
     #[pyo3(signature = (data, *, group, control=None, anchors=None, iters=5))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         group: Vec<String>,
         control: Option<Vec<String>>,
         anchors: Option<HashMap<String, f64>>,
         iters: usize,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         // Extract documents as ordered token lists (PV-DM needs word order).
         let docs_str: Vec<Vec<String>> = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -248,7 +248,7 @@ impl PartyEmbeddings {
         }
         let mut vocab_pairs: Vec<(&str, u32)> = freq
             .iter()
-            .filter(|&(_, &c)| c as usize >= self.min_count)
+            .filter(|&(_, &c)| c as usize >= slf.min_count)
             .map(|(&w, &c)| (w, c))
             .collect();
         vocab_pairs.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
@@ -333,15 +333,15 @@ impl PartyEmbeddings {
         };
 
         let cfg = PvdmConfig {
-            vector_size: self.vector_size,
-            window: self.window,
-            negative: self.negative,
-            sample: self.sample,
-            start_lr: self.learning_rate,
-            min_lr: (self.learning_rate * 1e-4).min(1e-4),
+            vector_size: slf.vector_size,
+            window: slf.window,
+            negative: slf.negative,
+            sample: slf.sample,
+            start_lr: slf.learning_rate,
+            min_lr: (slf.learning_rate * 1e-4).min(1e-4),
             epochs: iters,
         };
-        let seed = self.seed;
+        let seed = slf.seed;
         let model = py.allow_threads(move || {
             party_embeddings::fit_pvdm(
                 &docs_ids,
@@ -358,7 +358,7 @@ impl PartyEmbeddings {
 
         // Placement: PCA of the party vectors, standardized, sign-oriented to the
         // anchors (each dimension independently).
-        let mut positions = crate::reduce::pca(&model.group_matrix(), self.num_dims, self.seed);
+        let mut positions = crate::reduce::pca(&model.group_matrix(), slf.num_dims, slf.seed);
         standardize_columns(&mut positions);
         if !anchor_pairs.is_empty() && !positions.is_empty() {
             let ndim = positions[0].len();
@@ -372,13 +372,13 @@ impl PartyEmbeddings {
             }
         }
 
-        self.loss_history = model.loss_history.clone();
-        self.positions = Some(positions);
-        self.model = Some(model);
-        self.id_to_word = id_to_word;
-        self.author_names = group_names;
-        self.fitted = true;
-        Ok(())
+        slf.loss_history = model.loss_history.clone();
+        slf.positions = Some(positions);
+        slf.model = Some(model);
+        slf.id_to_word = id_to_word;
+        slf.author_names = group_names;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]

--- a/src/python/pltm.rs
+++ b/src/python/pltm.rs
@@ -220,11 +220,11 @@ impl PolylingualLDA {
     /// document `[]` at that index.
     #[pyo3(signature = (data, *, iters=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let (languages, str_docs) = extract_languages(data)?;
 
         // Build one corpus per language (independent vocabularies), preserving
@@ -257,7 +257,7 @@ impl PolylingualLDA {
             }
         }
         for c in &corpora {
-            if c.num_types() < self.num_topics {
+            if c.num_types() < slf.num_topics {
                 return Err(PyValueError::new_err(
                     "each language's vocabulary must have at least num_topics words",
                 ));
@@ -266,15 +266,15 @@ impl PolylingualLDA {
 
         let vocab_sizes: Vec<usize> = corpora.iter().map(|c| c.num_types()).collect();
         let docs_by_lang: Vec<Vec<Vec<u32>>> = corpora.iter().map(|c| c.docs.clone()).collect();
-        let iters = iters.unwrap_or(self.iters);
-        let alpha_init = self.alpha.unwrap_or(0.01);
-        let beta = vec![self.beta; languages.len()];
+        let iters = iters.unwrap_or(slf.iters);
+        let alpha_init = slf.alpha.unwrap_or(0.01);
+        let beta = vec![slf.beta; languages.len()];
         let (optimize_alpha, optimize_interval, optimize_burn_in, seed, k) = (
-            self.optimize_alpha,
-            self.optimize_interval,
-            self.optimize_burn_in,
-            self.seed,
-            self.num_topics,
+            slf.optimize_alpha,
+            slf.optimize_interval,
+            slf.optimize_burn_in,
+            slf.seed,
+            slf.num_topics,
         );
 
         let model = py.allow_threads(move || {
@@ -293,12 +293,12 @@ impl PolylingualLDA {
             )
         });
 
-        self.model = Some(model);
-        self.corpora = corpora;
-        self.languages = languages;
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpora = corpora;
+        slf.languages = languages;
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     /// Infer tuple-topic distributions θ (num_tuples, num_topics) for new aligned

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -385,7 +385,7 @@ impl Scholar {
                         convergence_tol=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         covariates: Option<&Bound<'_, PyAny>>,
@@ -393,7 +393,7 @@ impl Scholar {
         content: Option<&Bound<'_, PyAny>>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -447,8 +447,8 @@ impl Scholar {
 
         // Covariates / content (optional): empty rows when absent. Require at least
         // one of covariates / labels / content so the model has metadata to condition on.
-        let has_covars = covariates.is_some() || self.covariates.is_some();
-        let has_content = content.is_some() || self.content.is_some();
+        let has_covars = covariates.is_some() || slf.covariates.is_some();
+        let has_content = content.is_some() || slf.content.is_some();
         if !has_covars && label_idx.is_none() && !has_content {
             return Err(PyValueError::new_err(
                 "Scholar needs covariates, labels, and/or content: pass covariates=, labels=, \
@@ -456,50 +456,50 @@ impl Scholar {
             ));
         }
         let pcs = if has_covars {
-            self.resolve_covariates(covariates, num_docs)?
+            slf.resolve_covariates(covariates, num_docs)?
         } else {
             vec![Vec::new(); num_docs]
         };
         let n_prior_covars = pcs[0].len();
         let tcs = if has_content {
-            self.resolve_content(content, num_docs)?
+            slf.resolve_content(content, num_docs)?
         } else {
             vec![Vec::new(); num_docs]
         };
         let n_topic_covars = tcs[0].len();
 
         let num_types = corpus.num_types();
-        if num_types < self.num_topics {
+        if num_types < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
         }
-        let names = match &self.covariate_names {
+        let names = match &slf.covariate_names {
             Some(n) if n.len() == n_prior_covars => n.clone(),
             _ => (0..n_prior_covars)
                 .map(|c| format!("covariate_{c}"))
                 .collect(),
         };
-        let content_names = match &self.content_names {
+        let content_names = match &slf.content_names {
             Some(n) if n.len() == n_topic_covars => n.clone(),
             _ => (0..n_topic_covars)
                 .map(|c| format!("content_{c}"))
                 .collect(),
         };
-        let tol = convergence_tol.unwrap_or(self.convergence_tol);
+        let tol = convergence_tol.unwrap_or(slf.convergence_tol);
         let ep = iters.unwrap_or(200);
-        let interactions = self.interactions && n_topic_covars > 0;
+        let interactions = slf.interactions && n_topic_covars > 0;
         let (k, h, a, dp, bs, lr, l2, l1c) = (
-            self.num_topics,
-            self.hidden_size,
-            self.alpha,
-            self.dropout,
-            self.batch_size,
-            self.lr,
-            self.l2_prior_reg,
-            self.l1_content_reg,
+            slf.num_topics,
+            slf.hidden_size,
+            slf.alpha,
+            slf.dropout,
+            slf.batch_size,
+            slf.lr,
+            slf.l2_prior_reg,
+            slf.l1_content_reg,
         );
-        let seed = self.seed;
+        let seed = slf.seed;
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let m = crate::scholar::fit_scholar(
@@ -526,14 +526,14 @@ impl Scholar {
             );
             (m, corpus)
         });
-        self.model = Some(model);
-        self.corpus = Some(corpus);
-        self.covariate_names = Some(names);
-        self.content_names = Some(content_names);
-        self.classes = classes;
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpus = Some(corpus);
+        slf.covariate_names = Some(names);
+        slf.content_names = Some(content_names);
+        slf.classes = classes;
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]

--- a/src/python/sentence_ideal.rs
+++ b/src/python/sentence_ideal.rs
@@ -122,14 +122,14 @@ impl IdealPointSentenceTM {
     #[pyo3(signature = (embeddings, *, group=None, anchors=None, iters=None,
                         convergence_tol=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         embeddings: &Bound<'_, PyAny>,
         group: Option<Vec<String>>,
         anchors: Option<HashMap<String, f64>>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let emb = parse_features(embeddings)?;
         let n = emb.len();
         if n == 0 {
@@ -193,14 +193,9 @@ impl IdealPointSentenceTM {
             }
         };
 
-        let tol = convergence_tol.unwrap_or(self.convergence_tol);
+        let tol = convergence_tol.unwrap_or(slf.convergence_tol);
         let it = iters.unwrap_or(100);
-        let (k, dd, xpv, seed) = (
-            self.num_topics,
-            self.num_dims,
-            self.x_prior_variance,
-            self.seed,
-        );
+        let (k, dd, xpv, seed) = (slf.num_topics, slf.num_dims, slf.x_prior_variance, slf.seed);
         let model = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             sentence_ideal::fit_sentence_ideal(
@@ -217,11 +212,11 @@ impl IdealPointSentenceTM {
             )
         });
 
-        self.model = Some(model);
-        self.author_names = author_names;
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.author_names = author_names;
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]

--- a/src/python/tbip.rs
+++ b/src/python/tbip.rs
@@ -148,14 +148,14 @@ impl TBIP {
     #[pyo3(signature = (data, *, group=None, iters=None, batch_size=None,
                         learning_rate=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         group: Option<Vec<String>>,
         iters: Option<usize>,
         batch_size: Option<usize>,
         learning_rate: Option<f64>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let (docs_str, doc_names): (Vec<Vec<String>>, Vec<String>) =
             if let Ok(c) = data.extract::<Corpus>() {
                 let strings = c
@@ -214,12 +214,12 @@ impl TBIP {
         }
         let mut vocab_pairs: Vec<(&str, usize)> = freq
             .iter()
-            .filter(|&(_, &c)| c >= self.min_count)
+            .filter(|&(_, &c)| c >= slf.min_count)
             .map(|(&w, &c)| (w, c))
             .collect();
         vocab_pairs.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
         let vocabulary: Vec<String> = vocab_pairs.iter().map(|&(w, _)| w.to_string()).collect();
-        if vocabulary.len() < self.num_topics {
+        if vocabulary.len() < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words after min_count pruning",
             ));
@@ -265,13 +265,13 @@ impl TBIP {
         };
 
         let cfg = TbipConfig {
-            a_gamma: self.a_gamma,
-            b_gamma: self.b_gamma,
-            iters: iters.unwrap_or(self.iters),
-            batch_size: batch_size.unwrap_or(self.batch_size).max(1),
-            learning_rate: learning_rate.unwrap_or(self.learning_rate),
+            a_gamma: slf.a_gamma,
+            b_gamma: slf.b_gamma,
+            iters: iters.unwrap_or(slf.iters),
+            batch_size: batch_size.unwrap_or(slf.batch_size).max(1),
+            learning_rate: learning_rate.unwrap_or(slf.learning_rate),
         };
-        let (k, seed) = (self.num_topics, self.seed);
+        let (k, seed) = (slf.num_topics, slf.seed);
         let model = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             tbip::fit_tbip(
@@ -285,13 +285,13 @@ impl TBIP {
             )
         });
 
-        self.model = Some(model);
-        self.corpus = Some(coherence_corpus);
-        self.id_to_word = vocabulary;
-        self.author_names = author_names;
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.corpus = Some(coherence_corpus);
+        slf.id_to_word = vocabulary;
+        slf.author_names = author_names;
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]

--- a/src/python/tlda.rs
+++ b/src/python/tlda.rs
@@ -219,11 +219,11 @@ impl TensorLDA {
     /// Fit the model on the given corpus or token lists.
     #[pyo3(signature = (data, *, iters=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -244,20 +244,20 @@ impl TensorLDA {
         };
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
-        if num_docs < self.num_topics {
+        if num_docs < slf.num_topics {
             return Err(PyValueError::new_err(format!(
                 "corpus must have at least num_topics={} documents, got {}",
-                self.num_topics, num_docs
+                slf.num_topics, num_docs
             )));
         }
-        if num_types < self.num_topics {
+        if num_types < slf.num_topics {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
         }
 
         let max_rank = num_docs.min(num_types);
-        let n_eigen = self.n_eigenvec.unwrap_or(self.num_topics);
+        let n_eigen = slf.n_eigenvec.unwrap_or(slf.num_topics);
         if n_eigen > max_rank {
             return Err(PyValueError::new_err(format!(
                 "whitening rank n_eigenvec={} cannot exceed min(num_docs, vocab_size)={}",
@@ -265,17 +265,17 @@ impl TensorLDA {
             )));
         }
 
-        let n_iter_train = iters.unwrap_or(self.n_iter_train);
+        let n_iter_train = iters.unwrap_or(slf.n_iter_train);
         let (k, alpha_0, n_iter_test, lr, bs, smoothing, theta, n_eigen, seed) = (
-            self.num_topics,
-            self.alpha_0,
-            self.n_iter_test,
-            self.learning_rate,
-            self.batch_size,
-            self.smoothing,
-            self.theta,
-            self.n_eigenvec,
-            self.seed,
+            slf.num_topics,
+            slf.alpha_0,
+            slf.n_iter_test,
+            slf.learning_rate,
+            slf.batch_size,
+            slf.smoothing,
+            slf.theta,
+            slf.n_eigenvec,
+            slf.seed,
         );
 
         let (model, corpus) = py.allow_threads(move || {
@@ -296,15 +296,15 @@ impl TensorLDA {
             (m, corpus)
         });
 
-        self.model = Some(model);
-        self.corpus = Some(corpus);
-        self.topic_names = (0..self.num_topics).map(|i| format!("topic_{i}")).collect();
-        self.fitted = true;
+        slf.model = Some(model);
+        slf.corpus = Some(corpus);
+        slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
+        slf.fitted = true;
         // A batch fit supersedes any half-built stream.
-        self.stream = None;
-        self.stream_index = None;
-        self.stream_vocab = None;
-        Ok(())
+        slf.stream = None;
+        slf.stream_index = None;
+        slf.stream_vocab = None;
+        Ok(slf.into())
     }
 
     /// Update the model with a batch of documents (streaming / online fit).

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -125,7 +125,7 @@ impl Wordfish {
     #[pyo3(signature = (data, *, group=None, control=None, anchors=None, iters=None,
                         convergence_tol=None))]
     fn fit(
-        &mut self,
+        mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         group: Option<Vec<String>>,
@@ -133,7 +133,7 @@ impl Wordfish {
         anchors: Option<HashMap<String, f64>>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
-    ) -> PyResult<()> {
+    ) -> PyResult<Py<Self>> {
         let (docs_str, doc_names): (Vec<Vec<String>>, Vec<String>) =
             if let Ok(c) = data.extract::<Corpus>() {
                 let strings = c
@@ -235,7 +235,7 @@ impl Wordfish {
         }
         let mut vocab_pairs: Vec<(&str, usize)> = freq
             .iter()
-            .filter(|&(_, &c)| c >= self.min_count)
+            .filter(|&(_, &c)| c >= slf.min_count)
             .map(|(&w, &c)| (w, c))
             .collect();
         vocab_pairs.sort_by(|a, b| b.1.cmp(&a.1).then(a.0.cmp(b.0)));
@@ -296,9 +296,9 @@ impl Wordfish {
             }
         };
 
-        let tol = convergence_tol.unwrap_or(self.convergence_tol);
+        let tol = convergence_tol.unwrap_or(slf.convergence_tol);
         let it = iters.unwrap_or(100);
-        let (bsd, tsd) = (self.beta_prior_sd, self.theta_prior_sd);
+        let (bsd, tsd) = (slf.beta_prior_sd, slf.theta_prior_sd);
         let model = py.allow_threads(move || {
             wordfish::fit_wordfish_controlled(
                 &counts,
@@ -313,12 +313,12 @@ impl Wordfish {
             )
         });
 
-        self.model = Some(model);
-        self.id_to_word = id_to_word;
-        self.author_names = author_names;
-        self.control_names = control_names;
-        self.fitted = true;
-        Ok(())
+        slf.model = Some(model);
+        slf.id_to_word = id_to_word;
+        slf.author_names = author_names;
+        slf.control_names = control_names;
+        slf.fitted = true;
+        Ok(slf.into())
     }
 
     #[getter]

--- a/tests/test_combinedtm.py
+++ b/tests/test_combinedtm.py
@@ -51,7 +51,7 @@ def test_fit_surface(cls):
     docs, embs, vocab = _planted()
     m = _model(cls, seed=1)
     out = m.fit(docs, embs, iters=120)
-    assert out is None  # fit() trains in place
+    assert out is m  # fit() trains in place and returns self (#402)
     assert m.num_topics == 3
     assert m.topic_word.shape == (3, len(vocab))
     assert m.doc_topic.shape == (len(docs), 3)

--- a/tests/test_fit_returns_self.py
+++ b/tests/test_fit_returns_self.py
@@ -1,0 +1,77 @@
+"""#402 — `fit()` returns `self`, matching the estimator contract (`-> Self`).
+
+Every model's `fit` returns the bound model so calls chain
+(`topica.LDA(3, seed=1).fit(docs)`), and the returned object *is* the same
+instance (not a copy). Callers that ignore the return value are unaffected.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import topica
+
+topica.enable_experimental()
+
+_DOCS = [
+    ["a", "b", "c", "d"],
+    ["b", "c", "d", "e"],
+    ["a", "d", "e", "f"],
+    ["c", "e", "f", "a"],
+    ["b", "f", "a", "d"],
+] * 4
+
+# (name, construct, fit) — fit(model) calls fit on _DOCS with a light budget and
+# returns whatever fit returned. Covers a Gibbs, variational, neural, matrix,
+# short-text, nonparametric, and guided model plus a covariate model.
+_CASES = {
+    "LDA": (lambda: topica.LDA(3), lambda m: m.fit(_DOCS, iters=5)),
+    "CTM": (lambda: topica.CTM(3), lambda m: m.fit(_DOCS)),
+    "NMF": (lambda: topica.NMF(3), lambda m: m.fit(_DOCS)),
+    "LSA": (lambda: topica.LSA(3), lambda m: m.fit(_DOCS)),
+    "HDP": (lambda: topica.HDP(), lambda m: m.fit(_DOCS, iters=5)),
+    "GSDMM": (lambda: topica.GSDMM(3), lambda m: m.fit(_DOCS, iters=5)),
+    "BTM": (lambda: topica.BTM(3), lambda m: m.fit(_DOCS, iters=5)),
+    "ProdLDA": (lambda: topica.ProdLDA(3), lambda m: m.fit(_DOCS)),
+    "SeededLDA": (
+        lambda: topica.SeededLDA({"t0": ["a", "b"], "t1": ["e", "f"]}),
+        lambda m: m.fit(_DOCS, iters=5),
+    ),
+    "LabeledLDA": (
+        lambda: topica.LabeledLDA(),
+        lambda m: m.fit(_DOCS, [["x"], ["y"], ["x"], ["y"], ["x"]] * 4, iters=5),
+    ),
+}
+
+
+@pytest.mark.parametrize("name", sorted(_CASES))
+def test_fit_returns_same_instance(name):
+    construct, do_fit = _CASES[name]
+    model = construct()
+    returned = do_fit(model)
+    assert returned is model, f"{name}.fit() returned {returned!r}, not self"
+
+
+def test_chaining_one_liner():
+    model = topica.LDA(3, seed=1).fit(_DOCS, iters=5)
+    assert model is not None
+    assert model.topic_word.shape[0] == 3
+
+
+def test_stub_fit_returns_not_none():
+    """The .pyi must not regress `fit` back to `-> None` while the runtime chains."""
+    import ast
+    import pathlib
+
+    stub = pathlib.Path(__file__).parent.parent / "python" / "topica" / "_topica.pyi"
+    tree = ast.parse(stub.read_text())
+    offenders = []
+    for cls in tree.body:
+        if not isinstance(cls, ast.ClassDef):
+            continue
+        for m in cls.body:
+            if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef)) and m.name == "fit":
+                r = m.returns
+                if isinstance(r, ast.Constant) and r.value is None:
+                    offenders.append(cls.name)
+    assert not offenders, f"fit stubs still typed -> None: {offenders}"


### PR DESCRIPTION
Closes #402 (the `fit`-returns-self half; the Corpus-stub half was already fixed by #406).

## Problem

`fit` returned `PyResult<()>` (Python `None`), so `m = topica.LDA(3, seed=1).fit(docs)` bound `None` and chaining silently broke — even though `docs/contributing/estimator-contract.md` and the #386 scaffold both document `fit(...) -> Self`.

## Change

All 36 `fit` pymethods now use the idiomatic PyO3 0.22 self-returning form:

```rust
fn fit(mut slf: PyRefMut<'_, Self>, py: Python<'_>, ...) -> PyResult<Py<Self>> {
    ...
    Ok(slf.into())   // on every successful path
}
```

- **No new borrow/reentrancy hazard.** `PyRefMut` carries the same mutable pyclass borrow the previous `&mut self` receiver already held for the duration of the call, across `py.allow_threads` and progress callbacks. Same-model access from within a progress callback stays unsupported, exactly as before.
- **Every success path converts**, including early returns (e.g. the empty-corpus guards) and dispatcher tails (IdealPointTM).
- **Six `fit_transform` helpers** that called `self.fit(...)` internally now consume their `PyRefMut` into `fit` and read `doc_topic` from the returned handle.
- **Additive**: callers that ignore the return value are unaffected.

## Approach

The receiver/return/`self.`→`slf.` rewrite was applied by a single scripted transform over all 36 methods (line-modifying only, so it is compiler-gated — a missed `self.` or `Ok(())` is a hard type error, not a silent bug), then the handful of internal-caller and dispatcher sites were fixed by hand. Pattern validated against pyo3-0.22.6 source (`instance.rs`, `test_sequence.rs`) via an independent second-opinion pass before implementation.

## Tests

- New `tests/test_fit_returns_self.py`: asserts `fit(...) is model` across Gibbs/variational/neural/matrix/short-text/nonparametric/guided models, the one-liner chain, and a stub guard that `fit` never regresses to `-> None`.
- `.pyi` stub: all 37 `fit` returns changed `-> None` → `-> "<Class>"`.
- Updated the one test (`test_combinedtm`) that had codified the old `out is None` contract.
- Full suite `3386 passed`, `cargo test --lib` `174 passed`, preflight (fmt + clippy + tables + stub) green.

Second of the #400-series follow-ups from the analysis manifest (#394); independent of #400 (PR #407).

🤖 Generated with [Claude Code](https://claude.com/claude-code)