### PR TITLE
feat(gsdmm): add transform() to soft-assign held-out short texts (#490)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2359,6 +2359,14 @@ class GSDMM:
         ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
+    def transform(self, data: Corpus | list[list[str]]) -> numpy.typing.NDArray[numpy.float64]:
+        """Soft cluster assignment of held-out documents, shape (num_docs, num_topics).
+
+        Scores each document with the fitted Movie-Group-Process conditional
+        (Yin & Wang Eq. 4), restricted to the discovered clusters and renormalized;
+        out-of-vocabulary words are dropped. The fitted counts are not modified.
+        """
+        ...
     @property
     def doc_cluster(self) -> numpy.typing.NDArray[numpy.int64]:
         """Hard cluster assignment per document, shape (num_docs,)."""

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -483,6 +483,10 @@ struct GsdmmState {
     trace: Vec<(usize, usize, f64)>,
     #[serde(default)]
     topic_names: Vec<String>,
+    // Retained Gibbs state for held-out `transform`. `serde(default)` -> None on
+    // pre-transform saves, which `transform` reports with a clear "refit" error.
+    #[serde(default)]
+    model: Option<gsdmm::GsdmmModel>,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct SeededState {
@@ -11586,6 +11590,9 @@ pub struct GSDMM {
     theta: Option<Array2<f64>>, // num_docs × num_used (soft assignment)
     doc_cluster: Vec<usize>,    // hard assignment per doc, remapped to 0..num_used
     corpus: Option<corpus::Corpus>,
+    // The final Gibbs state, retained so `transform` can score held-out docs via
+    // the same Eq. 4 conditional `fit` uses (`GsdmmModel::doc_cluster_dist`).
+    model: Option<gsdmm::GsdmmModel>,
     // Discovery/convergence trace: (iteration, num_clusters, log-likelihood).
     trace: Vec<(usize, usize, f64)>,
 }
@@ -11599,6 +11606,25 @@ impl GSDMM {
                 "model is not fitted yet; call fit() first",
             ))
         }
+    }
+
+    /// Map token-string documents to id documents over the fitted vocabulary,
+    /// dropping out-of-vocabulary words (words unseen at fit contribute no
+    /// evidence, matching held-out inference in the other bindings).
+    fn to_ids(&self, docs: &[Vec<String>]) -> Vec<Vec<u32>> {
+        let id_to_word = &self.corpus.as_ref().unwrap().id_to_word;
+        let map: std::collections::HashMap<&str, u32> = id_to_word
+            .iter()
+            .enumerate()
+            .map(|(i, w)| (w.as_str(), i as u32))
+            .collect();
+        docs.iter()
+            .map(|d| {
+                d.iter()
+                    .filter_map(|w| map.get(w.as_str()).copied())
+                    .collect()
+            })
+            .collect()
     }
 }
 
@@ -11655,6 +11681,7 @@ impl GSDMM {
             theta: None,
             doc_cluster: Vec::new(),
             corpus: None,
+            model: None,
             trace: Vec::new(),
         })
     }
@@ -11765,6 +11792,7 @@ impl GSDMM {
         slf.topic_names = (0..num_used).map(|i| format!("topic_{i}")).collect();
         slf.corpus = Some(corpus);
         slf.trace = model.trace.clone();
+        slf.model = Some(model);
         slf.fitted = true;
         Ok(slf.into())
     }
@@ -11813,6 +11841,72 @@ impl GSDMM {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
     }
