### PR TITLE
feat(disclda): calibrated class-prior semantics for the direct classifier (#460)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -1105,6 +1105,17 @@ restricts tokens to a document's own labels, DiscLDA is the one that builds the
 class-specific-vs-shared split and a discriminative representation. Determinism is
 `seed-reproducible`.
 
+`predict` / `predict_proba` are a topica-native **plug-in** classifier, not part of
+the paper: each class score is the document's posterior-mean-θ likelihood combined
+with a class prior and softmaxed, so treat `predict_proba` as a prior-calibrated
+score rather than exact evidence. The prior is set by `class_prior`: `"empirical"`
+(default) uses the observed class frequencies from fit — so on an imbalanced corpus
+the probabilities track prevalence, and an empty/all-out-of-vocabulary document
+returns the prior (the majority class) rather than a sorted-order tie. Pass
+`class_prior="uniform"` for an equal prior, or a sequence of per-class weights (in
+`classes` order) for a custom one; `m.class_prior` and `m.class_counts` report what
+was used.
+
 DiscLDA has no canonical reference implementation, so it is validated against the
 paper's 20 Newsgroups result (`parity/disclda_20ng.py`): DiscLDA's topic-proportion
 features feed a linear classifier better than unsupervised-LDA features of matched

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2563,8 +2563,16 @@ class DiscLDA:
         beta: float = 0.01,
         iters: int = 1000,
         infer_sweeps: int = 100,
+        class_prior: str | Sequence[float] | None = None,
         seed: int = 42,
-    ) -> None: ...
+    ) -> None:
+        """class_prior sets the prior the direct classifier combines with each
+        document's plug-in likelihood: "empirical" (default) uses the observed
+        class frequencies from fit, so predict_proba is calibrated to class
+        prevalence; "uniform" gives every class an equal prior; or pass a sequence
+        of positive per-class weights (in the sorted-class order of `classes`),
+        which is normalised."""
+        ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2580,15 +2588,29 @@ class DiscLDA:
         """Class-marginalized discriminative representation (num_docs, num_topics)."""
         ...
     def predict(self, data: Corpus | Sequence[Sequence[str]]) -> list[str]:
-        """MAP class label per document."""
+        """Predicted class label per document (argmax of predict_proba). An empty /
+        all-OOV document resolves to the most probable class under class_prior (the
+        majority class for the default empirical prior)."""
         ...
     def predict_proba(
         self, data: Corpus | Sequence[Sequence[str]]
     ) -> numpy.typing.NDArray[numpy.float64]:
-        """Class posteriors (num_docs, num_classes), columns in `classes` order."""
+        """Approximate class posteriors (num_docs, num_classes), columns in
+        `classes` order. A topica-native plug-in classifier: each class score is
+        the posterior-mean-theta likelihood combined with class_prior (empirical by
+        default) and softmaxed — a prior-calibrated score, not exact evidence."""
         ...
     @property
     def classes(self) -> list[str]: ...
+    @property
+    def class_prior(self) -> list[float]:
+        """The resolved class prior p(c) used by predict/predict_proba, in `classes`
+        order (sums to 1)."""
+        ...
+    @property
+    def class_counts(self) -> list[int]:
+        """Observed per-class document counts from fit, in `classes` order."""
+        ...
     @property
     def num_topics(self) -> int: ...
     @property

