### PR TITLE
fix(btm): biterm-weight the background pw_b, not raw token counts (#492)

### DIFF
--- a/parity/btm_compare.py
+++ b/parity/btm_compare.py
@@ -34,7 +34,26 @@ def _corpus(seed=0):
     return docs, vocab
 
 
-def _reference_phi(docs, tmp):
+def _corpus_varlen(seed=0):
+    """Variable-length corpus: alternating short (3-token) and long (20-token)
+    documents. Biterm participation then diverges from raw token frequency, so the
+    background distribution `pw_b` (and every topic it perturbs) is only correct if
+    `pw_b` is accumulated over biterm words, not tokens (#492).
+
+    Uses K-1 planted blocks so the K-1 *content* topics (topic 0 is the background
+    under background=True) cover the blocks one-to-one — otherwise which block the
+    scarce content topics merge is RNG-dependent and not cross-impl comparable."""
+    nblocks = K - 1
+    rng = np.random.default_rng(seed)
+    vocab = [f"b{b}_w{i}" for b in range(nblocks) for i in range(BLOCK)]
+    docs = []
+    for d in range(NDOCS):
+        length = 3 if d % 2 == 0 else 20
+        docs.append([f"b{d % nblocks}_w{int(rng.integers(BLOCK))}" for _ in range(length)])
+    return docs, vocab
+
+
+def _reference_phi(docs, tmp, background=False):
     """Run the R BTM package and return (tokens, phi[V x K]); None if unavailable."""
     if shutil.which("Rscript") is None:
         return None
@@ -46,13 +65,14 @@ def _reference_phi(docs, tmp):
             for tok in doc:
                 w.writerow([f"doc{i}", tok])
     phip = os.path.join(tmp, "phi.csv")
+    bg = "TRUE" if background else "FALSE"
     rscript = f"""
     ok <- suppressWarnings(suppressMessages(require(BTM)))
     if (!ok) quit(status = 42)
     set.seed(123)
     d <- read.csv("{csvp}", stringsAsFactors = FALSE, colClasses = "character")
     m <- BTM(d, k = {K}, alpha = {ALPHA}, beta = {BETA}, iter = {ITERS},
-             window = {WINDOW}, background = FALSE, trace = FALSE)
+             window = {WINDOW}, background = {bg}, trace = FALSE)
     phi <- m$phi
     write.csv(data.frame(token = rownames(phi), phi), "{phip}", row.names = FALSE)
     """
@@ -82,31 +102,66 @@ def _aligned_cosine(a, b):
     return cs
 
 
-def run_comparison():
-    docs, _ = _corpus()
+def _compare(docs, background, label, cosine_min=COSINE_MIN):
+    """Fit R + topica BTM on `docs` with the given `background` flag and assert the
+    aligned topic-word cosine clears the bar. Returns False if R is unavailable.
+
+    Under background=True the shared background topic (index 0 in both topica and
+    R BTM) is EXCLUDED: its phi is emitted from the biterm counts it accumulated,
+    not the pw_b it sampled from, so it depends on each engine's RNG and is not
+    cross-implementation comparable. The K-1 content topics are what the pw_b fix
+    (#492) governs, and they are compared."""
     tmp = tempfile.mkdtemp()
-    ref = _reference_phi(docs, tmp)
+    ref = _reference_phi(docs, tmp, background=background)
     if ref is None:
-        print("Reference R BTM not available. Skipping parity check.")
-        return
+        print(f"[{label}] Reference R BTM not available. Skipping.")
+        return False
     r_tokens, r_phi = ref  # V x K
     rmap = {t: i for i, t in enumerate(r_tokens)}
 
-    m = topica.BTM(num_topics=K, alpha=ALPHA, beta=BETA, iters=ITERS, window=WINDOW, seed=123)
+    m = topica.BTM(
+        num_topics=K, alpha=ALPHA, beta=BETA, iters=ITERS, window=WINDOW,
+        background=background, seed=123,
+    )
     m.fit(docs)
-    t_phi = m.topic_word  # K x V
+    t_phi = np.asarray(m.topic_word)  # K x V
     vocab = m.vocabulary
     r_aligned = np.zeros((K, len(vocab)))
     for j, tok in enumerate(vocab):
         if tok in rmap:
             r_aligned[:, j] = r_phi[rmap[tok], :]
 
-    cs = _aligned_cosine(t_phi, r_aligned)
-    print("topica-vs-R BTM aligned topic-word cosine:")
+    # Topic 0 is the background under background=True; compare only content topics.
+    t_cmp, r_cmp = (t_phi[1:], r_aligned[1:]) if background else (t_phi, r_aligned)
+    cs = _aligned_cosine(t_cmp, r_cmp)
+    kind = "content topic" if background else "topic"
+    print(f"[{label}] topica-vs-R BTM aligned cosine (background={background}):")
     for i, c in enumerate(cs):
-        print(f"  topic {i}: cosine={c:.6f}")
-        assert c > COSINE_MIN, f"BTM parity mismatch: cosine {c:.6f} < {COSINE_MIN}"
-    print(f"mean cosine {np.mean(cs):.6f}")
+        print(f"  {kind} {i}: cosine={c:.6f}")
+        assert c > cosine_min, f"[{label}] BTM parity mismatch: cosine {c:.6f} < {cosine_min}"
+    print(f"[{label}] mean cosine {np.mean(cs):.6f}  PASS")
+    return True
+
+
+def run_comparison():
+    ran = False
+    # Leg 1: the original uniform-length, background=False content parity.
+    docs, _ = _corpus()
+    ran |= _compare(docs, background=False, label="uniform/bg=False")
+    # Leg 2 (#492): a background=True variable-length sanity check — confirms
+    # topica's background=True mode still tracks R BTM (K-1 content topics match at
+    # cosine ~1.0; the RNG-dependent background topic 0 is excluded). NOTE this is
+    # NOT a discriminating test of the pw_b fix: on separable corpora R BTM's
+    # background topic stays near-empty (theta_0 ~ 0.005), so token- vs
+    # biterm-weighted pw_b barely propagates to the content topics and the leg
+    # passes either way. The discriminating guard for the fix is the deterministic
+    # Rust unit test `pw_b_is_biterm_weighted_not_token_weighted`, which pins the
+    # exact biterm-participation shares.
+    vdocs, _ = _corpus_varlen()
+    ran |= _compare(vdocs, background=True, label="varlen/bg=True")
+    if not ran:
+        print("Reference R BTM not available. Skipping parity check.")
+        return
     print("SUCCESS: BTM parity check passed!")
 
 

--- a/src/btm.rs
+++ b/src/btm.rs
@@ -74,6 +74,30 @@ fn gen_biterms(doc: &[u32], window: usize, out: &mut Vec<(u32, u32)>) {
     }
 }
 
