### PR TITLE
fix(sage): correctness cleanup — convergence gate, validation, non-finite guard (#422 part 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Fixed
+
+- **SAGE correctness (#422):** the opt-in `convergence_tol` early stop tripped at
+  iter 20 (before any content-deviation `κ` was learned), because with `κ=0` the
+  monitored word log-likelihood is a corpus constant; it is now gated on a completed
+  `κ` update. Added input validation (`alpha > 0`, `lbfgs_iters >= 1`,
+  `num_samples >= 1`, finite non-negative `convergence_tol`, no duplicate
+  `group_names`), a guard that skips (and warns on) a non-finite `κ` optimization
+  step instead of corrupting the topics, and corrected the early-stop docstring
+  (the monitored quantity is the word-emission log-likelihood, not a full collapsed
+  model-fit likelihood). Default fitted output is unchanged. The faithfulness fix
+  (SAGE's sparse prior vs. the current Gaussian ridge) is tracked separately.
+
 ### Added
 
 - **`RTM`, the relational topic model** ([Chang & Blei 2010](https://www.jstor.org/stable/27801582))

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -5466,8 +5466,8 @@ impl SAGE {
                 (
                     "SAGE: a κ (content-deviation) optimization step returned a non-finite \
                   result and was skipped; the affected topics keep their previous \
-                  content deviations. Check for empty topic-group cells or reduce the \
-                  learning aggressiveness (e.g. raise prior_variance).",
+                  content deviations. Check for empty topic-group cells or use a less \
+                  extreme prior_variance.",
                 ),
             )?;
         }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -5181,6 +5181,12 @@ impl SAGE {
         if !finite_pos(prior_variance) {
             return Err(PyValueError::new_err("prior_variance must be > 0"));
         }
+        if !finite_pos(alpha) {
+            return Err(PyValueError::new_err("alpha must be > 0 and finite"));
+        }
+        if lbfgs_iters == 0 {
+            return Err(PyValueError::new_err("lbfgs_iters must be >= 1"));
+        }
         Ok(SAGE {
             num_topics,
             alpha,
@@ -5219,7 +5225,10 @@ impl SAGE {
     /// `convergence_tol` (default 0.0, disabled) enables opt-in early stopping: the
     /// run stops once the relative change in the recorded log-likelihood between the
     /// last two trace points, |ΔLL| / |LL|, falls below it, setting `converged`. The
-    /// monitored quantity is the collapsed model-fit log-likelihood; the comparison
+    /// monitored quantity is the word-emission log-likelihood under the current topic
+    /// assignments (Σ n·log β), not a full collapsed model-fit likelihood. It is a
+    /// corpus constant until the first κ update, so the early-stop test is only applied
+    /// after κ has been re-estimated (issue #422). The comparison
     /// window is the trace cadence (`check_every` / `progress_interval`), so a coarser
     /// cadence compares more widely spaced sweeps. This is a pragmatic early-stop
     /// heuristic on the log-likelihood trace, not a guarantee the Gibbs chain has
@@ -5268,6 +5277,17 @@ impl SAGE {
         if num_docs == 0 {
             return Err(PyValueError::new_err("corpus contains no documents"));
         }
+        if num_samples == 0 {
+            return Err(PyValueError::new_err(
+                "num_samples must be >= 1 (it is the number of posterior snapshots \
+                 averaged into doc_topic; 0 leaves doc_topic undefined)",
+            ));
+        }
+        if !convergence_tol.is_finite() || convergence_tol < 0.0 {
+            return Err(PyValueError::new_err(
+                "convergence_tol must be finite and >= 0 (0 disables early stopping)",
+            ));
+        }
 
         let groups_str = parse_groups(groups)?;
         if groups_str.len() != num_docs {
@@ -5279,7 +5299,17 @@ impl SAGE {
         }
 
         let group_vocab: Vec<String> = match group_names {
-            Some(n) => n,
+            Some(n) => {
+                // Duplicates would train one group (HashMap last-wins) but resolve to
+                // another at lookup (`.position` first-wins), so reject them outright.
+                let mut seen = HashSet::new();
+                if let Some(dup) = n.iter().find(|g| !seen.insert(g.as_str())) {
+                    return Err(PyValueError::new_err(format!(
+                        "group_names contains a duplicate: {dup:?}"
+                    )));
+                }
+                n
+            }
             None => {
                 let mut set: HashSet<String> = groups_str.iter().cloned().collect();
                 let mut v: Vec<String> = set.drain().collect();
@@ -5320,7 +5350,7 @@ impl SAGE {
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
-        let (beta, acc_theta, theta_draw_buf, ll_history, converged_flag, corpus) = py
+        let (beta, acc_theta, theta_draw_buf, ll_history, converged_flag, kappa_ok, corpus) = py
             .allow_threads(move || {
                 let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
                 let mut ll_history: Vec<(usize, f64)> = Vec::new();
@@ -5340,10 +5370,23 @@ impl SAGE {
                     ll
                 };
 
+                // Early stopping is only meaningful once κ has been updated: with κ=0
+                // every cell's β is the shared background softmax, so the word-emission
+                // LL is a corpus constant independent of the topic assignments and would
+                // trip any convergence_tol immediately (issue #422). Gate the test on
+                // completed κ updates, and require two trace points recorded after the
+                // first one before comparing.
+                let mut kappa_updates = 0usize;
+                let mut post_kappa_traces = 0usize;
+                let mut kappa_ok = true;
                 'outer: for iter in 1..=iters {
                     sage::run_sweep_sage(&mut model, &corpus.docs, &groups_idx, &mut rng);
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
-                        sage::optimize_kappa(&mut model, lbfgs_iters);
+                        if sage::optimize_kappa(&mut model, lbfgs_iters) {
+                            kappa_updates += 1;
+                        } else {
+                            kappa_ok = false;
+                        }
                     }
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
                         let counts = doc_topic_counts(&model.doc_topics, k);
@@ -5369,17 +5412,22 @@ impl SAGE {
                     if check_every > 0 && iter % check_every == 0 {
                         let ll = compute_ll(&model);
                         ll_history.push((iter, ll));
-                        if convergence_tol > 0.0 && ll_history.len() >= 2 {
-                            let prev = ll_history[ll_history.len() - 2].1;
-                            let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
-                            if rel < convergence_tol {
-                                converged_flag = true;
-                                break 'outer;
+                        if convergence_tol > 0.0 && kappa_updates >= 1 {
+                            post_kappa_traces += 1;
+                            if post_kappa_traces >= 2 {
+                                let prev = ll_history[ll_history.len() - 2].1;
+                                let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
+                                if rel < convergence_tol {
+                                    converged_flag = true;
+                                    break 'outer;
+                                }
                             }
                         }
                     }
                 }
-                sage::optimize_kappa(&mut model, lbfgs_iters); // final β refresh
+                if !sage::optimize_kappa(&mut model, lbfgs_iters) {
+                    kappa_ok = false; // final β refresh
+                }
 
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
                 for _ in 0..num_samples {
@@ -5406,9 +5454,23 @@ impl SAGE {
                     theta_draw_buf,
                     ll_history,
                     converged_flag,
+                    kappa_ok,
                     corpus,
                 )
             });
+
+        if !kappa_ok {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1(
+                "warn",
+                (
+                    "SAGE: a κ (content-deviation) optimization step returned a non-finite \
+                  result and was skipped; the affected topics keep their previous \
+                  content deviations. Check for empty topic-group cells or reduce the \
+                  learning aggressiveness (e.g. raise prior_variance).",
+                ),
+            )?;
+        }
 
         let mut theta = Array2::<f64>::zeros((num_docs, k));
         for (d, row) in acc_theta.iter().enumerate() {

--- a/src/sage.rs
+++ b/src/sage.rs
@@ -412,6 +412,45 @@ mod tests {
     }
 
     #[test]
+    fn optimize_kappa_rolls_back_on_non_finite() {
+        // A degenerate (effectively zero) prior variance overflows inv_var to +inf,
+        // so the L-BFGS solve returns non-finite. optimize_kappa must return false
+        // and leave κ and β byte-for-byte unchanged (issue #422).
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let mut docs = Vec::new();
+        let mut groups = Vec::new();
+        for i in 0..40 {
+            if i % 2 == 0 {
+                docs.push(vec![0u32, 1, 0, 1]);
+                groups.push(0usize);
+            } else {
+                docs.push(vec![2u32, 3, 2, 3]);
+                groups.push(1usize);
+            }
+        }
+        let mut model = SageModel::new(1, 2, 4, 0.1, 1.0);
+        model.set_background(&docs);
+        model.initialize(&docs, &groups, &mut rng);
+        for _ in 0..30 {
+            run_sweep_sage(&mut model, &docs, &groups, &mut rng);
+        }
+        assert!(optimize_kappa(&mut model, 20)); // a healthy update first
+
+        let kappa_t_before = model.kappa_t.clone();
+        let kappa_i_before = model.kappa_i.clone();
+        let beta_before = model.beta.clone();
+
+        model.prior_variance = 5e-324; // smallest subnormal -> 1/var = +inf
+        assert!(
+            !optimize_kappa(&mut model, 20),
+            "expected a non-finite failure"
+        );
+        assert_eq!(model.kappa_t, kappa_t_before, "κT mutated on failure");
+        assert_eq!(model.kappa_i, kappa_i_before, "κI mutated on failure");
+        assert_eq!(model.beta, beta_before, "β mutated on failure");
+    }
+
+    #[test]
     fn sage_conforms() {
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let mut docs = Vec::new();

--- a/src/sage.rs
+++ b/src/sage.rs
@@ -188,8 +188,11 @@ pub fn run_sweep_sage<R: Rng>(
 }
 
 /// MAP-estimate the κ deviations (Gaussian prior) from the current counts, then
-/// refresh the cached β. One L-BFGS run.
-pub fn optimize_kappa(model: &mut SageModel, max_iter: usize) {
+/// refresh the cached β. One L-BFGS run. Returns `false` if the optimizer produced
+/// a non-finite result, in which case κ (and β) are left unchanged rather than
+/// corrupted — the caller surfaces this to the user (issue #422).
+#[must_use]
+pub fn optimize_kappa(model: &mut SageModel, max_iter: usize) -> bool {
     let k_n = model.num_topics;
     let g_n = model.num_groups;
     let v_n = model.num_types;
@@ -270,6 +273,13 @@ pub fn optimize_kappa(model: &mut SageModel, max_iter: usize) {
         1e-4,
     );
 
+    // Guard against a non-finite solve (line-search collapse, degenerate counts):
+    // leave κ and β untouched rather than propagate NaN/inf into the topic-word
+    // distributions.
+    if x.iter().any(|v| !v.is_finite()) {
+        return false;
+    }
+
     // Unpack.
     for k in 0..k_n {
         model.kappa_t[k].copy_from_slice(&x[k * v_n..(k + 1) * v_n]);
@@ -284,6 +294,7 @@ pub fn optimize_kappa(model: &mut SageModel, max_iter: usize) {
     }
 
     model.recompute_beta();
+    true
 }
 
 use crate::estimator::{DirichletModel, Estimator, ModelFamily};
@@ -387,7 +398,7 @@ mod tests {
         for iter in 1..=200 {
             run_sweep_sage(&mut model, &docs, &groups, &mut rng);
             if iter > 50 && iter % 25 == 0 {
-                optimize_kappa(&mut model, 20);
+                assert!(optimize_kappa(&mut model, 20));
             }
         }
 
@@ -420,7 +431,7 @@ mod tests {
         for iter in 1..=200 {
             run_sweep_sage(&mut model, &docs, &groups, &mut rng);
             if iter > 50 && iter % 25 == 0 {
-                optimize_kappa(&mut model, 20);
+                assert!(optimize_kappa(&mut model, 20));
             }
         }
         let base = crate::conformance::check_conformance(&model);

--- a/tests/test_sage.py
+++ b/tests/test_sage.py
@@ -586,3 +586,64 @@ class TestSAGETopWordsCanonicalSignature:
         words = {w for w, _ in result}
         # Must be German words (fully disjoint vocabulary)
         assert words <= _DE_VOCAB
+
+
+# ---------------------------------------------------------------------------
+# Issue #422 correctness fixes
+# ---------------------------------------------------------------------------
+def _group_corpus(seed=0, n=60):
+    rng = np.random.default_rng(seed)
+    A = "cat dog pet vet paw".split()
+    B = "star moon sky sun orbit".split()
+    docs, grp = [], []
+    for i in range(n):
+        base = A if i % 2 == 0 else B
+        docs.append(list(rng.choice(base, size=12)) + list(rng.choice(A + B, size=2)))
+        grp.append("g0" if i < n // 2 else "g1")
+    return docs, grp
+
+
+class TestSageConvergenceFix:
+    """convergence_tol must not trip before any kappa is learned (issue #422):
+    with kappa=0 the word LL is a corpus constant, so the old code stopped at
+    iter 20, before burn_in."""
+
+    def test_no_false_stop_before_kappa(self):
+        docs, grp = _group_corpus()
+        # burn_in=200 -> first kappa update at iter 250; must not stop before then
+        m = SAGE(2, seed=1).fit(docs, grp, iters=300,
+                                convergence_tol=1e-4, check_every=10)
+        if m.converged:
+            assert m.fit_history[-1][0] > 200  # never the old iter-20 stop
+
+    def test_early_stop_still_fires_after_kappa(self):
+        docs, grp = _group_corpus()
+        m = SAGE(2, seed=1, burn_in=40, optimize_interval=10).fit(
+            docs, grp, iters=2000, convergence_tol=1e-3, check_every=10)
+        assert m.converged
+        assert m.fit_history[-1][0] > 50  # after the first kappa update (iter 50)
+
+
+class TestSageValidation:
+    """Input validation added in issue #422."""
+
+    @pytest.mark.parametrize("kwargs", [{"alpha": 0.0}, {"alpha": -1.0},
+                                        {"lbfgs_iters": 0}])
+    def test_bad_constructor_args(self, kwargs):
+        with pytest.raises(ValueError):
+            SAGE(2, **kwargs)
+
+    def test_num_samples_zero_rejected(self):
+        docs, grp = _group_corpus()
+        with pytest.raises(ValueError):
+            SAGE(2).fit(docs, grp, iters=50, num_samples=0)
+
+    def test_negative_convergence_tol_rejected(self):
+        docs, grp = _group_corpus()
+        with pytest.raises(ValueError):
+            SAGE(2).fit(docs, grp, iters=20, convergence_tol=-1.0)
+
+    def test_duplicate_group_names_rejected(self):
+        docs, grp = _group_corpus()
+        with pytest.raises(ValueError):
+            SAGE(2).fit(docs, grp, group_names=["g0", "g0"], iters=20)

--- a/tests/test_sage.py
+++ b/tests/test_sage.py
@@ -616,6 +616,17 @@ class TestSageConvergenceFix:
         if m.converged:
             assert m.fit_history[-1][0] > 200  # never the old iter-20 stop
 
+    def test_earliest_stop_is_the_second_post_kappa_trace(self):
+        """Misaligned update/trace cadences lock the off-by-one: with the first
+        kappa update at iter 49 (optimize_interval=7 past burn_in=45, NOT a trace
+        iteration) and traces at 50, 60, ..., the earliest legitimate stop is the
+        second post-kappa trace (iter 60), never a pre-kappa point (40/50)."""
+        docs, grp = _group_corpus()
+        m = SAGE(2, seed=1, burn_in=45, optimize_interval=7).fit(
+            docs, grp, iters=400, convergence_tol=0.5, check_every=10)
+        assert m.converged
+        assert m.fit_history[-1][0] == 60  # exactly the first valid comparison
+
     def test_early_stop_still_fires_after_kappa(self):
         docs, grp = _group_corpus()
         m = SAGE(2, seed=1, burn_in=40, optimize_interval=10).fit(
@@ -624,10 +635,30 @@ class TestSageConvergenceFix:
         assert m.fit_history[-1][0] > 50  # after the first kappa update (iter 50)
 
 
+class TestSageNonFiniteGuard:
+    """A non-finite kappa optimization step must not corrupt the topics (#422)."""
+
+    def test_extreme_prior_variance_warns_and_stays_finite(self):
+        import warnings
+        docs, grp = _group_corpus()
+        # 5e-324 (smallest subnormal) -> inv_var overflows -> non-finite L-BFGS result
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            m = SAGE(2, seed=1, prior_variance=5e-324).fit(
+                docs, grp, iters=300, convergence_tol=1e-3, check_every=10)
+        msgs = [str(x.message) for x in caught if "non-finite" in str(x.message)]
+        assert len(msgs) == 1                       # warned once, aggregated
+        assert np.isfinite(m.topic_word).all()      # topics not corrupted
+        assert np.isfinite(m.doc_topic).all()
+        np.testing.assert_allclose(m.doc_topic.sum(axis=1), 1.0, atol=1e-9)
+        assert not m.converged                      # early stop impossible (LL constant)
+
+
 class TestSageValidation:
     """Input validation added in issue #422."""
 
     @pytest.mark.parametrize("kwargs", [{"alpha": 0.0}, {"alpha": -1.0},
+                                        {"alpha": float("nan")}, {"alpha": float("inf")},
                                         {"lbfgs_iters": 0}])
     def test_bad_constructor_args(self, kwargs):
         with pytest.raises(ValueError):
@@ -638,12 +669,15 @@ class TestSageValidation:
         with pytest.raises(ValueError):
             SAGE(2).fit(docs, grp, iters=50, num_samples=0)
 
-    def test_negative_convergence_tol_rejected(self):
+    @pytest.mark.parametrize("tol", [-1.0, float("nan"), float("inf")])
+    def test_bad_convergence_tol_rejected(self, tol):
         docs, grp = _group_corpus()
         with pytest.raises(ValueError):
-            SAGE(2).fit(docs, grp, iters=20, convergence_tol=-1.0)
+            SAGE(2).fit(docs, grp, iters=20, convergence_tol=tol)
 
     def test_duplicate_group_names_rejected(self):
+        # Both real groups (g0, g1) are present, so only the duplicate check can
+        # raise — the pre-#422 code would train g0 twice without error.
         docs, grp = _group_corpus()
-        with pytest.raises(ValueError):
-            SAGE(2).fit(docs, grp, group_names=["g0", "g0"], iters=20)
+        with pytest.raises(ValueError, match="duplicate"):
+            SAGE(2).fit(docs, grp, group_names=["g0", "g1", "g0"], iters=20)


### PR DESCRIPTION
Part 1 of 2 for #422. The **faithfulness** fix (SAGE's sparse prior vs. the current Gaussian ridge) follows in a second PR; this one is the unambiguous correctness cleanup. **Default fitted output is unchanged** (the changes affect opt-in early stopping and previously-accepted invalid inputs).

## The convergence bug (the headline)
The opt-in `convergence_tol` early stop tripped at **iter 20**, before any content-deviation `κ` was learned. With `κ=0`, every (topic, group) cell's `β` is the shared background softmax, so the monitored word log-likelihood `Σ n·log β` is a **corpus constant** independent of the topic assignments — any `convergence_tol > 0` stops immediately.

Fix: gate the test on **completed `κ` updates** (require two trace points recorded after the first update). A simple `iter > burn_in` gate is *not* sufficient — the first `κ` update lands at `burn_in + optimize_interval` (iter 250 under defaults, not 201), so `iter > burn_in` would still compare flat pre-`κ` points and stop at ~220.

Verified: no stop before the first `κ` update, and early stopping still fires legitimately once the LL stabilizes.

## Also fixed
- **Input validation:** `alpha` (>0, finite), `lbfgs_iters` (≥1), `num_samples` (≥1 — 0 left `doc_topic` all-zero, violating rows-sum-to-1), `convergence_tol` (finite, ≥0), and **reject duplicate `group_names`** (they trained one group via a last-wins map but resolved to another via first-wins `.position()` at lookup).
- **Non-finite `κ` guard:** `optimize_kappa` now reports whether it applied a finite update; a non-finite solve leaves `κ`/`β` unchanged and the fit emits a warning, instead of silently propagating NaN/inf into the topic-word distributions.
- **Docstring:** the monitored early-stop quantity is the word-emission log-likelihood under the current assignments, not a "collapsed model-fit log-likelihood."

## Tests / gates
New regression tests in `tests/test_sage.py` (convergence no-false-stop + still-fires, all five validations). `cargo test --lib` (177), `pytest` (SAGE + input-validation + invariants + settings + stub all green), fmt+clippy clean.

Plan reviewed by the codex second-opinion agent, which caught that the `iter > burn_in` gate was itself insufficient (hence the `κ`-update counter).

🤖 Generated with [Claude Code](https://claude.com/claude-code)