### PR TITLE
fix(seededlda): validate the seed weight (finite, in [0,1]) (#456)

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -11948,6 +11948,15 @@ impl SeededLDA {
         if !finite_pos(alpha) || !finite_pos(beta) {
             return Err(PyValueError::new_err("alpha and beta must be > 0"));
         }
+        // `weight` scales the seed pseudocount; an unvalidated value silently
+        // corrupted the fit — a negative weight yields negative topic-word
+        // probabilities and NaN/inf yield non-finite ones. The seededlda package
+        // restricts it to [0, 1], which topica claims to match (#456).
+        if !weight.is_finite() || !(0.0..=1.0).contains(&weight) {
+            return Err(PyValueError::new_err(
+                "weight must be finite and in [0, 1] (as in the seededlda package)",
+            ));
+        }
         if names.len() + residual < 2 {
             return Err(PyValueError::new_err(
                 "need at least 2 topics (seeded + residual)",

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -52,6 +52,16 @@ def test_other_constructors_reject_nan():
             cls(**kw)
 
 
+@pytest.mark.parametrize("bad", [NAN, INF, -0.01, 1.5])
+def test_seededlda_rejects_bad_weight(bad):
+    # #456: an unvalidated `weight` silently corrupted the seed prior — a negative
+    # weight gives negative topic-word probabilities and NaN/inf gives non-finite
+    # ones; the seededlda package restricts it to [0, 1].
+    seeds = {"sports": ["ball", "goal"], "politics": ["vote", "law"]}
+    with pytest.raises(ValueError, match="weight"):
+        topica.SeededLDA(seeds, weight=bad)
+
+
 def test_valid_hyperparameters_still_construct_and_fit():
     m = LDA(num_topics=2, beta=0.01, alpha_sum=1.0, seed=42)
     m.fit(DOCS, iters=20)


### PR DESCRIPTION
Fixes the correctness/validation part of #456.

The `SeededLDA` constructor validated `alpha`/`beta` but not `weight` (the seed-pseudocount scale). An unvalidated value silently corrupted the fit: **negative** weight → negative topic-word probabilities; **NaN/inf** → non-finite ones. The seededlda package restricts `weight` to `[0, 1]` (which topica's docstring already claims to match), so reject anything non-finite or outside that range.

**Test:** `weight ∈ {NaN, +inf, -0.01, 1.5}` now raises `ValueError`.

Deferred (the larger fidelity items in #456, noted for a follow-up reference-compatibility profile): corpus-frequency-scaled seed mass (`count·weight·100` vs the current flat `weight·100`) and the default `alpha`/`beta` differences vs the reference. Leaving #456 open scoped to those.

🤖 Generated with [Claude Code](https://claude.com/claude-code)