### PR TITLE
fix(keyatm): restore alpha on a fully-rejected slice step + honest turbo_alpha_stride docs (#418)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -4354,11 +4354,14 @@ class KeyATM:
         turbo_alpha_stride (default 1, exact) is an opt-in approximate speedup
         for the base model's asymmetric-alpha slice sampler, the dominant
         non-sweep cost on large corpora. With a stride s > 1 the slice sampler
-        evaluates its Dirichlet-multinomial data term over every s-th document and
-        scales that sum up by s, an unbiased estimate of the full term that touches
-        ~1/s of the documents. It changes the estimated alpha (and therefore the
-        fit), so it is off by default; it applies to the base model only (it errors
-        with covariates or timestamps) and only when estimate_alpha is True."""
+        evaluates its Dirichlet-multinomial data term over every s-th document
+        (fixed stride in corpus order) and scales that sum up by s. This is not
+        unbiased: the slice sampler then targets the subsampled posterior rather
+        than the full-data one, and because the subset is deterministic the bias
+        also depends on document order. It changes the estimated alpha (and
+        therefore the fit), so it is off by default; use stride=1 for the exact
+        alpha. It applies to the base model only (it errors with covariates or
+        timestamps) and only when estimate_alpha is True."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -2011,6 +2011,7 @@ fn dyn_sample_alpha_state<R: Rng>(
         let slice_ =
             store_loglik - 2.0 * (1.0 - previous_p).ln() + rng.gen::<f64>().max(1e-300).ln();
 
+        let mut accepted = false;
         for _ in 0..MAX_SHRINK_TIME {
             let new_p = start + (end - start) * rng.gen::<f64>();
             alpha[k] = new_p / (1.0 - new_p); // expandp
@@ -2020,15 +2021,27 @@ fn dyn_sample_alpha_state<R: Rng>(
             let new_likelihood = new_loglik - 2.0 * (1.0 - new_p).ln();
 
             if slice_ < new_likelihood {
+                accepted = true;
                 break;
             } else if previous_p < new_p {
                 end = new_p;
             } else if new_p < previous_p {
                 start = new_p;
             } else {
-                alpha[k] = keep;
+                // The shrink interval has collapsed onto the current point; stop
+                // and restore below (falling through to the `!accepted` guard).
                 break;
             }
+        }
+        // A slice step that never lands inside the slice — every one of the
+        // MAX_SHRINK_TIME proposals rejected, or the interval collapsing onto the
+        // current point — must return the current value, not the last rejected
+        // proposal (#418). Only the accept branch keeps the drawn value; every
+        // other exit restores `keep`, preserving the slice-sampler invariant.
+        // (The RNG draw count is unchanged, so a fit that never hit fall-through
+        // stays bit-identical.)
+        if !accepted {
+            alpha[k] = keep;
         }
     }
 }
@@ -3195,5 +3208,47 @@ mod tests {
         let t_b = f(4, 9);
         assert_eq!(t_a.topic_word_all(), t_b.topic_word_all());
         assert_eq!(t_a.doc_topic(), t_b.doc_topic());
+    }
+
+    /// #418: a slice step that never accepts must return the current value, not
+    /// the last rejected proposal. `dyn_sample_alpha_state` backs both the base
+    /// (single-state) and dynamic keyATM α samplers, so this invariant protects
+    /// the default `estimate_alpha=true` path too. A non-finite likelihood (here a
+    /// NaN in `doc_len`) makes `slice_ < new_likelihood` false for every proposal,
+    /// forcing the shrink loop to exhaust `MAX_SHRINK_TIME` without accepting —
+    /// exactly the fall-through the fix guards. Every α entry must be restored to
+    /// its pre-call value; before the fix each was left at a rejected draw.
+    #[test]
+    fn dyn_alpha_slice_restores_current_value_when_no_proposal_is_accepted() {
+        let num_keyword_topics = 1; // topic count is taken from `alpha.len()` (3)
+                                    // Two documents; a NaN weighted length forces a NaN log-likelihood for
+                                    // every candidate α, so no proposal can land inside the slice.
+        let ndk: Vec<Vec<f64>> = vec![vec![2.0, 1.0, 3.0], vec![1.0, 4.0, 1.0]];
+        let doc_len = vec![f64::NAN, 6.0];
+        let min_v = shrinkp(1e-9);
+        let max_v = shrinkp(100.0);
+        let initial = vec![0.7f64, 1.3, 0.4];
+        let mut alpha = initial.clone();
+        let mut rng = ChaCha8Rng::seed_from_u64(12345);
+        dyn_sample_alpha_state(
+            &mut alpha,
+            num_keyword_topics,
+            0,
+            1,
+            &ndk,
+            &doc_len,
+            1.0,
+            1.0,
+            2.0,
+            1.0,
+            min_v,
+            max_v,
+            1,
+            &mut rng,
+        );
+        assert_eq!(
+            alpha, initial,
+            "a fully-rejected slice step must leave α at its current value, not a rejected proposal"
+        );
     }
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13282,10 +13282,13 @@ impl KeyATM {
     /// opt-in early stopping: the run stops once the relative change in the recorded
     /// model-fit log-likelihood between the last two trace points falls below it,
     /// setting `converged` (ignored by the CVB0 backend, which keeps no trace).
-    /// `turbo_alpha_stride` (default 1, exact) subsamples the base model's α
-    /// slice-sampler data term over every s-th document and scales it up by s, an
-    /// unbiased estimate that touches ~1/s of the documents; it changes the
-    /// estimated α (base model only, `estimate_alpha=True`).
+    /// `turbo_alpha_stride` (default 1, exact) is an approximate speed knob for
+    /// the base model's α slice-sampler: it evaluates the data term over every
+    /// s-th document (fixed stride in corpus order) and scales it up by s, cutting
+    /// the dominant lgamma cost to ~1/s. It is **not** unbiased — the slice sampler
+    /// then targets the subsampled posterior rather than the full-data one, and
+    /// because the stride subset is deterministic the bias also depends on document
+    /// order. Use `stride=1` for the exact α (base model only, `estimate_alpha=True`).
     #[pyo3(signature = (data, *, iters=1500, covariates=None, feature_names=None,
                         times=None, timestamps=None, num_states=5, weights="information-theory",
                         num_threads=None, optimize_interval=50, burn_in=200, prior_variance=1.0,


### PR DESCRIPTION
Addresses the two substantive items in #418 (keyATM correctness review).

## 1. Slice sampler leaves α at a rejected proposal on fall-through (correctness)

`dyn_sample_alpha_state`'s per-coordinate shrinkage loop only restored the current value in the exact-equality branch. If all `MAX_SHRINK_TIME` proposals are rejected and the loop falls through, `alpha[k]` was left at the **last rejected** proposal — a slice-sampler invariant violation (a fully-rejected step must return the current value).

This sampler backs **both** the dynamic model and the **base keyATM's single-state α sampler** (the base model treats the whole corpus as one state and reuses it), so the bug affects the default `estimate_alpha=true` path, not just the dynamic model.

**Fix:** track acceptance; only the accept branch keeps the drawn value, every other exit restores `keep`. The RNG draw count is unchanged, so any fit that never hit fall-through stays **bit-identical** — confirmed by the keyATM determinism/R-parity pytests (148 passed).

**Regression test:** a non-finite likelihood (NaN `doc_len`) forces every proposal to be rejected, exercising the fall-through; every α entry must be restored to its pre-call value (before the fix each was left at a rejected draw).

## 2. `turbo_alpha_stride` is not "unbiased" (docs)

Corrected the binding docstring and `.pyi`: the fixed-stride subsample makes the slice sampler target the *subsampled* posterior (not the full-data one), and the deterministic subset makes the bias depend on document order. `stride=1` remains exact.

## Out of scope (noted for #418 follow-up)
- Rust-API input-validation gaps (time_index contiguity, keyword-topic contiguity, duplicate keywords) — the Python layer already guards these.
- Covariate-SE-at-final-counts — the keyATM analogue of the DMR SE fix just landed in #459; a separate PR should apply the same `optimize_lambda` convergence-gated pattern.

Gates: `cargo fmt --check` · clippy (`--all-targets --all-features`) · `cargo test --lib keyatm` (14) · keyATM pytests (148 passed) · preflight all green.

Closes part of #418.

🤖 Generated with [Claude Code](https://claude.com/claude-code)