### PR TITLE
fix(models): easy follow-ups from the model-review batch (#490/#494/#495/#496/#497)

### DIFF
--- a/parity/gsdmm_gold.py
+++ b/parity/gsdmm_gold.py
@@ -1,6 +1,11 @@
 """Planted self-consistency gold for topica GSDMM (Yin & Wang 2014, short-text DMM) (issue #271, Wave 2).
 
-GSDMM has no external reference; it auto-prunes empty clusters so the frozen topic count is what the fit settled on, so this is a PLANTED self-consistency / planted-recovery gold, NOT a
+The canonical ``rwalk/gsdmm`` implementation exists, but it assumes deduplicated
+documents and omits the paper's ``+ j - 1`` numerator term, so it agrees with
+topica's Eq. 4 only on unique-token docs (topica follows Yin & Wang exactly; see
+``src/gsdmm.rs``). There is thus no committed cross-implementation reference, and
+GSDMM auto-prunes empty clusters so the frozen topic count is what the fit settled
+on, so this is a PLANTED self-consistency / planted-recovery gold, NOT a
 cross-implementation one (mirrors ``parity/sage_gold.py``). We fit topica gsdmm
 ONCE on a fixed-seed planted corpus and freeze its topic-word + doc-topic
 matrices and the planted layout; the test then refits and asserts the fit

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -427,7 +427,7 @@ class CTM:
     @property
     def initialization(self) -> str | None:
         """The initialization route the fit took (#410): 'spectral',
-        'random-fallback', 'random', or 'provided'; None before fit."""
+        'random-fallback', or 'random'; None before fit."""
         ...
 
     @property
@@ -598,7 +598,7 @@ class STM:
     @property
     def initialization(self) -> str | None:
         """The initialization route the fit took (#410): 'spectral',
-        'random-fallback', 'random', or 'provided'; None before fit."""
+        'random-fallback', or 'random'; None before fit."""
         ...
 
     @property
@@ -823,7 +823,7 @@ class STS:
     @property
     def initialization(self) -> str | None:
         """The initialization route the fit took (#410): 'spectral',
-        'random-fallback', 'random', or 'provided'; None before fit."""
+        'random-fallback', or 'random'; None before fit."""
         ...
 
     @property
@@ -1155,7 +1155,7 @@ class DTM:
     @property
     def initialization(self) -> str | None:
         """The initialization route the fit took (#410): 'spectral',
-        'random-fallback', 'random', or 'provided'; None before fit."""
+        'random-fallback', or 'random'; None before fit."""
         ...
 
     @property
@@ -2910,9 +2910,10 @@ class HLDA:
         seed: int = 42,
         eta: Optional[float] = None,
     ) -> None:
-        """depth is the number of levels in the topic tree. gamma controls
-        branching (higher = more nodes). beta is the topic-word Dirichlet base
-        measure. alpha is the document-path concentration.
+        """depth is the number of levels in the topic tree. gamma is the nCRP
+        branching concentration (higher = more nodes). beta is the topic-word
+        Dirichlet base measure. alpha is the symmetric Dirichlet smoothing over the
+        L path levels (the per-document level distribution).
 
         eta is a deprecated alias for beta."""
         ...

--- a/src/detm.rs
+++ b/src/detm.rs
@@ -684,9 +684,6 @@ impl EtaNet {
                     let gb_hh = &mut g.b_hh[layer];
                     for j in 0..eh {
                         let dpj = dp[j];
-                        if dpj == 0.0 {
-                            // bias still gets 0; skip the inner loops cheaply.
-                        }
                         let row = (blk * eh + j) * eh;
                         gb_ih[blk * eh + j] += dpj;
                         gb_hh[blk * eh + j] += dpj;

--- a/src/dtm.rs
+++ b/src/dtm.rs
@@ -633,6 +633,10 @@ pub fn fit_dtm<R: Rng>(
 
     let mut bound = 0.0;
     let mut lda_max_iter = 25usize;
+    // gensim's fit_lda_seq runs at least `em_min_iter` EM sweeps before honoring the
+    // convergence break (`while iter_ < em_min_iter or ...`); default 6. Bounded by
+    // the user's `em_iters` budget, so a smaller budget still caps the work.
+    const EM_MIN_ITER: usize = 6;
     for iter in 0..em_iters {
         let old_bound = bound;
         // E-step: per-document inference, accumulate topic suff-stats per slice.
@@ -669,7 +673,10 @@ pub fn fit_dtm<R: Rng>(
         if bound < old_bound && lda_max_iter < 10 {
             lda_max_iter *= 2; // gensim: back off when the bound dips
         }
-        if iter > 0 && old_bound != 0.0 && ((bound - old_bound) / old_bound).abs() < 1e-4 {
+        if iter + 1 >= EM_MIN_ITER
+            && old_bound != 0.0
+            && ((bound - old_bound) / old_bound).abs() < 1e-4
+        {
             break;
         }
     }

--- a/src/gsdmm.rs
+++ b/src/gsdmm.rs
@@ -28,6 +28,12 @@
 //! where `c_{dw}` is the count of word `w` in document `d` and `N_d` is the
 //! total token count of document `d`.  The denominator of the document-cluster
 //! prior `(D − 1 + K·α)` is constant across clusters and is omitted.
+//!
+//! Note on the popular `rwalk/gsdmm` implementation: it assumes deduplicated
+//! documents and omits the `+ j − 1` rising-factorial term in the numerator
+//! (its `j` is always 1). The two therefore agree on unique-token documents and
+//! diverge only when a document repeats a token, where this port follows the
+//! paper — scoring a twice-seen word as `(nw+β)(nw+β+1)` rather than `(nw+β)²`.
 
 use rand::Rng;
 

--- a/src/pa.rs
+++ b/src/pa.rs
@@ -468,10 +468,14 @@ pub fn fit_pam_with_draws<R: Rng>(
                         .collect()
                 })
                 .collect();
-            if model.theta_draws.len() < opts.cap {
-                model.theta_draws.push(snap);
-            } else {
-                model.theta_draws.remove(0);
+            // Ring buffer of theta snapshots; cap == 0 disables collection. Guard
+            // the pop so an empty buffer can never underflow on remove(0) (#497):
+            // ThetaDrawOpts::new forces thin == 0 when cap == 0, so this is a
+            // defensive invariant rather than a live path.
+            if opts.cap > 0 {
+                if model.theta_draws.len() >= opts.cap {
+                    model.theta_draws.remove(0);
+                }
                 model.theta_draws.push(snap);
             }
         }

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -905,9 +905,10 @@ impl DETM {
         Ok(d)
     }
 
-    /// Create an unfitted model. ``delta`` is the random-walk standard-deviation
-    /// knob on the topic-embedding and topic-prior trajectories (smaller = smoother
-    /// drift; reference default 0.005). ``hidden_size`` is the document encoder
+    /// Create an unfitted model. ``delta`` is the random-walk **variance** knob on
+    /// the topic-embedding and topic-prior trajectories (the reference sets the
+    /// prior log-variance to ``log(delta)``; smaller = smoother drift; reference
+    /// default 0.005). ``hidden_size`` is the document encoder
     /// width. ``eta_hidden_size``/``eta_nlayers`` size the LSTM that amortizes the
     /// per-time topic prior q(eta) (reference defaults 200 / 3).
     /// ``batch_size``/``lr``/``wdecay`` drive Adam; ``convergence_tol`` stops on the

--- a/tests/test_gsdmm_gold.py
+++ b/tests/test_gsdmm_gold.py
@@ -1,7 +1,9 @@
 """Offline planted-gold test for topica GSDMM (issue #271, Wave 2).
 
-GSDMM has NO external reference implementation, so this is a PLANTED
-self-consistency gold (see ``parity/gsdmm_gold.py``). It loads the committed gold
+There is no committed cross-implementation reference (the canonical
+``rwalk/gsdmm`` matches topica only on unique-token docs — topica follows the
+paper's Eq. 4 including the ``+ j - 1`` term rwalk omits; see ``src/gsdmm.rs``),
+so this is a PLANTED self-consistency gold (see ``parity/gsdmm_gold.py``). It loads the committed gold
 (``parity/gsdmm_gold.npz`` + ``.json``), refits topica on the same fixed-seed
 planted corpus, and asserts (1) the refit reproduces the frozen topic-word matrix
 in cosine (determinism), (2) the planted structure is recovered, and (3) the


### PR DESCRIPTION
Low-risk items from the model-by-model faithfulness audit. **No core-math changes** — every reviewed sampler/gradient is left as-is; these are the documentation, stub, and small-robustness follow-ups.

## Docs / stub (no behavior change)
- **DETM `delta`** — documented as "standard-deviation" but it is a **variance** (the reference sets prior log-variance = `log(delta)`). A user reading "std" misjudges smoothing strength by the square. (`neural.rs`, `.pyi`) — #495 F1
- **DETM dead code** — remove the empty `if dpj == 0.0 {}` block whose comment claimed a skip it never performed. (`detm.rs`) — #495 F4
- **HLDA `alpha` stub** — said "document-path concentration" (that is `gamma`'s role); it is the symmetric Dirichlet smoothing over the L path levels. (`.pyi`) — #496 FID-5
- **Init-route stub** — drop the unreachable `'provided'` value: no source emits it (`grep` confirms). Fixed across all four models sharing the #410 telemetry — CTM/STM/STS/DTM. (`.pyi`) — #494 #5 (extended to the 3 siblings with the same drift)
- **GSDMM "no external reference" wording** — `rwalk/gsdmm` exists but omits the paper's `+ j − 1` numerator term (it assumes deduplicated input), so it agrees with topica only on unique-token docs; topica follows Yin & Wang Eq. 4 exactly. Corrected in the gold/test headers + a module-docstring note. (`gsdmm.rs`, `parity/gsdmm_gold.py`, `tests/test_gsdmm_gold.py`) — #490 #3

## Robustness / behavioral (small, safe)
- **PA ring buffer** — guard so `remove(0)` can never underflow an empty `Vec` when `cap==0` (latent panic; unreachable via the public ctor since `ThetaDrawOpts::new` forces `thin=0` when `cap=0`, now a hardened invariant). (`pa.rs`) — #497 #1
- **DTM `em_min_iter` floor** — add gensim's minimum of 6 EM sweeps before honoring the convergence break (topica could stop at iter 1), bounded by the user's `iters` budget. The committed gold already ran ≥6 iters, so it is **unchanged** (verified: `test_dtm_gold` passes). (`dtm.rs`) — #494 #1

## Verification
- `pytest tests/test_dtm.py tests/test_dtm_gold.py tests/test_detm.py tests/test_pa_gold.py tests/test_gsdmm.py tests/test_gsdmm_gold.py tests/test_hlda_gold.py` → 47 passed, 1 skipped.
- `cargo test --lib detm::` → 7 passed (incl. the FD gradient gate).
- `scripts/preflight.sh` → clean (fmt, clippy, NaN-guard, model tables, stub sync 78 passed).

Each issue keeps its remaining (larger) items open: BTM `pw_b` #492, HLDA leaf-first delete #496 #1, the feature gaps (#490 transform, #497 doc_super, #494 doc_topic), and the FD/gold test-coverage gaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)