### PR TITLE
refactor(mathfun): deduplicate log_gamma across 6 models + fix the tiny-arg +inf bug

### DIFF
--- a/src/dmr.rs
+++ b/src/dmr.rs
@@ -21,30 +21,6 @@ use rand::Rng;
 use crate::optimize::digamma;
 use crate::sampler::sample_doc;
 
-/// Stirling-series log Γ. Shifts the argument to z ≥ 10 before applying the
-/// asymptotic series so the result (and, importantly for the optimizer, its
-/// numerical derivative) is accurate to ~1e-10. This is a local copy used only
-/// by the DMR objective; LDA's MALLET-matched log Γ lives in `output.rs`.
-fn log_gamma(z: f64) -> f64 {
-    const HALF_LOG_TWO_PI: f64 = 0.918_938_533_204_672_7;
-    // Shift the argument up to x >= 10 for the asymptotic series, accumulating the
-    // recurrence correction -Σ ln(z + k) from the ORIGINAL arguments as we go.
-    // Reconstructing that correction by decrementing the shifted value instead
-    // silently loses a tiny z (z + 1.0 rounds to exactly 1.0 for z below ~1e-16),
-    // and the reverse pass then evaluates ln(0.0) = -inf, so the function returned
-    // +inf — poisoning the DMR objective/gradient with NaN when α = exp(λ·x) is
-    // small. Computing ln(z) directly on the real argument keeps it finite.
-    let mut x = z;
-    let mut correction = 0.0f64;
-    while x < 10.0 {
-        correction -= x.ln();
-        x += 1.0;
-    }
-    HALF_LOG_TWO_PI + (x - 0.5) * x.ln() - x + 1.0 / (12.0 * x) - 1.0 / (360.0 * x * x * x)
-        + 1.0 / (1260.0 * x * x * x * x * x)
-        + correction
-}
-
 /// Per-document, per-topic prior `α_{d,t} = exp(λ_t · x_d + s_{d,t})`.
 ///
 /// `lambda` is `[num_topics][num_features]`, `features` is
@@ -341,6 +317,7 @@ pub fn dmr_lambda_cov(
     })
 }
 
+use crate::mathfun::log_gamma;
 use crate::variational::lbfgs_minimize;
 
 /// Optimize `lambda` in place to maximize the penalized DMR likelihood for the

--- a/src/dtm.rs
+++ b/src/dtm.rs
@@ -26,26 +26,6 @@ use rayon::prelude::*;
 const INIT_VARIANCE_CONST: f64 = 1000.0;
 const OBS_NORM_CUTOFF: f64 = 2.0;
 
