### PR TITLE
fix(gdmr): center the intercept prior at log(alpha), closing #426

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,10 +18,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   `variance = sigma**2 / prod_d (p_d+1)**(2*decay)`, so any `decay>0` shrinks and
   `decay=0` recovers the paper's decay-free prior. Existing `sigma`/`sigma0`/`decay`
   configurations now produce different (correct) fits; a `decay>0`, `sigma!=sigma0`
-  tomotopy parity leg was added to the gold. The `log(alpha)` intercept prior mean
-  (both references center the constant term at `log(alpha)`; topica's inner DMR is
-  zero-mean) remains a separate follow-up. Also: `tdf()` now uses a stable softmax,
-  and the `alpha` property / `sigma`/`sigma0`/`decay` docstrings were corrected.
+  tomotopy parity leg was added to the gold. GDMR also gained an `alpha` parameter
+  (default 0.1, tomotopy's default) that centers the constant-term prior at
+  `log(alpha)` and sets the baseline Dirichlet concentration (smaller `alpha` ->
+  sparser per-document topic mixtures), matching both reference implementations;
+  `alpha=1` reproduces the previous zero-mean intercept. This is realized through a
+  new optional `offset` argument on `DMR.fit` (a fixed `(num_docs, num_topics)`
+  term added inside the exponent). Also: `tdf()` now uses a stable softmax, and the
+  `alpha` property / `sigma`/`sigma0`/`decay` docstrings were corrected.
 
 - **SAGE now uses its defining sparse prior by default** (#422). The κ content
   deviations were previously fit under a fixed Gaussian ridge, which is not

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -286,14 +286,18 @@ class DMR:
         convergence_tol: float = 0.0,
         check_every: int = 10,
         covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
+        offset: Optional[numpy.typing.NDArray[numpy.float64]] = None,
     ) -> "DMR":
         """Fit by collapsed Gibbs with the per-document Dirichlet prior
-        alpha_{d,t} = exp(lambda_t . x_d). `features` (or `covariates`, a
-        symmetric alias) is required: an (num_docs, F) covariate matrix (no
-        intercept column — one is prepended), with feature_names naming the F
-        columns. The L-BFGS optimization of lambda runs every optimize_interval
-        sweeps after burn_in; topic-word phi is averaged over num_samples samples
-        taken every sample_interval sweeps."""
+        alpha_{d,t} = exp(lambda_t . x_d + offset[d, t]). `features` (or
+        `covariates`, a symmetric alias) is required: an (num_docs, F) covariate
+        matrix (no intercept column — one is prepended), with feature_names naming
+        the F columns. `offset` is an optional fixed (num_docs, num_topics) term
+        added inside the exponent (e.g. a constant log(alpha) to set the baseline
+        concentration); it shifts the predictor but is not itself estimated. The
+        L-BFGS optimization of lambda runs every optimize_interval sweeps after
+        burn_in; topic-word phi is averaged over num_samples samples taken every
+        sample_interval sweeps."""
         ...
 
     @property

--- a/python/topica/gdmr.py
+++ b/python/topica/gdmr.py
@@ -253,6 +253,13 @@ class GDMR:
         ``sigma**2 / prod_d (p_d + 1)**(2*decay)``.  Any ``decay > 0`` shrinks;
         ``decay == 0`` gives a uniform ``sigma`` over all non-constant terms (the
         original paper's decay-free prior).
+    alpha:
+        Baseline Dirichlet concentration (tomotopy ``GDMRModel.alpha``, default
+        0.1).  Applied as a constant ``log(alpha)`` offset in the DMR predictor, so
+        it sets the baseline topic concentration (smaller ``alpha`` -> sparser
+        per-document topic mixtures) and centers the intercept prior at
+        ``log(alpha)``, matching both reference implementations.  ``alpha = 1``
+        reproduces a zero-mean intercept prior (topica's pre-#426 behavior).
     metadata_range:
         Per-dimension ``(lo, hi)`` bounds for the [-1, 1] mapping.  If None,
         we infer from the training data at fit time.
@@ -275,6 +282,7 @@ class GDMR:
         sigma: float = 1.0,
         sigma0: float = 3.0,
         decay: float = 0.0,
+        alpha: float = 0.1,
         metadata_range: list[tuple[float, float]] | None = None,
         lbfgs_iters: int = 20,
         sampler: str = "sparse",
@@ -293,6 +301,8 @@ class GDMR:
             raise ValueError("sigma0 must be > 0")
         if decay < 0:
             raise ValueError("decay must be >= 0")
+        if alpha <= 0 or not np.isfinite(alpha):
+            raise ValueError("alpha must be finite and > 0")
 
         self._num_topics = num_topics
         self._degrees = list(degrees)
@@ -303,6 +313,7 @@ class GDMR:
         self._sigma = sigma
         self._sigma0 = sigma0
         self._decay = decay
+        self._alpha = alpha
         self._metadata_range: list[tuple[float, float]] | None = (
             [tuple(r) for r in metadata_range] if metadata_range is not None else None
         )
@@ -456,6 +467,15 @@ class GDMR:
             sampler=self._sampler,
         )
 
+        # Center the intercept (constant-term) prior at log(alpha) by adding a
+        # constant offset to the DMR predictor, matching tomotopy's GDMRModel (and
+        # the paper's g-dmr): alpha_{d,t} = exp(lambda_t . x_d + log(alpha)). This
+        # sets the baseline Dirichlet concentration (alpha=0.1 => sparser theta) and
+        # shifts the intercept prior mean; the DMR prior on the fitted coefficients
+        # stays zero-mean, so the effective intercept is centered at log(alpha).
+        num_docs = scaled_features.shape[0]
+        offset = np.full((num_docs, self._num_topics), np.log(self._alpha),
+                         dtype=np.float64)
         self._dmr.fit(
             data,
             scaled_features,
@@ -466,6 +486,7 @@ class GDMR:
             keep_theta_draws=keep_theta_draws,
             convergence_tol=convergence_tol,
             check_every=check_every,
+            offset=offset,
         )
 
         # Recover true coefficients as lambda_j = dmr_lambda_j * c_j. c_0 == 1 by
@@ -482,12 +503,20 @@ class GDMR:
             raise RuntimeError("model is not fitted yet; call fit() first")
 
     def _get_true_feature_effects(self) -> np.ndarray:
-        """Return true lambda (num_topics, num_basis) after undoing column scaling."""
-        # DMR feature_effects has shape (num_topics, num_basis)
-        # where column 0 is the DMR-prepended intercept, columns 1.. are our
-        # non-intercept Legendre columns.
+        """Return true lambda (num_topics, num_basis) after undoing column scaling.
+
+        Column 0 is the constant term. The inner DMR fits it under a zero-mean
+        prior with a fixed ``log(alpha)`` offset applied to the predictor, so the
+        effective constant coefficient is ``dmr_lambda_0 + log(alpha)`` — that
+        offset is folded back in here, so ``feature_effects`` and ``tdf`` are on
+        tomotopy's ``log(alpha)``-centered scale. (A uniform shift of the constant
+        across topics leaves the normalized ``tdf`` unchanged; it matters for the
+        reported coefficients and the ``alpha`` baseline.)
+        """
         dmr_fe = self._dmr.feature_effects  # (num_topics, num_basis)
-        return dmr_fe * self._recover_scales[np.newaxis, :]
+        fe = dmr_fe * self._recover_scales[np.newaxis, :]
+        fe[:, 0] = fe[:, 0] + np.log(self._alpha)
+        return fe
 
     def _build_basis_for_eval(self, metadata: np.ndarray) -> np.ndarray:
         """Build Legendre basis for evaluation, shape (P, num_basis)."""
@@ -633,6 +662,7 @@ class GDMR:
             "sigma": self._sigma,
             "sigma0": self._sigma0,
             "decay": self._decay,
+            "alpha": self._alpha,
             "metadata_range": (
                 [list(t) for t in self._metadata_range]
                 if self._metadata_range is not None
@@ -926,6 +956,7 @@ class GDMR:
             "sigma": self._sigma,
             "sigma0": self._sigma0,
             "decay": self._decay,
+            "alpha": self._alpha,
             "metadata_range": self._metadata_range,
             "metadata_names": self._metadata_names,
             "lbfgs_iters": self._lbfgs_iters,
@@ -961,6 +992,7 @@ class GDMR:
             sigma=state["sigma"],
             sigma0=state["sigma0"],
             decay=state["decay"],
+            alpha=state.get("alpha", 1.0),
             metadata_range=state["metadata_range"],
             lbfgs_iters=state["lbfgs_iters"],
             sampler=state["sampler"],

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -3557,6 +3557,11 @@ impl DMR {
     /// heuristic on the log-likelihood trace, not a guarantee the Gibbs chain has
     /// mixed. `check_every` is how often, in sweeps, the log-likelihood is recorded
     /// and the `convergence_tol` test is applied.
+    /// `offset` is an optional fixed `(num_docs, num_topics)` term added inside the
+    /// exponent of the per-document prior, `α_{d,t} = exp(λ_t · x_d + offset[d,t])`.
+    /// A constant offset shifts the baseline Dirichlet concentration (e.g. GDMR
+    /// passes `log(alpha)` to center the intercept prior at `log(alpha)`); `None`
+    /// (default) leaves the prior unshifted.
     #[pyo3(signature = (data, features=None, *, feature_names=None, iters=1000,
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -3560,7 +3560,8 @@ impl DMR {
     #[pyo3(signature = (data, features=None, *, feature_names=None, iters=1000,
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize, covariates=None))]
+                        convergence_tol=0.0_f64, check_every=10_usize, covariates=None,
+                        offset=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -3578,6 +3579,7 @@ impl DMR {
         convergence_tol: f64,
         check_every: usize,
         covariates: Option<&Bound<'_, PyAny>>,
+        offset: Option<&Bound<'_, PyAny>>,
     ) -> PyResult<Py<Self>> {
         // covariates= is a no-deprecation alias for features=
         let features: &Bound<'_, PyAny> = match (features, covariates) {
@@ -3662,6 +3664,24 @@ impl DMR {
         let num_docs = corpus.num_docs();
         let total_tokens = corpus.total_tokens().max(1) as f64;
 
+        // Optional fixed per-(doc, topic) offset added inside the exponent:
+        // α_{d,t} = exp(λ_t·x_d + offset[d][t]). A constant offset shifts the
+        // baseline concentration (e.g. GDMR passes log(alpha) to center the
+        // intercept prior at log(alpha), matching tomotopy's GDMRModel).
+        let offset: Option<Vec<Vec<f64>>> = match offset {
+            None => None,
+            Some(o) => {
+                let raw = parse_features(o)?;
+                if raw.len() != num_docs || raw.iter().any(|r| r.len() != k) {
+                    return Err(PyValueError::new_err(format!(
+                        "offset must have shape (num_docs={num_docs}, num_topics={k})"
+                    )));
+                }
+                check_all_finite_2d("offset", &raw)?;
+                Some(raw)
+            }
+        };
+
         // λ starts at zero -> α ≡ 1 (symmetric) before optimization kicks in.
         let mut lambda = vec![vec![0.0f64; nf]; k];
         let mut model = TopicModel::new(k, k as f64, slf.beta, num_types);
@@ -3701,7 +3721,7 @@ impl DMR {
                 // λ, not at counts that drifted afterwards (#419).
                 let mut se_counts: Option<Vec<Vec<f64>>> = None;
                 for iter in 1..=iters {
-                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
                     cv.set_doc_alpha(doc_alpha);
                     cv.sweep();
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
@@ -3714,7 +3734,7 @@ impl DMR {
                             nf,
                             prior_variance,
                             lbfgs_iters,
-                            None,
+                            offset.as_deref(),
                         );
                         se_counts = if converged { Some(dtc) } else { None };
                     }
@@ -3724,7 +3744,15 @@ impl DMR {
                 cv.phi_into(&mut acc_phi);
                 cv.theta_into(&mut acc_theta);
                 let se = se_counts.as_ref().and_then(|dtc| {
-                    dmr::dmr_lambda_se_checked(&lambda, &feats, dtc, k, nf, prior_variance, None)
+                    dmr::dmr_lambda_se_checked(
+                        &lambda,
+                        &feats,
+                        dtc,
+                        k,
+                        nf,
+                        prior_variance,
+                        offset.as_deref(),
+                    )
                 });
                 let model = cv.to_topic_model(&corpus);
                 (
@@ -3752,7 +3780,7 @@ impl DMR {
                 let mut se_counts: Option<Vec<Vec<f64>>> = None;
 
                 for iter in 1..=iters {
-                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
                     ws.set_doc_alpha(doc_alpha);
                     ws.sweep(&corpus, &mut rng);
 
@@ -3766,13 +3794,14 @@ impl DMR {
                             nf,
                             prior_variance,
                             lbfgs_iters,
-                            None,
+                            offset.as_deref(),
                         );
                         se_counts = if converged { Some(dtc) } else { None };
                     }
 
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
-                        let doc_alpha_snap = dmr::compute_doc_alpha(&lambda, &feats, None);
+                        let doc_alpha_snap =
+                            dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
                         let snap: Vec<Vec<f32>> = ws
                             .doc_topics()
                             .iter()
@@ -3802,7 +3831,7 @@ impl DMR {
                                 k,
                                 nf,
                                 prior_variance,
-                                None,
+                                offset.as_deref(),
                             );
                             let llpt = ll / total_tokens;
                             Python::with_gil(|py| {
@@ -3813,7 +3842,7 @@ impl DMR {
                 }
 
                 // Sampling phase: λ (and thus α per doc) fixed.
-                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
                 ws.set_doc_alpha(doc_alpha.clone());
                 let mut acc_phi = vec![vec![0.0f64; k]; num_types];
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
@@ -3843,7 +3872,15 @@ impl DMR {
                     }
                 }
                 let se = se_counts.as_ref().and_then(|dtc| {
-                    dmr::dmr_lambda_se_checked(&lambda, &feats, dtc, k, nf, prior_variance, None)
+                    dmr::dmr_lambda_se_checked(
+                        &lambda,
+                        &feats,
+                        dtc,
+                        k,
+                        nf,
+                        prior_variance,
+                        offset.as_deref(),
+                    )
                 });
                 let model = ws.to_topic_model();
                 (
@@ -3869,7 +3906,7 @@ impl DMR {
                 let mut se_counts: Option<Vec<Vec<f64>>> = None;
 
                 'outer: for iter in 1..=iters {
-                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
                     dmr::run_sweep_dmr(
                         &mut model.type_topic_counts,
                         &mut model.tokens_per_topic,
@@ -3894,14 +3931,15 @@ impl DMR {
                             nf,
                             prior_variance,
                             lbfgs_iters,
-                            None,
+                            offset.as_deref(),
                         );
                         se_counts = if converged { Some(dtc) } else { None };
                     }
 
                     // Snapshot θ = (n_dk + α_dk) / (N_d + Σα_d) every thin sweeps.
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
-                        let doc_alpha_snap = dmr::compute_doc_alpha(&lambda, &feats, None);
+                        let doc_alpha_snap =
+                            dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
                         let snap: Vec<Vec<f32>> = model
                             .doc_topics
                             .iter()
@@ -3931,7 +3969,7 @@ impl DMR {
                                 k,
                                 nf,
                                 prior_variance,
-                                None,
+                                offset.as_deref(),
                             );
                             let llpt = ll / total_tokens;
                             Python::with_gil(|py| {
@@ -3956,7 +3994,7 @@ impl DMR {
                 }
 
                 // Sampling phase: λ is now fixed, so α per doc is fixed too.
-                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, None);
+                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
                 let mut acc_phi = vec![vec![0.0f64; k]; num_types];
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
 
@@ -4001,7 +4039,15 @@ impl DMR {
                 }
 
                 let se = se_counts.as_ref().and_then(|dtc| {
-                    dmr::dmr_lambda_se_checked(&lambda, &feats, dtc, k, nf, prior_variance, None)
+                    dmr::dmr_lambda_se_checked(
+                        &lambda,
+                        &feats,
+                        dtc,
+                        k,
+                        nf,
+                        prior_variance,
+                        offset.as_deref(),
+                    )
                 });
                 (
                     acc_phi,

--- a/tests/test_gdmr.py
+++ b/tests/test_gdmr.py
@@ -901,3 +901,49 @@ class TestGdmrTomotopyPrior:
         shutil.move(str(d1 / "g.gdmr._inner_dmr"), str(d2 / "g.gdmr._inner_dmr"))
         loaded = topica.GDMR.load(str(d2 / "g.gdmr"))  # must find the moved sidecar
         npt.assert_allclose(loaded.feature_effects, m.feature_effects)
+
+    def test_alpha_is_exposed_and_defaults_to_tomotopy_default(self):
+        assert topica.GDMR(num_topics=2, degrees=[2]).settings["alpha"] == 0.1
+
+    def test_bad_alpha_rejected(self):
+        for bad in (0.0, -1.0, float("inf"), float("nan")):
+            with pytest.raises(ValueError):
+                topica.GDMR(num_topics=2, degrees=[2], alpha=bad)
+
+    def test_smaller_alpha_gives_sparser_doc_topic(self):
+        # alpha is the baseline Dirichlet concentration (log(alpha) offset): a
+        # smaller alpha concentrates each document on fewer topics (#426 #3).
+        rng = np.random.default_rng(0)
+        docs = [[f"w{int(rng.integers(9))}" for _ in range(10)] for _ in range(90)]
+        meta = np.linspace(0.0, 1.0, 90)[:, None]
+
+        def max_mass(alpha):
+            m = topica.GDMR(num_topics=3, degrees=[2], alpha=alpha, seed=1,
+                            burn_in=20)
+            m.fit(docs, meta, iters=80, num_samples=2, sample_interval=10)
+            return float(m.doc_topic.max(axis=1).mean())
+
+        assert max_mass(0.05) > max_mass(1.0)
+
+    def test_alpha_survives_save_load(self, tmp_path):
+        docs = [["w0", "w1", "w2"] for _ in range(30)]
+        meta = np.linspace(0.0, 1.0, 30)[:, None]
+        m = topica.GDMR(num_topics=2, degrees=[2], alpha=0.25, seed=1, burn_in=10)
+        m.fit(docs, meta, iters=30, num_samples=1, sample_interval=5)
+        p = str(tmp_path / "g.gdmr")
+        m.save(p)
+        loaded = topica.GDMR.load(p)
+        assert loaded.settings["alpha"] == 0.25
+        npt.assert_allclose(loaded.feature_effects, m.feature_effects)
+
+    def test_intercept_reflects_log_alpha(self):
+        # feature_effects/alpha are reported on tomotopy's log(alpha)-centered
+        # scale: the intercept baseline is exp(fe[:,0]) and reflects log(alpha).
+        docs = [["w0", "w1"] for _ in range(30)] + [["w2", "w3"] for _ in range(30)]
+        meta = np.concatenate([np.zeros(30), np.ones(30)])[:, None]
+        m = topica.GDMR(num_topics=2, degrees=[1], alpha=0.1, seed=1, burn_in=10)
+        m.fit(docs, meta, iters=40, num_samples=1, sample_interval=5)
+        # tdf is a valid simplex and unchanged by the uniform log(alpha) shift.
+        tdf = m.tdf(np.array([[0.5]]), normalize=True)
+        npt.assert_allclose(tdf.sum(), 1.0, atol=1e-9)
+        assert np.all(np.isfinite(m.feature_effects))


### PR DESCRIPTION
Completes **#426**. The prior faithfulness (sigma/sigma0 roles, per-dimension decay, clear bugs) landed in **#462**; this is the deferred **intercept-mean** piece — unblocked now that #459's DMR fit-path changes are on main.

## The gap
Both references (tomotopy `GDMRModel` and the paper's `bab2min/g-dmr`) center the constant term at `log(alpha)` with default `alpha=0.1`; topica's inner DMR used a zero-mean prior (implicit `alpha=1`). Column scaling maps *variances* only, so the wrapper alone couldn't fix a prior *mean* — the DMR predictor needs a constant offset.

## Change
- **`DMR.fit` gains an optional `offset`** — a fixed `(num_docs, num_topics)` term added inside the exponent, `α_{d,t} = exp(λ_t·x_d + offset[d,t])`. Threaded through the sparse/warp/cvb0 paths (sampling, optimization, **and** the SE), validated for shape/finiteness, documented in the stub. This exposes the offset the internal DMR already supported (keyATM/embedding DMR use it).
- **GDMR gains `alpha`** (default 0.1). It passes a constant `log(alpha)` offset, which:
  - **(a)** sets the baseline Dirichlet concentration — smaller `alpha` → sparser per-document topic mixtures (the substantive effect), and
  - **(b)** centers the intercept prior at `log(alpha)`.

  `feature_effects` / `alpha` / `tdf` fold `log(alpha)` back into the constant coefficient, so they're on tomotopy's `log(alpha)`-centered scale (a uniform shift across topics leaves the normalized `tdf` unchanged). `alpha=1` reproduces the previous zero-mean behavior; old saves load as `alpha=1`. Persisted in settings + save/load.

## Verified
- DMR offset makes θ sparser: `log(0.1)` offset raises mean per-doc max-topic mass **0.48 → 0.64**.
- GDMR: smaller `alpha` → sparser `doc_topic`; `alpha` exposed, validated (`≤0`/nan/inf rejected), round-trips through save/load; `tdf` stays a valid simplex.
- The tomotopy parity gold (decay=0.5) still matches at **tdf r = 0.92** with both sides now at `alpha=0.1`.

## Gates
`cargo fmt --all --check` ✓ · clippy (default + `--features python`) ✓ · `cargo test --lib` 197 ✓ · DMR/GDMR/stub/invariants pytests 384 passed / 3 skipped ✓ · `mkdocs build --strict` ✓

Closes #426.