### PR TITLE
fix(pltm): match transform dict input by language name, not insertion order (#450)

### DIFF
--- a/src/python/pltm.rs
+++ b/src/python/pltm.rs
@@ -303,7 +303,10 @@ impl PolylingualLDA {
 
     /// Infer tuple-topic distributions θ (num_tuples, num_topics) for new aligned
     /// tuples, holding the fitted per-language φ fixed. `data` has the same shape
-    /// as `fit`; out-of-vocabulary tokens are dropped per language.
+    /// as `fit`; out-of-vocabulary tokens are dropped per language. A dict is
+    /// matched to the fitted languages **by name** (insertion order does not
+    /// matter), and its keys must be exactly the fitted language names — a missing
+    /// or unknown name raises `ValueError`. A bare list is matched positionally.
     #[pyo3(signature = (data, *, sweeps=100))]
     fn transform<'py>(
         &self,
@@ -320,6 +323,36 @@ impl PolylingualLDA {
                 self.languages.len()
             )));
         }
+        // For dict input the key IS the language identity, so map each tuple slot
+        // by fitted language name, not by insertion order — otherwise a dict given
+        // in a different order than `fit` would silently score each language
+        // against another language's vocabulary (#450). A bare list has no names
+        // (auto-labeled `lang_0..`), so it stays positional, as documented.
+        let (names, str_docs) = if data.downcast::<PyDict>().is_ok() {
+            for n in &names {
+                if !self.languages.contains(n) {
+                    return Err(PyValueError::new_err(format!(
+                        "transform got unknown language {n:?}; the model was fit on {:?}",
+                        self.languages
+                    )));
+                }
+            }
+            let mut ordered_names = Vec::with_capacity(self.languages.len());
+            let mut ordered_docs = Vec::with_capacity(self.languages.len());
+            for fitted in &self.languages {
+                let idx = names.iter().position(|x| x == fitted).ok_or_else(|| {
+                    PyValueError::new_err(format!(
+                        "transform is missing language {fitted:?}; the model was fit on {:?}",
+                        self.languages
+                    ))
+                })?;
+                ordered_names.push(names[idx].clone());
+                ordered_docs.push(str_docs[idx].clone());
+            }
+            (ordered_names, ordered_docs)
+        } else {
+            (names, str_docs)
+        };
         // Map each language's new documents onto its training vocabulary.
         let mut mapped: Vec<Vec<Vec<u32>>> = Vec::with_capacity(self.languages.len());
         for (li, docs) in str_docs.iter().enumerate() {

--- a/tests/test_pltm.py
+++ b/tests/test_pltm.py
@@ -141,3 +141,43 @@ def test_unknown_lang_raises():
     m, _ = _fit()
     with pytest.raises(ValueError):
         m.topic_word(lang="es")
+
+
+# --------------------------------------------------------------------------- #
+# #450: dict transform must map by language NAME, not insertion order.
+# --------------------------------------------------------------------------- #
+
+def _disjoint():
+    """Two languages with completely disjoint vocabularies, so mapping one
+    against the other's vocab drops every token (the #450 mismap symptom)."""
+    en = [["e0", "e0", "e1"], ["e2", "e2", "e3"]] * 20
+    fr = [["f0", "f0", "f1"], ["f2", "f2", "f3"]] * 20
+    return en, fr
+
+
+def test_transform_dict_matched_by_name_not_insertion_order():
+    en, fr = _disjoint()
+    m = topica.PolylingualLDA(2, iters=100, seed=1)
+    m.fit({"en": en, "fr": fr})
+    correct = m.transform({"en": en, "fr": fr})
+    reversed_order = m.transform({"fr": fr, "en": en})
+    # Matched by name -> insertion order must not change the result. Pre-#450 the
+    # reversed dict scored each language against the other's vocab (near-uniform).
+    assert np.allclose(correct, reversed_order), np.abs(correct - reversed_order).max()
+
+
+def test_transform_unknown_language_raises():
+    en, fr = _disjoint()
+    m = topica.PolylingualLDA(2, iters=100, seed=1)
+    m.fit({"en": en, "fr": fr})
+    # Same count (2), but "de" is not a fitted language.
+    with pytest.raises(ValueError, match="unknown language"):
+        m.transform({"en": en, "de": fr})
+
+
+def test_transform_list_input_stays_positional():
+    en, fr = _disjoint()
+    m = topica.PolylingualLDA(2, iters=100, seed=1)
+    m.fit([en, fr])  # auto-named lang_0, lang_1 -> positional
+    theta = m.transform([en, fr])
+    assert theta.shape == (40, 2)


### PR DESCRIPTION
Fixes #450 — a silent-wrong-output bug in `PolylingualLDA.transform`.

## The bug
`transform` extracted the language names from a dict but then mapped each tuple slot against the fitted per-language vocabulary **positionally** (`str_docs[li]` → `self.corpora[li]`), ignoring the names. A dict given in a different order than `fit()` silently scored each language against **another** language's vocabulary — dropping (nearly) every token as out-of-vocabulary and returning near-uniform θ, with **no error**.

Repro (from the issue):
```python
m = topica.PolylingualLDA(2, iters=100, seed=1).fit({"en": en, "fr": fr})
m.transform({"en": en, "fr": fr})   # correct
m.transform({"fr": fr, "en": en})   # silently different (near-uniform)
```

## Fix
For **dict** input, reorder the per-language documents to the fitted language order **by name**, and reject a key that is not a fitted language (a missing one is caught by the reorder → `ValueError`). A bare **list** has no names (auto-labeled `lang_0..`), so it stays positional, as documented. Updated the `transform` docstring.

## Tests
- Reversed-order dict now yields the **same** θ as the fitted order (disjoint vocabularies make the pre-fix mismap near-uniform, so this fails pre-fix).
- An unknown language name raises `ValueError`.
- List input remains positional.

Gates: fmt · clippy `--all-targets --all-features` · `cargo test --lib pltm` (3) · `tests/test_pltm.py` (16) · all green.

Closes #450.

🤖 Generated with [Claude Code](https://claude.com/claude-code)