+
+    /// Soft cluster assignment of held-out documents, shape
+    /// ``(num_docs, num_topics)`` over the discovered (non-empty) clusters; rows
+    /// sum to 1.
+    ///
+    /// `data` is a Corpus or a list of token lists. Each document is scored with
+    /// the same Movie-Group-Process conditional the fit uses (Yin & Wang Eq. 4)
+    /// against the *fitted* cluster counts, then restricted to the used clusters
+    /// and renormalized — the held-out analog of the training `doc_topic`.
+    /// Out-of-vocabulary words are dropped (they carry no evidence); a document
+    /// with no in-vocabulary words falls back to the clusters' size prior. The
+    /// fitted counts are not modified.
+    fn transform<'py>(
+        &self,
+        py: Python<'py>,
+        data: &Bound<'_, PyAny>,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        let model = self.model.as_ref().ok_or_else(|| {
+            PyRuntimeError::new_err(
+                "this GSDMM was loaded from a pre-transform save (no retained Gibbs \
+                 state); refit to enable transform()",
+            )
+        })?;
+
+        // Accept a Corpus (map its ids back to strings via its own vocab) or a raw
+        // list of token lists, then realign to the fitted vocabulary.
+        let docs_str: Vec<Vec<String>> = if let Ok(c) = data.extract::<Corpus>() {
+            c.inner
+                .docs
+                .iter()
+                .map(|d| {
+                    d.iter()
+                        .map(|&w| c.inner.id_to_word[w as usize].clone())
+                        .collect()
+                })
+                .collect()
+        } else {
+            data.extract().map_err(|_| {
+                PyValueError::new_err("transform() expects a Corpus or a list of token lists")
+            })?
+        };
+        let id_docs = self.to_ids(&docs_str);
+
+        // Score against the fitted state, then restrict to the used clusters and
+        // renormalize — identical to how `fit` derives `doc_topic`.
+        let dist = model.doc_cluster_dist(&id_docs);
+        let used = model.used_clusters();
+        let num_used = used.len();
+        let mut out = Array2::<f64>::zeros((id_docs.len(), num_used));
+        for (di, row) in dist.iter().enumerate() {
+            let s: f64 = used.iter().map(|&old| row[old]).sum();
+            if s > 0.0 {
+                for (ni, &old) in used.iter().enumerate() {
+                    out[[di, ni]] = row[old] / s;
+                }
+            } else if num_used > 0 {
+                let u = 1.0 / num_used as f64;
+                for ni in 0..num_used {
+                    out[[di, ni]] = u;
+                }
+            }
+        }
+        Ok(out.to_pyarray_bound(py))
+    }
+
     /// Hard cluster assignment of each document, shape ``(num_docs,)``; values in
     /// ``0..num_topics``. GSDMM gives each document a single cluster.
     #[getter]
@@ -11906,6 +12000,7 @@ impl GSDMM {
                 corpus: self.corpus.clone(),
                 trace: self.trace.clone(),
                 topic_names: self.topic_names.clone(),
+                model: self.model.clone(),
             },
         )
     }
@@ -11930,6 +12025,7 @@ impl GSDMM {
             theta: arr2_back(s.theta)?,
             doc_cluster: s.doc_cluster,
             corpus: s.corpus,
+            model: s.model,
             trace: s.trace,
         })
     }

--- a/tests/test_gsdmm.py
+++ b/tests/test_gsdmm.py
@@ -121,3 +121,73 @@ class TestClusterDiscovery:
         ld = topica.GSDMM.load(path)
         assert ld.cluster_count_history == m.cluster_count_history
         assert ld.log_likelihood_history == m.log_likelihood_history
