### PR TITLE
fix(seededlda): reject non-finite doc_topic_prior; dedupe CVB0 seed denominator (#456)

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -12066,8 +12066,13 @@ impl SeededLDA {
                         "each doc_topic_prior row must have num_topics entries",
                     ));
                 }
-                if rows.iter().any(|r| r.iter().any(|&a| a <= 0.0)) {
-                    return Err(PyValueError::new_err("doc_topic_prior entries must be > 0"));
+                // `a <= 0.0` is false for NaN and +inf, so a non-finite prior would
+                // slip through and contaminate sampling/output. Require finite and
+                // positive (#456, same non-finite class as #472/#473).
+                if rows.iter().any(|r| r.iter().any(|&a| !finite_pos(a))) {
+                    return Err(PyValueError::new_err(
+                        "doc_topic_prior entries must be finite and > 0",
+                    ));
                 }
                 Some(rows)
             }

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -62,6 +62,19 @@ def test_seededlda_rejects_bad_weight(bad):
         topica.SeededLDA(seeds, weight=bad)
 
 
+@pytest.mark.parametrize("bad", [NAN, INF])
+def test_seededlda_rejects_nonfinite_doc_topic_prior(bad):
+    # #456: the doc_topic_prior guard was `a <= 0.0`, which is false for NaN and
+    # +inf, so a non-finite prior slipped through and contaminated the fit. It must
+    # be rejected up front (same non-finite class as the weight guard above).
+    seeds = {"sports": ["ball", "goal"], "politics": ["vote", "law"]}
+    docs = [["ball", "goal", "vote"], ["law", "vote", "ball"], ["goal", "law", "ball"]]
+    m = topica.SeededLDA(seeds, seed=1)
+    prior = [[1.0, bad] for _ in docs]
+    with pytest.raises(ValueError, match="finite"):
+        m.fit(docs, iters=10, doc_topic_prior=prior)
+
+
 def test_valid_hyperparameters_still_construct_and_fit():
     m = LDA(num_topics=2, beta=0.01, alpha_sum=1.0, seed=42)
     m.fit(DOCS, iters=20)

--- a/topica-core/src/cvb0.rs
+++ b/topica-core/src/cvb0.rs
@@ -214,9 +214,17 @@ impl Cvb0 {
         let mut beta_sum_k = vec![self.beta * v as f64; k];
         let mut inv_seeds: Vec<Vec<u32>> = vec![Vec::new(); v];
         for (t, ws) in seeds.iter().enumerate().take(k) {
-            beta_sum_k[t] += ws.len() as f64 * seed_weight;
+            // Count each DISTINCT, in-vocabulary seed word once. The numerator
+            // `beta + seed_weight` is applied per (topic, word) by a boolean
+            // membership test below, so the per-topic normalizer must equal
+            // Σ_w β_at(t, w) = V·β + (#distinct valid seeds)·seed_weight. Using
+            // `ws.len()` over-counted duplicate/out-of-vocab seed words, inflating
+            // the denominator and under-normalizing the seeded topic (matches the
+            // sparse and warp backends, which already dedupe).
+            let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
             for &w in ws {
-                if w < v {
+                if w < v && seen.insert(w) {
+                    beta_sum_k[t] += seed_weight;
                     inv_seeds[w].push(t as u32);
                 }
             }
@@ -483,6 +491,32 @@ mod tests {
             }
         }
         assert_eq!(covered.len(), n_blocks, "only recovered {covered:?}");
+    }
+
+    #[test]
+    fn set_seeds_dedupes_the_denominator() {
+        // A duplicated seed word (["tax","tax"]) must not inflate beta_sum_k or push
+        // its topic twice into inv_seeds: the numerator boost is a boolean membership
+        // test, so a duplicate would over-count the denominator and under-normalize
+        // the topic. Distinct-count and duplicate-count seeds must agree.
+        let (corpus, _) = planted(2, 3, 20);
+        let v = corpus.num_types();
+        let alpha = vec![0.1f64; 2];
+        let mut rng = Pcg64Mcg::seed_from_u64(1);
+
+        let mut dup = Cvb0::new(&corpus, 2, &alpha, 0.01, &mut rng);
+        dup.set_seeds(&[vec![0, 0, 1], vec![]], 5.0);
+        let mut uniq = Cvb0::new(&corpus, 2, &alpha, 0.01, &mut rng);
+        uniq.set_seeds(&[vec![0, 1], vec![]], 5.0);
+
+        let ds = dup.seed.as_ref().unwrap();
+        let us = uniq.seed.as_ref().unwrap();
+        // Two distinct seeds -> V*beta + 2*seed_weight; the duplicate must not add a
+        // third seed_weight.
+        assert_eq!(ds.beta_sum_k, us.beta_sum_k);
+        assert!((ds.beta_sum_k[0] - (v as f64 * 0.01 + 2.0 * 5.0)).abs() < 1e-9);
+        // word 0 seeds only topic 0, once.
+        assert_eq!(ds.inv_seeds[0], vec![0u32]);
     }
 
     #[test]


### PR DESCRIPTION
Addresses the two verified/confirmed correctness bugs from the #456 review follow-up (same non-finite/seed-mass class as #472/#473).

## Bug 1 — non-finite `doc_topic_prior` slips through (verified in the issue)

`fit`'s per-document prior guard was `a <= 0.0`. `NaN <= 0.0` and `+inf <= 0.0` are both `false`, so a non-finite `doc_topic_prior` passed validation and contaminated sampling/output. Now uses the existing `finite_pos` helper (`!finite_pos(a)` → reject non-finite or non-positive).

## Bug 2 — CVB0 under-normalizes a seeded topic with duplicate seeds (confirmed by reading the code)

CVB0's `set_seeds` added `ws.len() * seed_weight` to the per-topic normalizer `beta_sum_k`, but the numerator applies the boost via a boolean membership test (`beta + seed_weight` once per word). A duplicated (or out-of-vocab) seed word therefore inflated the denominator and under-normalized the seeded topic's φ. The **sparse** (`seeded.rs`) and **warp** (`warplda.rs`) backends already dedupe to distinct in-vocab seeds — this brings CVB0 in line.

## Tests
- `topica-core` CVB0 `set_seeds_dedupes_the_denominator`: a duplicated seed word produces the same `beta_sum_k`/`inv_seeds` as the distinct-count seeds.
- Python `test_seededlda_rejects_nonfinite_doc_topic_prior[NaN/inf]`.

Local: `cargo test -p topica-core cvb0` green (4 passed); seededlda Python suites green (52 passed); preflight clean.

## Out of scope (remains open on #456)
The larger seededlda **R-fidelity** items — corpus-frequency-scaled seed mass (`count·weight·100`), reference `alpha=0.5`/`beta=0.1` defaults, a documented `reference_compatible` profile, an R `seededlda` parity fixture, and quanteda-style dictionary matching — are a separate, larger port (design + the R package) and are not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)