+/// Empirical background word distribution `pw_b`, weighted by **biterm
+/// participation** (not raw token counts) and normalized to a simplex over the V
+/// words. The reference (xiaohuiyan `Model::load_docs`, wrapped by R `BTM`)
+/// accumulates over biterm endpoints — `pw_b[bi.wi] += 1; pw_b[bi.wj] += 1` per
+/// biterm — so a word is weighted by how many within-window neighbours it has
+/// (position- and length-dependent). This matters on variable-length corpora or
+/// when `window < doc len`; single-word / sub-window docs form no biterms and so
+/// contribute nothing, exactly as in the reference (#492). Returns all-zeros if
+/// there are no biterms (the caller's `background` path is inert then).
+fn biterm_word_dist(biterms: &[(u32, u32)], v: usize) -> Vec<f64> {
+    let mut pw_b = vec![0.0f64; v];
+    for &(w1, w2) in biterms {
+        pw_b[w1 as usize] += 1.0;
+        pw_b[w2 as usize] += 1.0;
+    }
+    let sum: f64 = pw_b.iter().sum();
+    if sum > 0.0 {
+        for p in pw_b.iter_mut() {
+            *p /= sum;
+        }
+    }
+    pw_b
+}
+
 /// Sample an index from an unnormalized weight vector by the inverse-CDF scan the
 /// reference uses (`Sampler::mult_sample`): draw `u ~ U(0,1)`, return the first
 /// `k` whose cumulative weight reaches `u * total`.
@@ -163,23 +187,13 @@ pub fn fit_btm<R: Rng>(
     let k = num_topics;
     let v = num_types;
 
-    // Empirical word distribution (for the optional background topic 0).
-    let mut pw_b = vec![0.0f64; v];
     let mut biterms: Vec<(u32, u32)> = Vec::new();
     for doc in docs {
         gen_biterms(doc, window, &mut biterms);
-        for &w in doc {
-            if (w as usize) < v {
-                pw_b[w as usize] += 1.0;
-            }
-        }
     }
-    let pw_sum: f64 = pw_b.iter().sum();
-    if pw_sum > 0.0 {
-        for p in pw_b.iter_mut() {
-            *p /= pw_sum;
-        }
-    }
+
+    // Empirical word distribution for the optional background topic 0.
+    let pw_b = biterm_word_dist(&biterms, v);
 
     let b = biterms.len();
     // Count tables: nb_z[k] = #biterms in topic k, nwz[k][w] = word occurrences
@@ -289,6 +303,60 @@ mod tests {
             })
             .collect();
         (docs, v)
