### PR TITLE
fix(stm): infer θ for an empty document from the prior mode, not uniform (#421)

### DIFF
--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -819,9 +819,20 @@ pub fn infer_theta(
     counts: &[f64],
 ) -> Vec<f64> {
     let km1 = mu.len();
-    let k = km1 + 1;
     if words.is_empty() {
-        return vec![1.0 / k as f64; k];
+        // With no observed tokens the variational objective reduces to the prior
+        // term, whose mode is η = μ, so θ = softmax([μ, 0]) (the reference topic
+        // K-1 has η = 0). Returning the uniform vector would ignore the document's
+        // prior mean — wrong for prevalence models where μ = Xγ varies per document.
+        let mut logits = mu.to_vec();
+        logits.push(0.0);
+        let m = logits.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let mut e: Vec<f64> = logits.iter().map(|&x| (x - m).exp()).collect();
+        let s: f64 = e.iter().sum();
+        for v in &mut e {
+            *v /= s;
+        }
+        return e;
     }
     let opt = lbfgs_minimize(
         vec![0.0; km1],
@@ -2325,5 +2336,43 @@ mod tests {
                 "active covariate {j} has wrong sign in enet solution"
             );
         }
+    }
+
+    /// An empty (or all-OOV) document has no likelihood term, so its inferred θ
+    /// must be the prior mode `softmax([μ, 0])`, not a uniform vector. This
+    /// matters for prevalence models where μ = Xγ varies per document.
+    #[test]
+    fn infer_theta_empty_doc_returns_prior_mode() {
+        // K = 4 topics -> μ has length K-1 = 3. Reference topic (index 3) has η = 0.
+        let mu = vec![1.0, -0.5, 0.0];
+        let k = mu.len() + 1;
+        // beta/siginv are unused on the empty-doc path, but must be shaped validly.
+        let beta = vec![vec![0.25; 3]; k]; // K×V, arbitrary
+        let siginv = vec![0.0; mu.len() * mu.len()];
+
+        let theta = infer_theta(&beta, &mu, &siginv, &[], &[]);
+
+        // Expected: softmax([1.0, -0.5, 0.0, 0.0]).
+        let logits = [1.0, -0.5, 0.0, 0.0];
+        let m = logits.iter().copied().fold(f64::NEG_INFINITY, f64::max);
+        let exps: Vec<f64> = logits.iter().map(|&x| (x - m).exp()).collect();
+        let s: f64 = exps.iter().sum();
+        let expected: Vec<f64> = exps.iter().map(|&x| x / s).collect();
+
+        assert_eq!(theta.len(), k);
+        let sum: f64 = theta.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-12, "θ must sum to 1, got {sum}");
+        for (t, (&got, &exp)) in theta.iter().zip(expected.iter()).enumerate() {
+            assert!(
+                (got - exp).abs() < 1e-12,
+                "topic {t}: θ = {got}, expected prior-mode {exp}"
+            );
+        }
+        // Regression: it must NOT be the old uniform fallback.
+        let uniform = 1.0 / k as f64;
+        assert!(
+            (theta[0] - uniform).abs() > 1e-6,
+            "θ collapsed to the uniform vector — prior mean μ was ignored"
+        );
     }
 }

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -2344,7 +2344,10 @@ mod tests {
     #[test]
     fn infer_theta_empty_doc_returns_prior_mode() {
         // K = 4 topics -> μ has length K-1 = 3. Reference topic (index 3) has η = 0.
-        let mu = vec![1.0, -0.5, 0.0];
+        // All four logits (μ plus the appended reference 0) are DISTINCT, so a bug
+        // that misplaced the reference topic would change the expected vector and
+        // fail this test — [.., 0.0] with a zero in μ would not catch that swap.
+        let mu = vec![1.0, -0.5, 0.7];
         let k = mu.len() + 1;
         // beta/siginv are unused on the empty-doc path, but must be shaped validly.
         let beta = vec![vec![0.25; 3]; k]; // K×V, arbitrary
@@ -2352,8 +2355,8 @@ mod tests {
 
         let theta = infer_theta(&beta, &mu, &siginv, &[], &[]);
 
-        // Expected: softmax([1.0, -0.5, 0.0, 0.0]).
-        let logits = [1.0, -0.5, 0.0, 0.0];
+        // Expected: softmax([1.0, -0.5, 0.7, 0.0]).
+        let logits = [1.0, -0.5, 0.7, 0.0];
         let m = logits.iter().copied().fold(f64::NEG_INFINITY, f64::max);
         let exps: Vec<f64> = logits.iter().map(|&x| (x - m).exp()).collect();
         let s: f64 = exps.iter().sum();
@@ -2373,6 +2376,30 @@ mod tests {
         assert!(
             (theta[0] - uniform).abs() > 1e-6,
             "θ collapsed to the uniform vector — prior mean μ was ignored"
+        );
+    }
+
+    /// A large prevalence predictor must not overflow the empty-doc softmax: the
+    /// max-shift keeps every exponent <= 0, so θ stays finite and normalized and
+    /// concentrates on the dominant topic.
+    #[test]
+    fn infer_theta_empty_doc_large_mu_is_finite() {
+        let mu = vec![800.0, -800.0, 0.0]; // exp(800) would overflow without the shift
+        let k = mu.len() + 1;
+        let beta = vec![vec![0.25; 3]; k];
+        let siginv = vec![0.0; mu.len() * mu.len()];
+
+        let theta = infer_theta(&beta, &mu, &siginv, &[], &[]);
+
+        assert!(
+            theta.iter().all(|x| x.is_finite()),
+            "θ has non-finite entries: {theta:?}"
+        );
+        let sum: f64 = theta.iter().sum();
+        assert!((sum - 1.0).abs() < 1e-12, "θ must sum to 1, got {sum}");
+        assert!(
+            theta[0] > 0.999,
+            "θ should concentrate on the dominant topic, got {theta:?}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the empty-document item of #421. `ctm::infer_theta` returned a **uniform** θ = `[1/K, …, 1/K]` for a held-out document with no in-vocabulary tokens. With no likelihood term the variational objective reduces to the prior, whose mode is η = μ, so the correct point estimate is `θ = softmax([μ, 0])` (the reference topic K-1 has η = 0).

The uniform fallback silently ignored the document's prior mean. That is wrong for **prevalence models**, where μ = Xγ varies per document: an empty / all-OOV held-out doc should fall back to its covariate-implied prevalence, not a flat vector. This matches R `stm`, which returns the prior mean for a document with no tokens.

## Change

`topica-core/src/ctm.rs` only — the empty-doc branch of `infer_theta`. Uses a max-shifted softmax so a large prevalence predictor cannot overflow. The `python/mod.rs` callers are unchanged.

## Verification

- New unit test `infer_theta_empty_doc_returns_prior_mode` asserts the `softmax([μ, 0])` result **and**, as a regression guard, that θ is **not** the uniform vector.
- Confirmed the test **fails on the pre-fix code** (returns uniform) and passes after.
- Full CTM suite (11 tests incl. `fit_ctm_golden` — no numerical regression), `cargo fmt --all --check`, and `cargo clippy -D warnings` all green.

## Scope

File-disjoint from #431 (alias samplers) and #422 (SAGE, which owns the `python/mod.rs` SAGE section). The SVI, content-`recompute_nu`, and non-PD-Σ items of #421 remain open for follow-ups. No version/CHANGELOG bump (per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)