### PR TITLE
fix(bindings): harden remaining #481-class hyperparameter guards across the review batch

### DIFF
--- a/src/hlda.rs
+++ b/src/hlda.rs
@@ -421,55 +421,35 @@ impl HldaModel {
             .expect("tree must have a root")
     }
 
-    /// Delete subtrees whose root node has zero customers. A node with no
-    /// customers has no tokens either (its counts were removed first), so it is
-    /// safe to drop along with its (necessarily also-empty) descendants.
+    /// Delete every subtree whose root node has zero customers. A node with no
+    /// customers has no tokens either (its counts were removed first), and if a
+    /// node is empty so are all of its descendants, so the whole empty region is
+    /// safe to drop.
+    ///
+    /// We remove empty nodes **leaf-first**: repeatedly drop any non-root node
+    /// that is empty *and currently childless*, re-scanning after each
+    /// `swap_remove`. An empty internal node is only removed once its (also-empty)
+    /// children are gone, so no node index is ever held across the `swap_remove`
+    /// that could invalidate it. The previous recurse-then-detach walk read
+    /// `self.nodes[i].parent` after descendant `swap_remove`s had already
+    /// relocated `i`, which corrupted links / panicked once an empty subtree
+    /// spanned three or more removal levels (reachable at `depth >= 4`).
     fn delete_empty_subtrees(&mut self) {
-        // Mark reachable-and-nonempty nodes; collect deletions of any node with
-        // ndocs == 0 that is not the root.
         loop {
-            let mut to_delete = None;
-            for i in 0..self.nodes.len() {
-                if self.nodes[i].level != 0 && self.nodes[i].ndocs == 0 {
-                    to_delete = Some(i);
-                    break;
-                }
+            let target = (0..self.nodes.len()).find(|&i| {
+                self.nodes[i].level != 0
+                    && self.nodes[i].ndocs == 0
+                    && self.nodes[i].children.is_empty()
+            });
+            let Some(i) = target else { break };
+            // Detach the childless empty leaf from its parent, then swap-remove it.
+            // `swap_remove_node` remaps the one element it moves; because `i` has no
+            // children, nothing we still need points into `i`.
+            if let Some(p) = self.nodes[i].parent {
+                self.nodes[p].children.retain(|&c| c != i);
             }
-            match to_delete {
-                None => break,
-                Some(i) => self.remove_node(i),
-            }
+            self.swap_remove_node(i);
         }
-    }
-
-    /// Remove a single (childless or empty-subtree) node `i`, detaching it from
-    /// its parent. Assumes `i` has ndocs == 0; if it has children they must also
-    /// be empty and will be removed on subsequent passes (we only remove leaves
-    /// of the empty region here by requiring no children).
-    fn remove_node(&mut self, i: usize) {
-        // If it still has children, remove them first (they are empty too).
-        let children = self.nodes[i].children.clone();
-        for c in children {
-            self.remove_node_subtree_member(c);
-        }
-        // Detach from parent.
-        if let Some(p) = self.nodes[i].parent {
-            self.nodes[p].children.retain(|&c| c != i);
-        }
-        self.swap_remove_node(i);
-    }
-
-    /// Recursively remove a node and its descendants (all empty) without touching
-    /// the parent link cleanup of the top call.
-    fn remove_node_subtree_member(&mut self, i: usize) {
-        let children = self.nodes[i].children.clone();
-        for c in children {
-            self.remove_node_subtree_member(c);
-        }
-        if let Some(p) = self.nodes[i].parent {
-            self.nodes[p].children.retain(|&c| c != i);
-        }
-        self.swap_remove_node(i);
     }
 
     /// `swap_remove` node `i` from the Vec and fix up every index that referred to
@@ -758,5 +738,98 @@ mod tests {
         let model = fit_hlda(&docs, v, 2, 1.0, 0.1, 0.5, 80, &mut rng);
         let base = crate::conformance::check_conformance(&model);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
+    }
+
+    #[test]
+    fn depth4_delete_empty_subtrees_stays_consistent() {
+        // Regression for #496: `delete_empty_subtrees` used to hold node indices
+        // across `swap_remove` and corrupt links / panic once an empty subtree
+        // spanned three removal levels — reachable only at `depth >= 4`. Fit a
+        // churny depth-4 tree over several seeds and assert the tree stays fully
+        // consistent (no panic, every parent/child link and document path valid,
+        // no empty non-root node left behind).
+        for seed in [1u64, 7, 42, 99, 2024, 31337] {
+            let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            // A churny random corpus (not the stable planted one): many short docs
+            // over a small vocab, with a high nCRP concentration so the sampler
+            // spawns deep transient subtrees that then empty out as documents
+            // resample — the regime that makes an empty subtree span 3+ removal
+            // levels. depth=5 gives the extra level headroom over the depth-3-safe
+            // region.
+            let v = 12usize;
+            let mut docs = Vec::new();
+            for d in 0..220 {
+                let len = 3 + (d % 5);
+                let mut doc = Vec::new();
+                for _ in 0..len {
+                    doc.push((rng.gen::<f64>() * v as f64) as u32 % v as u32);
+                }
+                docs.push(doc);
+            }
+            let model = fit_hlda(&docs, v, 5, 4.0, 0.1, 0.5, 80, &mut rng);
+
+            let n = model.num_nodes();
+            assert_eq!(
+                (0..n).filter(|&i| model.nodes[i].level == 0).count(),
+                1,
+                "seed {seed}: expected exactly one root"
+            );
+            for i in 0..n {
+                match model.nodes[i].parent {
+                    Some(p) => {
+                        assert!(p < n, "seed {seed}: node {i} parent {p} out of range");
+                        assert!(
+                            model.nodes[p].children.contains(&i),
+                            "seed {seed}: node {i} missing from parent {p}'s children"
+                        );
+                        assert_eq!(
+                            model.nodes[p].level + 1,
+                            model.nodes[i].level,
+                            "seed {seed}: node {i} level != parent level + 1"
+                        );
+                    }
+                    None => assert_eq!(
+                        model.nodes[i].level, 0,
+                        "seed {seed}: parentless node {i} is not the root"
+                    ),
+                }
+                for &c in &model.nodes[i].children {
+                    assert!(c < n, "seed {seed}: node {i} child {c} out of range");
+                    assert_eq!(
+                        model.nodes[c].parent,
+                        Some(i),
+                        "seed {seed}: child {c}'s parent link != {i}"
+                    );
+                }
+                assert!(
+                    model.nodes[i].level == 0 || model.nodes[i].ndocs > 0,
+                    "seed {seed}: empty non-root node {i} survived pruning"
+                );
+            }
+            // Every document path is a valid root->leaf chain of length `depth`.
+            for (d, path) in model.paths.iter().enumerate() {
+                assert_eq!(
+                    path.len(),
+                    model.depth,
+                    "seed {seed}: doc {d} path len != depth"
+                );
+                assert_eq!(
+                    model.nodes[path[0]].level, 0,
+                    "seed {seed}: doc {d} path[0] is not the root"
+                );
+                for w in 1..path.len() {
+                    assert!(
+                        path[w] < n,
+                        "seed {seed}: doc {d} path node {} out of range",
+                        path[w]
+                    );
+                    assert_eq!(
+                        model.nodes[path[w]].parent,
+                        Some(path[w - 1]),
+                        "seed {seed}: doc {d} path broken at level {w}"
+                    );
+                }
+            }
+        }
     }
 }

