### PR TITLE
fix(nmf): reject NNDSVD above rank min(D,V) with a ValueError, not a panic (#448)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3912,7 +3912,9 @@ class NMF:
     ) -> None:
         """beta_loss is 'frobenius' or 'kullback-leibler' (alias 'kl'); init is
         'nndsvd' or 'random'; weighting is 'count' or 'tfidf'. seed affects only
-        init='random'."""
+        init='random'. The 'nndsvd' init is scikit-learn's NNDSVDa variant (exact
+        zeros filled with the data mean) and requires num_topics <=
+        min(num_documents, num_words); use 'random' above that rank."""
         ...
     def fit(
         self,

--- a/src/nmf.rs
+++ b/src/nmf.rs
@@ -520,6 +520,10 @@ pub(crate) fn randomized_svd_seeded(x: &SpMat, k: usize, seed: u64) -> (Mat, Vec
 /// NNDSVD initialization with the "a" zero-fill (Boutsidis & Gallopoulos). Builds
 /// `W (d x k)` and `H (k x v)` from the signed singular vectors, then fills exact
 /// zeros with `mean(X)`.
+/// NNDSVDa initialization. Precondition: `k <= min(x.rows, x.cols)`; above that
+/// the truncated SVD returns fewer than `k` triplets and the loops below index
+/// out of bounds. The `NMF` binding enforces this for `init="nndsvd"` (#448);
+/// direct Rust callers must respect it too.
 fn nndsvd_init(x: &SpMat, k: usize) -> (Mat, Mat) {
     let (d, v) = (x.rows, x.cols);
     let (u, s, vt) = randomized_svd(x, k);

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -12,7 +12,10 @@ use pyo3::types::PyDict;
 /// the squared Frobenius loss (default) and the generalized Kullback-Leibler
 /// divergence. The reference implementation is scikit-learn's
 /// ``sklearn.decomposition.NMF`` (BSD-3-Clause); we read it to match the
-/// initialization and update detail. The topic-word matrix is each row of ``H``
+/// initialization and the multiplicative-update formulas. The update order and
+/// the convergence-check cadence differ from sklearn (see the notes in
+/// ``nmf.rs``), so the guarantee is eventual close agreement of the fitted
+/// factors, not iteration-for-iteration parity. The topic-word matrix is each row of ``H``
 /// normalized to sum 1, and the document-topic matrix is each row of ``W``
 /// normalized to sum 1.
 #[pyclass(module = "topica")]
@@ -129,7 +132,10 @@ impl NMF {
     /// Create an unfitted model. `num_topics` is K (2 <= K <= vocabulary size).
     /// `beta_loss` is `"frobenius"` (default) or `"kullback-leibler"` (alias
     /// `"kl"`). `init` is `"nndsvd"` (default, deterministic SVD-based init) or
-    /// `"random"` (seeded by `seed`). `weighting` is `"count"` (default, raw term
+    /// `"random"` (seeded by `seed`). The `"nndsvd"` init fills exact-zero entries
+    /// of the SVD factors with the data mean (scikit-learn's NNDSVDa variant), so
+    /// the initial factors are dense; it requires `num_topics <= min(num_documents,
+    /// num_words)` (use `"random"` above that rank). `weighting` is `"count"` (default, raw term
     /// counts) or `"tfidf"`. `convergence_tol` stops early on the relative
     /// reconstruction-error decrease. `seed` affects only `init="random"`.
     #[new]
@@ -198,6 +204,25 @@ impl NMF {
             return Err(PyValueError::new_err(
                 "vocabulary must have at least num_topics words",
             ));
+        }
+        // NNDSVD-family init needs `num_topics` leading singular triplets, which
+        // only exist up to rank min(num_documents, num_words). Above that,
+        // `nndsvd_init` would index past the truncated SVD and panic. Reject it
+        // here with a clear error (matching sklearn, which raises ValueError for
+        // NNDSVD above min(n_samples, n_features)); `init="random"` has no such
+        // rank limit, so this guard is init-specific (#448).
+        if matches!(slf.init, nmf::Init::Nndsvd) {
+            let max_rank = corpus.num_docs().min(num_types);
+            if slf.num_topics > max_rank {
+                return Err(PyValueError::new_err(format!(
+                    "init=\"nndsvd\" requires num_topics <= min(num_documents, num_words) \
+                     = {max_rank} (got num_topics={} with {} documents and {} words). \
+                     Reduce num_topics, or use init=\"random\", which supports a larger rank.",
+                    slf.num_topics,
+                    corpus.num_docs(),
+                    num_types,
+                )));
+            }
         }
         let it = iters.unwrap_or(200);
         let (k, bl, ini, tfidf, seed) = (

--- a/tests/test_nmf.py
+++ b/tests/test_nmf.py
@@ -174,3 +174,35 @@ def test_iters_override():
     m.fit(docs, iters=5)
     assert m.iters_run == 5
     assert len(m.error_history) == 6  # initial error + one per iteration
+
+
+# --------------------------------------------------------------------------- #
+# #448: NNDSVD rank boundary must raise ValueError, never panic.
+# --------------------------------------------------------------------------- #
+
+def test_nndsvd_above_rank_raises_valueerror():
+    """K > min(num_docs, num_words) with NNDSVD must be a clean ValueError.
+
+    Repro from #448: 2 docs, vocab {a,b,c} (V=3), K=3 -> min(D,V)=2 < 3, which
+    previously reached an out-of-bounds access in nndsvd_init and panicked.
+    """
+    docs = [["a", "b"], ["a", "c"]]  # D=2, V=3 -> min=2
+    with pytest.raises(ValueError, match="min\\(num_documents, num_words\\)"):
+        topica.NMF(3).fit(docs)  # init defaults to nndsvd
+
+
+def test_random_init_allowed_above_nndsvd_rank():
+    """The rank guard is init-specific: random init has no such limit."""
+    docs = [["a", "b"], ["a", "c"]]  # min(D,V)=2
+    m = topica.NMF(3, init="random", seed=1)
+    m.fit(docs, iters=5)  # must not raise
+    assert m.topic_word.shape[0] == 3
+
+
+def test_nndsvd_at_exactly_the_rank_is_accepted():
+    """K == min(num_docs, num_words) is within range and must fit."""
+    # 3 docs, vocab {a,b,c} -> min(D,V)=3; K=3 is the boundary.
+    docs = [["a", "b", "c"], ["a", "a", "b"], ["b", "c", "c"]]
+    m = topica.NMF(3, init="nndsvd")
+    m.fit(docs, iters=5)  # must not raise/panic
+    assert m.topic_word.shape[0] == 3


### PR DESCRIPTION
Fixes the primary bug in #448 (NMF correctness review) and folds in the two doc-honesty items.

## The panic (primary)
`init="nndsvd"` needs `num_topics` leading singular triplets, which only exist up to rank `min(num_documents, num_words)`. Above that, `nndsvd_init` indexes past the truncated SVD and panics. The existing guard only checked `num_topics <= num_words`, missing the document dimension.

Repro (from the issue):
```python
topica.NMF(3).fit([["a", "b"], ["a", "c"]])   # D=2, V=3, min=2 < 3  -> PanicException
```

**Fix:** an init-specific guard in the binding — for `init="nndsvd"`, require `num_topics <= min(num_documents, num_words)` and return a clear `ValueError` (matching scikit-learn, which raises `ValueError` for NNDSVD above that rank). `init="random"` has no such rank limit, so the guard is init-specific. The precondition is also documented on `nndsvd_init` for direct Rust callers.

## Doc honesty (issue items 2 & 3)
- `init="nndsvd"` is scikit-learn's **NNDSVDa** variant (exact zeros filled with the data mean → dense initial factors). Now disclosed in the constructor docstring and `.pyi`.
- Narrowed the module-level sklearn-parity claim: the update order and convergence cadence differ (documented in `nmf.rs`), so the guarantee is eventual close agreement of the factors, not iteration-for-iteration parity.

## Tests
- `NMF(3).fit(2-doc corpus)` → `ValueError` (the repro).
- `init="random"` fits at the same rank.
- `num_topics == min(D,V)` (the boundary) is accepted.

## Deferred (maintainer decision, noted in #448)
- Whether to rename the option to `nndsvda` and expose a true zero-preserving `nndsvd` (a breaking API decision).
- Expanding the parity-fixture coverage beyond Frobenius/NNDSVDa.

Gates: fmt · clippy `--all-targets --all-features` · `cargo test --lib nmf` (6) · `tests/test_nmf.py` (17) · all green.

Closes part of #448.

🤖 Generated with [Claude Code](https://claude.com/claude-code)