### PR TITLE
feat(models): record the init route for exact config-aware determinism (#410)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -417,6 +417,12 @@ class CTM:
     correlate (unlike LDA's Dirichlet). Fit by variational EM (STM's Laplace
     E-step)."""
     @property
+    def initialization(self) -> str | None:
+        """The initialization route the fit took (#410): 'spectral',
+        'random-fallback', 'random', or 'provided'; None before fit."""
+        ...
+
+    @property
     def settings(self) -> dict:
         """The constructor configuration as a JSON-serialisable dict,
         keyword-named to match ``__init__`` (issue #400)."""
@@ -578,6 +584,12 @@ class STM:
     """Structural Topic Model (Roberts, Stewart & Tingley): the correlated-topic
     core (CTM) plus prevalence covariates — the prior topic mean is a regression
     on document covariates (mu_d = X_d gamma)."""
+    @property
+    def initialization(self) -> str | None:
+        """The initialization route the fit took (#410): 'spectral',
+        'random-fallback', 'random', or 'provided'; None before fit."""
+        ...
+
     @property
     def settings(self) -> dict:
         """The constructor configuration as a JSON-serialisable dict,
@@ -797,6 +809,12 @@ class STS:
     plus a per-document, per-topic continuous sentiment-discourse latent that
     modulates the topic-word distribution, with both prevalence and sentiment
     driven by document covariates. Fit by Laplace variational EM."""
+    @property
+    def initialization(self) -> str | None:
+        """The initialization route the fit took (#410): 'spectral',
+        'random-fallback', 'random', or 'provided'; None before fit."""
+        ...
+
     @property
     def settings(self) -> dict:
         """The constructor configuration as a JSON-serialisable dict,
@@ -1105,6 +1123,12 @@ class DTM:
     Fit variationally with Kalman smoothing (a port of Blei's C dtm /
     gensim's LdaSeqModel). Query a topic's distribution at a slice with
     topic_word(time) and a word's trajectory with word_evolution(topic, word)."""
+    @property
+    def initialization(self) -> str | None:
+        """The initialization route the fit took (#410): 'spectral',
+        'random-fallback', 'random', or 'provided'; None before fit."""
+        ...
+
     @property
     def settings(self) -> dict:
         """The constructor configuration as a JSON-serialisable dict,

--- a/python/topica/anchor.py
+++ b/python/topica/anchor.py
@@ -105,6 +105,7 @@ def _find_anchors(q, k, seed, candidates=None):
     norms = np.where(candidates, norms, -1.0)
     anchors = [int(np.argmax(norms))]
     basis = [q[anchors[0]] / np.linalg.norm(q[anchors[0]])]
+    fallback_used = False  # set when the seeded degenerate-basis fallback fires (#410)
     for _ in range(k - 1):
         bmat = np.array(basis)
         resid = q - (q @ bmat.T) @ bmat
@@ -116,12 +117,14 @@ def _find_anchors(q, k, seed, candidates=None):
         nb = np.linalg.norm(b)
         if nb < 1e-12:
             pool = [i for i in range(v) if candidates[i] and i not in anchors]
-            nxt = int(rng.choice(pool)) if pool else nxt
+            if pool:
+                nxt = int(rng.choice(pool))  # seeded random pick -> seed-dependent
+                fallback_used = True
             b = resid[nxt]
             nb = np.linalg.norm(b)
         anchors.append(nxt)
         basis.append(b / nb if nb > 1e-12 else b)
-    return anchors
+    return anchors, fallback_used
 
 
 def _recover_l2(q, anchors):
@@ -256,6 +259,7 @@ class AnchorLDA:
         self.frequency_temper = float(frequency_temper)
         self.anchor_min_doc_freq = float(anchor_min_doc_freq)
         self._fitted = False
+        self._anchor_fallback_used = None  # set by fit (#410); None until fitted
         self._topic_word = None
         self._doc_topic = None
         self._vocab = None
@@ -283,6 +287,14 @@ class AnchorLDA:
             "anchor_min_doc_freq": self.anchor_min_doc_freq,
         }
 
+    @property
+    def anchor_fallback_used(self) -> bool | None:
+        """Whether anchor selection hit its seeded degenerate-basis fallback during
+        fit (issue #410). ``None`` before fit. When ``True`` the recovered topics are
+        seed-dependent (a random anchor was drawn); when ``False`` selection was
+        deterministic. Read by :func:`topica.effective_determinism`."""
+        return self._anchor_fallback_used
+
     # -- fitting ------------------------------------------------------------
     def fit(self, data, *, iters=None, min_count=None):
         """Recover topics from ``data`` (a :class:`~topica.Corpus` or a list of
@@ -309,7 +321,9 @@ class AnchorLDA:
         thresh = (self.anchor_min_doc_freq * n_docs
                   if self.anchor_min_doc_freq < 1.0 else self.anchor_min_doc_freq)
         candidates = doc_freq >= max(1.0, thresh) if thresh > 0 else None
-        anchors = _find_anchors(q, self._k, self.seed, candidates)
+        anchors, self._anchor_fallback_used = _find_anchors(
+            q, self._k, self.seed, candidates
+        )
         if self.recover == "kl":
             n_iters = 200 if iters is None else int(iters)
             c, self._fit_history, self._converged = _recover_kl(

--- a/python/topica/registry.py
+++ b/python/topica/registry.py
@@ -327,10 +327,12 @@ def effective_determinism(model, *, fit_settings: dict | None = None) -> dict:
     Scope (minimal, honest): claims the configuration determines are made exactly.
     Where the deciding factor is a *runtime* outcome the config cannot know — did a
     spectral initialization succeed or silently fall back to a seeded random one? did
-    anchor selection hit its degenerate-basis fallback? — this keeps the common-case
-    class and records the caveat in ``notes`` rather than over- or under-claiming.
-    Recording the actual initialization route in the fitted model (so those cases
-    become exact) is tracked as follow-up work.
+    anchor selection hit its degenerate-basis fallback? — the report reads the route
+    the fit actually took, recorded on the fitted model (``model.initialization`` for
+    STM/CTM/STS/DTM, ``model.anchor_fallback_used`` for AnchorLDA, issue #410), and
+    makes the exact call. For an *unfitted* model, or one saved before that route was
+    recorded, it falls back to the common-case class plus a caveat in ``notes`` rather
+    than over- or under-claiming.
 
     Parameters
     ----------
@@ -361,6 +363,10 @@ def effective_determinism(model, *, fit_settings: dict | None = None) -> dict:
     init = settings.get("init")
     inference = fit_settings.get("inference")
     is_cvb0 = sampler == "cvb0"
+    # The initialization route the fit actually took, recorded on the fitted model
+    # (issue #410). `None` before fit or for a model saved before it was recorded —
+    # then we fall back to the config-only caveat below.
+    route = getattr(model, "initialization", None)
 
     if is_cvb0:
         # cvb0 seeds only the initial responsibilities, then is deterministic;
@@ -383,27 +389,49 @@ def effective_determinism(model, *, fit_settings: dict | None = None) -> dict:
             notes.append(
                 "inference='svi' shuffles documents with the seeded RNG each epoch"
             )
+        elif route is not None:
+            # The fit recorded which init actually ran (#410) — an exact claim.
+            if route in ("random", "random-fallback"):
+                effective = "seed-reproducible"
+                notes.append(
+                    "init ran as 'random-fallback' (spectral recovery returned None)"
+                    if route == "random-fallback"
+                    else "init='random' seeds the initialization"
+                )
+            # "spectral"/"provided" -> keep the bit-exact base, no caveat needed.
         elif init == "random":
             effective = "seed-reproducible"
             notes.append(
                 "init='random' seeds the initialization; bit-exact only with "
                 "init='spectral'"
             )
-        else:  # init == "spectral", batch inference
+        else:  # init == "spectral", batch, unfitted or old save (route unknown)
             notes.append(
-                "bit-exact assumes spectral recovery succeeded; a degenerate corpus "
-                "falls back to a seeded random init (not recorded here)"
+                "bit-exact assumes spectral recovery succeeded; fit the model (or "
+                "re-save it) so the actual init route is recorded"
             )
-    elif cls == "DTM" and init == "spectral":
-        notes.append(
-            "init='spectral' is deterministic when spectral recovery succeeds; a "
-            "degenerate corpus falls back to a seeded static-LDA init"
-        )
+    elif cls == "DTM":
+        # DTM stays seed-reproducible either way (its post-init variational fit is
+        # not established as bit-exact); the recorded route just sharpens the note.
+        if route == "random-fallback":
+            notes.append("init requested spectral but fell back to a seeded static-LDA init")
+        elif route == "spectral":
+            notes.append("spectral init succeeded (deterministic); the fit remains seed-reproducible")
+        elif init == "spectral":
+            notes.append(
+                "init='spectral' is deterministic when spectral recovery succeeds; a "
+                "degenerate corpus falls back to a seeded static-LDA init"
+            )
     elif cls == "AnchorLDA":
-        notes.append(
-            "bit-exact assumes anchor selection did not hit its seeded degenerate-basis "
-            "fallback; not bit-identical across BLAS/LAPACK backends"
-        )
+        fallback = getattr(model, "anchor_fallback_used", None)
+        if fallback:
+            effective = "seed-reproducible"
+            notes.append("anchor selection hit its seeded degenerate-basis fallback")
+        else:
+            notes.append(
+                "not bit-identical across BLAS/LAPACK backends"
+                + ("" if fallback is False else "; assumes anchor selection did not hit its seeded fallback")
+            )
 
     replay: dict = {}
     if effective == "seed-reproducible":

--- a/src/dtm.rs
+++ b/src/dtm.rs
@@ -500,6 +500,10 @@ pub struct DtmModel {
     pub alpha: f64,
     chains: Vec<Sslm>,
     pub bound: f64,
+    /// The initialization route the fit actually took (issue #410): `"spectral"`,
+    /// `"random-fallback"` (spectral requested but recovery returned `None`, so the
+    /// seeded static-LDA init ran), or `"random"` (`init="random"`).
+    pub initialization: String,
 }
 
 impl DtmModel {
@@ -602,7 +606,7 @@ pub fn fit_dtm<R: Rng>(
     // distributions directly is sufficient. Falls back to the random static-LDA
     // seed when the spectral solve is unavailable (e.g. K > vocab) or when the
     // caller asks for it (init="random", which matches gensim's LdaModel seed).
-    let seed: Vec<Vec<f64>> = match init_spectral
+    let (seed, init_route): (Vec<Vec<f64>>, &'static str) = match init_spectral
         .then(|| crate::spectral::spectral_init(docs, k, v))
         .flatten()
     {
@@ -614,9 +618,16 @@ pub fn fit_dtm<R: Rng>(
                     s[w][kk] = bw;
                 }
             }
-            s
+            (s, "spectral")
         }
-        None => init_suffstats(docs, v, k, 50, rng),
+        None => (
+            init_suffstats(docs, v, k, 50, rng),
+            if init_spectral {
+                "random-fallback"
+            } else {
+                "random"
+            },
+        ),
     };
     let mut chains: Vec<Sslm> = (0..k)
         .map(|kk| {
@@ -690,6 +701,7 @@ pub fn fit_dtm<R: Rng>(
         alpha,
         chains,
         bound,
+        initialization: init_route.to_string(),
     }
 }
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -271,6 +271,8 @@ struct CtmState {
     topic_names: Vec<String>,
     #[serde(default = "default_variational")]
     variational: String,
+    #[serde(default)]
+    initialization: Option<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct StmState {
@@ -305,6 +307,8 @@ struct StmState {
     variational: String,
     #[serde(default)]
     content_kappa: Option<ctm::ContentKappa>,
+    #[serde(default)]
+    initialization: Option<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct StsState {
@@ -332,6 +336,8 @@ struct StsState {
     converged: bool,
     #[serde(default)]
     topic_names: Vec<String>,
+    #[serde(default)]
+    initialization: Option<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct HdpState {
@@ -368,6 +374,8 @@ struct DtmState {
     topic_names: Vec<String>,
     #[serde(default = "default_false")]
     init_spectral: bool,
+    #[serde(default)]
+    initialization: Option<String>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SldaState {
@@ -5931,6 +5939,8 @@ pub struct CTM {
     variational: String,
 
     fitted: bool,
+    // The initialization route the fit took (#410); None until fitted.
+    initialization: Option<String>,
     topic_names: Vec<String>,
     beta: Option<Array2<f64>>,     // (num_topics, num_words)
     theta: Option<Array2<f64>>,    // (num_docs, num_topics)
@@ -6033,6 +6043,7 @@ impl CTM {
             init_spectral,
             variational: variational.to_string(),
             fitted: false,
+            initialization: None,
             topic_names: Vec::new(),
             beta: None,
             theta: None,
@@ -6254,6 +6265,7 @@ impl CTM {
         };
 
         slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.initialization = Some(model.initialization.clone());
         slf.beta = Some(beta);
         slf.theta = Some(theta);
         slf.corr = Some(corr);
@@ -6311,6 +6323,15 @@ impl CTM {
     #[getter]
     fn variational(&self) -> String {
         self.variational.clone()
+    }
+
+    /// The initialization route the fit actually took (issue #410): ``"spectral"``,
+    /// ``"random-fallback"`` (spectral requested but recovery fell back to a seeded
+    /// random init), or ``"random"``. ``None`` before the model is fitted, and after
+    /// loading a model saved before this was recorded.
+    #[getter]
+    fn initialization(&self) -> Option<String> {
+        self.initialization.clone()
     }
 
     /// Uniform convergence trace: ``(iteration, bound)`` pairs, one per EM
@@ -6432,6 +6453,8 @@ impl CTM {
             em_iters_run: 0,
             // Recompute ν in the same mode the fit used (laplace/diagonal).
             diagonal: self.variational == "diagonal",
+            // Unused by recompute_nu; carry the recorded route if present.
+            initialization: self.initialization.clone().unwrap_or_default(),
         };
         let nu = py.allow_threads(|| ctm::recompute_nu(&model_stub, &sparse));
         let mut out = Array3::<f32>::zeros((d, km1, km1));
@@ -6594,6 +6617,7 @@ impl CTM {
                 converged: self.converged,
                 topic_names: self.topic_names.clone(),
                 variational: self.variational.clone(),
+                initialization: self.initialization.clone(),
             },
         )
     }
@@ -6616,6 +6640,7 @@ impl CTM {
             init_spectral: s.init_spectral,
             variational: s.variational,
             fitted: s.fitted,
+            initialization: s.initialization,
             topic_names,
             beta: arr2_back(s.beta)?,
             theta: arr2_back(s.theta)?,
@@ -6667,6 +6692,8 @@ pub struct STM {
     variational: String,
 
     fitted: bool,
+    // The initialization route the fit took (#410); None until fitted.
+    initialization: Option<String>,
     topic_names: Vec<String>,
     beta: Option<Array2<f64>>,
     theta: Option<Array2<f64>>,
@@ -6760,8 +6787,12 @@ impl STM {
     /// Create an unfitted model. `sigma_shrink` ∈ [0,1] shrinks Σ toward its
     /// diagonal each M-step. `init` is ``"spectral"`` (default; deterministic
     /// anchor-word init, matching STM's default — `seed` is then irrelevant for
-    /// β init) or ``"random"`` (seeded). Spectral init applies to the
-    /// topic-word β; with a content model the per-group β is always random.
+    /// β init) or ``"random"`` (seeded). Spectral init applies to the base
+    /// topic-word β with or without a content covariate: the content (SAGE)
+    /// deviations κ are then derived deterministically from that base β, so a
+    /// content fit under spectral init is seed-independent too. Spectral can fall
+    /// back to a seeded random init for a degenerate corpus; ``initialization``
+    /// records which route ran.
     /// `variational` selects the per-document variational-covariance mode:
     /// ``"laplace"`` (default; full posterior covariance ν = H⁻¹) or
     /// ``"diagonal"`` (mean-field ν = diag(1/H_ii), which skips the per-document
@@ -6800,6 +6831,7 @@ impl STM {
             init_spectral,
             variational: variational.to_string(),
             fitted: false,
+            initialization: None,
             topic_names: Vec::new(),
             beta: None,
             theta: None,
@@ -7247,6 +7279,7 @@ impl STM {
         };
 
         slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
+        slf.initialization = Some(model.initialization.clone());
         slf.beta = Some(beta);
         slf.theta = Some(theta);
         slf.corr = Some(corr);
@@ -7312,6 +7345,15 @@ impl STM {
     #[getter]
     fn variational(&self) -> String {
         self.variational.clone()
+    }
+
+    /// The initialization route the fit actually took (issue #410): ``"spectral"``,
+    /// ``"random-fallback"`` (spectral requested but recovery fell back to a seeded
+    /// random init), or ``"random"``. ``None`` before the model is fitted, and after
+    /// loading a model saved before this was recorded.
+    #[getter]
+    fn initialization(&self) -> Option<String> {
+        self.initialization.clone()
     }
 
     /// Uniform convergence trace: ``(iteration, bound)`` pairs, one per EM
@@ -7444,6 +7486,8 @@ impl STM {
             em_iters_run: 0,
             // Recompute ν in the same mode the fit used (laplace/diagonal).
             diagonal: self.variational == "diagonal",
+            // Unused by recompute_nu; carry the recorded route if present.
+            initialization: self.initialization.clone().unwrap_or_default(),
         };
         let nu = py.allow_threads(|| ctm::recompute_nu(&model_stub, &sparse));
         let mut out = Array3::<f32>::zeros((d, km1, km1));
@@ -7781,6 +7825,7 @@ impl STM {
                 topic_names: self.topic_names.clone(),
                 variational: self.variational.clone(),
                 content_kappa: self.content_kappa.clone(),
+                initialization: self.initialization.clone(),
             },
         )
     }
@@ -7803,6 +7848,7 @@ impl STM {
             init_spectral: s.init_spectral,
             variational: s.variational,
             fitted: s.fitted,
+            initialization: s.initialization,
             topic_names,
             beta: arr2_back(s.beta)?,
             theta: arr2_back(s.theta)?,
@@ -8138,6 +8184,8 @@ pub struct STS {
     init_spectral: bool,
 
     fitted: bool,
+    // The initialization route the fit took (#410); None until fitted.
+    initialization: Option<String>,
     topic_names: Vec<String>,
     beta: Option<Array2<f64>>,      // K×V baseline topic-word (α^(s)=0)
     theta: Option<Array2<f64>>,     // D×K prevalence
@@ -8226,6 +8274,7 @@ impl STS {
             seed,
             init_spectral,
             fitted: false,
+            initialization: None,
             topic_names: Vec::new(),
             beta: None,
             theta: None,
@@ -8503,6 +8552,7 @@ impl STS {
         slf.bound = model.bound_history.last().copied().unwrap_or(f64::NAN);
         slf.bound_history = model.bound_history;
         slf.converged = model.converged;
+        slf.initialization = Some(model.initialization.clone());
         slf.fitted = true;
         Ok(slf.into())
     }
@@ -8551,6 +8601,13 @@ impl STS {
     fn sentiment<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.sentiment.as_ref().unwrap().to_pyarray_bound(py))
+    }
+
+    /// The initialization route the fit actually took (issue #410): ``"spectral"``,
+    /// ``"random-fallback"``, or ``"random"``. ``None`` before fit / for old saves.
+    #[getter]
+    fn initialization(&self) -> Option<String> {
+        self.initialization.clone()
     }
 
     /// Prevalence regression coefficients Γ^(p), shape ``(num_features,
@@ -8687,6 +8744,8 @@ impl STS {
             bound_history: Vec::new(),
             converged: false,
             em_iters_run: 0,
+            // Unused by recompute_nu_sts; carry the recorded route if present.
+            initialization: self.initialization.clone().unwrap_or_default(),
         };
 
         let nu = py.allow_threads(|| sts::recompute_nu_sts(&model_stub, &sparse));
@@ -8819,6 +8878,7 @@ impl STS {
                 bound_history: self.bound_history.clone(),
                 converged: self.converged,
                 topic_names: self.topic_names.clone(),
+                initialization: self.initialization.clone(),
             },
         )
     }
@@ -8839,6 +8899,7 @@ impl STS {
             seed: s.seed,
             init_spectral: s.init_spectral,
             fitted: s.fitted,
+            initialization: s.initialization,
             topic_names,
             beta: arr2_back(s.beta)?,
             theta: arr2_back(s.theta)?,
@@ -9546,6 +9607,8 @@ pub struct DTM {
     init_spectral: bool,
 
     fitted: bool,
+    // The initialization route the fit took (#410); None until fitted.
+    initialization: Option<String>,
     topic_names: Vec<String>,
     num_times: usize,
     bound: f64,
@@ -9637,6 +9700,7 @@ impl DTM {
             seed,
             init_spectral,
             fitted: false,
+            initialization: None,
             topic_names: Vec::new(),
             num_times: 0,
             bound: 0.0,
@@ -9731,6 +9795,7 @@ impl DTM {
         slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         slf.bound = model.bound;
         slf.topic_words = Some(tw);
+        slf.initialization = Some(model.initialization.clone());
         slf.corpus = Some(corpus);
         slf.fitted = true;
         Ok(slf.into())
@@ -9879,6 +9944,14 @@ impl DTM {
         Ok(self.num_times)
     }
 
+    /// The initialization route the fit actually took (issue #410): ``"spectral"``,
+    /// ``"random-fallback"`` (spectral fell back to the seeded static-LDA init), or
+    /// ``"random"``. ``None`` before fit / for old saves.
+    #[getter]
+    fn initialization(&self) -> Option<String> {
+        self.initialization.clone()
+    }
+
     /// The final variational bound (ELBO) reached during fitting.
     #[getter]
     fn bound(&self) -> PyResult<f64> {
@@ -9946,6 +10019,7 @@ impl DTM {
                 corpus: self.corpus.clone(),
                 topic_names: self.topic_names.clone(),
                 init_spectral: self.init_spectral,
+                initialization: self.initialization.clone(),
             },
         )
     }
@@ -9967,6 +10041,7 @@ impl DTM {
             seed: s.seed,
             init_spectral: s.init_spectral,
             fitted: s.fitted,
+            initialization: s.initialization,
             topic_names,
             num_times: s.num_times,
             bound: s.bound,

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -362,6 +362,11 @@ pub struct StsModel {
     pub bound_history: Vec<f64>,
     pub converged: bool,
     pub em_iters_run: usize,
+    /// The initialization route the fit actually took (issue #410): `"spectral"`,
+    /// `"random-fallback"` (spectral requested but recovery returned `None`), or
+    /// `"random"`. Lets the determinism report distinguish an exact spectral fit
+    /// from a seeded random fallback.
+    pub initialization: String,
 }
 
 impl StsModel {
@@ -820,23 +825,10 @@ pub fn fit_sts<R: Rng>(
     let mv: Vec<f64> = (0..v).map(|i| (freq[i] / total).ln()).collect();
 
     // β init (anchor-word spectral, else random), then κ_t = ln β − m so that at
-    // α^(s)=0 the topics start at β; κ_s fixed proportional to κ_t.
-    let beta = if init_spectral {
-        crate::spectral::spectral_init(docs, k, v).unwrap_or_else(|| {
-            let mut b = vec![vec![0.0f64; v]; k];
-            for row in b.iter_mut() {
-                let mut s = 0.0;
-                for x in row.iter_mut() {
-                    *x = 1.0 + rng.gen::<f64>();
-                    s += *x;
-                }
-                for x in row.iter_mut() {
-                    *x /= s;
-                }
-            }
-            b
-        })
-    } else {
+    // α^(s)=0 the topics start at β; κ_s fixed proportional to κ_t. `init_route`
+    // records which path actually ran (issue #410): spectral can fall back to the
+    // seeded random init when recovery returns None.
+    let random_beta = |rng: &mut R| -> Vec<Vec<f64>> {
         let mut b = vec![vec![0.0f64; v]; k];
         for row in b.iter_mut() {
             let mut s = 0.0;
@@ -849,6 +841,14 @@ pub fn fit_sts<R: Rng>(
             }
         }
         b
+    };
+    let (beta, init_route): (Vec<Vec<f64>>, &'static str) = if init_spectral {
+        match crate::spectral::spectral_init(docs, k, v) {
+            Some(b) => (b, "spectral"),
+            None => (random_beta(rng), "random-fallback"),
+        }
+    } else {
+        (random_beta(rng), "random")
     };
     // Aggregation groups for the κ M-step: the distinct levels of the sentiment
     // seed. Without a seed, a single group leaves κ_s unidentified and the model
@@ -1114,6 +1114,7 @@ pub fn fit_sts<R: Rng>(
         bound_history,
         converged,
         em_iters_run,
+        initialization: init_route.to_string(),
     }
 }
 

--- a/tests/test_init_route.py
+++ b/tests/test_init_route.py
@@ -1,0 +1,143 @@
+"""#410 — the fitted model records the initialization route it actually took,
+so config-aware determinism (#401) can make an exact claim instead of a caveat.
+
+`model.initialization` is one of "spectral" / "random-fallback" / "random" /
+"provided" (None before fit / for a pre-#410 save). `effective_determinism` reads
+it: a confirmed spectral fit is bit-exact with no caveat; a spectral run that
+silently fell back to a seeded random init is correctly seed-reproducible.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+import topica
+from topica import effective_determinism as ed
+
+topica.enable_experimental()
+
+_DOCS = [
+    ["a", "b", "c", "d"],
+    ["b", "c", "d", "e"],
+    ["a", "d", "e", "f"],
+    ["c", "e", "f", "a"],
+    ["b", "f", "a", "d"],
+    ["e", "a", "c", "b"],
+] * 4
+_X = np.random.RandomState(0).randn(len(_DOCS), 1)
+_SENT = [(-1.0 if i % 2 else 1.0) for i in range(len(_DOCS))]
+_TIMES = [i % 3 for i in range(len(_DOCS))]
+
+def _fit(m, **kw):
+    m.fit(_DOCS, **kw)
+    return m
+
+
+def test_ctm_stm_sts_record_spectral_vs_random():
+    assert _fit(topica.CTM(3)).initialization == "spectral"
+    assert _fit(topica.CTM(3, init="random")).initialization == "random"
+    assert _fit(topica.STM(3), prevalence=_X).initialization == "spectral"
+    assert _fit(topica.STM(3, init="random"), prevalence=_X).initialization == "random"
+    sts = topica.STS(3)
+    sts.fit(_DOCS, _SENT)
+    assert sts.initialization == "spectral"
+    sts_r = topica.STS(3, init="random")
+    sts_r.fit(_DOCS, _SENT)
+    assert sts_r.initialization == "random"
+
+
+def test_dtm_default_is_random_route():
+    # DTM's constructor default is init="random" (gensim-style), unlike STM/CTM.
+    d = topica.DTM(3)
+    d.fit(_DOCS, times=_TIMES, iters=3)
+    assert d.initialization == "random"
+    ds = topica.DTM(3, init="spectral")
+    ds.fit(_DOCS, times=_TIMES, iters=3)
+    assert ds.initialization in ("spectral", "random-fallback")
+
+
+def test_spectral_fallback_is_recorded():
+    # K larger than the tiny vocabulary makes spectral recovery return None, so the
+    # fit silently falls back to a seeded random init — now recorded, not hidden.
+    tiny = [["a", "b"], ["b", "a"]] * 6
+    m = topica.CTM(3)
+    m.fit(tiny)
+    assert m.initialization == "random-fallback"
+
+
+def test_unfitted_is_none():
+    assert topica.CTM(3).initialization is None
+    assert topica.STM(3).initialization is None
+    assert topica.DTM(3).initialization is None
+
+
+@pytest.mark.parametrize(
+    "make",
+    [
+        lambda: _fit(topica.CTM(3)),
+        lambda: _fit(topica.STM(3), prevalence=_X),
+        lambda: _dtm(),
+    ],
+)
+def test_initialization_survives_save_load(make, tmp_path):
+    m = make()
+    route = m.initialization
+    assert route is not None
+    p = str(tmp_path / "m.bin")
+    m.save(p)
+    assert type(m).load(p).initialization == route
+
+
+def _dtm():
+    d = topica.DTM(3)
+    d.fit(_DOCS, times=_TIMES, iters=3)
+    return d
+
+
+def test_sts_save_load_route(tmp_path):
+    m = topica.STS(3)
+    m.fit(_DOCS, _SENT)
+    p = str(tmp_path / "sts.bin")
+    m.save(p)
+    assert topica.STS.load(p).initialization == m.initialization
+
+
+# --- effective_determinism uses the recorded route (exact, no caveat) ----------
+
+def test_effective_determinism_exact_from_route():
+    spec = _fit(topica.CTM(3))
+    r = ed(spec)
+    assert r["effective"] == "bit-exact"
+    assert r["notes"] == []  # confirmed spectral: no fallback caveat
+
+    rnd = _fit(topica.CTM(3, init="random"))
+    assert ed(rnd)["effective"] == "seed-reproducible"
+
+    tiny = [["a", "b"], ["b", "a"]] * 6
+    fb = topica.CTM(3)
+    fb.fit(tiny)
+    assert ed(fb)["effective"] == "seed-reproducible"  # fallback detected
+
+
+def test_unfitted_keeps_config_caveat():
+    r = ed(topica.CTM(3))
+    assert r["effective"] == "bit-exact"
+    assert any("spectral" in n for n in r["notes"])  # caveat retained when route unknown
+
+
+def test_anchorlda_fallback_flag_and_determinism():
+    a = topica.AnchorLDA(3)
+    a.fit(_DOCS)
+    assert a.anchor_fallback_used is False  # clean corpus, deterministic selection
+    assert topica.AnchorLDA(3).anchor_fallback_used is None  # unfitted
+    r = ed(a)
+    assert r["effective"] == "bit-exact"
+    assert not any("fallback" in n for n in r["notes"])  # no fallback caveat when it didn't fire
+
+
+def test_manifest_records_route_backed_determinism():
+    m = _fit(topica.CTM(3))
+    rec = topica.record_fit(m, corpus=topica.Corpus.from_documents(_DOCS))
+    assert rec.model["determinism"] == "bit-exact"
+    assert rec.model["determinism_detail"]["notes"] == []

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -423,6 +423,13 @@ pub struct CtmModel {
     /// default of `false` for old saves) lives on the `CtmState`/`StmState`
     /// structs in `python.rs`.
     pub diagonal: bool,
+    /// The initialization route the fit actually took (issue #410): one of
+    /// `"spectral"` (anchor-word init succeeded), `"random-fallback"` (spectral
+    /// was requested but recovery returned `None`, so a seeded random init ran),
+    /// `"random"` (`init="random"`), or `"provided"` (a caller-supplied `init_beta`).
+    /// Lets the config-aware determinism report distinguish a genuinely bit-exact
+    /// spectral fit from a seeded random fallback.
+    pub initialization: String,
 }
 
 /// Build per-group topic-word β (G×K×V) from the SAGE content deviations:
@@ -1128,12 +1135,13 @@ pub fn fit_ctm<R: Rng>(
     // A caller-supplied `init_beta` (K×V) overrides spectral/random init — the
     // warm-start hook that lets an STM-compatible front end inject an externally
     // computed base β (e.g. R `stm`'s exact spectral β) and reproduce that fit.
-    let mut beta = match init_beta {
-        Some(b) => b.iter().map(|row| row.to_vec()).collect(),
-        None if init_spectral => {
-            crate::spectral::spectral_init(docs, k, num_types).unwrap_or_else(|| random_beta(rng))
-        }
-        None => random_beta(rng),
+    let (mut beta, init_route): (Vec<Vec<f64>>, &'static str) = match init_beta {
+        Some(b) => (b.iter().map(|row| row.to_vec()).collect(), "provided"),
+        None if init_spectral => match crate::spectral::spectral_init(docs, k, num_types) {
+            Some(b) => (b, "spectral"),
+            None => (random_beta(rng), "random-fallback"),
+        },
+        None => (random_beta(rng), "random"),
     };
 
     // Content covariate state: background m_v and SAGE deviations κ; per-group β.
@@ -1434,6 +1442,7 @@ pub fn fit_ctm<R: Rng>(
         converged,
         em_iters_run,
         diagonal,
+        initialization: init_route.to_string(),
     }
 }
 
@@ -1482,10 +1491,13 @@ pub fn fit_ctm_svi<R: Rng>(
         }
         b
     };
-    let mut beta = if init_spectral {
-        crate::spectral::spectral_init(docs, k, num_types).unwrap_or_else(|| random_beta(rng))
+    let (mut beta, init_route): (Vec<Vec<f64>>, &'static str) = if init_spectral {
+        match crate::spectral::spectral_init(docs, k, num_types) {
+            Some(b) => (b, "spectral"),
+            None => (random_beta(rng), "random-fallback"),
+        }
     } else {
-        random_beta(rng)
+        (random_beta(rng), "random")
     };
 
     let mut mu_shared = vec![0.0f64; km1];
@@ -1646,6 +1658,7 @@ pub fn fit_ctm_svi<R: Rng>(
         converged: true,
         em_iters_run: epochs,
         diagonal,
+        initialization: init_route.to_string(),
     }
 }
 


### PR DESCRIPTION
Closes #410. The rigorous completion of #401 (config-aware determinism), unblocked by #411.

## What

`effective_determinism` (#401) couldn't tell, for a CTM/STM/STS/DTM fit with `init="spectral"`, whether spectral recovery **succeeded** (bit-exact) or **silently fell back** to a seeded random init (seed-reproducible) — the `spectral_init(...).unwrap_or_else(random)` call hid the outcome — so it kept the common-case class plus a caveat.

This records the route the fit actually took and uses it for an exact call.

## Changes

- **Cores** capture the route as `"spectral"` / `"random-fallback"` / `"random"` / `"provided"` and store it on the model: `topica-core/src/ctm.rs` (shared CTM/STM core + its SVI path), `src/sts.rs`, `src/dtm.rs`.
- **Bindings** (CTM/STM/STS/DTM) expose `model.initialization` (`None` before fit), set it after fit, and **persist it through save/load** (`#[serde(default)]` → `None` for pre-#410 saves).
- **AnchorLDA**: `_find_anchors` now reports whether its seeded degenerate-basis fallback fired → `model.anchor_fallback_used`.
- **`effective_determinism`** reads the route:
  - confirmed `spectral`/`provided` → **bit-exact, no caveat**
  - `random`/`random-fallback` → **seed-reproducible**
  - AnchorLDA → bit-exact unless the fallback fired
  - unfitted / old save → falls back to the #401 config-only caveat
- Corrects the stale STM docstring (content per-group β is **not** "always random" — it derives κ deterministically from a spectral base β).

## Correctness

The init refactors **do not change fit output** — they only capture which branch ran. The Rust golden/parity tests are bit-identical (174 pass). `tests/test_init_route.py` covers route capture, the spectral fallback (K > vocab), save/load persistence, the AnchorLDA flag, and the route-backed determinism upgrades. Full pytest `3531 passed`, preflight and strict docs green.

## Before / after

```python
m = topica.CTM(20); m.fit(corpus)          # spectral succeeds
topica.effective_determinism(m)
# #401: {"effective": "bit-exact", "notes": ["bit-exact assumes spectral recovery succeeded; ..."]}
# #410: {"effective": "bit-exact", "notes": []}   # exact, no caveat

m2 = topica.CTM(20); m2.fit(tiny_corpus)   # spectral falls back
topica.effective_determinism(m2)
# #410: {"effective": "seed-reproducible", "notes": ["init ran as 'random-fallback' ..."]}
```

This closes the #401 follow-up chain (#411 fixed large-vocab spectral bit-reproducibility; this makes the determinism claims exact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)