### PR TITLE
fix(dmr): compute feature-effect SEs at the optimum, not drifted counts (#419)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -334,9 +334,13 @@ class DMR:
     def feature_effect_se(self) -> numpy.typing.NDArray[numpy.float64] | None:
         """Standard error of each feature weight lambda, shape (num_topics,
         num_features), from the observed information of the penalized
-        Dirichlet-multinomial likelihood at the fit. Aligned to feature_effects; an
-        effect more than ~2 SEs from zero is the usual significance cue. None for
-        models saved before this was added."""
+        Dirichlet-multinomial likelihood evaluated at the counts lambda was last
+        optimized against. Aligned to feature_effects; an effect more than ~2 SEs
+        from zero is the usual significance cue. None when lambda was never
+        optimized to a stationary point (e.g. optimize_interval=0, burn_in>=iters,
+        lbfgs_iters=0, or L-BFGS did not converge), since the observed information
+        is only a valid covariance at an optimum; also None for models saved before
+        this was added."""
         ...
 
     @property

--- a/src/dmr.rs
+++ b/src/dmr.rs
@@ -21,6 +21,21 @@ use rand::Rng;
 use crate::optimize::digamma;
 use crate::sampler::sample_doc;
 
+/// Clamp on the linear predictor `λ_t · x_d + s_{d,t}` before exponentiation.
+/// Standalone DMR deliberately does not standardize covariates, so a large-scale
+/// covariate or coefficient can drive the predictor to `+inf` (or `-inf`),
+/// yielding non-finite α and NaNs through digamma/trigamma (#419). `exp(500)`
+/// (~1.4e217) is astronomically larger than any meaningful α yet leaves ample
+/// headroom below `f64::MAX` even summed over many topics, so this bites only
+/// pathological inputs and never a realistic fit.
+const PREDICTOR_CLAMP: f64 = 500.0;
+
+/// `exp` of the DMR linear predictor with the [`PREDICTOR_CLAMP`] guard.
+#[inline]
+fn predictor_exp(dot: f64, off: f64) -> f64 {
+    (dot + off).clamp(-PREDICTOR_CLAMP, PREDICTOR_CLAMP).exp()
+}
+
 /// Per-document, per-topic prior `α_{d,t} = exp(λ_t · x_d + s_{d,t})`.
 ///
 /// `lambda` is `[num_topics][num_features]`, `features` is
@@ -42,7 +57,7 @@ pub fn compute_doc_alpha(
                 .map(|(t, lt)| {
                     let dot: f64 = lt.iter().zip(x).map(|(l, xi)| l * xi).sum();
                     let off = offset.map_or(0.0, |o| o[d][t]);
-                    (dot + off).exp()
+                    predictor_exp(dot, off)
                 })
                 .collect()
         })
@@ -143,7 +158,7 @@ pub fn dmr_objective_and_gradient(
         for t in 0..num_topics {
             let dot: f64 = lambda[t].iter().zip(x).map(|(l, xi)| l * xi).sum();
             let off = offset.map_or(0.0, |o| o[d][t]);
-            let a = (dot + off).exp();
+            let a = predictor_exp(dot, off);
             alpha[t] = a;
             alpha_sum += a;
         }
@@ -267,7 +282,7 @@ pub fn dmr_lambda_cov(
         for tt in 0..t {
             let dot: f64 = lambda[tt].iter().zip(x).map(|(l, xi)| l * xi).sum();
             let off = offset.map_or(0.0, |o| o[d][tt]);
-            a[tt] = (dot + off).exp();
+            a[tt] = predictor_exp(dot, off);
             alpha_sum += a[tt];
         }
         let counts = &doc_topic_counts[d];
@@ -318,10 +333,17 @@ pub fn dmr_lambda_cov(
 }
 
 use crate::mathfun::log_gamma;
-use crate::variational::lbfgs_minimize;
+use crate::variational::lbfgs_minimize_status;
 
 /// Optimize `lambda` in place to maximize the penalized DMR likelihood for the
 /// current topic counts (one L-BFGS run, used periodically during sampling).
+///
+/// Returns whether L-BFGS reached a stationary point on its own criterion, rather
+/// than exhausting its iteration budget. The caller uses this to decide whether the
+/// observed-information standard errors are valid — an SE is only a covariance at an
+/// optimum, so a run that hit `max_iter` (or was given `max_iter == 0`) reports
+/// `false` and no SE is emitted (#419).
+#[must_use]
 pub fn optimize_lambda(
     lambda: &mut [Vec<f64>],
     features: &[Vec<f64>],
@@ -331,13 +353,13 @@ pub fn optimize_lambda(
     prior_variance: f64,
     max_iter: usize,
     offset: Option<&[Vec<f64>]>,
-) {
+) -> bool {
     let mut x0 = Vec::with_capacity(num_topics * num_features);
     for lt in lambda.iter() {
         x0.extend_from_slice(lt);
     }
 
-    let x = lbfgs_minimize(
+    let (x, converged) = lbfgs_minimize_status(
         x0,
         |flat| {
             let mut lam = vec![vec![0.0f64; num_features]; num_topics];
@@ -368,6 +390,53 @@ pub fn optimize_lambda(
     for t in 0..num_topics {
         lambda[t].copy_from_slice(&x[t * num_features..(t + 1) * num_features]);
     }
+    converged
+}
+
+/// Guarded standard errors for the DMR weights: [`dmr_lambda_se`] evaluated at the
+/// exact counts `lambda` was last optimized against, returning `None` when the
+/// observed information is not a valid covariance at the returned `lambda`. The
+/// caller must pass the `doc_topic_counts` snapshot from the last *converged*
+/// [`optimize_lambda`]; this adds finiteness guards on the objective, gradient, and
+/// the resulting SE matrix (the last catching a non-SPD information that the
+/// diagonal-dominance fallback could not repair). See #419: previously the SE was
+/// computed from the post-sampling counts, which have drifted away from the counts
+/// `lambda` was fit to, so it was not `J^{-1}` at the optimum for the returned
+/// `lambda`.
+pub fn dmr_lambda_se_checked(
+    lambda: &[Vec<f64>],
+    features: &[Vec<f64>],
+    doc_topic_counts: &[Vec<f64>],
+    num_topics: usize,
+    num_features: usize,
+    prior_variance: f64,
+    offset: Option<&[Vec<f64>]>,
+) -> Option<Vec<Vec<f64>>> {
+    let (value, grad) = dmr_objective_and_gradient(
+        lambda,
+        features,
+        doc_topic_counts,
+        num_topics,
+        num_features,
+        prior_variance,
+        offset,
+    );
+    if !value.is_finite() || grad.iter().flatten().any(|g| !g.is_finite()) {
+        return None;
+    }
+    let se = dmr_lambda_se(
+        lambda,
+        features,
+        doc_topic_counts,
+        num_topics,
+        num_features,
+        prior_variance,
+        offset,
+    );
+    if se.iter().flatten().any(|v| !v.is_finite()) {
+        return None;
+    }
+    Some(se)
 }
 
 #[cfg(test)]
@@ -569,7 +638,7 @@ mod tests {
             }
         }
         let mut lambda = vec![vec![0.0f64; num_features]; num_topics];
-        optimize_lambda(
+        let converged = optimize_lambda(
             &mut lambda,
             &features,
             &counts,
@@ -579,6 +648,7 @@ mod tests {
             100,
             None,
         );
+        assert!(converged, "L-BFGS should reach a stationary point here");
 
         // The covariate weight should push topic 1 up and topic 0 down.
         let effect_topic1 = lambda[1][1] - lambda[0][1];
@@ -586,6 +656,55 @@ mod tests {
             effect_topic1 > 0.5,
             "expected positive covariate effect on topic 1, got {}",
             effect_topic1
+        );
+    }
+
+    // #419: optimize_lambda reports non-convergence when it cannot take a real step
+    // (max_iter = 0), which the SE guard uses to withhold an invalid covariance.
+    #[test]
+    fn optimize_lambda_reports_nonconvergence_when_it_cannot_step() {
+        let features = vec![vec![1.0, 1.0], vec![1.0, -1.0], vec![1.0, 0.5]];
+        let counts = vec![vec![5.0, 1.0], vec![1.0, 5.0], vec![3.0, 3.0]];
+        let mut lambda = vec![vec![0.0f64; 2]; 2];
+        let converged = optimize_lambda(&mut lambda, &features, &counts, 2, 2, 100.0, 0, None);
+        assert!(
+            !converged,
+            "max_iter=0 leaves lambda un-optimized, so it must not report convergence"
+        );
+    }
+
+    // #419: dmr_lambda_se_checked returns Some finite SEs at a real optimum and None
+    // when the objective/gradient are non-finite (e.g. corrupted counts).
+    #[test]
+    fn dmr_lambda_se_checked_guards_the_covariance() {
+        let features = vec![
+            vec![1.0, 1.0],
+            vec![1.0, -1.0],
+            vec![1.0, 0.5],
+            vec![1.0, -0.5],
+        ];
+        let counts = vec![
+            vec![8.0, 2.0],
+            vec![2.0, 8.0],
+            vec![6.0, 4.0],
+            vec![4.0, 6.0],
+        ];
+        let mut lambda = vec![vec![0.0f64; 2]; 2];
+        let converged = optimize_lambda(&mut lambda, &features, &counts, 2, 2, 100.0, 200, None);
+        assert!(converged);
+        let se = dmr_lambda_se_checked(&lambda, &features, &counts, 2, 2, 100.0, None);
+        let se = se.expect("SE should be available at a converged optimum");
+        assert!(se.iter().flatten().all(|v| v.is_finite() && *v > 0.0));
+
+        // A non-finite count makes the objective non-finite -> no SE.
+        let bad_counts = vec![
+            vec![f64::NAN, 2.0],
+            vec![2.0, 8.0],
+            vec![6.0, 4.0],
+            vec![4.0, 6.0],
+        ];
+        assert!(
+            dmr_lambda_se_checked(&lambda, &features, &bad_counts, 2, 2, 100.0, None).is_none()
         );
     }
 

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -1790,7 +1790,9 @@ pub fn fit_keyatm_cov<R: Rng>(
             rng,
         );
         if opt_interval > 0 && it + 1 > burn_in && (it + 1 - burn_in).is_multiple_of(opt_interval) {
-            crate::dmr::optimize_lambda(
+            // keyATM-cov shares DMR's "periodic optimize, SE from final counts"
+            // pattern; wiring this convergence flag into its λ-SE guard is #418.
+            let _converged = crate::dmr::optimize_lambda(
                 &mut lambda,
                 &features_std,
                 &model.ndk,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -3696,36 +3696,36 @@ impl DMR {
             py.allow_threads(move || {
                 let alpha0 = vec![1.0f64; k];
                 let mut cv = cvb0::Cvb0::new(&corpus, k, &alpha0, beta, &mut rng);
+                // Counts from the last *converged* λ optimization; the SE is computed
+                // from exactly these so it is J^{-1} at the optimum for the returned
+                // λ, not at counts that drifted afterwards (#419).
+                let mut se_counts: Option<Vec<Vec<f64>>> = None;
                 for iter in 1..=iters {
                     let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
                     cv.set_doc_alpha(doc_alpha);
                     cv.sweep();
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
-                        dmr::optimize_lambda(
+                        let dtc: Vec<Vec<f64>> = cv.doc_topic_expected().to_vec();
+                        let converged = dmr::optimize_lambda(
                             &mut lambda,
                             &feats,
-                            cv.doc_topic_expected(),
+                            &dtc,
                             k,
                             nf,
                             prior_variance,
                             lbfgs_iters,
                             None,
                         );
+                        se_counts = if converged { Some(dtc) } else { None };
                     }
                 }
                 let mut acc_phi = vec![vec![0.0f64; k]; num_types];
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
                 cv.phi_into(&mut acc_phi);
                 cv.theta_into(&mut acc_theta);
-                let se = dmr::dmr_lambda_se(
-                    &lambda,
-                    &feats,
-                    cv.doc_topic_expected(),
-                    k,
-                    nf,
-                    prior_variance,
-                    None,
-                );
+                let se = se_counts.as_ref().and_then(|dtc| {
+                    dmr::dmr_lambda_se_checked(&lambda, &feats, dtc, k, nf, prior_variance, None)
+                });
                 let model = cv.to_topic_model(&corpus);
                 (
                     acc_phi,
@@ -3747,6 +3747,9 @@ impl DMR {
             py.allow_threads(move || {
                 let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
                 let mut ws = warplda::WarpLda::new(&corpus, k, &vec![1.0f64; k], beta, &mut rng);
+                // See the sparse/CVB0 paths: SE is computed from the last converged
+                // optimization's counts, not the drifted post-sampling counts (#419).
+                let mut se_counts: Option<Vec<Vec<f64>>> = None;
 
                 for iter in 1..=iters {
                     let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
@@ -3755,7 +3758,7 @@ impl DMR {
 
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                         let dtc = doc_topic_counts(ws.doc_topics(), k);
-                        dmr::optimize_lambda(
+                        let converged = dmr::optimize_lambda(
                             &mut lambda,
                             &feats,
                             &dtc,
@@ -3765,6 +3768,7 @@ impl DMR {
                             lbfgs_iters,
                             None,
                         );
+                        se_counts = if converged { Some(dtc) } else { None };
                     }
 
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
@@ -3838,15 +3842,9 @@ impl DMR {
                         *v /= n;
                     }
                 }
-                let se = dmr::dmr_lambda_se(
-                    &lambda,
-                    &feats,
-                    &doc_topic_counts(ws.doc_topics(), k),
-                    k,
-                    nf,
-                    prior_variance,
-                    None,
-                );
+                let se = se_counts.as_ref().and_then(|dtc| {
+                    dmr::dmr_lambda_se_checked(&lambda, &feats, dtc, k, nf, prior_variance, None)
+                });
                 let model = ws.to_topic_model();
                 (
                     acc_phi,
@@ -3866,6 +3864,9 @@ impl DMR {
                 let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
                 let mut ll_history: Vec<(usize, f64)> = Vec::new();
                 let mut converged_flag = false;
+                // See the CVB0 path: SE from the last converged optimization's counts,
+                // not the drifted post-sampling counts (#419).
+                let mut se_counts: Option<Vec<Vec<f64>>> = None;
 
                 'outer: for iter in 1..=iters {
                     let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
@@ -3885,7 +3886,7 @@ impl DMR {
 
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                         let dtc = doc_topic_counts(&model.doc_topics, k);
-                        dmr::optimize_lambda(
+                        let converged = dmr::optimize_lambda(
                             &mut lambda,
                             &feats,
                             &dtc,
@@ -3895,6 +3896,7 @@ impl DMR {
                             lbfgs_iters,
                             None,
                         );
+                        se_counts = if converged { Some(dtc) } else { None };
                     }
 
                     // Snapshot θ = (n_dk + α_dk) / (N_d + Σα_d) every thin sweeps.
@@ -3998,15 +4000,9 @@ impl DMR {
                     }
                 }
 
-                let se = dmr::dmr_lambda_se(
-                    &lambda,
-                    &feats,
-                    &doc_topic_counts(&model.doc_topics, k),
-                    k,
-                    nf,
-                    prior_variance,
-                    None,
-                );
+                let se = se_counts.as_ref().and_then(|dtc| {
+                    dmr::dmr_lambda_se_checked(&lambda, &feats, dtc, k, nf, prior_variance, None)
+                });
                 (
                     acc_phi,
                     acc_theta,
@@ -4040,19 +4036,26 @@ impl DMR {
                 fe[[t, f]] = val;
             }
         }
-        let mut fe_se = Array2::<f64>::zeros((k, nf));
-        for (t, row) in feat_eff_se.iter().enumerate() {
-            for (f, &val) in row.iter().enumerate() {
-                fe_se[[t, f]] = val;
+        // feature_effect_se is None when λ was never optimized (e.g.
+        // optimize_interval=0, burn_in>=iters, lbfgs_iters=0) or the last
+        // optimization did not reach a stationary point — the observed information
+        // is only a valid covariance at an optimum (#419).
+        let fe_se = feat_eff_se.map(|rows| {
+            let mut m = Array2::<f64>::zeros((k, nf));
+            for (t, row) in rows.iter().enumerate() {
+                for (f, &val) in row.iter().enumerate() {
+                    m[[t, f]] = val;
+                }
             }
-        }
+            m
+        });
 
         slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         slf.phi = Some(phi);
         slf.theta = Some(theta);
         slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, k, None);
         slf.feature_effects = Some(fe);
-        slf.feature_effect_se = Some(fe_se);
+        slf.feature_effect_se = fe_se;
         slf.feature_names = names;
         slf.log_likelihood_history = ll_history;
         slf.converged = converged_flag;

--- a/tests/test_dmr_feature_effect_se_419.py
+++ b/tests/test_dmr_feature_effect_se_419.py
@@ -1,0 +1,105 @@
+"""#419: DMR feature_effect_se was computed from the post-sampling topic counts,
+which drift away from the counts lambda was optimized against (the extra
+num_samples*sample_interval sweeps mutate them). It is now computed from the last
+converged optimization's counts, so it is J^-1 at the optimum for the returned
+lambda -- and therefore invariant to the sampling controls. It is also None when
+lambda was never optimized to a stationary point."""
+import numpy as np
+import pytest
+import topica
+
+
+def _corpus(seed=0, n=120, k=3, block=6):
+    # Deliberately ambiguous: each doc is only ~60% from its block and ~40% drawn
+    # uniformly over the whole vocabulary, with short docs, so the Gibbs sampler
+    # keeps reassigning tokens and the per-doc counts genuinely fluctuate across
+    # sweeps (needed for the drift witness below to be meaningful).
+    rng = np.random.default_rng(seed)
+    v = k * block
+    docs, feats = [], []
+    for d in range(n):
+        b = d % k
+        toks = []
+        for _ in range(10):
+            if rng.random() < 0.6:
+                toks.append(f"w{b * block + int(rng.integers(block))}")
+            else:
+                toks.append(f"w{int(rng.integers(v))}")
+        docs.append(toks)
+        feats.append([float(b == j) for j in range(k)])  # one-hot-ish covariates
+    return docs, np.asarray(feats)
+
+
+def _fit(sampler, num_samples, sample_interval, **kw):
+    docs, feats = _corpus()
+    m = topica.DMR(num_topics=3, seed=42, optimize_interval=10, burn_in=20,
+                   sampler=sampler, **kw)
+    m.fit(docs, features=feats, iters=80, num_samples=num_samples,
+          sample_interval=sample_interval, keep_theta_draws=False)
+    return m
+
+
+# Only the stochastic samplers run a post-training sampling phase (the issue notes
+# these are where the drift is worst); CVB0 is deterministic and ignores num_samples.
+@pytest.mark.parametrize("sampler", ["sparse", "warp"])
+def test_se_is_invariant_to_the_sampling_controls(sampler):
+    # The training loop (and thus lambda + the counts it was optimized at) is
+    # identical; only the post-training sampling phase differs. The SE must not
+    # move. Pre-#419 it was read from the drifted post-sampling counts and did.
+    a = _fit(sampler, num_samples=1, sample_interval=5)
+    b = _fit(sampler, num_samples=8, sample_interval=30)
+    se_a = a.feature_effect_se
+    se_b = b.feature_effect_se
+    assert se_a is not None and se_b is not None
+    assert np.allclose(se_a, se_b, atol=1e-10), np.abs(se_a - se_b).max()
+    # lambda itself is likewise unaffected by the sampling controls.
+    assert np.allclose(a.feature_effects, b.feature_effects, atol=1e-10)
+    # Witness that the invariance is non-trivial: the sampling phase genuinely
+    # diverges, so the post-sampling counts differ between the two runs. The old
+    # code fed exactly those counts to the SE, so it would NOT have matched here.
+    assert not np.allclose(a.doc_topic, b.doc_topic)
+
+
+def test_cvb0_se_is_invariant_to_trailing_non_optimize_sweeps():
+    # optimize_interval=10, burn_in=20 -> the last optimization is at iter 50 for
+    # both runs; the second run just does 8 more (non-optimizing) CVB0 sweeps, which
+    # drift the expected counts. The SE, taken from the iter-50 counts, must match.
+    # Pre-#419 it was read from the drifted final expected counts and would not.
+    docs, feats = _corpus()
+
+    def fit(iters):
+        m = topica.DMR(num_topics=3, seed=42, optimize_interval=10, burn_in=20,
+                       sampler="cvb0")
+        m.fit(docs, features=feats, iters=iters, keep_theta_draws=False)
+        return m
+
+    a, b = fit(50), fit(58)
+    assert a.feature_effect_se is not None and b.feature_effect_se is not None
+    assert np.allclose(a.feature_effect_se, b.feature_effect_se, atol=1e-10)
+    assert np.allclose(a.feature_effects, b.feature_effects, atol=1e-10)
+
+
+def test_normal_fit_has_finite_positive_se():
+    m = _fit("sparse", num_samples=3, sample_interval=10)
+    se = m.feature_effect_se
+    assert se is not None
+    assert np.all(np.isfinite(se)) and np.all(se > 0.0)
+
+
+def test_no_optimization_yields_no_se():
+    # optimize_interval=0 disables lambda optimization entirely: an observed-
+    # information SE would be meaningless, so it must be None rather than fabricated.
+    docs, feats = _corpus()
+    m = topica.DMR(num_topics=3, seed=42, optimize_interval=0, burn_in=20)
+    m.fit(docs, features=feats, iters=60, num_samples=2, sample_interval=10,
+          keep_theta_draws=False)
+    assert m.feature_effect_se is None
+
+
+def test_zero_lbfgs_iters_yields_no_se():
+    # lbfgs_iters=0 means lambda can never reach a stationary point.
+    docs, feats = _corpus()
+    m = topica.DMR(num_topics=3, seed=42, optimize_interval=10, burn_in=20, lbfgs_iters=0)
+    m.fit(docs, features=feats, iters=60, num_samples=2, sample_interval=10,
+          keep_theta_draws=False)
+    assert m.feature_effect_se is None

--- a/topica-core/src/variational/lbfgs.rs
+++ b/topica-core/src/variational/lbfgs.rs
@@ -7,13 +7,26 @@ fn dot(a: &[f64], b: &[f64]) -> f64 {
 /// Minimize `f` (value + gradient) with limited-memory BFGS and a backtracking
 /// Armijo line search. Compact by design: DMR re-optimizes frequently between
 /// sampling sweeps, so a short history and iteration budget suffice.
-pub fn lbfgs_minimize<F>(
+pub fn lbfgs_minimize<F>(x0: Vec<f64>, f: F, max_iter: usize, history: usize, tol: f64) -> Vec<f64>
+where
+    F: FnMut(&[f64]) -> (f64, Vec<f64>),
+{
+    lbfgs_minimize_status(x0, f, max_iter, history, tol).0
+}
+
+/// As [`lbfgs_minimize`], but also reports whether the run reached a stationary
+/// point on its own criterion (gradient below `tol`, or a relative function change
+/// below `tol`) rather than exhausting `max_iter`. Callers that build asymptotic
+/// standard errors from the result need this: the observed-information inverse is
+/// only a valid covariance at an optimum, so a run that hit `max_iter` (or was
+/// given `max_iter == 0`) must not be treated as converged.
+pub fn lbfgs_minimize_status<F>(
     x0: Vec<f64>,
     mut f: F,
     max_iter: usize,
     history: usize,
     tol: f64,
-) -> Vec<f64>
+) -> (Vec<f64>, bool)
 where
     F: FnMut(&[f64]) -> (f64, Vec<f64>),
 {
@@ -24,9 +37,11 @@ where
     let mut s_list: Vec<Vec<f64>> = Vec::new();
     let mut y_list: Vec<Vec<f64>> = Vec::new();
     let mut rho_list: Vec<f64> = Vec::new();
+    let mut converged = false;
 
     for _ in 0..max_iter {
         if g.iter().map(|v| v * v).sum::<f64>().sqrt() < tol {
+            converged = true;
             break;
         }
 
@@ -103,13 +118,14 @@ where
             y_list.push(y);
         }
 
-        let converged = (fx - fx_new).abs() < tol * (1.0 + fx.abs());
+        let fx_converged = (fx - fx_new).abs() < tol * (1.0 + fx.abs());
         x = x_new;
         fx = fx_new;
         g = g_new;
-        if converged {
+        if fx_converged {
+            converged = true;
             break;
         }
     }
-    x
+    (x, converged)
 }

--- a/topica-core/src/variational/mod.rs
+++ b/topica-core/src/variational/mod.rs
@@ -5,7 +5,7 @@
 //! family trait.
 
 pub mod lbfgs;
-pub use lbfgs::lbfgs_minimize;
+pub use lbfgs::{lbfgs_minimize, lbfgs_minimize_status};
 
 pub mod sparse;
 pub use sparse::doc_sparse;


### PR DESCRIPTION
Addresses #419. DMR review (Codex `gpt-5.6-sol` + independent source read; Codex's "reproduced" numbers discarded — read-only). Finding 2 (local `log_gamma` +inf) already shipped in **#434**; this covers findings 1 and 3.

## Finding 1 — SE evaluated at counts that don't match the returned λ (cross-model)
`λ` is L-BFGS-optimized only on scheduled sweeps, but the SE (inverse observed information) was computed at the end from whatever counts existed then. For the **sparse and warp** paths it's worse: after training, `num_samples * sample_interval` extra Gibbs sweeps run and mutate the counts *before* the SE is taken — so the Hessian was evaluated at counts that drifted away from the ones `λ` was fit to. It was also emitted when `λ` was never optimized (`optimize_interval=0`, `burn_in>=iters`, `lbfgs_iters=0`) or L-BFGS hit its cap without converging.

- `optimize_lambda` now **returns whether L-BFGS reached a stationary point**, via a new `lbfgs_minimize_status` in topica-core (reports convergence vs hitting `max_iter`). `lbfgs_minimize` stays a thin wrapper — **no other L-BFGS caller changes**.
- All three DMR paths retain the `doc_topic_counts` snapshot from the last **converged** optimization and compute the SE from exactly those (new `dmr_lambda_se_checked`, which also returns `None` on a non-finite objective/gradient or a non-SPD information the fallback couldn't repair).
- `feature_effect_se` is now `None` when no valid SE exists, instead of a covariance evaluated away from the optimum. keyATM-cov shares this pattern (#418) and now has the flag available to wire in.

**Verified fail-on-old** (a stale old-code build failed *exactly* these, all four green on the fix): SE is invariant to `num_samples`/`sample_interval` (sparse/warp) and to trailing non-optimize sweeps (cvb0); `optimize_interval=0` and `lbfgs_iters=0` both give `None`. The sparse/warp test carries a witness that the sampling phase genuinely drifts the counts, so the old code *would* have differed.

## Finding 3 — unbounded `exp(λ·x + offset)`
Standalone DMR doesn't standardize covariates, so a large-scale covariate/coefficient drove the predictor to `±inf` → non-finite α → NaNs through digamma/trigamma. Clamp the predictor to `±500` before `exp` (`exp(500) ≈ 1.4e217`, far above any meaningful α yet finite) via a shared `predictor_exp` at all three exponentiation sites. The L-BFGS "reject non-finite trials" hardening is deferred to keep the blast radius in DMR.

## Not changed (verified correct in review)
FD-verified gradient/Hessian, the sparse leave-one-out sampler, and coefficients already on the original covariate scale.

## Gates
`cargo fmt --all --check` ✓ · clippy (default + `--features python`) ✓ · `cargo test --lib` 195 ✓ · DMR/keyATM/stub pytests 476 passed / 1 skipped ✓