### PR TITLE
fix(prodlda): track BatchNorm running variance with Bessel's correction (#428)

### DIFF
--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -131,7 +131,21 @@ impl BatchNorm {
                 out[i][j] = h;
             }
         }
-        (out, BnCache { xhat, inv_std }, mean, var)
+        // The in-batch normalization above uses the biased variance (÷ n), but the
+        // running statistic must track the UNBIASED (Bessel-corrected, ÷ (n-1))
+        // variance — that is what PyTorch/Pyro BatchNorm accumulates, and eval-time
+        // normalization reads the running variance. Returning the biased var here
+        // left the running variance systematically too small (× (n-1)/n), so a
+        // topica-trained model normalized held-out documents differently from the
+        // reference at inference. (n ≥ 2 here: the training loop skips smaller
+        // batches; guard n == 1 anyway.)
+        let bessel = if n > 1 {
+            n as f64 / (n as f64 - 1.0)
+        } else {
+            1.0
+        };
+        let running_var: Vec<f64> = var.iter().map(|&v| v * bessel).collect();
+        (out, BnCache { xhat, inv_std }, mean, running_var)
     }
 
     /// Fold a batch's statistics into the running estimates.
@@ -2492,6 +2506,41 @@ mod tests {
             covered.len(),
             k,
             "stick-breaking: topics did not cover all blocks"
+        );
+    }
+
+    /// BatchNorm must normalize the batch with the biased variance but track the
+    /// running variance with Bessel's correction (unbiased), matching PyTorch.
+    #[test]
+    fn batchnorm_running_var_is_unbiased() {
+        // x = [[0], [2]]: mean = 1, biased var = 1, unbiased var = 2.
+        let mut bn = BatchNorm::new(1);
+        assert!((bn.running_var[0] - 1.0).abs() < 1e-12);
+        assert!((bn.momentum - 0.1).abs() < 1e-12);
+
+        let x = vec![vec![0.0], vec![2.0]];
+        let (out, cache, mean, var) = bn.forward_train(&x);
+
+        assert!((mean[0] - 1.0).abs() < 1e-12, "mean = {}", mean[0]);
+        // The stat returned for the running update is the UNBIASED variance (2.0),
+        // not the biased 1.0.
+        assert!(
+            (var[0] - 2.0).abs() < 1e-12,
+            "returned running var = {}",
+            var[0]
+        );
+        // In-batch normalization still uses the biased variance (1.0).
+        let inv_std_biased = 1.0 / (1.0 + BN_EPS).sqrt();
+        assert!((cache.inv_std[0] - inv_std_biased).abs() < 1e-12);
+        assert!((out[0][0] + inv_std_biased).abs() < 1e-9); // (0-1)*inv_std
+        assert!((out[1][0] - inv_std_biased).abs() < 1e-9); // (2-1)*inv_std
+
+        bn.update_running(&mean, &var);
+        // running_var = (1 - 0.1) * 1.0 + 0.1 * 2.0 = 1.1 (would be 1.0 with biased var).
+        assert!(
+            (bn.running_var[0] - 1.1).abs() < 1e-12,
+            "running_var = {}, expected 1.1",
+            bn.running_var[0]
         );
     }
 }

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -101,6 +101,16 @@ impl BatchNorm {
     /// caller can fold them into the running statistics.
     fn forward_train(&self, x: &[Vec<f64>]) -> (Vec<Vec<f64>>, BnCache, Vec<f64>, Vec<f64>) {
         let n = x.len();
+        // Bessel's correction for the running variance is undefined for a single
+        // sample, so a batch of one has no well-defined running-stat update. Every
+        // caller already skips batches smaller than two (chunks(batch_size.max(2))
+        // + an `if n < 2 { continue }` guard); enforce that invariant loudly here
+        // rather than silently decaying the running variance toward zero (#436).
+        assert!(
+            n >= 2,
+            "BatchNorm::forward_train requires a batch of >= 2 documents; \
+             callers must skip smaller batches"
+        );
         let f = if n > 0 { x[0].len() } else { 0 };
         let mut mean = vec![0.0; f];
         for row in x {
@@ -137,13 +147,9 @@ impl BatchNorm {
         // normalization reads the running variance. Returning the biased var here
         // left the running variance systematically too small (× (n-1)/n), so a
         // topica-trained model normalized held-out documents differently from the
-        // reference at inference. (n ≥ 2 here: the training loop skips smaller
-        // batches; guard n == 1 anyway.)
-        let bessel = if n > 1 {
-            n as f64 / (n as f64 - 1.0)
-        } else {
-            1.0
-        };
+        // reference at inference. n >= 2 is guaranteed by the assert above, so the
+        // Bessel factor cannot divide by zero.
+        let bessel = n as f64 / (n as f64 - 1.0);
         let running_var: Vec<f64> = var.iter().map(|&v| v * bessel).collect();
         (out, BnCache { xhat, inv_std }, mean, running_var)
     }
@@ -2542,5 +2548,15 @@ mod tests {
             "running_var = {}, expected 1.1",
             bn.running_var[0]
         );
+    }
+
+    /// A singleton batch has no defined Bessel-corrected variance, so
+    /// `forward_train` must reject it loudly rather than silently decay the running
+    /// variance toward zero (#436). Every real caller already skips n < 2.
+    #[test]
+    #[should_panic(expected = "requires a batch of >= 2")]
+    fn batchnorm_forward_train_rejects_singleton_batch() {
+        let bn = BatchNorm::new(1);
+        let _ = bn.forward_train(&[vec![2.0]]);
     }
 }


### PR DESCRIPTION
## Summary

Fixes the BatchNorm running-variance item of #428. The hand-coded `BatchNorm` normalized each minibatch with the **biased** variance (÷ n) — correct, matching PyTorch — but then folded that **same biased variance** into the running statistic. PyTorch/Pyro `BatchNorm1d` accumulate the **unbiased** (Bessel-corrected, ÷ (n-1)) variance into the running stat, so topica's running variance was systematically too small by `(n-1)/n`.

The running variance is what eval-time normalization (`forward_eval_row`) reads, so a topica-trained **ProdLDA / Scholar / InfoCTM** (all share `batch_forward`) normalized held-out documents slightly differently from the PyTorch reference at inference. Negligible at the default `batch_size=1000` (×0.999) — which is why the coherence parity held — but material for small batches.

## The fix

`forward_train` returns the Bessel-corrected variance for the running-stat update while keeping the **biased** variance for in-batch normalization (`inv_std` unchanged). Training forward/backward is untouched; only the running statistic — and thus eval-time `transform` — changes. The returned batch var is consumed only by `update_running`, so the change is fully localized.

## Verification

- Added a BatchNorm parity test: `x = [[0], [2]]` → mean 1, biased var 1, **unbiased var 2**; with momentum 0.1 the running var moves to `(0.9)(1.0) + (0.1)(2.0) = 1.1` (would be 1.0 with the biased var), and in-batch normalization still uses the biased var.
- Confirmed the test **fails on the pre-fix code** and passes after.
- Full `prodlda` (22), `scholar` (9), `infoctm` (3) suites pass — topic recovery and seed-determinism unaffected. `cargo fmt --all --check` and `cargo clippy -D warnings` clean.
- Python determinism tests are self-consistency (two same-seed fits equal), preserved; the ProdLDA gold is a coherence lower-bar, unaffected by the ×0.999 shift.

## Scope

`src/prodlda.rs` only — file-disjoint from other in-flight work. The Dirichlet-transform, Weibull-floor, and reconstruction-floor items of #428 are left for follow-ups. No version/CHANGELOG bump (per repo convention).

🤖 Generated with [Claude Code](https://claude.com/claude-code)