### PR TITLE
docs(ideal-point): document sign/rotation non-identifiability of the position outputs (#498/#499/#505/#506/#508)

### DIFF
--- a/src/python/idealpoint.rs
+++ b/src/python/idealpoint.rs
@@ -490,6 +490,15 @@ impl IdealPointTM {
     }
     /// Author positions (num_authors, num_dims): the latent ideal points,
     /// standardized to mean 0 / unit variance per dimension.
+    ///
+    /// Identifiability: the scale is fixed but the axis is identified only up to
+    /// **sign** per dimension — and, for `num_dims > 1`, up to an arbitrary
+    /// **rotation** of the axes (the likelihood is invariant under
+    /// `x -> x @ R`, `W -> R^-1 @ W`). Pass `anchors` to `fit()` to fix the sign of
+    /// dimension 0; without them the orientation is deterministic for a given seed
+    /// but otherwise arbitrary (it can flip across seeds/corpora), and
+    /// multi-dimensional positions are best read through the loadings, not
+    /// coordinate-by-coordinate.
     #[getter]
     fn author_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         Ok(vecs_to_arr2(self.fitted_model()?.x()).to_pyarray_bound(py))

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -392,11 +392,11 @@ impl PartyEmbeddings {
     /// Column 0 is the left-right scale.
     ///
     /// Identifiability: **without anchors the sign of each dimension is arbitrary**
-    /// (PCA components are sign-invariant), and for `num_dims > 1` the axes are
-    /// identified only up to a rotation — pass `anchors` to `fit()` to orient them.
-    /// Columns are also standardized independently, so the relative scale of the
-    /// principal components is not preserved; read the raw `author_vectors` if you
-    /// need it.
+    /// — PCA fixes the axes by variance, so each placement column is identified up
+    /// to sign (not rotation, unlike the fit-x-directly ideal-point models); pass
+    /// `anchors` to `fit()` to fix those signs. Columns are also standardized
+    /// independently, so the relative scale of the principal components is not
+    /// preserved; read the raw `author_vectors` if you need it.
     #[getter]
     fn author_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.fitted_model()?;

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -388,7 +388,15 @@ impl PartyEmbeddings {
 
     /// Party placements as a (num_authors, num_dims) matrix: the leading principal
     /// components of the learned party vectors, standardized to mean 0 / unit
-    /// variance and sign-oriented to the anchors. Column 0 is the left-right scale.
+    /// variance and, when `anchors` are supplied to `fit()`, sign-oriented to them.
+    /// Column 0 is the left-right scale.
+    ///
+    /// Identifiability: **without anchors the sign of each dimension is arbitrary**
+    /// (PCA components are sign-invariant), and for `num_dims > 1` the axes are
+    /// identified only up to a rotation — pass `anchors` to `fit()` to orient them.
+    /// Columns are also standardized independently, so the relative scale of the
+    /// principal components is not preserved; read the raw `author_vectors` if you
+    /// need it.
     #[getter]
     fn author_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.fitted_model()?;

--- a/src/python/sentence_ideal.rs
+++ b/src/python/sentence_ideal.rs
@@ -232,6 +232,13 @@ impl IdealPointSentenceTM {
         Ok(self.fitted_model()?.num_authors)
     }
     /// Author positions (num_authors, num_dims), standardized to mean 0 / unit var.
+    ///
+    /// Identifiability: identified only up to **sign** per dimension — and, for
+    /// `num_dims > 1`, up to an arbitrary **rotation** of the axes (the Gaussian
+    /// mixture is invariant under `x -> x @ R`, `V -> R^-1 @ V`). Pass `anchors` to
+    /// `fit()` to fix the sign of dimension 0; without them the orientation is
+    /// deterministic for a given seed but otherwise arbitrary, and multi-dimensional
+    /// positions are best read through the loadings, not coordinate-by-coordinate.
     #[getter]
     fn author_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         Ok(vecs_to_arr2(&self.fitted_model()?.x).to_pyarray_bound(py))

--- a/src/python/tbip.rs
+++ b/src/python/tbip.rs
@@ -303,6 +303,12 @@ impl TBIP {
         Ok(self.fitted_model()?.num_authors)
     }
     /// Author ideal points (num_authors,), the posterior-mean positions mu_x.
+    ///
+    /// Identifiability: identified only up to **sign** — the model is invariant
+    /// under `x -> -x, eta -> -eta`, so the direction is arbitrary and determined by
+    /// the seed (TBIP has no anchoring). Compare runs by absolute correlation, or
+    /// flip to a chosen reference author. The scale is only softly pinned by the
+    /// N(0, 1) prior.
     #[getter]
     fn ideal_points<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         Ok(Array1::from(self.fitted_model()?.ideal_points()).to_pyarray_bound(py))

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -331,6 +331,13 @@ impl Wordfish {
     }
     /// Author positions as a (num_authors, 1) matrix, standardized to mean 0 / unit
     /// variance. The latent left-right scale.
+    ///
+    /// Identifiability: identified only up to **sign** — the scale is symmetric, so
+    /// which pole is "left" is arbitrary. Pass `anchors` to `fit()` to orient it;
+    /// without anchors the sign is deterministic for a given corpus but otherwise
+    /// arbitrary (it can flip across corpora). Note R quanteda instead *always*
+    /// orients by default (`dir = c(1, 2)`, i.e. document 1 < document 2), so an
+    /// unanchored topica axis may point opposite to quanteda's.
     #[getter]
     fn author_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         Ok(vecs_to_arr2(&self.fitted_model()?.positions()).to_pyarray_bound(py))


### PR DESCRIPTION
Third bundle from the model-review sweep: a **family-wide documentation fix** for the sign/rotation non-identifiability the review flagged across every ideal-point model (#498, #499, #505, #506, #508). Each model's position accessor is unidentified up to sign (and, for `num_dims > 1`, an arbitrary rotation of the axes), but the docstrings never said so — a user comparing runs across seeds, or reading "left/right" onto the sign, can be misled.

## What changed (docstrings only)

A consistent **Identifiability** note added to each position accessor:

| Model | Issue | Accessor | Note |
|---|---|---|---|
| IdealPointTM | #498 | `author_positions` | sign per dimension + rotation for `num_dims > 1` (`x -> xR`, `W -> R⁻¹W`); read multi-dim positions through the loadings, not coordinate-by-coordinate; `anchors` fixes dim 0 |
| IdealPointSentenceTM | #499 | `author_positions` | same, for the Gaussian-mixture form (`V -> R⁻¹V`) |
| Wordfish | #505 | `author_positions` | sign-only; **R quanteda always orients by default (`dir = c(1, 2)`)**, so an unanchored topica axis may point the other way |
| PartyEmbeddings | #508 | `author_positions` | PCA components are sign-invariant → without `anchors` each dimension's sign is arbitrary; columns standardized independently, so PC relative scale is not preserved (use raw `author_vectors`) |
| TBIP | #506 | `ideal_points` | invariant under `x -> -x, eta -> -eta`; no anchoring, so sign is seed-determined — compare by absolute correlation |

## Scope / non-goals

- **Documentation only** — no behavior, signature, or stub-name change. The remaining option from these findings (enforce a canonical rotation for `num_dims > 1`, or default-orient like quanteda) is deliberately left out; documenting the invariance is the low-risk fix, and callers who want a fixed orientation already have `anchors`.
- The `.pyi` stub is type/name-only for these accessors (`test_stub_sync` checks member names, not prose), so the user-facing text lives in the Rust `///` docstrings surfaced via `help()`.

## Verification

- `cargo fmt --all --check` clean; `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean.
- Verified every referenced name exists: `anchors=` on the four `fit()` methods, `author_vectors` on PartyEmbeddings, and that TBIP has no anchoring.
- No build/test rebuild needed (comment-only, stub-name-neutral); the full suite + stub-sync run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
