### PR TITLE
fix(ctm): SVI Σ shrinkage must scale with the step, not compound per minibatch (#421)

### DIFF
--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -1602,12 +1602,16 @@ pub fn fit_ctm_svi<R: Rng>(
                     for eta in &etas {
                         cross += (eta[i] - mu_shared[i]) * (eta[j] - mu_shared[j]);
                     }
-                    let shat = (sigma_ss[i * km1 + j] + cross) / bsz;
-                    let mut newv = (1.0 - rho) * sigma[i * km1 + j] + rho * shat;
+                    let mut shat = (sigma_ss[i * km1 + j] + cross) / bsz;
+                    // Shrink the minibatch TARGET, then take the Robbins-Monro step.
+                    // Multiplying the blended value instead applied the shrink on
+                    // every minibatch regardless of ρ, so off-diagonals contracted
+                    // by (1-shrink) per step and collapsed to ~0 (a spurious
+                    // diagonal Σ) rather than shrinking gently as ρ → 0.
                     if sigma_shrink > 0.0 && i != j {
-                        newv *= 1.0 - sigma_shrink;
+                        shat *= 1.0 - sigma_shrink;
                     }
-                    sigma[i * km1 + j] = newv;
+                    sigma[i * km1 + j] = (1.0 - rho) * sigma[i * km1 + j] + rho * shat;
                 }
             }
         }
@@ -1879,6 +1883,60 @@ mod tests {
                 assert!((x - y).abs() < 1e-12);
             }
         }
+    }
+
+    /// #421: SVI Σ shrinkage must scale with the Robbins-Monro step, not be applied
+    /// on every minibatch. Multiplying the blended value by (1-shrink) each step
+    /// collapsed the off-diagonals toward 0 (a spurious diagonal Σ) regardless of ρ.
+    #[test]
+    fn svi_shrinkage_scales_with_step_not_per_minibatch() {
+        // Topics A and B co-occur, so Σ has a large positive off-diagonal.
+        let corr_docs = || {
+            let mut rng = ChaCha8Rng::seed_from_u64(1);
+            let mut docs: Vec<Vec<u32>> = Vec::new();
+            for _ in 0..300 {
+                if rng.gen::<f64>() < 0.7 {
+                    docs.push(vec![0, 1, 2, 3, 4, 5, 0, 1, 3, 4]);
+                } else {
+                    docs.push(vec![6, 7, 8, 6, 7, 8, 6, 7, 8, 6]);
+                }
+            }
+            docs
+        };
+        let max_offdiag = |m: &CtmModel| -> f64 {
+            let km1 = m.num_topics - 1;
+            let mut w = 0.0f64;
+            for i in 0..km1 {
+                for j in 0..km1 {
+                    if i != j {
+                        w = w.max(m.sigma[i * km1 + j].abs());
+                    }
+                }
+            }
+            w
+        };
+        let fit = |shrink: f64| {
+            let docs = corr_docs();
+            let mut rng = ChaCha8Rng::seed_from_u64(2);
+            fit_ctm_svi(
+                &docs, 3, 9, 40, 16, 64.0, 0.7, shrink, false, false, false, &mut rng,
+            )
+        };
+        let off0 = max_offdiag(&fit(0.0));
+        assert!(
+            off0 > 1.0,
+            "correlated topics should give a large off-diagonal, got {off0}"
+        );
+        let off3 = max_offdiag(&fit(0.3));
+        // Shrinkage should reduce the off-diagonal, but must NOT collapse it to ~0.
+        assert!(
+            off3 < off0,
+            "shrinkage should reduce the off-diagonal ({off3} vs {off0})"
+        );
+        assert!(
+            off3 > 0.05,
+            "shrinkage collapsed the off-diagonal to ~0 (the per-minibatch bug): {off3}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes the SVI Σ-shrinkage item of #421. `fit_ctm_svi` applied the off-diagonal shrinkage by multiplying the **blended** Σ value by `(1 - sigma_shrink)` on every minibatch. As the Robbins-Monro step `ρ → 0` a stochastic update should approach the identity — but this contracted the off-diagonals by `(1 - shrink)` **every step regardless of ρ**, so over many minibatches they collapsed to ~0. The result is a spurious diagonal Σ that erases the very topic correlations the logistic-normal model exists to capture.

## Evidence

Corpus with two co-occurring topic blocks (K=3, 40 epochs), max |off-diagonal| of Σ:

| `sigma_shrink` | before fix | after fix |
|---|---|---|
| 0.0 | 4.19 | 4.19 (identical) |
| 0.3 | **0.0002** (collapsed) | **0.26** (shrunk, intact) |
| 0.6 | 0.0002 | 0.024 |

## Fix

Shrink the minibatch **target** before the ρ blend, so `ρ → 0` is the identity and the shrinkage acts gently and proportionally. The `sigma_shrink = 0` path is **bit-for-bit unchanged**.

## Verification

- New test: a correlated-topic SVI fit asserts the off-diagonal is reduced by `sigma_shrink` but **not collapsed to ~0** (> 0.05). **Verified to fail on the pre-fix code** (0.0002) and pass after (0.26).
- Full `topica-core` suite (33) passes, including `svi_recovers_planted_blocks` (unaffected — `shrink=0`). `cargo fmt --all --check` and `cargo clippy -D warnings` clean.

## Scope

`topica-core/src/ctm.rs` only. The other two SVI items of #421 — β blending normalized minibatch ratios instead of scaled sufficient statistics, and the Σ minibatch covariance centered on the already-updated μ — are a coupled redesign of the global update (maintain λ suff-stats + a second moment) and are left as a follow-up. I measured those as smaller-magnitude than this shrinkage collapse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)