### PR TITLE
fix(keyatm): compute covariate λ SE at the optimum, not drifted counts (#418)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -4404,12 +4404,15 @@ class KeyATM:
         the intercept. Raises if fit without covariates."""
         ...
     @property
-    def feature_effect_se(self) -> numpy.typing.NDArray[numpy.float64]:
+    def feature_effect_se(self) -> numpy.typing.NDArray[numpy.float64] | None:
         """Covariate model: standard errors of feature_effects (lambda), same
         shape and column order, on the original covariate scale (observed
         information in the standardized fit space mapped back by the
         standardization Jacobian, issue #316). NaN where the standardized lambda
-        hit the +/-5 bound. Raises if fit without covariates."""
+        hit the +/-5 bound. None when lambda was never optimized to a stationary
+        point (optimize_interval past iters, burn_in>=iters, lbfgs_iters=0, or
+        non-convergence), since the observed information is only a valid covariance
+        at an optimum (#418). Raises if fit without covariates."""
         ...
     @property
     def feature_names(self) -> list[str]:

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -212,8 +212,10 @@ pub struct KeyAtmModel {
     /// information of the penalized Dirichlet-multinomial in the standardized fit
     /// space mapped back by the standardization Jacobian (issue #316). Entries
     /// whose standardized `λ` sat at the ±[`LAMBDA_BOUND`] clamp are `NaN` (the
-    /// unconstrained asymptotic SE is invalid at the bound). `None` for the base
-    /// and dynamic models. A fit-time artifact, not persisted across save/load.
+    /// unconstrained asymptotic SE is invalid at the bound). `None` for the base and
+    /// dynamic models, and for a covariate fit where `λ` was never optimized to a
+    /// stationary point (`opt_interval=0`, `burn_in>=iters`, `lbfgs_iters=0`, or
+    /// non-convergence). A fit-time artifact, not persisted across save/load.
     #[serde(default)]
     pub lambda_se: Option<Vec<Vec<f64>>>,
 }
@@ -1778,6 +1780,12 @@ pub fn fit_keyatm_cov<R: Rng>(
     }
     let mut nkw_t = build_nkw_t(&model.nkw, num_types, num_topics);
 
+    // Counts from the last *converged* λ optimization; the SE is computed from
+    // exactly these so it is the observed information at the optimum for the
+    // returned λ, not at counts that drifted through the later sampling sweeps
+    // (#418, the same cross-model issue fixed for DMR in #419).
+    let mut se_counts: Option<Vec<Vec<f64>>> = None;
+
     for it in 0..iters {
         run_sweep(
             &mut model,
@@ -1790,9 +1798,7 @@ pub fn fit_keyatm_cov<R: Rng>(
             rng,
         );
         if opt_interval > 0 && it + 1 > burn_in && (it + 1 - burn_in).is_multiple_of(opt_interval) {
-            // keyATM-cov shares DMR's "periodic optimize, SE from final counts"
-            // pattern; wiring this convergence flag into its λ-SE guard is #418.
-            let _converged = crate::dmr::optimize_lambda(
+            let converged = crate::dmr::optimize_lambda(
                 &mut lambda,
                 &features_std,
                 &model.ndk,
@@ -1802,6 +1808,13 @@ pub fn fit_keyatm_cov<R: Rng>(
                 lbfgs_iters,
                 offset,
             );
+            // Snapshot the counts this optimization ran against (before the next
+            // sweep mutates them); only a converged run yields a valid SE optimum.
+            se_counts = if converged {
+                Some(model.ndk.clone())
+            } else {
+                None
+            };
             // Bound λ to ±LAMBDA_BOUND in the standardized space (R keyATM's
             // slice bounds), so a runaway coefficient cannot blow up α (#270).
             for lk in lambda.iter_mut() {
@@ -1828,21 +1841,26 @@ pub fn fit_keyatm_cov<R: Rng>(
         }
     }
 
-    // Standard errors of λ (issue #316): computed in the standardized fit space
-    // at the final counts, then mapped to the original scale by the same
-    // standardization Jacobian used for λ below. Done before the λ mapback so the
-    // bound check sees the standardized coefficients that were actually clamped.
-    let lambda_se = covariate_lambda_se(
-        &lambda,
-        &features_std,
-        &model.ndk,
-        num_topics,
-        num_features,
-        prior_variance,
-        &feat_mean,
-        &feat_sd,
-        offset,
-    );
+    // Standard errors of λ (issue #316): computed in the standardized fit space at
+    // the counts of the last converged optimization (#418), then mapped to the
+    // original scale by the same standardization Jacobian used for λ below. Done
+    // before the λ mapback so the bound check sees the standardized coefficients
+    // that were actually clamped. `None` when λ was never optimized to a stationary
+    // point (opt_interval=0, burn_in>=iters, lbfgs_iters=0, or non-convergence),
+    // since the observed information is only a valid covariance at an optimum.
+    let lambda_se = se_counts.as_ref().map(|ndk| {
+        covariate_lambda_se(
+            &lambda,
+            &features_std,
+            ndk,
+            num_topics,
+            num_features,
+            prior_variance,
+            &feat_mean,
+            &feat_sd,
+            offset,
+        )
+    });
 
     // Map λ from the standardized space back to the original covariate scale, so
     // that exp(features · λ_orig) == exp(features_std · λ_std): for f ≥ 1,
@@ -1864,7 +1882,7 @@ pub fn fit_keyatm_cov<R: Rng>(
     model.lambda = Some(lambda_orig);
     model.features = Some(features.to_vec());
     model.prior_offset = offset.map(|o| o.to_vec());
-    model.lambda_se = Some(lambda_se);
+    model.lambda_se = lambda_se;
     model.theta_draws = theta_draw_buf;
     model
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13741,14 +13741,24 @@ impl KeyATM {
     /// (issue #316). A coefficient is notable when ``|feature_effects| /
     /// feature_effect_se`` exceeds ~2. Entries are ``NaN`` where the standardized
     /// λ hit the ±5 bound (the constrained estimate has no valid asymptotic SE).
-    /// Raises if the model was fit without covariates.
+    /// ``None`` when λ was never optimized to a stationary point (#418). Raises if
+    /// the model was fit without covariates.
     #[getter]
-    fn feature_effect_se<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
+    fn feature_effect_se<'py>(
+        &self,
+        py: Python<'py>,
+    ) -> PyResult<Option<Bound<'py, PyArray2<f64>>>> {
         self.require_fitted()?;
-        self.feature_effect_se
+        // A covariate model always has `feature_effects`; if it lacks the SE, λ was
+        // never optimized to a stationary point (#418) -> None. A model fit without
+        // covariates has neither -> raise.
+        if self.feature_effects.is_none() {
+            return Err(PyRuntimeError::new_err("model was fit without covariates"));
+        }
+        Ok(self
+            .feature_effect_se
             .as_ref()
-            .map(|e| e.to_pyarray_bound(py))
-            .ok_or_else(|| PyRuntimeError::new_err("model was fit without covariates"))
+            .map(|e| e.to_pyarray_bound(py)))
     }
 
     /// Covariate model: names aligned with `feature_effects` columns

--- a/tests/test_keyatm_covariate.py
+++ b/tests/test_keyatm_covariate.py
@@ -178,3 +178,37 @@ def test_covariate_collapse_regression_at_scale():
     m.fit(docs, covariates=X, iters=500)
     eff = _effective_topics(m.doc_topic)
     assert eff > k * 0.4, f"covariate theta collapsed at scale: eff#topics={eff:.1f}/{k}"
+
+
+# --- #418: covariate SE at the optimum, not drifted counts -------------------
+def test_feature_effect_se_is_invariant_to_trailing_sweeps():
+    # optimize_interval=100, burn_in=100 -> the last lambda optimization is at
+    # iter 200 for both runs; the second just does 30 more (non-optimizing) sweeps
+    # that drift the counts. lambda and its SE, taken from the iter-200 counts, must
+    # match. Pre-#418 the SE was read from the drifted final counts and would not.
+    docs, party = _corpus(seed=1)
+    cov = party.reshape(-1, 1)
+
+    def fit(iters):
+        m = topica.KeyATM(SEEDS, num_topics=2, seed=1)
+        m.fit(docs, covariates=cov, feature_names=["is_D"], iters=iters,
+              optimize_interval=100, burn_in=100)
+        return m
+
+    a, b = fit(200), fit(230)
+    assert a.feature_effect_se is not None and b.feature_effect_se is not None
+    np.testing.assert_allclose(a.feature_effect_se, b.feature_effect_se, atol=1e-10)
+    np.testing.assert_allclose(a.feature_effects, b.feature_effects, atol=1e-10)
+    # Witness that the invariance is non-trivial: the extra sweeps genuinely drift
+    # the state, so the old code (SE from final counts) would have differed.
+    assert not np.allclose(a.doc_topic, b.doc_topic)
+
+
+def test_feature_effect_se_is_none_without_optimization():
+    # No optimize step ever runs (optimize_interval past iters), so an observed-
+    # information SE would be meaningless: it must be None, not fabricated.
+    docs, party = _corpus(seed=2)
+    m = topica.KeyATM(SEEDS, num_topics=2, seed=1)
+    m.fit(docs, covariates=party.reshape(-1, 1), feature_names=["is_D"],
+          iters=150, optimize_interval=10000, burn_in=50)
+    assert m.feature_effect_se is None


### PR DESCRIPTION
keyATM review follow-up. The slice-sampler rejected-proposal bug and the `turbo_alpha_stride` overclaim shipped in **#464**; this is the remaining substantive item — the covariate-model λ standard errors, the **same cross-model issue** fixed for DMR in #419 (#459).

## The bug
The covariate fit optimizes λ by L-BFGS only on scheduled sweeps, but the SE (inverse observed information) was computed at the end from the **final** counts. After the last optimization, more sampling sweeps run and drift `ndk`, so the Hessian was evaluated at counts that no longer match the returned λ — not `J⁻¹` at the optimum.

## Fix
- Retain the `ndk` snapshot from the last **converged** optimization (`optimize_lambda` already returns its convergence flag since #459) and compute `covariate_lambda_se` against exactly those counts.
- `lambda_se` is now `None` when λ was never optimized to a stationary point (`optimize_interval` past `iters`, `burn_in>=iters`, `lbfgs_iters=0`, or non-convergence) instead of a covariance evaluated away from the optimum. The Python `feature_effect_se` getter returns `None` in that case for a covariate model, and still raises for a base/dynamic (no-covariate) model.

## Verified
- SE (and λ) are invariant to trailing non-optimize sweeps (`iters=200` vs `230`, same optimize schedule), with a witness that the extra sweeps genuinely drift the state — **proven to fail on the pre-fix final-counts SE** (spliced + rebuilt).
- No optimization step → `feature_effect_se=None`.

## Not included (noted follow-up)
The review's Rust-API input-validation gaps (gapped `time_index`, duplicate keywords, interspersed keyword/regular topics, nonpositive hyperparameters) are "public Rust API only; the Python wrapper already guarantees these." Left for a separate hardening pass to keep this PR focused on the SE correctness item.

## Gates
`cargo fmt --all --check` ✓ · clippy (`--features python`) ✓ · `cargo test --lib` keyatm 14 ✓ · keyATM + stub pytests 229 passed / 1 skipped ✓