+    }
+
+    #[test]
+    fn pw_b_is_biterm_weighted_not_token_weighted() {
+        // A variable-length corpus where biterm participation and raw token counts
+        // give DIFFERENT background distributions (#492). At window=2 each adjacent
+        // pair is a biterm:
+        //   doc A: [0,0,0,0]  -> (0,0) x3 (pos 0-1,1-2,2-3):   pw_b[0] += 6
+        //   doc B: [1,2]      -> (1,2):                        pw_b[1]+=1, pw_b[2]+=1
+        //   doc C: [3,4,5]    -> (3,4),(4,5):        pw_b[3]+=1, pw_b[4]+=2, pw_b[5]+=1
+        //   doc D: [6]        -> single word, no biterm:       contributes nothing
+        // This test is the discriminating guard for the fix: a token-weighted pw_b
+        // would give the `tok` shares below and fail the equality assertion.
+        let v = 7usize;
+        let window = 2usize;
+        let docs: Vec<Vec<u32>> = vec![vec![0, 0, 0, 0], vec![1, 2], vec![3, 4, 5], vec![6]];
+
+        let mut biterms: Vec<(u32, u32)> = Vec::new();
+        for d in &docs {
+            gen_biterms(d, window, &mut biterms);
+        }
+        let pw_b = biterm_word_dist(&biterms, v);
+
+        // Hand-computed biterm-participation counts (see the table above).
+        let raw = [6.0, 1.0, 1.0, 1.0, 2.0, 1.0, 0.0];
+        let sum: f64 = raw.iter().sum();
+        for w in 0..v {
+            assert!(
+                (pw_b[w] - raw[w] / sum).abs() < 1e-12,
+                "pw_b[{w}] = {} != biterm share {}",
+                pw_b[w],
+                raw[w] / sum
+            );
+        }
+
+        // It must NOT equal the token-frequency distribution the old code used.
+        let tok = [4.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0]; // raw token counts
+        let tok_sum: f64 = tok.iter().sum();
+        let token_dist: Vec<f64> = tok.iter().map(|&c| c / tok_sum).collect();
+        let differs = (0..v).any(|w| (pw_b[w] - token_dist[w]).abs() > 1e-6);
+        assert!(
+            differs,
+            "pw_b must differ from the token-frequency distribution"
+        );
+        // Word 4 has two within-window neighbours -> up-weighted vs its single token.
+        assert!(
+            pw_b[4] > token_dist[4],
+            "biterm weighting should up-weight word 4"
+        );
+        // The single-word doc's word contributes nothing.
+        assert_eq!(
+            pw_b[6], 0.0,
+            "a word appearing only in a biterm-less doc gets 0"
+        );
     }
 
     #[test]

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -115,7 +115,12 @@ impl BTM {
     }
 
     /// Create an unfitted BTM model. `alpha` defaults to `50 / num_topics`
-    /// (the reference default), `beta` to `0.01`, `window` to 15.
+    /// (the reference default), `beta` to `0.01`, `window` to 15. With
+    /// `background=True`, topic 0 becomes a background topic that absorbs corpus-wide
+    /// common words (drawn from the biterm-participation word distribution), leaving
+    /// `num_topics - 1` content topics; its reported `topic_word` row is emitted from
+    /// the biterm counts it accumulated, not the background distribution it sampled
+    /// from.
     #[new]
     #[pyo3(signature = (num_topics, *, alpha=None, beta=0.01, iters=1000,
                         window=15, background=false, seed=42))]


### PR DESCRIPTION
Fixes the one fidelity bug from the BTM review (#492): the `background=True` variant built its empirical background word distribution `pw_b` from raw token counts, but the reference (xiaohuiyan `Model::load_docs`, wrapped by R `BTM`) accumulates over **biterm endpoints** -- `pw_b[bi.wi] += 1; pw_b[bi.wj] += 1` per biterm. A word is weighted by its within-window neighbour count (position/length dependent); single-word / sub-window docs contribute nothing.

Invisible on uniform-length corpora with `window >= len` (the two differ by a constant that normalizes away -- which is why the `background=False` parity harness never caught it), but on variable-length corpora / `window < len` they genuinely differ, changing which biterms the background topic absorbs and perturbing every content topic.

## Fix
Derive `pw_b` from the biterm list (new `biterm_word_dist` helper) instead of the token stream -- matches `Model::load_docs` exactly.

## Validation
- **New Rust unit test** `pw_b_is_biterm_weighted_not_token_weighted` (deterministic, gates CI): on a variable-length corpus, asserts `pw_b` equals the biterm-participation shares (a word with two neighbours is up-weighted vs its single token; a biterm-less single-word doc contributes 0) and differs from the old token-frequency distribution.
- **New `background=True` parity leg** in `parity/btm_compare.py` (live R BTM, skips without Rscript), run locally: on a variable-length corpus the K-1 content topics now match R BTM at **aligned cosine 1.0**. The shared background topic is excluded (its phi is emitted from counts, RNG-dependent, not cross-impl comparable). The original uniform/`background=False` leg still matches at cosine 1.0.
- Docstring note that `background=True` yields K-1 content topics and topic 0's reported phi is its accumulated counts, not the pw_b it sampled from.

Verification: `cargo test --lib btm::` (4); `pytest tests/test_btm.py` (8); both parity legs cosine 1.0 vs live R BTM; preflight clean.

Closes #492.

Generated with Claude Code