--- a/src/disclda.rs
+++ b/src/disclda.rs
@@ -40,6 +40,14 @@ pub struct DiscLdaModel {
     /// Document-topic matrix θ (D × L); rows sum to 1, mass only on the document's
     /// class block and the shared block.
     pub doc_topic: Vec<Vec<f64>>,
+    /// Log class prior `ln p(c)` used by `predict`/`predict_proba`, length
+    /// `num_classes`. The direct classifier is a topica-native plug-in: it scores
+    /// a document under each class and combines the scores with this prior. The
+    /// binding resolves it from the constructor's `class_prior` (empirical class
+    /// frequencies by default, uniform, or a user-supplied vector); `fit_disclda`
+    /// initialises it uniform. A shift-invariant softmax means only the prior's
+    /// *relative* magnitudes matter.
+    pub class_log_prior: Vec<f64>,
 }
 
 impl DiscLdaModel {
@@ -197,6 +205,8 @@ pub fn fit_disclda<R: Rng>(
         num_topics: l,
         topic_word,
         doc_topic,
+        // Uniform by default; the binding overrides from `class_prior` after fit.
+        class_log_prior: vec![-(num_classes as f64).ln(); num_classes],
     }
 }
 
@@ -210,8 +220,8 @@ pub fn fit_disclda<R: Rng>(
 /// because every class's allowed set has the same size (`k_class + k_shared`), so no
 /// class gets a capacity advantage in the `predict`/`predict_proba` comparison — do
 /// not make `k_class` vary by class without revisiting this.
-/// An empty document (no in-vocab tokens) yields loglik 0 for every class, so
-/// `predict` returns a uniform posterior (its argmax is class 0).
+/// An empty document (no in-vocab tokens) yields loglik 0 for every class, so its
+/// posterior in `predict_doc` reduces to the class prior.
 pub fn infer_doc_class<R: Rng>(
     doc: &[u32],
     c: usize,
@@ -275,9 +285,17 @@ pub fn infer_doc_class<R: Rng>(
     (theta, loglik)
 }
 
-/// Predict class posteriors p(c|w) for a document (uniform class prior), and the
-/// class-marginalized discriminative representation Σ_c p(c|w)·θ_c (length L). Runs
-/// one `infer_doc_class` per class.
+/// Predict class posteriors p(c|w) for a document and the class-marginalized
+/// discriminative representation Σ_c p(c|w)·θ_c (length L). Runs one
+/// `infer_doc_class` per class and softmaxes `ln p(c) + plug-in loglik(doc|c)`,
+/// using `model.class_log_prior` (empirical class frequencies by default).
+///
+/// This is a plug-in *approximate* posterior: the per-class score is the
+/// posterior-mean-θ likelihood, not the fully marginalized evidence. An empty /
+/// all-OOV document has an identical (zero) likelihood under every class, so its
+/// posterior is exactly the class prior — `predict`'s argmax is then the most
+/// probable class under the prior (the majority class for an empirical prior),
+/// not a sorted-order tie break.
 pub fn predict_doc<R: Rng>(
     doc: &[u32],
     model: &DiscLdaModel,
@@ -289,10 +307,10 @@ pub fn predict_doc<R: Rng>(
     let mut thetas = vec![Vec::new(); c];
     for ci in 0..c {
         let (theta, ll) = infer_doc_class(doc, ci, model, sweeps, rng);
-        logliks[ci] = ll;
+        logliks[ci] = ll + model.class_log_prior.get(ci).copied().unwrap_or(0.0);
         thetas[ci] = theta;
     }
-    // softmax over class log-likelihoods (uniform prior)
+    // softmax over class log-posteriors (log-prior + plug-in log-likelihood)
     let m = logliks.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
     let mut post: Vec<f64> = logliks.iter().map(|&x| (x - m).exp()).collect();
     let s: f64 = post.iter().sum();
@@ -427,5 +445,22 @@ mod tests {
         let b = run();
         assert_eq!(a.topic_word, b.topic_word);
         assert_eq!(a.doc_topic, b.doc_topic);
+    }
+
+    #[test]
+    fn empty_doc_posterior_equals_class_prior() {
+        // An empty / all-OOV document has zero likelihood under every class, so its
+        // posterior must be exactly the (softmaxed) class prior — not a uniform
+        // tie or a sorted-order argmax.
+        let (nc, cbw, sbw) = (2, 5, 5);
+        let (docs, labels, v) = planted(nc, cbw, sbw, 80, 10, 5);
+        let mut rng = ChaCha8Rng::seed_from_u64(1);
+        let mut m = fit_disclda(&docs, &labels, nc, 2, 2, v, 0.1, 0.01, 100, &mut rng);
+        // A skewed empirical-style prior: p = [0.8, 0.2].
+        m.class_log_prior = vec![0.8f64.ln(), 0.2f64.ln()];
+        let mut prng = ChaCha8Rng::seed_from_u64(2);
+        let (post, _) = predict_doc(&[], &m, 30, &mut prng);
+        assert!((post[0] - 0.8).abs() < 1e-9, "post {post:?}");
+        assert!((post[1] - 0.2).abs() < 1e-9, "post {post:?}");
     }
 }

--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -123,13 +123,19 @@ fn resolve_log_prior(
             if w.len() != num_classes {
                 return Err(PyValueError::new_err(format!(
                     "class_prior has {} weights but there are {num_classes} classes \
-                     (weights are in sorted-class order: {:?})",
+                     (weights are in sorted-class order)",
                     w.len(),
-                    counts.len()
                 )));
             }
-            let s: f64 = w.iter().sum();
-            Ok(w.iter().map(|&x| (x / s).ln()).collect())
+            // Normalise stably. Dividing by the max weight before summing keeps the
+            // denominator in `(0, num_classes]`, so an extreme-but-valid weight (e.g.
+            // 1e308) cannot overflow the raw sum to +inf and collapse every log-prior
+            // to -inf — which would make predict_proba NaN (#460). The max cancels, so
+            // `(x/wmax) / Σ(x/wmax)` == `x / Σx` exactly; the largest-weight class
+            // always keeps a finite log-prior, so the softmax stays well-defined.
+            let wmax = w.iter().cloned().fold(0.0f64, f64::max);
+            let s: f64 = w.iter().map(|&x| x / wmax).sum();
+            Ok(w.iter().map(|&x| ((x / wmax) / s).ln()).collect())
         }
         _ => Err(PyValueError::new_err(format!(
             "unknown class_prior mode {mode:?}"

--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -24,6 +24,13 @@ pub struct DiscLDA {
     iters: usize,
     infer_sweeps: usize,
     seed: u64,
+    // Class-prior policy for the direct classifier: "empirical" (default,
+    // observed class frequencies), "uniform", or "custom" (per-class weights in
+    // `class_prior_custom`, sorted-class order). Resolved to a log-prior at fit.
+    class_prior_mode: String,
+    class_prior_custom: Option<Vec<f64>>,
+    // Observed class document counts (sorted-class order), set at fit.
+    class_counts: Vec<usize>,
     fitted: bool,
     classes: Vec<String>,
     topic_names: Vec<String>,
@@ -49,6 +56,85 @@ struct DiscLdaState {
     num_topics: Option<usize>,
     topic_word: Option<Vec<Vec<f64>>>,
     doc_topic: Option<Vec<Vec<f64>>>,
+    // Class-prior policy + the resolved log-prior (older saves default to uniform).
+    #[serde(default = "disclda_prior_mode_legacy")]
+    class_prior_mode: String,
+    #[serde(default)]
+    class_prior_custom: Option<Vec<f64>>,
+    #[serde(default)]
+    class_counts: Vec<usize>,
+    #[serde(default)]
+    class_log_prior: Option<Vec<f64>>,
+}
+
+fn disclda_prior_mode_legacy() -> String {
+    "uniform".to_string()
+}
+
+/// Parse the `class_prior` constructor argument into (mode, custom weights).
+fn parse_class_prior(spec: Option<&Bound<'_, PyAny>>) -> PyResult<(String, Option<Vec<f64>>)> {
+    let Some(obj) = spec else {
+        return Ok(("empirical".to_string(), None));
+    };
+    if let Ok(s) = obj.extract::<String>() {
+        return match s.as_str() {
+            "empirical" | "uniform" => Ok((s, None)),
+            other => Err(PyValueError::new_err(format!(
+                "class_prior must be \"empirical\", \"uniform\", or a sequence of \
+                 per-class weights, got {other:?}"
+            ))),
+        };
+    }
+    let v: Vec<f64> = obj.extract().map_err(|_| {
+        PyValueError::new_err(
+            "class_prior must be \"empirical\", \"uniform\", or a sequence of floats",
+        )
+    })?;
+    if v.is_empty() || v.iter().any(|x| !x.is_finite() || *x <= 0.0) {
+        return Err(PyValueError::new_err(
+            "class_prior weights must be non-empty, finite, and > 0",
+        ));
+    }
+    Ok(("custom".to_string(), Some(v)))
+}
+
+/// Resolve the class-prior policy to a log-prior (length `num_classes`) given the
+/// observed per-class document counts (sorted-class order).
+fn resolve_log_prior(
+    mode: &str,
+    custom: &Option<Vec<f64>>,
+    counts: &[usize],
+    num_classes: usize,
+) -> PyResult<Vec<f64>> {
+    match mode {
+        "uniform" => Ok(vec![-(num_classes as f64).ln(); num_classes]),
+        "empirical" => {
+            let total: usize = counts.iter().sum();
+            let total = total.max(1) as f64;
+            Ok(counts
+                .iter()
+                .map(|&c| ((c as f64).max(1e-300) / total).ln())
+                .collect())
+        }
+        "custom" => {
+            let w = custom
+                .as_ref()
+                .ok_or_else(|| PyValueError::new_err("custom class_prior weights missing"))?;
+            if w.len() != num_classes {
+                return Err(PyValueError::new_err(format!(
+                    "class_prior has {} weights but there are {num_classes} classes \
+                     (weights are in sorted-class order: {:?})",
+                    w.len(),
+                    counts.len()
+                )));
+            }
+            let s: f64 = w.iter().sum();
+            Ok(w.iter().map(|&x| (x / s).ln()).collect())
+        }
+        _ => Err(PyValueError::new_err(format!(
+            "unknown class_prior mode {mode:?}"
+        ))),
+    }
 }
 
 impl DiscLDA {
@@ -134,6 +220,10 @@ impl DiscLDA {
         d.set_item("beta", self.beta)?;
         d.set_item("iters", self.iters)?;
         d.set_item("infer_sweeps", self.infer_sweeps)?;
+        match (&self.class_prior_mode, &self.class_prior_custom) {
+            (mode, Some(w)) if mode == "custom" => d.set_item("class_prior", w.clone())?,
+            (mode, _) => d.set_item("class_prior", mode)?,
+        }
         d.set_item("seed", self.seed)?;
         Ok(d)
     }
@@ -144,9 +234,16 @@ impl DiscLDA {
     /// at fit. `alpha` defaults to 0.1 (per allowed topic), `beta` to 0.01.
     /// `infer_sweeps` is the restricted-Gibbs passes used per class in
     /// `transform`/`predict`.
+    ///
+    /// `class_prior` sets the prior the direct classifier combines with each
+    /// document's plug-in likelihood: ``"empirical"`` (default) uses the observed
+    /// class frequencies from fit, so `predict_proba` is calibrated to class
+    /// prevalence; ``"uniform"`` gives every class equal prior; or pass a sequence
+    /// of positive per-class weights (in the sorted-class order of `classes`),
+    /// which is normalised.
     #[new]
     #[pyo3(signature = (k_class, k_shared, *, alpha=None, beta=0.01, iters=1000,
-                        infer_sweeps=100, seed=42))]
+                        infer_sweeps=100, class_prior=None, seed=42))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         k_class: usize,
@@ -155,8 +252,10 @@ impl DiscLDA {
         beta: f64,
         iters: usize,
         infer_sweeps: usize,
+        class_prior: Option<&Bound<'_, PyAny>>,
         seed: u64,
     ) -> PyResult<Self> {
+        let (class_prior_mode, class_prior_custom) = parse_class_prior(class_prior)?;
         if k_class == 0 {
             return Err(PyValueError::new_err("k_class must be >= 1"));
         }
@@ -186,6 +285,9 @@ impl DiscLDA {
             beta,
             iters,
             infer_sweeps,
+            class_prior_mode,
+            class_prior_custom,
+            class_counts: Vec::new(),
             seed,
             fitted: false,
             classes: Vec::new(),
@@ -261,7 +363,20 @@ impl DiscLDA {
         let alpha = slf.alpha.unwrap_or(0.1);
         let (k_class, k_shared, beta, seed) = (slf.k_class, slf.k_shared, slf.beta, slf.seed);
 
-        let (model, corpus) = py.allow_threads(move || {
+        // Observed per-class document counts (sorted-class order) — the empirical
+        // prior and the reported `class_counts`.
+        let mut class_counts = vec![0usize; num_classes];
+        for &c in &labels {
+            class_counts[c] += 1;
+        }
+        let class_log_prior = resolve_log_prior(
+            &slf.class_prior_mode,
+            &slf.class_prior_custom,
+            &class_counts,
+            num_classes,
+        )?;
+
+        let (mut model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
             let m = crate::disclda::fit_disclda(
                 &corpus.docs,
@@ -277,6 +392,8 @@ impl DiscLDA {
             );
             (m, corpus)
         });
+        model.class_log_prior = class_log_prior;
+        slf.class_counts = class_counts;
         slf.model = Some(model);
         slf.corpus = Some(corpus);
         slf.classes = classes;
@@ -310,9 +427,10 @@ impl DiscLDA {
         Ok(vecs_to_arr2(&rep).to_pyarray_bound(py))
     }
 
-    /// Predict the class label of each document (MAP under p(class|words)). A
-    /// document with no in-vocabulary tokens has a uniform posterior and resolves to
-    /// the first class.
+    /// Predict the class label of each document (argmax of `predict_proba`). A
+    /// document with no in-vocabulary tokens carries no likelihood signal, so its
+    /// prediction is the most probable class under `class_prior` (the majority
+    /// class for the default empirical prior).
     fn predict(&self, py: Python<'_>, data: &Bound<'_, PyAny>) -> PyResult<Vec<String>> {
         let m = self.fitted_model()?;
         let mapped = map_to_vocab(self.corpus.as_ref().unwrap(), data)?;
@@ -334,8 +452,14 @@ impl DiscLDA {
         }))
     }
 
-    /// Class posterior probabilities p(class|words) for each document
+    /// Approximate class posterior probabilities for each document
     /// (num_docs, num_classes), columns in `classes` order.
+    ///
+    /// This is a topica-native **plug-in** classifier, not a fully marginalized
+    /// DiscLDA evidence: each class score is the posterior-mean-θ likelihood of the
+    /// document under that class, combined with `class_prior` (empirical class
+    /// frequencies by default) and softmaxed. Treat it as a well-behaved,
+    /// prior-calibrated score rather than an exact p(class | words).
     fn predict_proba<'py>(
         &self,
         py: Python<'py>,
@@ -366,6 +490,22 @@ impl DiscLDA {
     fn classes(&self) -> PyResult<Vec<String>> {
         self.fitted_model()?;
         Ok(self.classes.clone())
+    }
+
+    /// The resolved class prior p(c) used by `predict`/`predict_proba`, length
+    /// `num_classes` in `classes` order (sums to 1). Empirical class frequencies
+    /// by default; uniform or the normalised custom weights otherwise.
+    #[getter]
+    fn class_prior(&self) -> PyResult<Vec<f64>> {
+        let m = self.fitted_model()?;
+        Ok(m.class_log_prior.iter().map(|&lp| lp.exp()).collect())
+    }
+
+    /// The observed per-class document counts from fit, in `classes` order.
+    #[getter]
+    fn class_counts(&self) -> PyResult<Vec<usize>> {
+        self.fitted_model()?;
+        Ok(self.class_counts.clone())
     }
 
     /// Topic-word matrix φ (num_topics, vocab); rows sum to 1. Topics are ordered
@@ -527,6 +667,10 @@ impl DiscLDA {
                 num_topics: Some(m.num_topics),
                 topic_word: Some(m.topic_word.clone()),
                 doc_topic: Some(m.doc_topic.clone()),
+                class_prior_mode: self.class_prior_mode.clone(),
+                class_prior_custom: self.class_prior_custom.clone(),
+                class_counts: self.class_counts.clone(),
+                class_log_prior: Some(m.class_log_prior.clone()),
             },
         )
     }
@@ -535,8 +679,13 @@ impl DiscLDA {
     #[classmethod]
     fn load(_cls: &Bound<'_, PyType>, path: &str) -> PyResult<Self> {
         let s: DiscLdaState = read_state(path, MODEL_TAG_DISCLDA)?;
+        let num_classes = s.classes.len();
         let model = if s.fitted && s.topic_word.is_some() {
-            let num_classes = s.classes.len();
+            // Older saves have no class_log_prior; fall back to uniform.
+            let clp = s
+                .class_log_prior
+                .clone()
+                .unwrap_or_else(|| vec![-(num_classes as f64).ln(); num_classes]);
             Some(crate::disclda::DiscLdaModel {
                 num_classes,
                 k_class: s.k_class,
@@ -547,6 +696,7 @@ impl DiscLDA {
                 num_topics: s.num_topics.unwrap_or(num_classes * s.k_class + s.k_shared),
                 topic_word: s.topic_word.unwrap_or_default(),
                 doc_topic: s.doc_topic.unwrap_or_default(),
+                class_log_prior: clp,
             })
         } else {
             None
@@ -558,6 +708,9 @@ impl DiscLDA {
             beta: s.beta,
             iters: s.iters,
             infer_sweeps: s.infer_sweeps,
+            class_prior_mode: s.class_prior_mode,
+            class_prior_custom: s.class_prior_custom,
+            class_counts: s.class_counts,
             seed: s.seed,
             fitted: s.fitted,
             classes: s.classes,

--- a/tests/test_disclda.py
+++ b/tests/test_disclda.py
@@ -204,6 +204,27 @@ def test_custom_prior_is_normalized_and_ordered():
     assert m.settings["class_prior"] == [3.0, 1.0]
 
 
+@pytest.mark.parametrize("weights", [[1e308, 1e308], [1e308, 1.0], [1e-300, 1e300]])
+def test_extreme_custom_prior_stays_finite(weights):
+    # Huge/tiny but finite weights must not overflow the normalizer to +inf (which
+    # would collapse every log-prior to -inf and yield NaN posteriors). The prior
+    # normalises exactly and predict_proba stays finite and sums to 1 (#460).
+    docs, y = _imbalanced_identical()
+    m = topica.DiscLDA(2, 2, iters=100, infer_sweeps=20, seed=1, class_prior=weights)
+    m.fit(docs, y)
+    prior = np.asarray(m.class_prior)
+    assert np.isfinite(prior).all()
+    np.testing.assert_allclose(prior.sum(), 1.0, atol=1e-9)
+    # Reference normalised the same stable way (dividing by max first) — a naive
+    # np.sum([1e308, 1e308]) itself overflows to inf, which is exactly the trap.
+    w = np.asarray(weights, dtype=float)
+    scaled = w / w.max()
+    np.testing.assert_allclose(prior, scaled / scaled.sum(), atol=1e-9)
+    proba = np.asarray(m.predict_proba([["w1", "w2", "w3"], ["not_in_vocab"]]))
+    assert np.isfinite(proba).all()
+    np.testing.assert_allclose(proba.sum(axis=1), 1.0, atol=1e-9)
+
+
 def test_bad_class_prior_string_rejected_at_construction():
     with pytest.raises(ValueError, match="empirical"):
         topica.DiscLDA(2, 2, class_prior="bogus")

--- a/tests/test_disclda.py
+++ b/tests/test_disclda.py
@@ -152,6 +152,94 @@ def test_zero_infer_sweeps_rejected():
         topica.DiscLDA(2, 2, infer_sweeps=0)
 
 
+# --- #460: direct-classifier class-prior semantics --------------------------
+
+def _imbalanced_identical(n=200, dlen=8, seed=0, maj_frac=0.9):
+    """A deliberately imbalanced corpus whose two classes are language-identical:
+    every document draws from the SAME vocabulary regardless of label, so the
+    likelihood carries no class signal and the classifier output is driven purely
+    by the class prior. The review's calibration test case."""
+    rng = np.random.default_rng(seed)
+    vocab = [f"w{i}" for i in range(12)]
+    docs = [[vocab[int(rng.integers(len(vocab)))] for _ in range(dlen)] for _ in range(n)]
+    n_maj = int(round(n * maj_frac))
+    y = ["maj"] * n_maj + ["min"] * (n - n_maj)
+    return docs, y
+
+
+def test_empirical_prior_calibrates_to_class_prevalence():
+    # Language-identical 90:10 corpus: with the empirical prior (default),
+    # predict_proba tracks prevalence rather than collapsing to ~0.5/0.5.
+    docs, y = _imbalanced_identical(maj_frac=0.9)
+    m = topica.DiscLDA(2, 2, iters=200, infer_sweeps=40, seed=1)
+    m.fit(docs, y)
+    assert m.classes == ["maj", "min"]
+    assert m.class_counts == [180, 20]
+    np.testing.assert_allclose(m.class_prior, [0.9, 0.1], atol=1e-9)
+    # A held-out language-identical doc leans to the majority class near the prior.
+    proba = np.asarray(m.predict_proba([["w1", "w2", "w3"]]))[0]
+    assert proba[0] > proba[1] and proba[0] > 0.75
+    # An empty / all-OOV document returns exactly the prior (majority prediction),
+    # not a sorted-order tie break.
+    oov = np.asarray(m.predict_proba([["not_in_vocab"]]))[0]
+    np.testing.assert_allclose(oov, [0.9, 0.1], atol=1e-9)
+    assert m.predict([[]]) == ["maj"]
+
+
+def test_uniform_prior_is_uninformative_on_identical_classes():
+    docs, y = _imbalanced_identical(maj_frac=0.9)
+    m = topica.DiscLDA(2, 2, iters=200, infer_sweeps=40, seed=1, class_prior="uniform")
+    m.fit(docs, y)
+    np.testing.assert_allclose(m.class_prior, [0.5, 0.5], atol=1e-9)
+    oov = np.asarray(m.predict_proba([["not_in_vocab"]]))[0]
+    np.testing.assert_allclose(oov, [0.5, 0.5], atol=1e-9)
+
+
+def test_custom_prior_is_normalized_and_ordered():
+    docs, y = _imbalanced_identical()
+    # Weights are in sorted-class order: classes == ["maj", "min"].
+    m = topica.DiscLDA(2, 2, iters=100, infer_sweeps=20, seed=1, class_prior=[3.0, 1.0])
+    m.fit(docs, y)
+    np.testing.assert_allclose(m.class_prior, [0.75, 0.25], atol=1e-9)
+    assert m.settings["class_prior"] == [3.0, 1.0]
+
+
+def test_bad_class_prior_string_rejected_at_construction():
+    with pytest.raises(ValueError, match="empirical"):
+        topica.DiscLDA(2, 2, class_prior="bogus")
+
+
+def test_wrong_length_custom_prior_rejected_at_fit():
+    # Length is only checkable once num_classes is known (at fit): 3 weights, 2 classes.
+    docs, y = _imbalanced_identical()
+    m = topica.DiscLDA(2, 2, iters=10, class_prior=[1.0, 2.0, 3.0])
+    with pytest.raises(ValueError, match="classes"):
+        m.fit(docs, y)
+
+
+@pytest.mark.parametrize("bad", [[1.0, -1.0], [1.0, float("nan")], []])
+def test_bad_custom_prior_weights_rejected_at_construction(bad):
+    with pytest.raises(ValueError, match="class_prior"):
+        topica.DiscLDA(2, 2, class_prior=bad)
+
+
+def test_class_prior_survives_save_load(tmp_path):
+    docs, y = _imbalanced_identical()
+    m = topica.DiscLDA(2, 2, iters=100, infer_sweeps=20, seed=1)  # empirical
+    m.fit(docs, y)
+    p = tmp_path / "disclda_prior.topica"
+    m.save(str(p))
+    ml = topica.DiscLDA.load(str(p))
+    np.testing.assert_allclose(ml.class_prior, m.class_prior, atol=1e-12)
+    assert ml.class_counts == m.class_counts
+    # predictions reproduce after reload
+    np.testing.assert_allclose(
+        np.asarray(ml.predict_proba([["not_in_vocab"]])),
+        np.asarray(m.predict_proba([["not_in_vocab"]])),
+        atol=1e-12,
+    )
+
+
 def test_fit_iters_zero_rejected():
     # The constructor rejects iters == 0; a per-fit override must too (#460).
     docs, y = _corpus()


### PR DESCRIPTION
Completes the classifier-semantics half of #460 (PR #473 did the hyperparameter/zero-step validation; this is the follow-up it deferred).

## Problem

`predict_doc` softmaxed per-class **plug-in** likelihoods under a hard-coded **uniform** prior. So:
- `predict_proba` was not calibrated to class prevalence — on a 90:10 corpus with language-identical documents it returned ~0.5/0.5 rather than the base rate.
- An empty / all-OOV document (zero likelihood under every class) resolved to a **sorted-order tie break** (class 0), not anything meaningful.

## Fix

A `class_prior` policy, resolved at fit from observed class frequencies and applied as `ln p(c) + plug-in loglik(doc|c)` before the softmax:

- **`"empirical"` (new default)** — uses the class prevalence seen at fit, so `predict_proba` tracks the base rate and an empty/all-OOV document returns the **prior** (majority class), not a sorted-order tie.
- **`"uniform"`** — the previous equal-prior behavior, now explicit.
- **a sequence of per-class weights** (sorted-`classes` order) — custom, normalized.

New `class_prior` (resolved p(c), sums to 1) and `class_counts` getters report what was used; both persist through save/load (older saves default to uniform). `predict`/`predict_proba` docstrings + the docs now state honestly this is a topica-native **plug-in, prior-calibrated score**, not fully marginalized evidence, and keep the fixed-transform §4.1 scope explicit.

Verified on the language-identical 90:10 case:
```
empirical  class_prior=[0.9,0.1]  OOV_proba=[0.9,0.1]  predict([[]])=maj
uniform    class_prior=[0.5,0.5]  OOV_proba=[0.5,0.5]
[3,1]      class_prior=[0.75,0.25]
```

## Tests
- Committed 90:10 language-identical fixture: empirical tracks prevalence, uniform stays ~0.5, custom is normalized, empty-doc → prior, getters, save/load persistence, bad-prior rejection (string at construction, wrong-length custom at fit, non-positive weights).
- Rust unit test: an empty document's posterior equals the (softmaxed) class prior.
- `cargo test --lib disclda` (4) + `tests/test_disclda.py` (25) + `test_save_load_fixes` green; preflight + `mkdocs --strict` clean.

## Scope
This closes the #460 acceptance criteria (validation was #473; classifier semantics here). The §4.2 **learned-transform** variant remains a separate future item (already noted in the docstring/docs), not part of #460.

Closes #460.

🤖 Generated with [Claude Code](https://claude.com/claude-code)