### PR TITLE
fix(anchor): reject a no-cooccurrence corpus with ValueError, not a NaN model (#449)

### DIFF
--- a/python/topica/anchor.py
+++ b/python/topica/anchor.py
@@ -73,6 +73,15 @@ def _build_q(counts):
     averaged over documents with at least two tokens (Arora et al. 2013)."""
     n = counts.sum(axis=1)
     keep = n >= 2
+    # The co-occurrence estimator averages over documents with >= 2 in-vocab
+    # tokens; with none, `qbar /= keep.sum()` divides by zero and returns an
+    # all-NaN Q (and a fitted-looking but all-NaN model). Fail clearly instead (#449).
+    if not keep.any():
+        raise ValueError(
+            "AnchorLDA needs word co-occurrence evidence, but no document has at "
+            "least 2 in-vocabulary tokens after preprocessing. Supply longer "
+            "documents or relax the vocabulary filter (min_df / max_df)."
+        )
     h = counts[keep]
     nk = n[keep]
     w = 1.0 / (nk * (nk - 1))

--- a/tests/test_anchor.py
+++ b/tests/test_anchor.py
@@ -388,3 +388,13 @@ class TestAnchorDocFreq:
         m = topica.AnchorLDA(4, min_count=2, anchor_min_doc_freq=0.999, seed=0).fit(docs)
         assert len(m.anchors) == 4
         assert np.isfinite(np.asarray(m.topic_word)).all()
+
+
+def test_no_cooccurrence_evidence_raises():
+    # Every document has a single token, so no document has >= 2 in-vocab tokens
+    # and the co-occurrence estimator Q has no evidence. Previously this hit a
+    # divide-by-zero in _build_q and returned an all-NaN (but fitted-looking)
+    # model; it must raise a clear ValueError instead (#449).
+    docs = [[f"w{i % 4}"] for i in range(40)]
+    with pytest.raises(ValueError, match="co-occurrence"):
+        topica.AnchorLDA(2, seed=0).fit(docs)


### PR DESCRIPTION
Fixes #449 — a silent-wrong bug in AnchorLDA.

`_build_q` averages the co-occurrence estimator over documents with >= 2 in-vocab tokens (`qbar /= keep.sum()`). With none, `keep.sum() == 0` divides by zero → all-NaN Q → a fitted-looking but all-NaN model (only a RuntimeWarning, no error).

**Fix:** an early guard in `_build_q` raises a clear `ValueError` when there is no co-occurrence evidence, pointing at longer documents / a looser vocab filter.

**Test:** a corpus of single-token documents now raises instead of returning NaNs.

Closes #449.

🤖 Generated with [Claude Code](https://claude.com/claude-code)