### PR TITLE
docs(gsdmm): clarify doc_topic is an in-sample soft conditional (#490)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2361,7 +2361,17 @@ class GSDMM:
         """Always False; GSDMM has no early-stop criterion."""
         ...
     @property
-    def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
+    def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]:
+        """Document-topic matrix, shape (num_docs, num_topics); rows sum to 1.
+
+        The in-sample Movie-Group-Process soft conditional (Yin & Wang Eq. 4) over
+        the discovered clusters, with the document's own words still counted (not
+        held out), matching the reference gsdmm `score()`. It is a plug-in estimate,
+        not a Gibbs-averaged posterior, and its argmax is usually but not guaranteed
+        to equal the hard `doc_cluster`. Use `doc_cluster` for the hard label,
+        `transform` for the same conditional on held-out docs.
+        """
+        ...
     def transform(self, data: Corpus | list[list[str]]) -> numpy.typing.NDArray[numpy.float64]:
         """Soft cluster assignment of held-out documents, shape (num_docs, num_topics).
 

--- a/src/gsdmm.rs
+++ b/src/gsdmm.rs
@@ -358,6 +358,11 @@ impl Estimator for GsdmmModel {
         (0..self.k_max).map(|k| self.cluster_word(k)).collect()
     }
 
+    // The generic Estimator surface returns the HARD assignment as a one-hot over
+    // `k_max` (what composition/conformance machinery expects for a single-membership
+    // model). This intentionally differs from the Python `doc_topic` getter, which
+    // exposes the SOFT in-sample Eq. 4 conditional remapped to the used clusters —
+    // the same distinction as `doc_cluster` (hard) vs the soft scores (#490).
     fn doc_topic(&self) -> Vec<Vec<f64>> {
         self.z
             .iter()

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -11841,6 +11841,17 @@ impl GSDMM {
         Ok(false)
     }
     /// Document-topic matrix θ, shape ``(num_docs, num_topics)``; rows sum to 1.
+    ///
+    /// Each row is the Movie-Group-Process soft conditional (Yin & Wang Eq. 4) of
+    /// the training document over the discovered clusters, scored **in-sample**:
+    /// the document's own words are still counted in its cluster (it is not held
+    /// out), matching the reference `gsdmm` `score()`. Two consequences worth
+    /// knowing: (1) it is an in-sample plug-in estimate, not a Gibbs-draw-averaged
+    /// posterior; and (2) because GSDMM is a hard-clustering (single-membership)
+    /// model, `doc_topic.argmax(axis=1)` is *usually* but not *guaranteed* to equal
+    /// the hard :attr:`doc_cluster` (the last sampled assignment). Use
+    /// :attr:`doc_cluster` for the hard label; use `doc_topic` for the soft scores.
+    /// :meth:`transform` applies the same conditional to held-out documents.
     #[getter]
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;


### PR DESCRIPTION
Closes #490's `doc_topic` reconcile item (item 2) by **documentation** — Neal's call, and the faithful one: topica's `doc_topic` already matches the reference `gsdmm` `score()` (which scores in-sample), so leave-one-out would *deviate* from the reference. Docs-only, no behavior change.

The #490 review flagged three inconsistent `doc_topic` representations. This documents them:
- **Python `doc_topic` getter** — now says each row is the in-sample MGP Eq. 4 conditional (focal doc's words still counted, not held out), a plug-in estimate (not Gibbs-averaged), whose argmax is *usually but not guaranteed* to equal the hard `doc_cluster`. Points to `doc_cluster` (hard label) and `transform` (held-out analog). Mirrored in `.pyi`.
- **Rust `Estimator::doc_topic`** — gains a comment that it intentionally returns the HARD one-hot over `k_max` (for generic composition/conformance machinery), distinct from the soft used-cluster-width Python getter.

Verified: preflight clean; the note surfaces via `help(GSDMM.doc_topic)`.

Advances #490 (transform → #515, parity wording → #501); item-4 minors (K=1 policy, 51-point trace, u32 boundary) stay open.

Generated with Claude Code