+
+
+class TestTransform:
+    """Held-out cluster assignment via the Movie-Group-Process conditional (#490)."""
+
+    def _fit(self, seed=1, n=300):
+        docs = _short_corpus(n=n, seed=seed)
+        m = topica.GSDMM(num_topics=12, seed=seed).fit(docs, iters=40)
+        return m, docs
+
+    def test_shape_and_rows_sum_to_one(self):
+        m, _ = self._fit()
+        held = [["cat", "dog", "pet"], ["star", "sky"], ["tax", "vote", "law"]]
+        t = m.transform(held)
+        assert t.shape == (3, m.num_topics)
+        assert np.allclose(t.sum(axis=1), 1.0)
+        assert np.all(t >= 0.0)
+
+    def test_in_sample_matches_doc_topic(self):
+        # transform on the training docs reproduces the training-time scoring,
+        # so its argmax equals doc_topic's argmax (both are doc_cluster_dist).
+        m, docs = self._fit()
+        assert np.array_equal(m.transform(docs).argmax(1), np.asarray(m.doc_topic).argmax(1))
+
+    def test_pure_heldout_doc_lands_on_its_block(self):
+        m, _ = self._fit()
+        # A doc made only of one block's words concentrates on one cluster, and the
+        # three blocks map to three distinct clusters.
+        pure = [["cat", "dog", "pet", "vet"], ["star", "moon", "sky"], ["tax", "law", "bill"]]
+        t = m.transform(pure)
+        assert t.max(axis=1).min() > 0.9  # each row confident
+        assert len(set(t.argmax(axis=1))) == 3  # three distinct clusters
+
+    def test_oov_and_empty_fall_back_to_size_prior(self):
+        m, _ = self._fit()
+        t = m.transform([["zzzz", "qqqq"], []])  # all-OOV, then empty
+        assert np.allclose(t.sum(axis=1), 1.0)
+        assert np.all(np.isfinite(t))
+        # No in-vocabulary evidence -> the posterior reduces to the clusters' size
+        # prior, which is the SAME for every evidence-free document.
+        assert np.allclose(t[0], t[1])
+
+    def test_deterministic_and_leaves_fit_intact(self):
+        m, _ = self._fit()
+        held = [["cat", "dog"], ["star", "sun"]]
+        before = np.asarray(m.doc_topic).copy()
+        t1 = m.transform(held)
+        t2 = m.transform(held)
+        assert np.array_equal(t1, t2)
+        assert np.array_equal(np.asarray(m.doc_topic), before)  # not mutated
+
+    def test_accepts_corpus(self):
+        m, _ = self._fit()
+        c = topica.Corpus.from_documents([["cat", "dog", "pet"], ["tax", "vote"]])
+        t = m.transform(c)
+        assert t.shape == (2, m.num_topics)
+        assert np.allclose(t.sum(axis=1), 1.0)
+
+    def test_survives_save_load(self, tmp_path):
+        m, _ = self._fit()
+        held = [["cat", "dog", "pet"], ["star", "sky"]]
+        expected = m.transform(held)
+        path = str(tmp_path / "g.bin")
+        m.save(path)
+        ld = topica.GSDMM.load(path)
+        assert np.allclose(ld.transform(held), expected)
+
+    def test_requires_fit(self):
+        with pytest.raises(RuntimeError):
+            topica.GSDMM(num_topics=5).transform([["cat"]])


### PR DESCRIPTION
Implements the one real behavioral gap from the GSDMM review (#490 item 1): GSDMM was **train-only** — unlike essentially every other topica model, it could not label held-out short texts. The reference `gsdmm` exposes `score(doc)` / `choose_best_label(doc)` for exactly this.

## What it does

Adds `GSDMM.transform(data)` (a `Corpus` or a list of token lists) → `(num_docs, num_topics)` soft assignment over the discovered clusters; rows sum to 1. Each document is scored with the **same Movie-Group-Process conditional the fit uses** (Yin & Wang Eq. 4) against the *fitted* cluster counts, then restricted to the used clusters and renormalized — the held-out analog of the training `doc_topic`.

The machinery already existed: `GsdmmModel::doc_cluster_dist` computes Eq. 4 for arbitrary docs, and `fit` already calls it to build `doc_topic`. `transform` reuses that exact path:

- realigns tokens to the fitted vocabulary, **dropping OOV words** (they carry no evidence, matching held-out inference in the other bindings);
- an **evidence-free** doc (empty / all-OOV) falls back to the clusters' size prior (same distribution for every such doc);
- the fitted counts are **never modified**.

## Implementation

- Retains the final Gibbs state on the pyclass (`model: Option<GsdmmModel>`, which is already `Serialize`) so `transform` can call `doc_cluster_dist`.
- Serialized with `#[serde(default)]`: a **pre-transform save** loads with `model = None`, and `transform` then reports a clear `RuntimeError` ("refit to enable transform()") rather than failing obscurely. Existing saves keep loading.

## Verification (throwaway venv, never touched `.venv-dev`)

- New `TestTransform`: shape + rows-sum-to-1, **in-sample `transform` argmax == `doc_topic` argmax** (confirms it reproduces training-time scoring), pure held-out docs concentrate on their block (3 distinct clusters), OOV/empty → size prior, `Corpus` input, determinism + fit-state-intact, save/load round-trip, requires-fit.
- `pytest tests/test_gsdmm.py tests/test_gsdmm_gold.py tests/test_seeded_gsdmm_contracts.py tests/test_stub_sync.py tests/test_model_settings.py` → **229 passed** (stub-sync picks up `transform`; seeded-GSDMM contracts confirm the shared save/load is intact).
- `cargo fmt --all --check` + `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean; `gen_model_tables.py --check` up to date.

Doc-only follow-ups from #490 (parity-claim wording, the digamma-vs-lgamma `log_likelihood` note, `doc_topic` in-sample-vs-posterior clarification) are out of scope for this feature PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
