### PR TITLE
fix(warplda): count only distinct in-vocab seed words in the seeded-β normalizer (#430)

### DIFF
--- a/src/warplda.rs
+++ b/src/warplda.rs
@@ -157,9 +157,16 @@ impl WarpLda {
         let mut beta_sum_k = vec![self.beta * v as f64; k];
         let mut inv_seeds: Vec<Vec<u32>> = vec![Vec::new(); v];
         for (t, ws) in seeds.iter().enumerate().take(k) {
-            beta_sum_k[t] += ws.len() as f64 * seed_weight;
+            // Count each DISTINCT, in-vocabulary seed word once. `beta_at` adds the
+            // seed weight per (topic, word) via a membership test, so the per-topic
+            // normalizer `beta_sum_k[t]` must equal Σ_w beta_at(t, w) = V·β +
+            // (#distinct valid seeds)·seed_weight. Adding `ws.len()` verbatim
+            // over-counted out-of-vocabulary and duplicate seed words, inflating the
+            // denominator and under-normalizing the seeded topic's φ.
+            let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
             for &w in ws {
-                if w < v {
+                if w < v && seen.insert(w) {
+                    beta_sum_k[t] += seed_weight;
                     inv_seeds[w].push(t as u32);
                 }
             }
@@ -810,6 +817,30 @@ mod tests {
                 warp * 1e3,
                 sparse * 1e3,
                 warp / sparse
+            );
+        }
+    }
+
+    /// #430: `set_seeds` must keep the per-topic normalizer consistent with the
+    /// per-word betas: Σ_w beta_at(t, w) == beta_sum_at(t). Duplicate and
+    /// out-of-vocabulary seed words previously inflated `beta_sum_k` (it added
+    /// `ws.len()` verbatim) while `beta_at` counts each distinct in-vocab seed once.
+    #[test]
+    fn set_seeds_normalizer_matches_per_word_betas() {
+        let (corpus, _) = planted(2, 3, 20); // V = 6, ids 0..5
+        let k = 2;
+        let mut rng = Pcg64Mcg::seed_from_u64(0);
+        let mut w = WarpLda::new(&corpus, k, &vec![0.1; k], 0.05, &mut rng);
+        // Topic 0: a duplicate (0 twice) and an OOV id (99); topic 1: a duplicate.
+        let seeds = vec![vec![0usize, 1, 0, 99], vec![2usize, 2, 3]];
+        w.set_seeds(&seeds, 7.0);
+        let v = corpus.num_types();
+        for t in 0..k {
+            let summed: f64 = (0..v).map(|word| w.beta_at(t, word)).sum();
+            let norm = w.beta_sum_at(t);
+            assert!(
+                (summed - norm).abs() < 1e-9,
+                "topic {t}: Σ_w beta_at = {summed} != beta_sum_at = {norm}"
             );
         }
     }


### PR DESCRIPTION
## Summary

Fixes the seed-hygiene item of #430. `set_seeds` built the per-topic normalizer as `beta_sum_k[t] = V·β + ws.len()·seed_weight` — adding the seed-word count verbatim. But `beta_at(t, w)` grants the seed weight per `(topic, word)` via a **membership** test, so it counts each *distinct in-vocabulary* seed word once.

Out-of-vocabulary seed ids (skipped when building `inv_seeds`) and **duplicate** seed words therefore inflated `beta_sum_k` with no matching per-word contribution, breaking the invariant `Σ_w beta_at(t, w) == beta_sum_at(t)` and **under-normalizing the seeded topic's φ** (materially so when `seed_weight` is large). Reachable via `topica.SeededLDA`, whose Python layer strips OOV seeds but **not** duplicates.

## Fix

Count each distinct, in-vocabulary seed word once, for both `beta_sum_k` and `inv_seeds`. `src/warplda.rs` only.

## Verification

- New test `set_seeds_normalizer_matches_per_word_betas`: seeds with a duplicate and an OOV id, then assert `Σ_w beta_at(t,w) == beta_sum_at(t)` for every topic. **Verified to fail on the pre-fix code** and pass after.
- `warplda` (5) and `seeded` (5) suites pass; `cargo fmt --all --check` and `cargo clippy -D warnings` clean.

## What this PR does NOT include (from #430)

- **`Alias::build` corruption** — already fixed in #431 (merged).
- **`set_hyper` β-update proposal mismatch** — I measured this and it is **negligible**: after a β step, the pending word-proposals were drawn with β_old while the doc-phase cancels the word factor assuming β_new, but the dropped residual factor is worst-case ~2% for an unrealistic 3× β jump (`R≈0.981`) and ~0.01% mean decision sensitivity for realistic (+10%) steps — proposals to zero-count topics (the only case with a large residual) are rare, and β changes slowly. Below MCMC noise; not worth the redraw complexity + RNG-determinism change. Documented on #430.

_(Branch name is historical; the shipped fix is the seed normalizer.)_

🤖 Generated with [Claude Code](https://claude.com/claude-code)