### PR TITLE
docs(models): document review-batch simplifications/differences (#494/#495/#496/#497)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1151,7 +1151,10 @@ class DTM:
     distributions evolve across time slices via a Gaussian state-space model.
     Fit variationally with Kalman smoothing (a port of Blei's C dtm /
     gensim's LdaSeqModel). Query a topic's distribution at a slice with
-    topic_word(time) and a word's trajectory with word_evolution(topic, word)."""
+    topic_word(time) and a word's trajectory with word_evolution(topic, word).
+
+    Exposes evolving topic-word distributions but no per-document `doc_topic` —
+    it targets topic evolution, not per-doc mixtures (#494)."""
     @property
     def initialization(self) -> str | None:
         """The initialization route the fit took (#410): 'spectral',
@@ -2781,7 +2784,11 @@ class RTM:
 class PA:
     """Pachinko Allocation Model (Li & McCallum 2006): a DAG of `num_super`
     super-topics over `num_sub` shared sub-topics over words, capturing topic
-    correlations. `super_sub` reports which sub-topics each super-topic groups."""
+    correlations. `super_sub` reports which sub-topics each super-topic groups.
+
+    Behavioral differences from MALLET's PAM: a small default `alpha=0.1` with a
+    hard single-super commitment at init, and α_s adaptation only in the final
+    quarter of sweeps. See ``help(PA)`` (#497)."""
     @property
     def settings(self) -> dict:
         """The constructor configuration as a JSON-serialisable dict,
@@ -2892,7 +2899,11 @@ class PA:
 class HLDA:
     """Hierarchical LDA (Blei et al.): topics arranged in a `depth`-level tree via
     the nested Chinese Restaurant Process. Each document follows a root-to-leaf
-    path; general words sit near the root, specific words near the leaves."""
+    path; general words sit near the root, specific words near the leaves.
+
+    Simplifies hlda-c: a symmetric level Dirichlet `alpha` (not the GEM stick),
+    a scalar `beta` (not per-level), and fixed hyperparameters; the default
+    `beta=0.01` is a sharp topica calibration. See ``help(HLDA)`` (#496)."""
     @property
     def settings(self) -> dict:
         """The constructor configuration as a JSON-serialisable dict,

--- a/src/detm.rs
+++ b/src/detm.rs
@@ -1431,7 +1431,14 @@ pub fn fit_detm<R: Rng>(
             a_w_ls.step(&mut enc.w_ls, &g_enc.w_ls);
             a_b_ls.step(&mut enc.b_ls, &g_enc.b_ls);
 
-            epoch_loss += batch_loss / coeff; // report per-doc-scaled (== /num_docs) loss
+            // Report a per-doc-scaled (== /num_docs) loss. NOTE (#495 F2): this
+            // divides the whole minibatch loss by coeff = D/batch, which also shrinks
+            // the once-per-minibatch global temporal KLs (kl_alpha, kl_eta) by
+            // batch/D. So `bound_history` is reconstruction-dominated and NOT on the
+            // reference's ELBO scale under minibatching — it is a consistent internal
+            // convergence signal, not directly comparable to adjidieng/DETM's printed
+            // ELBO. Optimization is unaffected (gradients use the separate g_* buffers).
+            epoch_loss += batch_loss / coeff;
             batches += 1;
         }
 

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -55,6 +55,16 @@ struct HldaState {
 /// super-topics over `num_sub` shared sub-topics over words, capturing topic
 /// *correlations* — `super_sub` reports which sub-topics each super-topic groups
 /// together. Collapsed Gibbs over (super, sub) pairs.
+///
+/// Behavioral differences from MALLET's PAM, worth knowing (#497): the default
+/// `alpha = 0.1` is much smaller than MALLET's effective ~50/num_super super
+/// prior, which (with the single-super-topic commitment at init) makes documents
+/// commit hard to their initial super-topic early — the intended "give the super
+/// layer something to specialize on" design, but a real difference. α_s is
+/// re-estimated only over the final quarter of sweeps (vs MALLET's periodic
+/// post-burn-in optimization), so short runs adapt little. `doc_topic` is the
+/// doc->sub marginal, floored by `alpha` (the doc->super prior; there is no
+/// canonical PAM doc->sub prior).
 #[pyclass(module = "topica")]
 pub struct PA {
     num_super: usize,
@@ -476,6 +486,16 @@ impl PA {
 /// the shared (general) topic; deeper nodes are progressively more specific.
 /// Each document follows a root-to-leaf path. Inspect the tree with
 /// `topic_word`/`node_levels`/`node_parents`/`doc_paths`.
+///
+/// Simplifications vs the hlda-c reference, worth knowing when comparing (#496):
+/// the level prior is a symmetric Dirichlet `alpha`, not the GEM stick-breaking
+/// prior, so there is no built-in bias of general words toward shallower levels
+/// (recovery relies on the likelihood); `beta` is a single scalar topic-word
+/// Dirichlet, not hlda-c's per-level (typically decreasing) vector, so deeper
+/// topics are not sharpened by the prior; the hyperparameters are held fixed (no
+/// per-sweep `eta`/`gamma`/GEM resampling); and the default `beta = 0.01` is
+/// topica's own sharp calibration, below hlda-c's ~0.1-1.0 norm — expect more,
+/// sparser nodes at the default.
 #[pyclass(module = "topica")]
 pub struct HLDA {
     depth: usize,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -10067,6 +10067,11 @@ impl HDP {
 /// port of Blei's C `dtm` / gensim's `LdaSeqModel`. After fitting, query a
 /// topic's word distribution at any slice with `topic_word(time)` and trace a
 /// word's trajectory with `word_evolution(topic, word)`.
+///
+/// Note (#494): DTM exposes the evolving topic-word distributions but not
+/// per-document topic proportions — the E-step `gamma` values gensim retains as
+/// `self.gammas` are consumed for the suff-stats and not stored, so there is no
+/// `doc_topic` output (the model targets topic *evolution*, not per-doc mixtures).
 #[pyclass(module = "topica")]
 pub struct DTM {
     num_topics: usize,


### PR DESCRIPTION
Documentation-only notes from the model-review audit -- **no logic changes** (confirmed: the diff touches only doc comments / docstrings). Each records a documented simplification or behavioral difference on the user-facing class docstring (surfaces via `help()`) plus a concise line in the `.pyi`:

- **HLDA** (#496 FID-1..4): symmetric level Dirichlet instead of the GEM stick, scalar `beta` instead of per-level, fixed hyperparameters, sharp default `beta=0.01` -- topica choices vs hlda-c.
- **PA** (#497): small default `alpha=0.1` + hard single-super init commitment, final-quarter-only α_s adaptation, alpha-floored doc->sub `doc_topic` -- differences from MALLET's PAM.
- **DTM** (#494): no per-document `doc_topic` -- the E-step gammas are consumed for suff-stats, not stored (targets topic evolution).
- **DETM** (#495 F2): a code comment that `bound_history` divides the global temporal KLs by the minibatch coefficient, so it is a consistent internal convergence signal, not on the reference's ELBO scale under minibatching.

Verified: preflight clean (fmt/clippy/stub-sync 78), `mkdocs --strict` clean, all three class docstrings surface the notes via `help()`.

Doc-only, so no separate code review -- the underlying claims were dual-reviewed in the source issues. Advances #494/#495/#496/#497 (their feature-gap/test items stay open).

Generated with Claude Code