--- a/src/python/idealpoint.rs
+++ b/src/python/idealpoint.rs
@@ -395,6 +395,14 @@ impl IdealPointTM {
                 "prior_variance, w_prior_variance and x_prior_variance must be > 0",
             ));
         }
+        // #481-class guards: a non-finite sigma_shrink feeds `1.0 - sigma_shrink`
+        // into the prior covariance -> NaN topics; it is a mixing ratio in [0, 1).
+        if !(sigma_shrink.is_finite() && (0.0..1.0).contains(&sigma_shrink)) {
+            return Err(PyValueError::new_err(format!(
+                "sigma_shrink must be in [0, 1) (got {sigma_shrink})"
+            )));
+        }
+        ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         Ok(IdealPointTM {
             num_topics,
             num_dims,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13116,6 +13116,11 @@ impl FASTopic {
             return Err(PyValueError::new_err("need at least 2 topics"));
         }
         ensure_finite_pos("theta_temp", theta_temp)?;
+        // #481-class guards: a NaN/+inf alpha flows into `log_k = -alpha*cost` and
+        // produces NaN transport plans -> NaN topics; a non-finite lr poisons Adam.
+        ensure_finite_pos("dt_alpha", dt_alpha)?;
+        ensure_finite_pos("tw_alpha", tw_alpha)?;
+        ensure_finite_pos("lr", lr)?;
         Ok(FASTopic {
             num_topics,
             lr,

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -1562,6 +1562,19 @@ impl InfoCTM {
         if !(mi_temperature > 0.0 && mi_temperature.is_finite()) {
             return Err(PyValueError::new_err("mi_temperature must be > 0"));
         }
+        // #481-class guards: a NaN/+inf mi_weight flows through `scale = weight/denom`
+        // into the beta gradient -> NaN topics; a non-finite lr poisons Adam; a NaN
+        // pos_threshold silently mis-densifies the alignment mask.
+        ensure_finite_pos("mi_weight", mi_weight)?;
+        ensure_finite_pos("lr", lr)?;
+        if hidden_size < 1 {
+            return Err(PyValueError::new_err("hidden_size must be >= 1"));
+        }
+        if !pos_threshold.is_finite() {
+            return Err(PyValueError::new_err(format!(
+                "pos_threshold must be finite (got {pos_threshold})"
+            )));
+        }
         Ok(InfoCTM {
             num_topics,
             mi_weight,
@@ -2049,6 +2062,15 @@ impl ProdLDA {
         }
         if !(0.0..1.0).contains(&dropout) {
             return Err(PyValueError::new_err("dropout must be in [0, 1)"));
+        }
+        // #481-class guards: a non-finite lr poisons Adam -> NaN topics; a zero
+        // hidden_size / batch_size is a degenerate encoder / empty minibatch.
+        ensure_finite_pos("lr", lr)?;
+        if hidden_size < 1 {
+            return Err(PyValueError::new_err("hidden_size must be >= 1"));
+        }
+        if batch_size < 1 {
+            return Err(PyValueError::new_err("batch_size must be >= 1"));
         }
         // Validate the flags eagerly so a bad prior/weight fails at construction.
         build_avitm_options(&prior, contrastive, contrastive_weight, contrastive_temp)?;
@@ -2618,6 +2640,15 @@ macro_rules! ctm_embedding_model {
                 }
                 if !(0.0..1.0).contains(&dropout) {
                     return Err(PyValueError::new_err("dropout must be in [0, 1)"));
+                }
+                // #481-class guards (shared with plain ProdLDA): a non-finite lr
+                // poisons Adam; a zero hidden_size / batch_size is degenerate.
+                ensure_finite_pos("lr", lr)?;
+                if hidden_size < 1 {
+                    return Err(PyValueError::new_err("hidden_size must be >= 1"));
+                }
+                if batch_size < 1 {
+                    return Err(PyValueError::new_err("batch_size must be >= 1"));
                 }
                 build_avitm_options(&prior, contrastive, contrastive_weight, contrastive_temp)?;
                 Ok($name {

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -164,6 +164,14 @@ impl PartyEmbeddings {
         if !learning_rate.is_finite() || learning_rate <= 0.0 {
             return Err(PyValueError::new_err("learning_rate must be > 0"));
         }
+        // #481-class guard: a NaN `sample` makes every keep-probability NaN, so every
+        // token is dropped and the model trains on nothing yet returns "fitted".
+        // Keep `0.0` legal — it is the documented "subsampling off" value.
+        if sample.is_nan() || sample < 0.0 {
+            return Err(PyValueError::new_err(format!(
+                "sample must be >= 0 (0 disables subsampling); got {sample}"
+            )));
+        }
         Ok(PartyEmbeddings {
             num_dims,
             vector_size,

--- a/src/python/sentence_ideal.rs
+++ b/src/python/sentence_ideal.rs
@@ -100,6 +100,9 @@ impl IdealPointSentenceTM {
         if !finite_pos(x_prior_variance) {
             return Err(PyValueError::new_err("x_prior_variance must be > 0"));
         }
+        // #481-class guard: a non-finite convergence_tol makes the relative-change
+        // early-stop always-false; reject it at the boundary for guard-parity.
+        ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         Ok(IdealPointSentenceTM {
             num_topics,
             num_dims,

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -98,6 +98,20 @@ impl Wordfish {
         convergence_tol: f64,
         seed: u64,
     ) -> PyResult<Self> {
+        // #481-class guards. Prior SDs: reject NaN/negative but keep `+inf` legal —
+        // it is the documented "flat prior / no regularization" value (the core maps
+        // any non-finite-or-nonpositive sd to zero precision).
+        for (name, sd) in [
+            ("beta_prior_sd", beta_prior_sd),
+            ("theta_prior_sd", theta_prior_sd),
+        ] {
+            if sd.is_nan() || sd < 0.0 {
+                return Err(PyValueError::new_err(format!(
+                    "{name} must be >= 0 (or +inf for a flat prior); got {sd}"
+                )));
+            }
+        }
+        ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         Ok(Wordfish {
             beta_prior_sd,
             theta_prior_sd,

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -90,6 +90,16 @@ _NONFINITE_POS_CASES = [
     ("RTM.negative_ratio", lambda bad: topica.RTM(3, negative_ratio=bad)),
     ("RTM.ridge", lambda bad: topica.RTM(3, ridge=bad)),
     ("FASTopic.theta_temp", lambda bad: topica.FASTopic(3, theta_temp=bad)),
+    # Second batch of #481-class guards from the model-review sweep (#498-#508):
+    # strictly-positive params that route through ensure_finite_pos.
+    ("FASTopic.dt_alpha", lambda bad: topica.FASTopic(3, dt_alpha=bad)),
+    ("FASTopic.tw_alpha", lambda bad: topica.FASTopic(3, tw_alpha=bad)),
+    ("FASTopic.lr", lambda bad: topica.FASTopic(3, lr=bad)),
+    ("InfoCTM.mi_weight", lambda bad: topica.InfoCTM(3, mi_weight=bad)),
+    ("InfoCTM.lr", lambda bad: topica.InfoCTM(3, lr=bad)),
+    ("ProdLDA.lr", lambda bad: topica.ProdLDA(3, lr=bad)),
+    ("CombinedTM.lr", lambda bad: topica.CombinedTM(3, lr=bad)),
+    ("ZeroShotTM.lr", lambda bad: topica.ZeroShotTM(3, lr=bad)),
 ]
 
 
@@ -113,6 +123,68 @@ def test_tlda_nonfinite_hyperparameters_rejected(param, bad):
     try:
         with pytest.raises(ValueError, match="finite"):
             topica.TensorLDA(3, **{param: bad})
+    finally:
+        topica.enable_experimental(was)
+
+
+# #481-class guards from the model-review sweep that are NOT plain finite-and-positive:
+# integer size params (>= 1), a [0, 1) mixing ratio, non-negative tolerances, prior
+# SDs that keep +inf legal (flat prior), and a subsample rate that keeps 0.0 legal.
+def test_zero_size_params_rejected():
+    for build in (
+        lambda: topica.ProdLDA(3, hidden_size=0),
+        lambda: topica.ProdLDA(3, batch_size=0),
+        lambda: topica.CombinedTM(3, hidden_size=0),
+        lambda: topica.ZeroShotTM(3, batch_size=0),
+        lambda: topica.InfoCTM(3, hidden_size=0),
+    ):
+        with pytest.raises(ValueError, match=">= 1"):
+            build()
+
+
+@pytest.mark.parametrize("bad", [NAN, INF])
+def test_infoctm_pos_threshold_must_be_finite(bad):
+    with pytest.raises(ValueError, match="finite"):
+        topica.InfoCTM(3, pos_threshold=bad)
+
+
+@pytest.mark.parametrize("bad", [NAN, -1.0])
+def test_wordfish_prior_sd_rejects_nan_and_negative_but_allows_inf(bad):
+    # Prior SDs reject NaN/negative but keep +inf legal (the documented flat prior).
+    with pytest.raises(ValueError):
+        topica.Wordfish(beta_prior_sd=bad)
+    with pytest.raises(ValueError):
+        topica.Wordfish(theta_prior_sd=bad)
+    topica.Wordfish(beta_prior_sd=INF, theta_prior_sd=INF)  # flat prior: must not raise
+
+
+@pytest.mark.parametrize("bad", [NAN, INF])
+def test_convergence_tol_rejects_nonfinite(bad):
+    with pytest.raises(ValueError, match="finite"):
+        topica.Wordfish(convergence_tol=bad)
+
+
+@pytest.mark.parametrize("bad", [NAN, -0.5])
+def test_partyembeddings_sample_rejects_nan_negative_allows_zero(bad):
+    with pytest.raises(ValueError):
+        topica.PartyEmbeddings(sample=bad)
+    topica.PartyEmbeddings(sample=0.0)  # subsampling off: must not raise
+
+
+def test_idealpoint_family_guards():
+    # IdealPointTM / IdealPointSentenceTM are experimental-gated.
+    was = topica.experimental_enabled()
+    topica.enable_experimental(True)
+    try:
+        for bad in (NAN, 1.0, -0.1):
+            with pytest.raises(ValueError, match="sigma_shrink"):
+                topica.IdealPointTM(3, sigma_shrink=bad)
+        topica.IdealPointTM(3, sigma_shrink=0.0)  # boundary: must not raise
+        for bad in (NAN, INF):
+            with pytest.raises(ValueError, match="finite"):
+                topica.IdealPointTM(3, convergence_tol=bad)
+            with pytest.raises(ValueError, match="finite"):
+                topica.IdealPointSentenceTM(3, convergence_tol=bad)
     finally:
         topica.enable_experimental(was)
 


### PR DESCRIPTION
Second bundle from the model-review sweep (after #501 and #507): closes the remaining **#481-class NaN/+inf-admitting constructor guard gaps** that the review found across seven neural / ideal-point models. Same theme as the original #481 arc (#483) — an invalid hyperparameter should fail at construction with a clean `ValueError`, not silently produce NaN topics or a fitted-looking-but-untrained model.

## Guards added (routed through the existing `ensure_finite_pos` / `ensure_finite_nonneg` helpers, or a purpose-matched inline check)

| Model | Issue | Params |
|---|---|---|
| FASTopic | #500 | `dt_alpha`, `tw_alpha`, `lr` (>0) — a non-finite alpha flows into `log_k = -alpha*cost` → NaN transport plan → NaN topics |
| InfoCTM | #504 | `mi_weight`, `lr` (>0); `hidden_size` (≥1); `pos_threshold` (finite — a cosine threshold, so not restricted to positive) |
| ProdLDA / CombinedTM / ZeroShotTM | #503 | `lr` (>0); `hidden_size`, `batch_size` (≥1) |
| Wordfish | #505 | `beta_prior_sd`, `theta_prior_sd` (reject NaN/negative, **keep `+inf` legal** = the documented flat prior); `convergence_tol` (finite ≥0) |
| IdealPointTM | #498 | `sigma_shrink` (finite, `[0,1)` — it feeds `1.0 - sigma_shrink` into the prior covariance); `convergence_tol` (finite ≥0) |
| IdealPointSentenceTM | #499 | `convergence_tol` (finite ≥0) |
| PartyEmbeddings | #508 | `sample` (reject NaN/negative, **keep `0.0` legal** = subsampling off; a NaN `sample` made every keep-probability NaN → a "fitted" model trained on nothing) |

## Preserved behavior

Legal edge values still construct: `+inf` prior SD (Wordfish flat prior), `sigma_shrink=0.0`, `sample=0.0`. The `window==0` / empty-vocab edge panics flagged in #508 are already unreachable (existing `window >= 1` / `min_count >= 1` + empty-corpus guards). Documentation / fidelity items in the referenced issues are out of scope for this bundle.

## Verification

- `maturin develop --release` clean; smoke-tested each guard fires on NaN/+inf/0 and the legal edge values still construct.
- New/extended regression tests in `tests/test_input_validation.py`.
- `pytest tests/test_input_validation.py` → 90 passed; affected-model suites → 213 passed.
- `scripts/preflight.sh` → clean, including its dedicated "no NaN-admitting `<= 0.0` guards (#481)" check and stub sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
