### PR TITLE
fix(disclda): reject non-finite hyperparameters + a zero-step fit override (#460)

### DIFF
--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -163,16 +163,21 @@ impl DiscLDA {
         if k_shared == 0 {
             return Err(PyValueError::new_err("k_shared must be >= 1"));
         }
+        // `<= 0.0` is false for NaN and +inf, so those slipped through and produced
+        // NaN topic-word / doc-topic / predict_proba. Require finite and positive (#460).
         if let Some(a) = alpha {
-            if a <= 0.0 {
-                return Err(PyValueError::new_err("alpha must be > 0.0"));
+            if !a.is_finite() || a <= 0.0 {
+                return Err(PyValueError::new_err("alpha must be finite and > 0.0"));
             }
         }
-        if beta <= 0.0 {
-            return Err(PyValueError::new_err("beta must be > 0.0"));
+        if !beta.is_finite() || beta <= 0.0 {
+            return Err(PyValueError::new_err("beta must be finite and > 0.0"));
         }
         if iters == 0 {
             return Err(PyValueError::new_err("iters must be > 0"));
+        }
+        if infer_sweeps == 0 {
+            return Err(PyValueError::new_err("infer_sweeps must be > 0"));
         }
         Ok(DiscLDA {
             k_class,
@@ -249,6 +254,10 @@ impl DiscLDA {
             ));
         }
         let iters = iters.unwrap_or(slf.iters);
+        // The constructor rejects iters == 0, but a per-fit override bypassed it.
+        if iters == 0 {
+            return Err(PyValueError::new_err("iters must be > 0"));
+        }
         let alpha = slf.alpha.unwrap_or(0.1);
         let (k_class, k_shared, beta, seed) = (slf.k_class, slf.k_shared, slf.beta, slf.seed);
 

--- a/tests/test_disclda.py
+++ b/tests/test_disclda.py
@@ -135,3 +135,26 @@ def test_single_class_raises():
     m = topica.DiscLDA(1, 2, iters=10)
     with pytest.raises(ValueError):
         m.fit(docs, ["A"] * len(docs))
+
+
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), -float("inf")])
+def test_non_finite_hyperparams_rejected(bad):
+    # #460: `<= 0.0` is false for NaN/+inf, so they slipped past the guard and
+    # produced NaN topic-word / doc-topic / predict_proba. Now rejected.
+    with pytest.raises(ValueError, match="finite"):
+        topica.DiscLDA(2, 2, alpha=bad)
+    with pytest.raises(ValueError, match="finite"):
+        topica.DiscLDA(2, 2, beta=bad)
+
+
+def test_zero_infer_sweeps_rejected():
+    with pytest.raises(ValueError, match="infer_sweeps"):
+        topica.DiscLDA(2, 2, infer_sweeps=0)
+
+
+def test_fit_iters_zero_rejected():
+    # The constructor rejects iters == 0; a per-fit override must too (#460).
+    docs, y = _corpus()
+    m = topica.DiscLDA(2, 2, iters=10)
+    with pytest.raises(ValueError, match="iters"):
+        m.fit(docs, y, iters=0)


### PR DESCRIPTION
Fixes the correctness/validation part of #460.

The `DiscLDA` constructor guarded `alpha`/`beta` with `<= 0.0`, which is **false for NaN and +inf** — so those passed and produced NaN `doc_topic` / `topic_word` / `predict_proba`. Now require finite and positive. Also:
- validate `infer_sweeps > 0` (was unguarded);
- re-check `iters > 0` inside `fit` — the constructor rejected `iters == 0` but a per-fit `fit(iters=0)` override bypassed it.

**Tests:** non-finite `alpha`/`beta` (NaN, +inf, -inf), `infer_sweeps=0`, and `fit(iters=0)` now raise `ValueError`.

Deferred (the fidelity item in #460): `predict_proba` softmaxes class log-likelihoods under a hard-coded uniform prior and retains no class counts, so it is not a calibrated `p(class|words)` — relabeling it and/or adding a retained/​configurable class prior is a separate change. Leaving #460 open scoped to that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)