### PR TITLE
fix(spectral): make large-vocab spectral init bit-reproducible (#411)

### DIFF
--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -292,6 +292,10 @@ impl Wordfish {
                         })?;
                     pairs.push((i, target));
                 }
+                // Sort by author index so the orientation sign-check sums the
+                // anchors in a fixed order regardless of the input dict's hash
+                // iteration order — Wordfish is bit-exact, keep it so (#411).
+                pairs.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.total_cmp(&b.1)));
                 pairs
             }
         };

--- a/tests/test_wordfish.py
+++ b/tests/test_wordfish.py
@@ -104,6 +104,19 @@ def test_determinism():
     assert np.array_equal(a.author_positions, b.author_positions)
 
 
+def test_determinism_with_multiple_anchors():
+    # Anchors arrive as a dict (a HashMap on the Rust side); the orientation must
+    # be a deterministic function of the corpus + anchors regardless of the dict's
+    # iteration order (#411 — anchor pairs are sorted before the sign check).
+    docs, group, _, _ = _planted(seed=4)
+    anchors = {"a0": -1.0, "a10": -0.5, "a20": 0.5, "a39": 1.0}
+    a = topica.Wordfish(seed=1)
+    a.fit(docs, group=group, anchors=anchors)
+    b = topica.Wordfish(seed=1)
+    b.fit(docs, group=group, anchors=dict(reversed(list(anchors.items()))))
+    assert np.array_equal(a.author_positions, b.author_positions)
+
+
 def test_save_load(tmp_path):
     docs, group, _, _ = _planted(seed=5)
     m = topica.Wordfish(seed=1)

--- a/topica-core/src/spectral.rs
+++ b/topica-core/src/spectral.rs
@@ -15,7 +15,7 @@
 use rand::Rng;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 /// Above this vocabulary size the dense V×V co-occurrence is replaced by a
 /// random projection to `PROJ_DIM` columns (Johnson-Lindenstrauss), turning the
@@ -286,7 +286,13 @@ fn cooccurrence_projected(
             continue;
         }
         used_docs += 1;
-        let mut wc: HashMap<usize, f64> = HashMap::new();
+        // BTreeMap (sorted-key iteration), not HashMap: the `s[j]` accumulation
+        // below sums c·R[w] across the document's words into a shared vector, so a
+        // nondeterministic (hash-randomized) iteration order would vary the
+        // floating-point summation order and break bit-reproducibility of the
+        // spectral init for vocabularies large enough to take this projected path
+        // (issue #411). Sorted order fixes the summation order.
+        let mut wc: BTreeMap<usize, f64> = BTreeMap::new();
         for &w in doc {
             *wc.entry(w as usize).or_insert(0.0) += 1.0;
         }
@@ -401,6 +407,36 @@ mod tests {
             "too few blocks separated: {:?}",
             covered
         );
+    }
+
+    #[test]
+    fn projected_path_is_bit_deterministic_large_vocab() {
+        // #411: the projected co-occurrence path accumulates the per-document S_d
+        // vector over the document's words; iterating an unsorted HashMap made the
+        // floating-point summation order depend on the per-run hash seed. The fix
+        // (a sorted BTreeMap) makes the projected path a deterministic function of
+        // the corpus by construction. This asserts within-process reproducibility
+        // (two inits on the same large-vocab corpus are bit-identical); it is a
+        // smoke test rather than a proof, since whether an unordered sum actually
+        // diverges in its low bits is data-dependent. V = 4000 > PROJ_THRESHOLD
+        // forces the projected path.
+        let nb = 10usize;
+        let bs = 400usize;
+        let v = nb * bs;
+        let blocks: Vec<Vec<u32>> = (0..nb)
+            .map(|b| (b * bs..b * bs + bs).map(|w| w as u32).collect())
+            .collect();
+        let mut docs = Vec::new();
+        for i in 0..(nb * 200) {
+            let blk = &blocks[i % nb];
+            // Longer, mixed-vocabulary docs so many distinct words land in one S_d
+            // sum — this is where an unordered iteration order used to bite.
+            let doc: Vec<u32> = (0..25).map(|j| blk[(i * 13 + j * 41) % bs]).collect();
+            docs.push(doc);
+        }
+        let a = spectral_init(&docs, nb, v).expect("projected spectral init");
+        let b = spectral_init(&docs, nb, v).expect("projected spectral init");
+        assert_eq!(a, b, "projected spectral init is not bit-reproducible");
     }
 
     #[test]


### PR DESCRIPTION
Closes #411. Prerequisite for #410 (init-route telemetry).

## The bug

Spectral (anchor-word) init is STM/CTM/STS/DTM's default and is supposed to be a **deterministic function of the corpus** (no seed). For vocabularies above `PROJ_THRESHOLD=3000` it takes the random-projection path (`cooccurrence_projected`), which accumulates each document's `S_d = Σ_w c_w·R[w]` into a shared vector by iterating the per-document word counts over an **unsorted `HashMap`**:

```rust
let mut wc: HashMap<usize, f64> = HashMap::new();  // hash-randomized order
...
for (&w, &c) in &wc { for j in 0..m { s[j] += c * r[w][j]; } }  // order-dependent float sum
```

Rust randomizes `HashMap` iteration order per instance, so the floating-point summation order — and the low bits of `S_d`, `Q̄·R`, and the recovered β — depended on the per-run hash seed, not just the corpus. So a "bit-exact" large-vocab spectral fit wasn't actually bit-reproducible.

## Fix

Iterate a sorted `BTreeMap` so the summation order is fixed. The projected path is now deterministic **by construction**. The dense path (V ≤ 3000, the common case) writes each `Q` cell exactly once and was already order-independent — untouched, so all existing small-vocab fits are byte-identical.

Also sorted **Wordfish**'s user-anchor pairs (another dict → `HashMap`) by author index before its orientation sign-check, so its bit-exact classification holds regardless of the anchor dict's order.

## On the test

A within-process reproducibility test on a 4000-word corpus is included, but I'm being honest in the comment that it's a **smoke test, not a proof**: whether an unordered sum actually diverges in its low bits is data-dependent (it passed even with the old `HashMap` here), so the guarantee is the sorted iteration, not the test. Plus a Wordfish multi-anchor determinism test.

`cargo test --lib` (174) and the full pytest suite (3518) pass.

## Why now

Per the #401 follow-up sequencing: this lands **before** #410 so that #410's "spectral → bit-exact" upgrade is a true claim for large vocabularies too, not just small ones.

🤖 Generated with [Claude Code](https://claude.com/claude-code)