### PR TITLE
feat(seededlda): quanteda-style dictionary seed matching (glob/regex/fixed) (#456)

### DIFF
--- a/docs/guides/guided.md
+++ b/docs/guides/guided.md
@@ -22,13 +22,23 @@ the package's `tfm` construction — and tokens are initialized at random
 initialization. You can read the exact per-topic, per-word pseudocounts a fit
 used from `model.seed_prior_matrix`.
 
+Seed patterns are matched to the vocabulary by `seed_match`, mirroring quanteda's
+dictionary `valuetype` (the matcher the `seededlda` package uses): `"fixed"`
+(default) is exact literal equality; `"glob"` reads `*`/`?` wildcards anchored to
+the whole token, so `"tax*"` seeds `tax`, `taxes`, and `taxation` at once; and
+`"regex"` matches a regular expression anywhere in the token. `case_insensitive`
+(default `False`) folds case — set it `True` with `seed_match="glob"` to reproduce
+quanteda's dictionary defaults. An expanding pattern seeds every matched word
+(each once); `seed_prior_matrix` reflects exactly what was applied.
+
 ```python
 import topica
 
 model = topica.SeededLDA(
-    {"economy": ["jobs", "wages", "tax"],
-     "immigration": ["border", "visa", "deport"]},
+    {"economy": ["job*", "wage*", "tax*"],
+     "immigration": ["border", "visa*", "deport*"]},
     residual=3,           # 3 extra unseeded topics
+    seed_match="glob",    # "job*" seeds jobs, "tax*" seeds tax/taxes/taxation
     seed=1,
 )
 model.fit(docs, iters=2000)

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2971,8 +2971,18 @@ class SeededLDA:
         seed: int = 42,
         seed_prior: str = "frequency",
         sampler: str = "sparse",
+        seed_match: str = "fixed",
+        case_insensitive: bool = False,
     ) -> None:
-        """seed_prior selects how each seed word's prior pseudocount is built:
+        """seed_match selects how each seed pattern is matched to the vocabulary:
+        "fixed" (default) exact literal equality; "glob" reads `*`/`?` wildcards
+        anchored to the whole token (e.g. "tax*" seeds tax, taxes, taxation);
+        "regex" matches a regular expression anywhere in the token. These mirror
+        quanteda's dictionary valuetype (the seededlda package's matcher).
+        case_insensitive (default False) folds case; set it True with
+        seed_match="glob" to reproduce quanteda's dictionary defaults.
+
+        seed_prior selects how each seed word's prior pseudocount is built:
         "frequency" (default) reproduces the seededlda package (pseudocount =
         corpus-frequency * weight * 100, random initialization); "uniform" gives
         every seed word the same weight * 100 pseudocount with seed-word tokens

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2980,7 +2980,10 @@ class SeededLDA:
         "regex" matches a regular expression anywhere in the token. These mirror
         quanteda's dictionary valuetype (the seededlda package's matcher).
         case_insensitive (default False) folds case; set it True with
-        seed_match="glob" to reproduce quanteda's dictionary defaults.
+        seed_match="glob" to reproduce quanteda's dictionary defaults. The "regex"
+        dialect is Rust's linear-time regex crate, not R's ICU/stringi: common
+        syntax matches identically, but backreferences and lookaround are
+        unsupported.
 
         seed_prior selects how each seed word's prior pseudocount is built:
         "frequency" (default) reproduces the seededlda package (pseudocount =

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -12150,6 +12150,9 @@ impl SeededLDA {
     /// package uses; an expanding pattern seeds every matched word (each once).
     /// `case_insensitive` (default False) folds case in the match — set it True
     /// with ``seed_match="glob"`` to reproduce quanteda's dictionary defaults.
+    /// The ``"regex"`` dialect is Rust's linear-time `regex` crate, not R's
+    /// ICU/stringi: common syntax (alternation, anchors, classes) matches
+    /// identically, but backreferences and lookaround are unsupported.
     #[new]
     #[pyo3(signature = (seed_words, *, residual=0, alpha=0.5, beta=0.1, weight=0.01, seed=42,
                         seed_prior="frequency", sampler="sparse", seed_match="fixed",

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -504,6 +504,12 @@ struct SeededState {
     // this field and used the uniform fixed-mass scheme, so default to "uniform".
     #[serde(default = "seeded_prior_legacy_default")]
     seed_prior: String,
+    // Seed-to-vocabulary matcher. Older saves predate these and used exact literal,
+    // case-sensitive matching, so default to "fixed" / case-sensitive.
+    #[serde(default = "seeded_match_legacy_default")]
+    seed_match: String,
+    #[serde(default)]
+    case_insensitive: bool,
     // Sampler backend flags.
     #[serde(default)]
     warp: bool,
@@ -515,6 +521,9 @@ struct SeededState {
 }
 fn seeded_prior_legacy_default() -> String {
     "uniform".to_string()
+}
+fn seeded_match_legacy_default() -> String {
+    "fixed".to_string()
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct KeyAtmState {
@@ -11901,28 +11910,130 @@ fn parse_seed_dict(d: &Bound<'_, PyDict>) -> PyResult<(Vec<String>, Vec<Vec<Stri
     Ok((names, words))
 }
 
-/// Map per-topic seed/keyword *words* to vocabulary ids (dropping out-of-vocab),
+/// How seed/keyword patterns are matched against the vocabulary, following
+/// quanteda's dictionary `valuetype` (the matcher the seededlda package uses).
+#[derive(Clone, Copy, PartialEq)]
+enum SeedMatch {
+    /// Exact literal equality (topica's original and default behavior).
+    Fixed,
+    /// Glob wildcards — `*` matches any run of characters, `?` a single one —
+    /// anchored to the whole token (quanteda's default `valuetype`).
+    Glob,
+    /// A regular expression, matched unanchored (found anywhere in the token),
+    /// as quanteda's `valuetype = "regex"` does via `stri_detect_regex`.
+    Regex,
+}
+
+impl SeedMatch {
+    fn parse(s: &str) -> PyResult<Self> {
+        match s {
+            "fixed" => Ok(SeedMatch::Fixed),
+            "glob" => Ok(SeedMatch::Glob),
+            "regex" => Ok(SeedMatch::Regex),
+            other => Err(PyValueError::new_err(format!(
+                "seed_match must be \"fixed\", \"glob\", or \"regex\", got {other:?}"
+            ))),
+        }
+    }
+}
+
+/// Translate a glob body (only `*` and `?` are special) into a regex body,
+/// escaping every regex metacharacter so the rest matches literally.
+fn glob_to_regex_body(glob: &str) -> String {
+    let mut body = String::with_capacity(glob.len() + 8);
+    for c in glob.chars() {
+        match c {
+            '*' => body.push_str(".*"),
+            '?' => body.push('.'),
+            '.' | '+' | '(' | ')' | '|' | '[' | ']' | '{' | '}' | '^' | '$' | '\\' => {
+                body.push('\\');
+                body.push(c);
+            }
+            _ => body.push(c),
+        }
+    }
+    body
+}
+
+/// Compile one glob/regex seed pattern. Glob is anchored to the whole token;
+/// regex is left unanchored (quanteda semantics). `(?i)` folds case when asked.
+fn compile_seed_pattern(pat: &str, mode: SeedMatch, case_insensitive: bool) -> PyResult<Regex> {
+    let body = match mode {
+        SeedMatch::Glob => format!("^(?:{})$", glob_to_regex_body(pat)),
+        SeedMatch::Regex => pat.to_string(),
+        SeedMatch::Fixed => unreachable!("Fixed does not compile a regex"),
+    };
+    let full = if case_insensitive {
+        format!("(?i){body}")
+    } else {
+        body
+    };
+    Regex::new(&full)
+        .map_err(|e| PyValueError::new_err(format!("invalid seed pattern {pat:?}: {e}")))
+}
+
+/// Map per-topic seed/keyword *patterns* to vocabulary ids (dropping non-matches),
 /// padding with empty lists up to `num_topics` total topics.
+///
+/// `mode` selects the matcher. `Fixed` (case-sensitive) keeps the original O(1)
+/// exact lookup, including its original duplicate-preserving, no-dedup behavior.
+/// `Glob`/`Regex` (and case-insensitive `Fixed`) scan the vocabulary per pattern
+/// and dedup within each topic, so an expanding pattern (or overlapping patterns)
+/// contributes each matched vocabulary word to a topic exactly once.
 fn seed_word_ids(
     word_strings: &[Vec<String>],
     id_to_word: &[String],
     num_topics: usize,
-) -> Vec<Vec<usize>> {
-    let index: HashMap<&str, usize> = id_to_word
-        .iter()
-        .enumerate()
-        .map(|(i, w)| (w.as_str(), i))
-        .collect();
-    let mut out: Vec<Vec<usize>> = word_strings
-        .iter()
-        .map(|ws| {
-            ws.iter()
-                .filter_map(|w| index.get(w.as_str()).copied())
-                .collect()
-        })
-        .collect();
+    mode: SeedMatch,
+    case_insensitive: bool,
+) -> PyResult<Vec<Vec<usize>>> {
+    let mut out: Vec<Vec<usize>> = Vec::with_capacity(word_strings.len());
+
+    if mode == SeedMatch::Fixed && !case_insensitive {
+        let index: HashMap<&str, usize> = id_to_word
+            .iter()
+            .enumerate()
+            .map(|(i, w)| (w.as_str(), i))
+            .collect();
+        for ws in word_strings {
+            out.push(
+                ws.iter()
+                    .filter_map(|w| index.get(w.as_str()).copied())
+                    .collect(),
+            );
+        }
+    } else {
+        for topic_pats in word_strings {
+            let mut ids: Vec<usize> = Vec::new();
+            let mut seen: std::collections::HashSet<usize> = std::collections::HashSet::new();
+            for pat in topic_pats {
+                match mode {
+                    SeedMatch::Fixed => {
+                        // Case-insensitive exact equality (scans to catch every
+                        // vocabulary casing that folds onto the pattern).
+                        let lp = pat.to_lowercase();
+                        for (i, w) in id_to_word.iter().enumerate() {
+                            if w.to_lowercase() == lp && seen.insert(i) {
+                                ids.push(i);
+                            }
+                        }
+                    }
+                    SeedMatch::Glob | SeedMatch::Regex => {
+                        let re = compile_seed_pattern(pat, mode, case_insensitive)?;
+                        for (i, w) in id_to_word.iter().enumerate() {
+                            if re.is_match(w) && seen.insert(i) {
+                                ids.push(i);
+                            }
+                        }
+                    }
+                }
+            }
+            out.push(ids);
+        }
+    }
+
     out.resize(num_topics, Vec::new());
-    out
+    Ok(out)
 }
 
 /// Seeded LDA (guided topic modeling): you supply a few **seed words** per topic
@@ -11944,6 +12055,11 @@ pub struct SeededLDA {
     // count·weight·100, tokens initialised at random) or "uniform" (every seed
     // word gets the same weight·100 mass, seed-word tokens anchored at init).
     seed_prior: String,
+    // How seed patterns are matched to the vocabulary: "fixed" (exact, default),
+    // "glob" (quanteda-style `*`/`?` wildcards), or "regex". `case_insensitive`
+    // folds case in the match (quanteda's default is case-insensitive).
+    seed_match: String,
+    case_insensitive: bool,
     seed: u64,
     // WarpLDA cache-efficient sampler (seeded word phase) instead of the default
     // SparseLDA seeded sweep. Recommended for large K.
@@ -11990,6 +12106,8 @@ impl SeededLDA {
         d.set_item("beta", self.beta)?;
         d.set_item("weight", self.weight)?;
         d.set_item("seed_prior", &self.seed_prior)?;
+        d.set_item("seed_match", &self.seed_match)?;
+        d.set_item("case_insensitive", self.case_insensitive)?;
         d.set_item("seed", self.seed)?;
         let sampler = if self.warp {
             "warp"
@@ -12023,9 +12141,20 @@ impl SeededLDA {
     ///
     /// `sampler` selects the inference backend: ``"sparse"`` (default), ``"warp"``
     /// (WarpLDA), or ``"cvb0"`` (deterministic collapsed variational Bayes).
+    ///
+    /// `seed_match` chooses how each seed pattern is matched to the vocabulary:
+    /// ``"fixed"`` (default) is exact literal equality; ``"glob"`` reads `*`/`?`
+    /// wildcards anchored to the whole token (e.g. ``"tax*"`` seeds tax, taxes,
+    /// taxation); ``"regex"`` matches a regular expression anywhere in the token.
+    /// These mirror quanteda's dictionary ``valuetype``, the matcher the seededlda
+    /// package uses; an expanding pattern seeds every matched word (each once).
+    /// `case_insensitive` (default False) folds case in the match — set it True
+    /// with ``seed_match="glob"`` to reproduce quanteda's dictionary defaults.
     #[new]
     #[pyo3(signature = (seed_words, *, residual=0, alpha=0.5, beta=0.1, weight=0.01, seed=42,
-                        seed_prior="frequency", sampler="sparse"))]
+                        seed_prior="frequency", sampler="sparse", seed_match="fixed",
+                        case_insensitive=false))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         seed_words: &Bound<'_, PyDict>,
         residual: usize,
@@ -12035,11 +12164,15 @@ impl SeededLDA {
         seed: u64,
         seed_prior: &str,
         sampler: &str,
+        seed_match: &str,
+        case_insensitive: bool,
     ) -> PyResult<Self> {
         let (names, words) = parse_seed_dict(seed_words)?;
         if !finite_pos(alpha) || !finite_pos(beta) {
             return Err(PyValueError::new_err("alpha and beta must be > 0"));
         }
+        // Validate seed_match up front so a typo fails at construction, not fit.
+        SeedMatch::parse(seed_match)?;
         // `weight` scales the seed pseudocount; an unvalidated value silently
         // corrupted the fit — a negative weight yields negative topic-word
         // probabilities and NaN/inf yield non-finite ones. The seededlda package
@@ -12077,6 +12210,8 @@ impl SeededLDA {
             beta,
             weight,
             seed_prior: seed_prior.to_string(),
+            seed_match: seed_match.to_string(),
+            case_insensitive,
             seed,
             warp,
             cvb0,
@@ -12146,7 +12281,14 @@ impl SeededLDA {
         }
         let num_topics = slf.num_topics_val();
         let num_types = corpus.num_types();
-        let seeds = seed_word_ids(&slf.seed_words, &corpus.id_to_word, num_topics);
+        let seed_match = SeedMatch::parse(&slf.seed_match)?;
+        let seeds = seed_word_ids(
+            &slf.seed_words,
+            &corpus.id_to_word,
+            num_topics,
+            seed_match,
+            slf.case_insensitive,
+        )?;
         let (alpha, beta) = (slf.alpha, slf.beta);
 
         // Build the per-(topic, seed word) prior mass, aligned to `seeds`.
@@ -12419,19 +12561,21 @@ impl SeededLDA {
                 }
             }
         }
-        let index: std::collections::HashMap<&str, usize> = corpus
-            .id_to_word
-            .iter()
-            .enumerate()
-            .map(|(i, w)| (w.as_str(), i))
-            .collect();
+        // Expand the seed patterns exactly as fit() does (fixed/glob/regex), so the
+        // reported mass matches what was applied — not just literal matches (#456).
+        let seed_match = SeedMatch::parse(&self.seed_match)?;
+        let seeds = seed_word_ids(
+            &self.seed_words,
+            &corpus.id_to_word,
+            num_topics,
+            seed_match,
+            self.case_insensitive,
+        )?;
         let mut m = Array2::<f64>::zeros((num_topics, num_types));
-        for (k, words) in self.seed_words.iter().enumerate() {
-            for w in words {
-                if let Some(&wid) = index.get(w.as_str()) {
-                    let base = if freq_scaled { word_freq[wid] } else { 1.0 };
-                    m[[k, wid]] = base * self.weight * 100.0;
-                }
+        for (k, ids) in seeds.iter().enumerate() {
+            for &wid in ids {
+                let base = if freq_scaled { word_freq[wid] } else { 1.0 };
+                m[[k, wid]] = base * self.weight * 100.0;
             }
         }
         Ok(m.to_pyarray_bound(py))
@@ -12523,6 +12667,8 @@ impl SeededLDA {
                 seed_words: self.seed_words.clone(),
                 residual: self.residual,
                 seed_prior: self.seed_prior.clone(),
+                seed_match: self.seed_match.clone(),
+                case_insensitive: self.case_insensitive,
                 warp: self.warp,
                 cvb0: self.cvb0,
                 theta_draws: arr3f32_opt(&self.theta_draws),
@@ -12542,6 +12688,8 @@ impl SeededLDA {
             beta: s.beta,
             weight: s.weight,
             seed_prior: s.seed_prior,
+            seed_match: s.seed_match,
+            case_insensitive: s.case_insensitive,
             seed: s.seed,
             warp: s.warp,
             cvb0: s.cvb0,
@@ -13686,7 +13834,15 @@ impl KeyATM {
                 )?;
             }
         }
-        let mut keys = seed_word_ids(&slf.keywords, &corpus.id_to_word, num_topics);
+        // KeyATM matches keywords by exact literal (issue #456's glob/regex matching
+        // is SeededLDA-scoped); the dedup below already covers repeated surface forms.
+        let mut keys = seed_word_ids(
+            &slf.keywords,
+            &corpus.id_to_word,
+            num_topics,
+            SeedMatch::Fixed,
+            false,
+        )?;
         // Duplicate keyword ids in a topic reach the core's "keyword id listed more
         // than once" invariant and panic across the FFI boundary. They arise from a
         // repeated keyword string *or* two distinct surface forms that resolve to the

--- a/tests/test_seeded_gsdmm_contracts.py
+++ b/tests/test_seeded_gsdmm_contracts.py
@@ -119,6 +119,135 @@ def test_seededlda_frequency_seed_mass_is_exact() -> None:
     assert m[ti["conflict"], vi["war"]] > m[ti["econ"], vi["budget"]]
 
 
+# ---------------------------------------------------------------------------
+# Dictionary seed matching (#456): quanteda-style fixed/glob/regex + case.
+# All checked exactly via seed_prior_matrix, which reflects the seeds actually
+# applied at fit — no reference toolchain required.
+# ---------------------------------------------------------------------------
+
+_DICT_DOCS = [
+    ["tax", "taxes", "taxation", "revenue"],
+    ["war", "conflict", "military"],
+    ["tax", "revenue", "budget"],
+    ["War", "Conflict", "defense"],
+]
+
+
+def _seeded_cells(model) -> set[tuple[str, str]]:
+    """(topic_name, word) pairs carrying nonzero seed mass."""
+    m = np.asarray(model.seed_prior_matrix)
+    vocab = list(model.vocabulary)
+    names = list(model.topic_names)
+    return {
+        (names[k], vocab[w])
+        for k in range(m.shape[0])
+        for w in range(m.shape[1])
+        if m[k, w] != 0.0
+    }
+
+
+def test_fixed_matching_is_exact_and_default() -> None:
+    """seed_match defaults to "fixed": a literal seed matches only that exact type,
+    not morphological variants sharing a prefix."""
+    model = topica.SeededLDA(
+        {"econ": ["tax"], "mil": ["war"]}, seed_prior="uniform", seed=1
+    )
+    assert model.settings["seed_match"] == "fixed"
+    assert model.settings["case_insensitive"] is False
+    model.fit(_DICT_DOCS, iters=0)
+    cells = _seeded_cells(model)
+    assert ("econ", "tax") in cells
+    # "taxes"/"taxation" are distinct types; a fixed "tax" seed must not reach them.
+    assert ("econ", "taxes") not in cells
+    assert ("econ", "taxation") not in cells
+    # Case-sensitive by default: "War" is a different type from the "war" seed.
+    assert ("mil", "War") not in cells
+
+
+def test_glob_expands_to_matching_vocabulary() -> None:
+    """seed_match="glob": "tax*" seeds every vocabulary type with that prefix."""
+    model = topica.SeededLDA(
+        {"econ": ["tax*"], "mil": ["war", "conflict"]},
+        seed_prior="uniform",
+        seed_match="glob",
+        seed=1,
+    )
+    model.fit(_DICT_DOCS, iters=0)
+    cells = _seeded_cells(model)
+    assert ("econ", "tax") in cells
+    assert ("econ", "taxes") in cells
+    assert ("econ", "taxation") in cells
+    # The glob is anchored, so "revenue" (no "tax" prefix) is not swept in.
+    assert ("econ", "revenue") not in cells
+
+
+def test_glob_case_insensitive_folds_case() -> None:
+    """case_insensitive=True folds case, so a lowercase glob also seeds the
+    capitalized surface forms (quanteda's dictionary default)."""
+    model = topica.SeededLDA(
+        {"econ": ["tax*"], "mil": ["war", "conflict"]},
+        seed_prior="uniform",
+        seed_match="glob",
+        case_insensitive=True,
+        seed=1,
+    )
+    model.fit(_DICT_DOCS, iters=0)
+    cells = _seeded_cells(model)
+    # Both "war"/"War" and "conflict"/"Conflict" are present in the vocab.
+    assert ("mil", "war") in cells
+    assert ("mil", "War") in cells
+    assert ("mil", "conflict") in cells
+    assert ("mil", "Conflict") in cells
+
+
+def test_regex_matches_unanchored() -> None:
+    """seed_match="regex" matches anywhere in the token (quanteda stri_detect_regex)."""
+    model = topica.SeededLDA(
+        {"econ": ["^tax"], "mil": ["war|conflict"]},
+        seed_prior="uniform",
+        seed_match="regex",
+        seed=1,
+    )
+    model.fit(_DICT_DOCS, iters=0)
+    cells = _seeded_cells(model)
+    # "^tax" anchors the start: tax, taxes, taxation.
+    assert {("econ", "tax"), ("econ", "taxes"), ("econ", "taxation")} <= cells
+    # Alternation, matched unanchored.
+    assert ("mil", "war") in cells
+    assert ("mil", "conflict") in cells
+
+
+def test_invalid_seed_match_rejected_at_construction() -> None:
+    with np.testing.assert_raises(ValueError):
+        topica.SeededLDA({"a": ["x"], "b": ["y"]}, seed_match="bogus")
+
+
+def test_invalid_regex_pattern_rejected_at_fit() -> None:
+    model = topica.SeededLDA(
+        {"a": ["["], "b": ["y"]}, seed_match="regex", seed=1
+    )
+    with np.testing.assert_raises(ValueError):
+        model.fit(_DICT_DOCS, iters=5)
+
+
+def test_seed_match_survives_save_load(tmp_path) -> None:
+    model = topica.SeededLDA(
+        {"econ": ["tax*"], "mil": ["war"]},
+        seed_prior="uniform",
+        seed_match="glob",
+        case_insensitive=True,
+        seed=1,
+    )
+    model.fit(_DICT_DOCS, iters=0)
+    before = _seeded_cells(model)
+    path = str(tmp_path / "seeded_glob.topica")
+    model.save(path)
+    reloaded = topica.SeededLDA.load(path)
+    assert reloaded.settings["seed_match"] == "glob"
+    assert reloaded.settings["case_insensitive"] is True
+    assert _seeded_cells(reloaded) == before
+
+
 def _manual_gsdmm_counts(docs: list[list[str]], clusters: np.ndarray, vocab: list[str]):
     word_index = {w: i for i, w in enumerate(vocab)}
     k = int(clusters.max()) + 1


### PR DESCRIPTION
Closes the remaining #456 checklist item: **dictionary seed matching**. SeededLDA matched seed words to the vocabulary by exact literal string only, but the `seededlda` package uses quanteda dictionaries, which match by `valuetype` — glob (default), regex, or fixed — with an optional case fold.

## What this adds
Two constructor parameters:
- `seed_match`: `"fixed"` (default, exact literal — unchanged behavior) | `"glob"` (`*`/`?` wildcards anchored to the whole token) | `"regex"` (matched anywhere in the token, quanteda's `stri_detect_regex` semantics).
- `case_insensitive` (default `False`): folds case in the match. Pair with `"glob"` to reproduce quanteda's dictionary defaults.

A glob like `"tax*"` seeds `tax`, `taxes`, and `taxation` at once; each matched vocabulary type is seeded once (deduped within a topic).

## Faithfulness details
- `seed_prior_matrix` now routes through the **same** expansion, so it reports exactly the mass applied at fit rather than only literal matches.
- `seed_match` / `case_insensitive` are serialized (save/load, with legacy-save defaults of `"fixed"` / case-sensitive) and surfaced in `settings`.
- KeyATM keeps exact-literal keyword matching — this feature is SeededLDA-scoped.
- Invalid `seed_match` raises at construction; an invalid regex raises at fit.

## Default choice
`seed_match="fixed"` + `case_insensitive=False` preserves current behavior exactly — no silent change to existing fits. Glob/regex/case-folding are explicit opt-ins, documented as reproducing quanteda's dictionary matching. (Flag if you'd prefer glob+case-insensitive as the default to match quanteda's out-of-the-box behavior.)

## Tests / docs
- Seven exact contract tests in `test_seeded_gsdmm_contracts.py` (fixed-is-exact-default, glob expansion, case-insensitive fold, regex unanchored, invalid seed_match, invalid regex, save/load round-trip), all driven deterministically by `seed_prior_matrix` — no reference toolchain needed.
- New "dictionary seed matching" section in `docs/guides/guided.md`.
- Full local gates green: preflight (fmt + clippy + table/stub sync), `mkdocs --strict`, and the seeded + keyATM suites (354 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)