-/// Stirling-series log Γ (accurate to ~1e-10 for the small positive arguments
-/// the bound needs); shifts the argument up to z ≥ 10 for accuracy.
-fn lgamma(mut z: f64) -> f64 {
-    const HALF_LOG_TWO_PI: f64 = 0.918_938_533_204_672_7;
-    let mut shift = 0i32;
-    while z < 10.0 {
-        z += 1.0;
-        shift += 1;
-    }
-    let mut result = HALF_LOG_TWO_PI + (z - 0.5) * z.ln() - z + 1.0 / (12.0 * z)
-        - 1.0 / (360.0 * z * z * z)
-        + 1.0 / (1260.0 * z * z * z * z * z);
-    while shift > 0 {
-        shift -= 1;
-        z -= 1.0;
-        result -= z.ln();
-    }
-    result
-}
-
 fn log_add(a: f64, b: f64) -> f64 {
     if a > b {
         a + (1.0 + (b - a).exp()).ln()
@@ -706,6 +686,7 @@ pub fn fit_dtm<R: Rng>(
 }
 
 use crate::estimator::{Estimator, ModelFamily};
+use crate::mathfun::log_gamma as lgamma;
 
 impl Estimator for DtmModel {
     fn num_topics(&self) -> usize {

--- a/src/hlda.rs
+++ b/src/hlda.rs
@@ -43,27 +43,6 @@
 
 use rand::Rng;
 
-/// Stirling-series log Γ. Shifts the argument to z ≥ 10 before applying the
-/// asymptotic series (a local copy in the style of `dmr.rs`/`dtm.rs`), used for
-/// the Dirichlet-multinomial path marginal likelihoods.
-fn log_gamma(mut z: f64) -> f64 {
-    const HALF_LOG_TWO_PI: f64 = 0.918_938_533_204_672_7;
-    let mut shift = 0i32;
-    while z < 10.0 {
-        z += 1.0;
-        shift += 1;
-    }
-    let mut result = HALF_LOG_TWO_PI + (z - 0.5) * z.ln() - z + 1.0 / (12.0 * z)
-        - 1.0 / (360.0 * z * z * z)
-        + 1.0 / (1260.0 * z * z * z * z * z);
-    while shift > 0 {
-        shift -= 1;
-        z -= 1.0;
-        result -= z.ln();
-    }
-    result
-}
-
 /// Sample an index proportional to weights given in **log** space (Gumbel-max via
 /// a single uniform after log-sum-exp normalization), using only `rng`.
 fn sample_log_index<R: Rng>(log_w: &[f64], rng: &mut R) -> usize {
@@ -617,6 +596,7 @@ pub fn fit_hlda<R: Rng>(
 }
 
 use crate::estimator::{Estimator, ModelFamily};
+use crate::mathfun::log_gamma;
 
 impl Estimator for HldaModel {
     fn num_topics(&self) -> usize {

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -53,6 +53,7 @@
 //! ```
 
 use crate::estimator::{DirichletModel, Estimator, ModelFamily};
+use crate::mathfun::log_gamma as lgamma;
 use rand::Rng;
 
 // ---------------------------------------------------------------------------
@@ -572,27 +573,6 @@ fn sample_index<R: Rng>(weights: &[f64], rng: &mut R) -> usize {
 // ---------------------------------------------------------------------------
 // Numeric helpers for the dynamic (HMM) sampler
 // ---------------------------------------------------------------------------
-
-/// Stirling-series log Γ; shifts the argument up to z ≥ 10 for accuracy (same
-/// approximation `dtm.rs` uses, adequate for the small positive α and counts
-/// the Dirichlet-multinomial marginal needs).
-fn lgamma(mut z: f64) -> f64 {
-    const HALF_LOG_TWO_PI: f64 = 0.918_938_533_204_672_7;
-    let mut shift = 0i32;
-    while z < 10.0 {
-        z += 1.0;
-        shift += 1;
-    }
-    let mut result = HALF_LOG_TWO_PI + (z - 0.5) * z.ln() - z + 1.0 / (12.0 * z)
-        - 1.0 / (360.0 * z * z * z)
-        + 1.0 / (1260.0 * z * z * z * z * z);
-    while shift > 0 {
-        shift -= 1;
-        z -= 1.0;
-        result -= z.ln();
-    }
-    result
-}
 
 /// Log density of Gamma(shape `a`, scale `b`), matching keyATM's `gammapdfln`:
 /// `-a·ln(b) - lnΓ(a) + (a-1)·ln(x) - x/b`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,6 +46,7 @@ pub mod keyatm;
 pub mod labeled;
 pub mod lightlda;
 pub mod lsa;
+pub mod mathfun;
 pub mod mh;
 pub mod model;
 pub mod nmf;

--- a/src/mathfun.rs
+++ b/src/mathfun.rs
@@ -1,0 +1,122 @@
+//! Shared special functions.
+//!
+//! `log_gamma` was copy-pasted, byte-for-byte, into half a dozen model files
+//! (`dmr`, `dtm`, `rtm`, `keyatm`, `pt`, `hlda`) — every copy carrying the same
+//! latent bug (see below). This module is the single source of truth for that
+//! general-purpose Stirling log Γ. (The MALLET-matched variant in
+//! [`crate::output`] uses a different shift threshold to reproduce MALLET's
+//! `Dirichlet.logGammaStirling` exactly and is intentionally kept separate.)
+
+/// Stirling-series `ln Γ(z)` for `z > 0`, accurate to ~1e-10.
+///
+/// The argument is shifted up to `x >= 10` for the asymptotic series and the
+/// recurrence `ln Γ(z) = ln Γ(z + 1) - ln z` is unwound to recover `ln Γ(z)`.
+///
+/// The historical per-model copies unwound that recurrence by decrementing the
+/// *shifted* value back down (`while shift > 0 { z -= 1.0; result -= z.ln(); }`).
+/// For a tiny argument the shift `z += 1.0` rounds to exactly `1.0` (any `z`
+/// below ~1e-16), so the reverse pass stepped through `0.0` and evaluated
+/// `ln(0.0) = -inf`, returning `+inf` — e.g. when a DMR prior `α = exp(λ·x)` is
+/// small. Here we keep that exact algorithm for all normal-range arguments (so
+/// results are bit-identical to the previous copies) and only lift a tiny `z`
+/// into the safe range first, evaluating `ln z` on the real argument.
+pub(crate) fn log_gamma(z: f64) -> f64 {
+    // Lift arguments small enough that the shift-then-decrement below would lose
+    // them (well above the ~1e-16 danger point). This branch is never taken for
+    // ordinary hyperparameters, so the common path is unchanged.
+    if z < 1e-10 {
+        return log_gamma(z + 1.0) - z.ln();
+    }
+    const HALF_LOG_TWO_PI: f64 = 0.918_938_533_204_672_7;
+    let mut z = z;
+    let mut shift = 0i32;
+    while z < 10.0 {
+        z += 1.0;
+        shift += 1;
+    }
+    let mut result = HALF_LOG_TWO_PI + (z - 0.5) * z.ln() - z + 1.0 / (12.0 * z)
+        - 1.0 / (360.0 * z * z * z)
+        + 1.0 / (1260.0 * z * z * z * z * z);
+    while shift > 0 {
+        shift -= 1;
+        z -= 1.0;
+        result -= z.ln();
+    }
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::log_gamma;
+
+    /// The exact per-model algorithm before deduplication, for bit-parity checks.
+    fn legacy(mut z: f64) -> f64 {
+        const HALF_LOG_TWO_PI: f64 = 0.918_938_533_204_672_7;
+        let mut shift = 0i32;
+        while z < 10.0 {
+            z += 1.0;
+            shift += 1;
+        }
+        let mut result = HALF_LOG_TWO_PI + (z - 0.5) * z.ln() - z + 1.0 / (12.0 * z)
+            - 1.0 / (360.0 * z * z * z)
+            + 1.0 / (1260.0 * z * z * z * z * z);
+        while shift > 0 {
+            shift -= 1;
+            z -= 1.0;
+            result -= z.ln();
+        }
+        result
+    }
+
+    #[test]
+    fn matches_known_values() {
+        let cases = [
+            (1.0, 0.0),
+            (2.0, 0.0),
+            (0.5, std::f64::consts::PI.sqrt().ln()),
+            (3.0, 2.0f64.ln()),
+            (5.0, 24.0f64.ln()),
+            (10.0, 362_880.0f64.ln()),
+            (0.1, 9.513_507_698_668_732_f64.ln()),
+        ];
+        for (z, expected) in cases {
+            assert!(
+                (log_gamma(z) - expected).abs() < 1e-9,
+                "log_gamma({z}) = {}, expected {expected}",
+                log_gamma(z)
+            );
+        }
+    }
+
+    #[test]
+    fn bit_identical_to_legacy_on_normal_args() {
+        // The dedup must not change any model's results: for every normal-range
+        // argument the shared helper must be bit-for-bit equal to the algorithm the
+        // per-model copies used.
+        let mut z = 1e-9f64;
+        while z < 60.0 {
+            assert_eq!(
+                log_gamma(z).to_bits(),
+                legacy(z).to_bits(),
+                "log_gamma diverged from the legacy copy at z = {z}"
+            );
+            z += 0.0007;
+        }
+    }
+
+    #[test]
+    fn finite_for_tiny_argument() {
+        // Regression: the legacy copies returned +inf here (ln(0) on the reverse
+        // pass). Γ(z) ≈ 1/z for small z, so ln Γ(z) ≈ -ln z.
+        for &e in &[-20.0f64, -40.0, -80.0, -300.0] {
+            let z = e.exp();
+            let got = log_gamma(z);
+            assert!(got.is_finite(), "log_gamma({z}) not finite: {got}");
+            assert!(
+                (got - (-z.ln())).abs() < 1e-3,
+                "log_gamma({z}) = {got}, expected ≈ {}",
+                -z.ln()
+            );
+        }
+    }
+}

--- a/src/pt.rs
+++ b/src/pt.rs
@@ -19,29 +19,8 @@
 //!     i.e. the real doc inherits its pseudo-doc's topic distribution.
 
 use crate::estimator::{DirichletModel, Estimator, ModelFamily};
+use crate::mathfun::log_gamma;
 use rand::Rng;
-
-// ---------------------------------------------------------------------------
-// Log-Gamma helper (Stirling series shifted to z ≥ 10, matching dmr.rs)
-// ---------------------------------------------------------------------------
-
-fn log_gamma(mut z: f64) -> f64 {
-    const HALF_LOG_TWO_PI: f64 = 0.918_938_533_204_672_7;
-    let mut shift = 0i32;
-    while z < 10.0 {
-        z += 1.0;
-        shift += 1;
-    }
-    let mut result = HALF_LOG_TWO_PI + (z - 0.5) * z.ln() - z + 1.0 / (12.0 * z)
-        - 1.0 / (360.0 * z * z * z)
-        + 1.0 / (1260.0 * z * z * z * z * z);
-    while shift > 0 {
-        shift -= 1;
-        z -= 1.0;
-        result -= z.ln();
-    }
-    result
-}
 
 // ---------------------------------------------------------------------------
 // Model struct

--- a/src/rtm.rs
+++ b/src/rtm.rs
@@ -25,6 +25,7 @@
 
 use crate::corpus::Corpus;
 use crate::estimator::{Estimator, ModelFamily};
+use crate::mathfun::log_gamma as lgamma;
 use crate::optimize::digamma;
 use rand::Rng;
 
@@ -484,26 +485,6 @@ pub fn fit_rtm<R: Rng>(
         fit_history: history,
         converged,
     }
-}
-
-/// `log Γ(z)` (Lanczos-free Stirling with recurrence), for the Dirichlet terms of
-/// the variational bound.
-fn lgamma(mut z: f64) -> f64 {
-    const HALF_LOG_TWO_PI: f64 = 0.918_938_533_204_672_7;
-    let mut shift = 0i32;
-    while z < 10.0 {
-        z += 1.0;
-        shift += 1;
-    }
-    let mut result = HALF_LOG_TWO_PI + (z - 0.5) * z.ln() - z + 1.0 / (12.0 * z)
-        - 1.0 / (360.0 * z * z * z)
-        + 1.0 / (1260.0 * z * z * z * z * z);
-    while shift > 0 {
-        shift -= 1;
-        z -= 1.0;
-        result -= z.ln();
-    }
-    result
 }
 
 /// The variational objective (evidence lower bound, paper §3.2): the word,


### PR DESCRIPTION
## Summary

Follow-up to #434. That PR fixed the `log_gamma` `+inf`-for-tiny-arguments bug in **one** file — but the identical Stirling `log_gamma`/`lgamma` was copy-pasted **byte-for-byte into six** model files (`dmr`, `dtm`, `rtm`, `keyatm`, `pt`, `hlda`), every copy carrying the same latent bug. This extracts a single `crate::mathfun::log_gamma` and routes all six through it.

## The bug (recap)

The copies unwound the shift recurrence by decrementing the *shifted* value, so a tiny argument (`z + 1.0` rounds to `1.0` for `z` below ~`1e-16`) drove the reverse pass through `0.0` and `ln(0.0) = -inf`, returning `+inf`. Reachable e.g. when a prior `α = exp(λ·x)` is very small.

## Why it's safe to dedup

The shared impl **keeps the exact historical algorithm for every normal-range argument** and only lifts a tiny argument into the safe range first (`ln Γ(z) = ln Γ(z+1) − ln z`). A unit test (`bit_identical_to_legacy_on_normal_args`) asserts the shared helper is **bit-for-bit identical** to the legacy copies across `[1e-9, 60)`, so **no model's results change** — only the latent `+inf` is fixed.

Note: dmr's #434 fix used an accumulate-from-original variant that differed from the historical value by ~1e-10 on normal args; routing dmr through the shared (bit-preserving) helper restores its pre-#434 normal-range values. dmr's tolerance-based FD/known-value tests pass either way.

## Scope

- **In:** `dmr`, `dtm`, `rtm`, `keyatm`, `pt`, `hlda` → one `crate::mathfun::log_gamma`.
- **Out:** `output.rs` keeps its own **MALLET-matched** variant (a different shift threshold reproduces `Dirichlet.logGammaStirling` exactly). Its arguments are always ≥ ~0.01, so the bug is **unreachable** there; deduping/fixing it needs separate MALLET LL re-validation and is a deliberate follow-up.

## Verification

- New `mathfun` tests: known `ln Γ` values, finiteness at `exp(-20..-300)`, and bit-parity vs the legacy algorithm.
- Full `cargo test --lib` suite (**186** passed) green; `dmr`/`dtm`/`rtm`/`keyatm`/`pt`/`hlda` suites all pass; `cargo fmt --all --check` and `cargo clippy -D warnings` clean.

Net: six identical copies → one shared helper (+129/−128), and five previously-unfixed copies now correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)