### PR TITLE
fix(lbfgs): reject non-finite line-search trials (#419)

### DIFF
--- a/src/sage.rs
+++ b/src/sage.rs
@@ -396,21 +396,41 @@ pub fn optimize_kappa(model: &mut SageModel, max_iter: usize) -> bool {
             } else {
                 reweight_precision(&x, prior, prior_variance, &mut w);
             }
-            let mut ok = true;
+            // A non-finite precision (e.g. a subnormal `prior_variance` whose inverse
+            // overflows) makes the penalized objective ill-posed. Since L-BFGS now
+            // keeps the last finite point rather than propagating a NaN, detect the
+            // degeneracy here and roll back (#419 / #422); a mid-loop non-finite
+            // reweight is still caught by the next solve's finiteness check.
+            let mut ok = w.iter().all(|v| v.is_finite());
             for _ in 0..SPARSE_OUTER_ITERS {
+                if !ok {
+                    break;
+                }
                 x = solve(x, &w);
                 if x.iter().any(|v| !v.is_finite()) {
                     ok = false;
                     break;
                 }
                 reweight_precision(&x, prior, prior_variance, &mut w);
+                // A non-finite reweighted precision means the next solve is degenerate
+                // (e.g. a subnormal `prior_variance` whose inverse overflows). L-BFGS
+                // now keeps the last finite point instead of returning NaN, so detect
+                // it here and roll back rather than accept a spuriously "finite" κ.
+                if w.iter().any(|v| !v.is_finite()) {
+                    ok = false;
+                    break;
+                }
             }
             (x, ok)
         } else {
             reweight_precision(&x, prior, prior_variance, &mut w); // uniform 1/σ²
-            x = solve(x, &w);
-            let ok = x.iter().all(|v| v.is_finite());
-            (x, ok)
+            if w.iter().any(|v| !v.is_finite()) {
+                (x, false) // degenerate precision -> leave κ unchanged
+            } else {
+                x = solve(x, &w);
+                let ok = x.iter().all(|v| v.is_finite());
+                (x, ok)
+            }
         }
     };
 

--- a/topica-core/src/variational/lbfgs.rs
+++ b/topica-core/src/variational/lbfgs.rs
@@ -90,6 +90,7 @@ where
         // always runs the body at least once, so no initial value is needed.
         let mut fx_new: f64;
         let mut g_new: Vec<f64>;
+        let accepted: bool;
         loop {
             for j in 0..n {
                 x_new[j] = x[j] + step * d[j];
@@ -97,10 +98,26 @@ where
             let r = f(&x_new);
             fx_new = r.0;
             g_new = r.1;
-            if fx_new <= fx + 1e-4 * step * dg || step < 1e-12 {
+            // A non-finite trial never satisfies Armijo (NaN comparisons are false),
+            // so the shrink loop would otherwise fall through and lock it in.
+            if fx_new.is_finite() && fx_new <= fx + 1e-4 * step * dg {
+                accepted = true;
+                break;
+            }
+            if step < 1e-12 {
+                // Give up shrinking. Accept the exhausted step only if it is at least
+                // finite (a negligible move that preserves the prior behaviour);
+                // reject a non-finite trial outright (#419).
+                accepted = fx_new.is_finite();
                 break;
             }
             step *= 0.5;
+        }
+        if !accepted {
+            // No finite decrease found: stop rather than corrupting x/g with a
+            // non-finite trial. `converged` stays false, so a caller that gates
+            // standard errors on convergence correctly withholds them.
+            break;
         }
 
         // Curvature update (skip if it would break positive-definiteness).
@@ -128,4 +145,43 @@ where
         }
     }
     (x, converged)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Regression: finite problems still converge exactly as before.
+    #[test]
+    fn minimizes_a_quadratic() {
+        // f(x) = (x0-3)^2 + (x1+2)^2, min at (3, -2).
+        let f = |x: &[f64]| -> (f64, Vec<f64>) {
+            let (a, b) = (x[0] - 3.0, x[1] + 2.0);
+            (a * a + b * b, vec![2.0 * a, 2.0 * b])
+        };
+        let (x, converged) = lbfgs_minimize_status(vec![0.0, 0.0], f, 100, 7, 1e-10);
+        assert!(converged);
+        assert!(
+            (x[0] - 3.0).abs() < 1e-4 && (x[1] + 2.0).abs() < 1e-4,
+            "{x:?}"
+        );
+    }
+
+    // #419: a line search whose every trial is non-finite must not lock the
+    // non-finite point into x. f(x0) = x0 for x0 >= 0 (the gradient pushes x0
+    // negative), NaN for x0 < 0, so every trial step lands in the NaN region.
+    #[test]
+    fn rejects_a_nonfinite_trial_and_keeps_the_last_finite_point() {
+        let f = |x: &[f64]| -> (f64, Vec<f64>) {
+            if x[0] >= 0.0 {
+                (x[0], vec![1.0])
+            } else {
+                (f64::NAN, vec![f64::NAN])
+            }
+        };
+        let (x, converged) = lbfgs_minimize_status(vec![0.0], f, 50, 7, 1e-6);
+        assert!(x.iter().all(|v| v.is_finite()), "x must stay finite: {x:?}");
+        assert!(!converged, "a failed line search is not convergence");
+        assert_eq!(x, vec![0.0], "must keep the last finite point");
+    }
 }


### PR DESCRIPTION
The last deferred #419 item (findings #1/#2 shipped in #459/#434; this is finding #3's L-BFGS half). The backtracking line search accepted a trial once `step < 1e-12` even when the trial objective was **non-finite** — a NaN/inf never satisfies Armijo (NaN comparisons are false), so the loop shrank to the floor and then locked the non-finite point into `x`/`g`, corrupting the fit and any observed-information SE built from it.

## Fix
Reject a non-finite trial outright: accept the exhausted step only if it is at least **finite** (a negligible move that preserves prior behaviour for every finite problem); otherwise stop and keep the last finite point with `converged = false`. Every finite optimization is byte-unchanged — only the non-finite path differs. Applies to all L-BFGS callers (DMR, keyATM, STM/CTM, GDMR, SAGE).

## SAGE interaction (kept its contract)
Because L-BFGS now keeps a finite point instead of surfacing NaN, SAGE's `optimize_kappa` no longer detects a degenerate prior via its *result*-finiteness check. It now detects it at the source — a non-finite reweighted precision (a subnormal `prior_variance` whose inverse overflows) — and rolls back, preserving the same "leave κ/β unchanged, warn once, do not converge" behaviour (the `test_extreme_prior_variance_warns_and_stays_finite` contract).

## Tests
- `minimizes_a_quadratic` (regression: finite problems converge as before).
- `rejects_a_nonfinite_trial_and_keeps_the_last_finite_point` — on a function whose every trial step is non-finite, L-BFGS returns the last finite point with `converged=false`. **Fails on the old code**, which returns a non-finite `x`.

## Gates
`cargo fmt --all --check` ✓ · clippy (workspace, all-targets, all-features) ✓ · `cargo test --lib --workspace` 204 + 37 ✓ · L-BFGS-caller pytest sweep (DMR/keyATM/STM/CTM/GDMR/SAGE) 1988 passed / 29 skipped ✓

Closes #419.