### PR TITLE
feat(manifest): config-aware determinism reporting (#401)

### DIFF
--- a/docs/api/manifest.md
+++ b/docs/api/manifest.md
@@ -46,6 +46,13 @@ class says it may still replay), or `unverifiable` (nothing recorded to check
 against, a bounded component, or a fingerprint from a spec this build does not
 recognise).
 
+The determinism the manifest records is **config-aware** (issue #401), not the
+coarse per-class registry tag: a `cvb0` sampler or an `init="random"` fit is
+recorded as `seed-reproducible` even when the model class is nominally `bit-exact`,
+and `determinism_detail` carries the machine-readable `replay_requires` (the `seed`,
+plus `num_threads` for the collapsed-Gibbs approximate parallel sampler) and any
+caveats. Compute it directly for any model with `topica.effective_determinism`.
+
 ## Recording evidence
 
 `record_fit(..., diagnostics=["coherence", "exclusivity"])` computes those
@@ -107,6 +114,8 @@ record.render("analysis-card.html", verification=record.verify(corpus, model))
 ## Reference
 
 ::: topica.record_fit
+
+::: topica.effective_determinism
 
 ::: topica.manifest.AnalysisManifest
 

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -211,7 +211,7 @@ from .mcmc import (  # noqa: E402
     multichain_diagnostics,
     MultiChainDiagnostics,
 )
-from .registry import list_models, ModelInfo, REGISTRY  # noqa: E402  model taxonomy / discovery
+from .registry import list_models, ModelInfo, REGISTRY, effective_determinism  # noqa: E402  model taxonomy / discovery
 
 from .validation import (  # noqa: E402  general, model-agnostic post-hoc analyses
     diagnostics,
@@ -298,6 +298,7 @@ __all__ = [
     "list_models",
     "ModelInfo",
     "REGISTRY",
+    "effective_determinism",
     "LDA",
     "DMR",
     "GDMR",

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -706,15 +706,28 @@ def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
     import topica
 
     cls = type(model).__name__
+    settings, settings_coverage = _capture_settings(model)
+
+    # Config-aware determinism (issue #401): the effective class for THIS instance's
+    # configuration, refining the coarse per-class registry tag. `determinism` stays a
+    # string (back-compatible with verify/compare/render); `determinism_detail` carries
+    # the registry class, machine-readable replay conditions, and human-readable caveats.
     determinism = None
+    determinism_detail = None
     reg = getattr(topica, "registry", None)
     if reg is not None and cls in reg.REGISTRY:
-        determinism = reg.REGISTRY[cls].determinism
+        det = reg.effective_determinism(model, fit_settings=fit_settings)
+        determinism = det["effective"]
+        determinism_detail = {
+            "registry_class": det["registry_class"],
+            "replay_requires": det["replay_requires"],
+            "notes": det["notes"],
+        }
 
-    settings, settings_coverage = _capture_settings(model)
     model_block: dict[str, Any] = {
         "class": cls,
         "determinism": determinism,
+        "determinism_detail": determinism_detail,
         "num_topics": getattr(model, "num_topics", None),
         "seed": getattr(model, "seed", None),  # most models do not expose it -> None
         "settings": settings,

--- a/python/topica/registry.py
+++ b/python/topica/registry.py
@@ -298,6 +298,136 @@ IMPL: dict[str, ImplInfo] = {
 }
 
 
+# The collapsed-Gibbs family (AD-LDA approximate parallel sampler): its
+# seed-reproducibility is conditional on the thread count when num_threads>1. The
+# cvb0 path within these models is exempt (deterministic sweeps, thread-independent).
+_GIBBS_FAMILY = frozenset(
+    name for name, info in REGISTRY.items() if info.inference == "gibbs"
+)
+
+
+def effective_determinism(model, *, fit_settings: dict | None = None) -> dict:
+    """The determinism class this *instance* actually has, given its configuration
+    (issue #401), refining the per-class :attr:`ModelInfo.determinism` tag.
+
+    Determinism is often per-configuration, not per-class: the same model can be
+    ``bit-exact`` under one setting and ``seed-reproducible`` under another. This
+    reads the model's :attr:`~topica` ``settings`` (constructor config, issue #400)
+    and the ``fit_settings`` you record, and returns::
+
+        {"effective": "seed-reproducible",     # the config-aware class
+         "registry_class": "bit-exact",        # the coarse per-class tag
+         "replay_requires": {"seed": 42},      # machine-readable replay conditions
+         "notes": ["..."]}                     # human-readable caveats
+
+    ``replay_requires`` carries the conditions an exact replay needs — always the
+    ``seed`` for a seed-reproducible fit, plus ``num_threads`` for the collapsed-Gibbs
+    approximate parallel sampler. ``bit-exact`` fits carry no replay requirements.
+
+    Scope (minimal, honest): claims the configuration determines are made exactly.
+    Where the deciding factor is a *runtime* outcome the config cannot know — did a
+    spectral initialization succeed or silently fall back to a seeded random one? did
+    anchor selection hit its degenerate-basis fallback? — this keeps the common-case
+    class and records the caveat in ``notes`` rather than over- or under-claiming.
+    Recording the actual initialization route in the fitted model (so those cases
+    become exact) is tracked as follow-up work.
+
+    Parameters
+    ----------
+    model : a topica model (fitted or not; reads its construction config).
+    fit_settings : the keyword arguments passed to ``fit`` (e.g. ``num_threads``,
+        ``inference``), which can override the constructor. Optional.
+    """
+    cls = type(model).__name__
+    info = REGISTRY.get(cls)
+    base = info.determinism if info is not None else None
+    settings = getattr(model, "settings", None) or {}
+    fit_settings = fit_settings or {}
+    notes: list[str] = []
+
+    if base == "llm-bounded":
+        return {
+            "effective": "llm-bounded",
+            "registry_class": base,
+            "replay_requires": {},
+            "notes": [
+                "output depends on an external model; stable at temperature 0, "
+                "not bit-reproducible"
+            ],
+        }
+
+    effective = base
+    sampler = settings.get("sampler")
+    init = settings.get("init")
+    inference = fit_settings.get("inference")
+    is_cvb0 = sampler == "cvb0"
+
+    if is_cvb0:
+        # cvb0 seeds only the initial responsibilities, then is deterministic;
+        # it never uses the thread count. Downgrade from any Gibbs base.
+        effective = "seed-reproducible"
+        notes.append(
+            "cvb0 seeds only the initial responsibilities, then runs a deterministic, "
+            "thread-independent sweep"
+        )
+    elif cls == "NMF":
+        if init == "random":
+            effective = "seed-reproducible"
+            notes.append(
+                "init='random' draws both factors from the seeded RNG; bit-exact "
+                "only with init='nndsvd'"
+            )
+    elif cls in ("CTM", "STM", "STS"):
+        if inference == "svi":
+            effective = "seed-reproducible"
+            notes.append(
+                "inference='svi' shuffles documents with the seeded RNG each epoch"
+            )
+        elif init == "random":
+            effective = "seed-reproducible"
+            notes.append(
+                "init='random' seeds the initialization; bit-exact only with "
+                "init='spectral'"
+            )
+        else:  # init == "spectral", batch inference
+            notes.append(
+                "bit-exact assumes spectral recovery succeeded; a degenerate corpus "
+                "falls back to a seeded random init (not recorded here)"
+            )
+    elif cls == "DTM" and init == "spectral":
+        notes.append(
+            "init='spectral' is deterministic when spectral recovery succeeds; a "
+            "degenerate corpus falls back to a seeded static-LDA init"
+        )
+    elif cls == "AnchorLDA":
+        notes.append(
+            "bit-exact assumes anchor selection did not hit its seeded degenerate-basis "
+            "fallback; not bit-identical across BLAS/LAPACK backends"
+        )
+
+    replay: dict = {}
+    if effective == "seed-reproducible":
+        replay["seed"] = settings.get("seed")
+        # Only the collapsed-Gibbs approximate parallel sampler is thread-conditional;
+        # the cvb0 path and the variational E-steps preserve serial reduction order.
+        if cls in _GIBBS_FAMILY and not is_cvb0:
+            threads = fit_settings.get("num_threads", settings.get("num_threads", 1))
+            threads = 1 if threads in (None, 0) else threads
+            replay["num_threads"] = threads
+            if threads > 1:
+                notes.append(
+                    f"num_threads={threads} uses the approximate parallel sampler; "
+                    f"replay requires the same thread count"
+                )
+
+    return {
+        "effective": effective,
+        "registry_class": base,
+        "replay_requires": replay,
+        "notes": notes,
+    }
+
+
 def list_models(
     *,
     group: str | None = None,

--- a/tests/test_effective_determinism.py
+++ b/tests/test_effective_determinism.py
@@ -1,0 +1,156 @@
+"""#401 — config-aware (per-instance) determinism.
+
+`topica.effective_determinism(model, fit_settings=)` refines the coarse per-class
+registry tag using the instance's configuration. Two kinds of check here:
+
+- the *claim* the helper makes for each config (the rule table), and
+- that the claim is *true* at runtime (same seed identical; a downgraded config is
+  actually seed-dependent; a thread-independent path really is).
+
+Scope is deliberately config-only: cases whose determinism depends on a runtime
+outcome the config cannot see (did spectral init succeed or fall back?) keep the
+common-case class plus a caveat note, and are not asserted bit-exact here.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import topica
+from topica import effective_determinism
+
+topica.enable_experimental()
+
+_DOCS = [
+    ["a", "b", "c", "d"],
+    ["b", "c", "d", "e"],
+    ["a", "d", "e", "f"],
+    ["c", "e", "f", "a"],
+    ["b", "f", "a", "d"],
+    ["e", "a", "c", "b"],
+] * 4
+
+
+# --------------------------------------------------------------------------
+# The rule table (what the helper claims)
+# --------------------------------------------------------------------------
+
+def test_cvb0_is_seed_reproducible_and_thread_independent():
+    for m in (
+        topica.LDA(3, sampler="cvb0"),
+        topica.DMR(3, sampler="cvb0"),
+        topica.KeyATM({"a": ["x"]}, num_topics=3, sampler="cvb0"),
+    ):
+        det = effective_determinism(m)
+        assert det["effective"] == "seed-reproducible"
+        assert "seed" in det["replay_requires"]
+        assert "num_threads" not in det["replay_requires"]  # cvb0 is thread-independent
+
+
+def test_nmf_init_conditional():
+    bit = effective_determinism(topica.NMF(3, init="nndsvd"))
+    assert bit["effective"] == "bit-exact"
+    assert bit["replay_requires"] == {}
+    rnd = effective_determinism(topica.NMF(3, init="random"))
+    assert rnd["effective"] == "seed-reproducible"
+    assert rnd["replay_requires"].get("seed") == 42
+
+
+def test_ctm_stm_init_and_svi():
+    # random init downgrades
+    assert effective_determinism(topica.CTM(3, init="random"))["effective"] == "seed-reproducible"
+    assert effective_determinism(topica.STM(3, init="random"))["effective"] == "seed-reproducible"
+    # svi (a fit-time arg) downgrades even under spectral init
+    svi = effective_determinism(topica.CTM(3), fit_settings={"inference": "svi"})
+    assert svi["effective"] == "seed-reproducible"
+    # default spectral batch stays bit-exact, with an honest fallback caveat
+    spec = effective_determinism(topica.CTM(3))
+    assert spec["effective"] == "bit-exact"
+    assert any("spectral" in n for n in spec["notes"])
+
+
+def test_gibbs_thread_conditionality():
+    # single-threaded: records num_threads=1
+    d1 = effective_determinism(topica.LDA(3))
+    assert d1["effective"] == "seed-reproducible"
+    assert d1["replay_requires"].get("num_threads") == 1
+    # multi-threaded via a fit-time override: replay needs that count, with a note
+    d4 = effective_determinism(topica.LDA(3), fit_settings={"num_threads": 4})
+    assert d4["replay_requires"].get("num_threads") == 4
+    assert any("num_threads=4" in n for n in d4["notes"])
+
+
+def test_wordfish_unconditionally_bit_exact():
+    det = effective_determinism(topica.Wordfish())
+    assert det["effective"] == "bit-exact"
+    assert det["replay_requires"] == {}
+
+
+def test_anchorlda_keeps_class_with_caveat():
+    det = effective_determinism(topica.AnchorLDA(3))
+    assert det["effective"] == "bit-exact"
+    assert det["notes"], "AnchorLDA should carry its fallback/backend caveat"
+
+
+def test_llm_bounded():
+    det = effective_determinism(topica.TopicGPT(backend=lambda p: ""))
+    assert det["effective"] == "llm-bounded"
+    assert det["replay_requires"] == {}
+
+
+@pytest.mark.parametrize(
+    "model,expected",
+    [
+        (topica.LDA(3), "seed-reproducible"),
+        (topica.NMF(3), "bit-exact"),
+        (topica.CTM(3), "bit-exact"),
+        (topica.STM(3), "bit-exact"),
+        (topica.ProdLDA(3), "seed-reproducible"),
+        (topica.HDP(), "seed-reproducible"),
+    ],
+)
+def test_default_config_matches_registry_tag(model, expected):
+    det = effective_determinism(model)
+    assert det["effective"] == expected == det["registry_class"]
+
+
+# --------------------------------------------------------------------------
+# The claims are true at runtime
+# --------------------------------------------------------------------------
+
+def test_nmf_nndsvd_seed_independent_random_seed_dependent():
+    a = topica.NMF(3, init="nndsvd", seed=1); a.fit(_DOCS)
+    b = topica.NMF(3, init="nndsvd", seed=999); b.fit(_DOCS)
+    assert np.allclose(a.topic_word, b.topic_word)  # nndsvd: seed-independent
+    c = topica.NMF(3, init="random", seed=1); c.fit(_DOCS)
+    d = topica.NMF(3, init="random", seed=999); d.fit(_DOCS)
+    assert not np.allclose(c.topic_word, d.topic_word)  # random: seed-dependent
+
+
+def test_cvb0_seed_dependent_but_thread_independent():
+    a = topica.LDA(3, sampler="cvb0", seed=1); a.fit(_DOCS, iters=20, num_threads=1)
+    b = topica.LDA(3, sampler="cvb0", seed=1); b.fit(_DOCS, iters=20, num_threads=4)
+    assert np.allclose(a.topic_word, b.topic_word)  # thread-independent
+    c = topica.LDA(3, sampler="cvb0", seed=7); c.fit(_DOCS, iters=20)
+    assert not np.allclose(a.topic_word, c.topic_word)  # seed-dependent
+
+
+# --------------------------------------------------------------------------
+# Manifest integration
+# --------------------------------------------------------------------------
+
+def test_manifest_records_effective_determinism():
+    m = topica.NMF(3, init="random"); m.fit(_DOCS)
+    rec = topica.record_fit(m, corpus=topica.Corpus.from_documents(_DOCS))
+    assert rec.model["determinism"] == "seed-reproducible"
+    detail = rec.model["determinism_detail"]
+    assert detail["registry_class"] == "bit-exact"
+    assert detail["replay_requires"].get("seed") == 42
+
+
+def test_manifest_cvb0_detail_has_no_thread_requirement():
+    m = topica.LDA(3, sampler="cvb0"); m.fit(_DOCS, iters=10)
+    rec = topica.record_fit(m, corpus=topica.Corpus.from_documents(_DOCS))
+    assert rec.model["determinism"] == "seed-reproducible"
+    assert "num_threads" not in rec.model["determinism_detail"]["replay_requires"]


### PR DESCRIPTION
Closes #401.

## What

Adds `topica.effective_determinism(model, *, fit_settings=None)` — the determinism class **this instance** actually has given its configuration, refining the coarse per-class `registry.ModelInfo.determinism` tag.

```python
topica.effective_determinism(topica.NMF(3, init="random"))
# {"effective": "seed-reproducible", "registry_class": "bit-exact",
#  "replay_requires": {"seed": 42}, "notes": ["init='random' draws both factors ..."]}
```

`record_fit` now stores it: `model.determinism` carries the **effective** class (a string — back-compatible with `verify`/`compare`/`render`) and a new `model.determinism_detail` carries `registry_class`, machine-readable `replay_requires`, and caveat `notes`. `verify` reads the effective class automatically, so its `environment_changed` / `unverifiable` / `artifact_changed` grading is more precise.

## The rules (corrected against the Rust core in independent review)

| Config | Effective | Replay |
|---|---|---|
| `sampler="cvb0"` (any of 5 models) | seed-reproducible | seed only — **thread-independent** |
| `NMF(init="nndsvd")` | bit-exact | — |
| `NMF(init="random")` | seed-reproducible | seed |
| CTM/STM/STS `init="random"` or `fit(inference="svi")` | seed-reproducible | seed |
| CTM/STM/STS spectral batch (default) | bit-exact | — (+ caveat note on spectral fallback) |
| Gibbs family, `num_threads=N>1` | seed-reproducible | seed + `num_threads=N` |
| Wordfish | bit-exact | — |
| TopicGPT | llm-bounded | — |

Default configs give `effective == registry tag`, so existing default manifests are unchanged; only non-default configs shift.

## Scope: minimal and honest (per plan)

Claims the configuration **determines** are made exactly and validated at runtime (tests assert NMF `nndsvd` is seed-independent while `random` is seed-dependent; `cvb0` is thread-independent but seed-dependent). Cases whose determinism depends on a **runtime outcome the config cannot see** — did a spectral init succeed or silently fall back to a seeded random one? did anchor selection hit its degenerate-basis fallback? — keep the common-case class and record the caveat in `notes` rather than over-claiming. The follow-ups below make those exact.

## Tests / gates

`tests/test_effective_determinism.py` (17 cases: rule table + runtime validation + manifest integration). Full suite `3518 passed`, preflight and strict docs green. Pure-Python change (no rebuild).

## Follow-ups (filed separately)

- Record the actual initialization route (`spectral` / `random-fallback` / `random` / `provided`) in the fitted CTM/STM/STS/DTM + an AnchorLDA fallback flag, so the caveated cases become exact config-aware claims.
- Fix the large-vocabulary spectral-init summation order (sums over an unsorted `HashMap`, `spectral.rs:289`), which breaks bit-reproducibility for V>3000 spectral fits independent of this issue.

Third of the #400-series follow-ups from the analysis manifest (#394); builds on #400's `settings` surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)