### PR TITLE
fix(tlda): make TensorLDA parity portable and gate topic recovery (#451)

### DIFF
--- a/docs/replications/tlda.md
+++ b/docs/replications/tlda.md
@@ -79,6 +79,24 @@ is init-sensitive, both implementations recover the same topics — including th
 same partial recoveries on hard corpora. `parity/tlda_compare.py` runs the
 comparison when the reference package is available.
 
+## Running the upstream comparison
+
+The reference ([TensorLy TLDA](https://github.com/tensorly/tlda)) is not on PyPI
+and is not a topica dependency, so the parity script locates it at run time and
+skips cleanly when it is absent. Obtain it once and point `TOPICA_TLDA_REF` at
+the checkout:
+
+```bash
+git clone https://github.com/tensorly/tlda /path/to/tlda
+export TOPICA_TLDA_REF=/path/to/tlda
+python parity/tlda_compare.py     # runs the square-rank comparison; exits 0 if the ref is absent
+```
+
+`parity/tlda_ref.py` centralizes this lookup. Because the script exits 0 when
+`TOPICA_TLDA_REF` is unset, it is safe to wire into CI or a scheduled integration
+job: the job is a no-op wherever the reference is not installed, and a real
+comparison wherever it is. No machine-specific path is baked into the repository.
+
 ## Current evidence
 
 ### Upstream comparison
@@ -99,8 +117,18 @@ is a small CPU benchmark, not a GPU comparison or a general performance claim.
 [`parity/tlda_true_lda_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/tlda_true_lda_compare.py)
 samples documents from an ordinary LDA generative process with known unequal
 Dirichlet topic weights, then reports aligned topic-word cosine, weight rank
-correlation, and document-topic recovery. It is intentionally a report rather
-than a pass/fail gate: current results establish a baseline for improvement.
+correlation, and document-topic recovery.
+
+The square-rank *topic-recovery* piece of that simulation is now an explicit,
+CI-runnable acceptance gate in
+[`tests/test_tlda_recovery.py`](https://github.com/nealcaren/topica/blob/main/tests/test_tlda_recovery.py):
+at `n_eigenvec = num_topics` it asserts a mean aligned topic-word cosine floor
+(0.50) and a per-topic floor (0.35), guarding against regression. Prevalence
+calibration is deliberately kept as a *separate, ungated* question — the test
+computes the planted-weight and document-topic diagnostics but does not assert on
+them, because the `weights` are not yet a validated prevalence estimator. The
+rectangular `n_eigenvec > num_topics` case is exercised as a Topica extension,
+not an upstream-parity claim.
 
 On its fixed simulation (2,500 documents, 100 tokens each, four topics), the
 current implementation obtains mean aligned topic-word cosine 0.529 at
@@ -126,10 +154,12 @@ for substantive covariate effects.
 
 Priorities before removing the experimental gate are:
 
-1. Improve and validate recovery on the known-truth LDA simulator across corpus
-   size, topic separation, and unequal prevalences.
-2. Make the upstream comparison portable and automated for its valid square-rank
-   configuration.
+1. Raise the known-truth topic-recovery acceptance floor (now enforced at square
+   rank in `tests/test_tlda_recovery.py`) across corpus size, topic separation,
+   and unequal prevalences.
+2. Broaden the now-portable upstream comparison (`parity/tlda_compare.py`,
+   located via `TOPICA_TLDA_REF`) beyond the small UCI example and wire it into a
+   scheduled integration job.
 3. Derive and validate a calibrated prevalence estimator, potentially separate
    from the tensor factorization's raw component norms.
 4. Add robustness results for overlapping vocabularies and covariate-structured

--- a/parity/tlda_compare.py
+++ b/parity/tlda_compare.py
@@ -1,17 +1,23 @@
-"""Parity comparison script for topica's TensorLDA vs the reference Python TLDA package.
+"""Parity comparison for topica's TensorLDA vs upstream TensorLy TLDA.
+
+The upstream reference (https://github.com/tensorly/tlda) is not a topica
+dependency. Point ``TOPICA_TLDA_REF`` at a checkout to run the comparison;
+without it the script reports that the reference is unavailable and exits 0, so
+it is safe to schedule as a CI / integration job. See ``parity/tlda_ref.py`` and
+``docs/replications/tlda.md`` for the one-time setup.
 """
 
+import os
 import sys
-sys.path.append("/Users/nealcaren/.gemini/antigravity/brain/d6ed7e63-64cd-4bfd-bf91-4edae64b50f4/scratch")
 
-import numpy as np
-import topica
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-try:
-    from tlda_wrapper import TLDA
-    HAS_REF = True
-except ImportError:
-    HAS_REF = False
+import numpy as np  # noqa: E402
+import topica  # noqa: E402
+from tlda_ref import load_reference_tlda  # noqa: E402
+
+TLDA = load_reference_tlda()
+HAS_REF = TLDA is not None
 
 def run_comparison():
     if not HAS_REF:
@@ -174,6 +180,12 @@ def run_streaming_comparison():
 
 
 if __name__ == "__main__":
+    if not HAS_REF:
+        print(
+            "Reference TensorLy TLDA not found. Set TOPICA_TLDA_REF to a checkout "
+            "of https://github.com/tensorly/tlda to run this comparison. Skipping."
+        )
+        sys.exit(0)
     run_comparison()
     print()
     run_streaming_comparison()

--- a/parity/tlda_ref.py
+++ b/parity/tlda_ref.py
@@ -36,15 +36,26 @@ def reference_dir() -> Optional[str]:
 def load_reference_tlda():
     """Return the upstream ``TLDA`` class, or ``None`` if the reference is absent.
 
-    The reference checkout is placed on ``sys.path`` only when
-    ``TOPICA_TLDA_REF`` points at a real directory. Several import shapes are
-    tried so a flat repo checkout, a packaged install, or a local convenience
-    wrapper all resolve.
+    The env-var-only contract is strict: with ``TOPICA_TLDA_REF`` unset we return
+    ``None`` immediately and never probe the ambient path, so a stray installed
+    ``tlda`` package or a leftover local ``tlda_wrapper.py`` cannot silently stand
+    in for the configured reference. When the var is set, the checkout is placed
+    on ``sys.path`` and several import shapes are tried (flat repo checkout,
+    packaged install, local wrapper) -- but a resolved module is accepted only if
+    it actually originates under the configured checkout, not from an ambient
+    install shadowing the same name.
+
+    If the var is set but nothing usable resolves (e.g. the reference's own deps
+    are broken), a warning is emitted to stderr so a misconfigured integration
+    job does not look like a clean skip.
     """
     ref = reference_dir()
-    if ref and ref not in sys.path:
+    if ref is None:
+        return None
+    if ref not in sys.path:
         sys.path.insert(0, ref)
 
+    ref_real = os.path.realpath(ref)
     for module, attr in (
         ("tlda_final", "TLDA"),   # flat tensorly/tlda checkout
         ("tlda", "TLDA"),         # packaged install
@@ -52,7 +63,16 @@ def load_reference_tlda():
     ):
         try:
             mod = __import__(module, fromlist=[attr])
-            return getattr(mod, attr)
+            cls = getattr(mod, attr)
         except (ImportError, AttributeError):
             continue
+        mod_file = getattr(mod, "__file__", None)
+        if mod_file and os.path.realpath(mod_file).startswith(ref_real + os.sep):
+            return cls
+
+    print(
+        f"[tlda_ref] TOPICA_TLDA_REF={ref!r} is set but no usable TLDA reference "
+        f"resolved under it (broken deps or unexpected layout); treating as absent.",
+        file=sys.stderr,
+    )
     return None

--- a/parity/tlda_ref.py
+++ b/parity/tlda_ref.py
@@ -1,0 +1,58 @@
+"""Portable locator for the upstream TensorLy TLDA reference implementation.
+
+topica's ``TensorLDA`` is validated against
+[TensorLy TLDA](https://github.com/tensorly/tlda), the reference NumPy
+implementation from Kangaslahti et al. (2026). That package is not on PyPI and
+is not a topica dependency, so the parity scripts locate it at run time and skip
+cleanly when it is absent.
+
+Obtaining the reference (one-time)::
+
+    git clone https://github.com/tensorly/tlda /path/to/tlda
+    export TOPICA_TLDA_REF=/path/to/tlda
+
+With ``TOPICA_TLDA_REF`` set, ``parity/tlda_compare.py`` runs the upstream
+comparison; without it (the CI default) the comparison reports that the
+reference is unavailable and exits 0. This module never mutates ``sys.path`` for
+a machine-specific hard-coded location -- the reference path is always taken from
+the environment.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Optional
+
+
+def reference_dir() -> Optional[str]:
+    """Return the reference checkout directory from ``TOPICA_TLDA_REF``, if set."""
+    path = os.environ.get("TOPICA_TLDA_REF")
+    if path and os.path.isdir(path):
+        return path
+    return None
+
+
+def load_reference_tlda():
+    """Return the upstream ``TLDA`` class, or ``None`` if the reference is absent.
+
+    The reference checkout is placed on ``sys.path`` only when
+    ``TOPICA_TLDA_REF`` points at a real directory. Several import shapes are
+    tried so a flat repo checkout, a packaged install, or a local convenience
+    wrapper all resolve.
+    """
+    ref = reference_dir()
+    if ref and ref not in sys.path:
+        sys.path.insert(0, ref)
+
+    for module, attr in (
+        ("tlda_final", "TLDA"),   # flat tensorly/tlda checkout
+        ("tlda", "TLDA"),         # packaged install
+        ("tlda_wrapper", "TLDA"),  # local convenience wrapper
+    ):
+        try:
+            mod = __import__(module, fromlist=[attr])
+            return getattr(mod, attr)
+        except (ImportError, AttributeError):
+            continue
+    return None

--- a/parity/tlda_true_lda_compare.py
+++ b/parity/tlda_true_lda_compare.py
@@ -1,9 +1,11 @@
 """Known-truth LDA recovery report for experimental TensorLDA.
 
-This is a deterministic validation benchmark, not a pass/fail parity gate. It
-samples documents from ordinary LDA with known topic-word distributions and
-unequal Dirichlet topic weights, fits TensorLDA at square and rectangular
-whitening ranks, and prints aligned recovery diagnostics.
+This is the fuller human-readable report over the same fixed simulation. The
+square-rank topic-recovery floor is enforced as an acceptance gate in
+``tests/test_tlda_recovery.py`` (CI-runnable, hermetic); this script prints the
+full diagnostics -- per-topic cosines at square and rectangular whitening ranks,
+plus the weight and document-topic recovery that remain a separate, ungated
+prevalence question.
 
     python parity/tlda_true_lda_compare.py
 """

--- a/tests/test_tlda_recovery.py
+++ b/tests/test_tlda_recovery.py
@@ -24,6 +24,19 @@ import pytest
 
 import topica
 
+
+@pytest.fixture(autouse=True)
+def _experimental_on():
+    """TensorLDA is gated; enable it for these tests and restore the process-global
+    flag afterwards so it does not bleed into later tests in the same pytest run."""
+    was = topica.experimental_enabled()
+    topica.enable_experimental(True)
+    try:
+        yield
+    finally:
+        topica.enable_experimental(was)
+
+
 # Square-rank topic-recovery floors. Current baseline on this fixed simulation is
 # mean aligned cosine 0.529 with a per-topic minimum of 0.443; these floors sit
 # safely below to catch regression without being brittle.
@@ -59,7 +72,6 @@ def _align(cosine: np.ndarray) -> np.ndarray:
 
 def _fit_and_score(rank: int):
     docs, beta, theta_true, weights_true = _simulate()
-    topica.enable_experimental(True)
     model = topica.TensorLDA(
         beta.shape[0], alpha_0=1.0, n_eigenvec=rank, n_iter_train=500,
         n_iter_test=50, learning_rate=0.01, batch_size=25, seed=2026,

--- a/tests/test_tlda_recovery.py
+++ b/tests/test_tlda_recovery.py
@@ -1,0 +1,117 @@
+"""Known-truth acceptance criteria for experimental TensorLDA topic recovery.
+
+These are the explicit, CI-runnable floors for TensorLDA's method-of-moments
+*topic recovery* on a fixed LDA simulation with known topic-word distributions
+and unequal Dirichlet weights. They guard the square-rank configuration
+(``n_eigenvec == num_topics``) against regression at its current baseline.
+
+Prevalence calibration is a deliberately separate question: the planted weights
+and document-topic correlations are computed and surfaced here as diagnostics
+but are NOT asserted, because TensorLDA's ``weights`` are not yet validated as
+calibrated prevalence estimates (see ``docs/replications/tlda.md``). The
+rectangular case ``n_eigenvec > num_topics`` is a Topica extension and is
+likewise reported, not gated.
+
+The simulation mirrors ``parity/tlda_true_lda_compare.py`` (same seed and
+config) so the numbers correspond; that script is the fuller human-readable
+report. This module is hermetic: it imports only topica and numpy.
+"""
+
+from itertools import permutations
+
+import numpy as np
+import pytest
+
+import topica
+
+# Square-rank topic-recovery floors. Current baseline on this fixed simulation is
+# mean aligned cosine 0.529 with a per-topic minimum of 0.443; these floors sit
+# safely below to catch regression without being brittle.
+MEAN_COSINE_FLOOR = 0.50
+MIN_TOPIC_COSINE_FLOOR = 0.35
+
+
+def _simulate(seed: int = 2026):
+    """Sample documents from ordinary LDA with known beta and unequal weights."""
+    rng = np.random.default_rng(seed)
+    k, block, v, d, length = 4, 20, 80, 2500, 100
+    weights = np.array([0.50, 0.25, 0.15, 0.10])
+    beta = np.full((k, v), 0.15 / v)
+    for topic in range(k):
+        beta[topic, topic * block:(topic + 1) * block] += 0.85 / block
+    beta /= beta.sum(axis=1, keepdims=True)
+
+    theta = rng.dirichlet(weights, size=d)
+    vocab = np.array([f"w{i}" for i in range(v)])
+    docs = []
+    for mixture in theta:
+        assignments = rng.choice(k, size=length, p=mixture)
+        docs.append([str(vocab[rng.choice(v, p=beta[topic])]) for topic in assignments])
+    return docs, beta, theta, weights
+
+
+def _align(cosine: np.ndarray) -> np.ndarray:
+    """Permutation of fitted topics maximizing total cosine against the truth."""
+    k = cosine.shape[0]
+    best = max(permutations(range(k)), key=lambda p: sum(cosine[i, p[i]] for i in range(k)))
+    return np.asarray(best)
+
+
+def _fit_and_score(rank: int):
+    docs, beta, theta_true, weights_true = _simulate()
+    topica.enable_experimental(True)
+    model = topica.TensorLDA(
+        beta.shape[0], alpha_0=1.0, n_eigenvec=rank, n_iter_train=500,
+        n_iter_test=50, learning_rate=0.01, batch_size=25, seed=2026,
+    )
+    model.fit(docs)
+    learned = np.asarray(model.topic_word)
+    cosine = beta @ learned.T / np.maximum(
+        np.linalg.norm(beta, axis=1)[:, None] * np.linalg.norm(learned, axis=1)[None, :],
+        1e-300,
+    )
+    fit_idx = _align(cosine)
+    diag = cosine[np.arange(beta.shape[0]), fit_idx]
+    return diag, model, fit_idx, theta_true, weights_true
+
+
+def test_square_rank_topic_recovery_meets_floor():
+    """Acceptance gate: square-rank (R=K) topic-word recovery must clear the floor."""
+    diag, _model, _fit_idx, _theta_true, _weights_true = _fit_and_score(rank=4)
+    mean_cos = float(diag.mean())
+    min_cos = float(diag.min())
+
+    assert mean_cos >= MEAN_COSINE_FLOOR, (
+        f"square-rank mean aligned topic cosine {mean_cos:.4f} regressed below "
+        f"the {MEAN_COSINE_FLOOR} acceptance floor; per-topic {np.round(diag, 4)}"
+    )
+    assert min_cos >= MIN_TOPIC_COSINE_FLOOR, (
+        f"a topic was recovered at cosine {min_cos:.4f}, below the "
+        f"{MIN_TOPIC_COSINE_FLOOR} per-topic floor; per-topic {np.round(diag, 4)}"
+    )
+
+
+def test_prevalence_is_reported_but_not_gated():
+    """Weight/theta recovery is surfaced as a diagnostic, deliberately un-asserted.
+
+    This documents the separation in code: TensorLDA's ``weights`` are not yet a
+    validated prevalence estimator, so recovery here is allowed to be weak. The
+    test only checks that the diagnostic quantities are well-formed and finite.
+    """
+    _diag, model, fit_idx, _theta_true, weights_true = _fit_and_score(rank=4)
+    recovered_weights = np.asarray(model.weights)[fit_idx]
+
+    assert recovered_weights.shape == weights_true.shape
+    assert np.all(np.isfinite(recovered_weights))
+    # Not asserted: agreement with weights_true. See module docstring.
+
+
+@pytest.mark.parametrize("rank", [8])
+def test_rectangular_rank_runs_as_extension(rank):
+    """n_eigenvec > num_topics is a Topica extension: it must run and stay finite.
+
+    No parity claim is made against the upstream square-rank method here.
+    """
+    diag, _model, _fit_idx, _theta_true, _weights_true = _fit_and_score(rank=rank)
+    assert diag.shape == (4,)
+    assert np.all(np.isfinite(diag))


### PR DESCRIPTION
Closes #451.

TensorLDA's parity infrastructure had two portability problems: the upstream comparison hard-coded a machine-specific `sys.path` to a personal scratch directory, and the known-truth LDA simulation was a print-only report with no acceptance criteria.

## What changed

**Portable reference (a):** New `parity/tlda_ref.py` locates the [TensorLy TLDA](https://github.com/tensorly/tlda) reference via the documented `TOPICA_TLDA_REF` env var — never a baked-in path — trying flat-checkout, packaged, and wrapper import shapes, returning `None` when absent. `parity/tlda_compare.py` drops the personal `sys.path` mutation and uses it.

**CI-runnable / schedulable (b):** `parity/tlda_compare.py` now exits 0 when the reference is unavailable, so it is safe to wire into CI or a scheduled integration job: a no-op wherever the ref is not installed, a real square-rank comparison wherever it is. Verified end-to-end against a real reference checkout (streaming aligned cosine ≈ 1.0).

**Explicit topic-recovery acceptance criteria (d):** New hermetic `tests/test_tlda_recovery.py` turns the square-rank (`n_eigenvec == num_topics`) known-truth simulation into a gate with a mean-cosine floor (0.50) and per-topic floor (0.35), below the current baseline (0.529 / min 0.443). Runs in ~4s, imports only topica + numpy.

**Prevalence kept separate (d) + extension status (c):** planted-weight and doc-topic recovery are computed as diagnostics but **not** asserted (the `weights` are not yet a validated prevalence estimator); `n_eigenvec > num_topics` is exercised as a Topica extension, not an upstream-parity claim. Docs updated with the reference-install steps and the gate/prevalence split.

## Verification
- `tests/test_tlda.py` + `test_tlda_gold.py` + `test_tlda_recovery.py`: 19 passed
- Discriminating check: raising the floor to 0.60 (above baseline) fails the gate; restored floor passes
- `cargo fmt --check`, `scripts/preflight.sh`, `mkdocs build --strict`: all green
- `parity/tlda_compare.py` with no env var exits 0; with `TOPICA_TLDA_REF` set runs the full comparison

🤖 Generated with [Claude Code](https://claude.com/claude-code)