### PR TITLE
fix(wordfish): honest se.theta docstring, default-orient axis, gate beta/SE in R parity (#505)

### DIFF
--- a/parity/wordfish_r_compare.py
+++ b/parity/wordfish_r_compare.py
@@ -32,6 +32,9 @@ wf <- textmodel_wordfish(d)
 out <- data.frame(speakerid = rownames(m), theta = as.numeric(wf$theta),
                   se = as.numeric(wf$se.theta))
 write.csv(out, args[2], row.names = FALSE)
+# Per-word discrimination beta, aligned to the dfm feature order (args[3]).
+bout <- data.frame(word = wf$features, beta = as.numeric(wf$beta))
+write.csv(bout, args[3], row.names = FALSE)
 """
 
 
@@ -91,13 +94,14 @@ def main() -> int:
     with tempfile.TemporaryDirectory() as td:
         infile = Path(td) / "counts.csv"
         outfile = Path(td) / "theta.csv"
+        betafile = Path(td) / "beta.csv"
         with open(infile, "w", newline="", encoding="utf-8") as fh:
             wr = csv.writer(fh)
             wr.writerow(["speakerid", *vocab])
             for a in authors:
                 wr.writerow([a, *[int(x) for x in counts[a]]])
         proc = subprocess.run(
-            ["Rscript", "-e", R_WORDFISH, str(infile), str(outfile)],
+            ["Rscript", "-e", R_WORDFISH, str(infile), str(outfile), str(betafile)],
             capture_output=True,
             text=True,
             timeout=1200,
@@ -106,8 +110,14 @@ def main() -> int:
             print("SKIP: quanteda wordfish run failed:\n", proc.stderr)
             return 0
         rows = list(csv.DictReader(open(outfile, encoding="utf-8")))
+        beta_rows = (
+            list(csv.DictReader(open(betafile, encoding="utf-8")))
+            if betafile.exists()
+            else []
+        )
     r_theta = {row["speakerid"]: float(row["theta"]) for row in rows}
     r_se = {row["speakerid"]: float(row["se"]) for row in rows if row.get("se")}
+    r_beta = {row["word"]: float(row["beta"]) for row in beta_rows if row.get("beta")}
     quanteda_theta = [r_theta[a] for a in authors]
 
     planted = [theta_true[int(a[1:])] for a in authors]
@@ -119,7 +129,20 @@ def main() -> int:
     print(f"topica   vs planted truth                      : |r| = {r_topica_truth:.4f}")
     print(f"quanteda vs planted truth                      : |r| = {r_quanteda_truth:.4f}")
 
-    # standard errors: topica's analytic position_se vs quanteda's se.theta
+    # per-word discrimination beta: topica vs quanteda, aligned by word.
+    beta_r = float("nan")
+    if r_beta:
+        t_beta = dict(zip(vocab, m.word_discrimination))
+        common_b = [w for w in vocab if w in r_beta]
+        if len(common_b) >= 2:
+            beta_r = _pearson(
+                [t_beta[w] for w in common_b], [r_beta[w] for w in common_b]
+            )
+            print(f"topica beta vs quanteda beta                   : |r| = {beta_r:.4f}")
+
+    # standard errors: topica's analytic position_se vs quanteda's se.theta. These
+    # need not be bit-equal (topica profiles out alpha and folds in the theta
+    # prior; see position_se docstring), so the ratio is gated loosely.
     se_r = float("nan"); se_ratio = float("nan")
     if r_se:
         common_se = [a for a in authors if a in r_se]
@@ -130,10 +153,23 @@ def main() -> int:
         print(f"topica position_se vs quanteda se.theta        : |r| = {se_r:.4f} "
               f"(median ratio {se_ratio:.3f})")
 
+    failures = []
     if r_vs_quanteda < 0.95:
-        print(f"FAIL: topica and quanteda disagree (|r|={r_vs_quanteda:.4f} < 0.95)")
+        failures.append(f"theta |r|={r_vs_quanteda:.4f} < 0.95")
+    # beta shares theta's identification, so a faithful scale recovers it too.
+    if not np.isnan(beta_r) and beta_r < 0.95:
+        failures.append(f"beta |r|={beta_r:.4f} < 0.95")
+    # SE is only comparable, not equal: require the same order of magnitude and a
+    # strong rank correlation, not exact equality.
+    if not np.isnan(se_r) and se_r < 0.90:
+        failures.append(f"se |r|={se_r:.4f} < 0.90")
+    if not np.isnan(se_ratio) and not (0.5 <= se_ratio <= 2.0):
+        failures.append(f"se median ratio {se_ratio:.3f} outside [0.5, 2.0]")
+
+    if failures:
+        print("FAIL: topica and quanteda disagree (" + "; ".join(failures) + ")")
         return 1
-    print("PASS: topica Wordfish matches quanteda's scale")
+    print("PASS: topica Wordfish matches quanteda's scale (theta, beta, se)")
     return 0
 
 

--- a/parity/wordfish_r_compare.py
+++ b/parity/wordfish_r_compare.py
@@ -82,6 +82,14 @@ def main() -> int:
     authors = sorted(pos)
     topica_theta = [pos[a] for a in authors]
 
+    # Unanchored fit: topica default-orients to the first two authors
+    # (theta[0] < theta[1]), mirroring quanteda's default dir = c(1, 2). Refit with
+    # no anchors so the *signed* correlation with quanteda validates the default
+    # orientation (finding #2), not just the axis up to sign.
+    mu = topica.Wordfish(seed=1)
+    mu.fit(docs, group=group, iters=200)
+    unanchored = dict(zip(mu.author_names, mu.author_positions[:, 0]))
+
     # Build the author x word count matrix for quanteda.
     vocab = m.vocabulary
     vidx = {w: j for j, w in enumerate(vocab)}
@@ -125,9 +133,18 @@ def main() -> int:
     r_topica_truth = _pearson(topica_theta, planted)
     r_quanteda_truth = _pearson(quanteda_theta, planted)
 
+    # Signed correlation of the *unanchored* topica fit vs quanteda: both default to
+    # dir = c(1, 2), so a faithful default orientation gives a positive sign, not
+    # merely |r| ~ 1.
+    unanchored_theta = [unanchored[a] for a in authors]
+    signed_default = float(
+        np.corrcoef(np.asarray(unanchored_theta), np.asarray(quanteda_theta))[0, 1]
+    )
+
     print(f"topica Wordfish vs quanteda textmodel_wordfish : |r| = {r_vs_quanteda:.4f}")
     print(f"topica   vs planted truth                      : |r| = {r_topica_truth:.4f}")
     print(f"quanteda vs planted truth                      : |r| = {r_quanteda_truth:.4f}")
+    print(f"topica (unanchored, default dir) vs quanteda   :  r  = {signed_default:+.4f}")
 
     # per-word discrimination beta: topica vs quanteda, aligned by word.
     beta_r = float("nan")
@@ -156,6 +173,10 @@ def main() -> int:
     failures = []
     if r_vs_quanteda < 0.95:
         failures.append(f"theta |r|={r_vs_quanteda:.4f} < 0.95")
+    # Default orientation (no anchors) must match quanteda's dir sign, i.e. a strong
+    # *positive* signed correlation.
+    if signed_default < 0.95:
+        failures.append(f"unanchored signed r={signed_default:+.4f} < 0.95")
     # beta shares theta's identification, so a faithful scale recovers it too.
     if not np.isnan(beta_r) and beta_r < 0.95:
         failures.append(f"beta |r|={beta_r:.4f} < 0.95")

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -357,8 +357,10 @@ impl Wordfish {
         Ok(vecs_to_arr2(&self.fitted_model()?.positions()).to_pyarray_bound(py))
     }
     /// Asymptotic standard error of each author position (num_authors,), from the
-    /// observed information of the penalized Poisson log-likelihood — the same
-    /// Hessian-based SE R quanteda reports as `se.theta`. Aligned to `author_names`.
+    /// observed information of the penalized Poisson log-likelihood — a Hessian-based
+    /// observed-information SE comparable to quanteda's `se.theta` (it profiles out
+    /// the verbosity nuisance and folds in the theta-prior precision, so it need not
+    /// equal quanteda's value exactly). Aligned to `author_names`.
     #[getter]
     fn position_se<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         Ok(Array1::from(self.fitted_model()?.position_se()).to_pyarray_bound(py))

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -347,11 +347,11 @@ impl Wordfish {
     /// variance. The latent left-right scale.
     ///
     /// Identifiability: identified only up to **sign** — the scale is symmetric, so
-    /// which pole is "left" is arbitrary. Pass `anchors` to `fit()` to orient it;
-    /// without anchors the sign is deterministic for a given corpus but otherwise
-    /// arbitrary (it can flip across corpora). Note R quanteda instead *always*
-    /// orients by default (`dir = c(1, 2)`, i.e. document 1 < document 2), so an
-    /// unanchored topica axis may point opposite to quanteda's.
+    /// which pole is "left" is a convention. Pass `anchors` to `fit()` to orient it
+    /// to a substantive direction; with no anchors the axis is default-oriented so
+    /// the first two authors satisfy `theta[0] < theta[1]`, mirroring R quanteda's
+    /// default (`dir = c(1, 2)`, i.e. document 1 < document 2). The sign is therefore
+    /// deterministic and reproducible against `textmodel_wordfish`.
     #[getter]
     fn author_positions<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         Ok(vecs_to_arr2(&self.fitted_model()?.positions()).to_pyarray_bound(py))

--- a/src/wordfish.rs
+++ b/src/wordfish.rs
@@ -48,8 +48,11 @@ impl WordfishModel {
     /// `I_aa = sum_j mu_ij`, `I_at = sum_j mu_ij beta_j`,
     /// `I_tt = sum_j mu_ij beta_j^2 + 1/sd^2` (with `mu_ij = exp(alpha_i + psi_j +
     /// beta_j theta_i)`); the marginal variance of `theta_i`, accounting for the
-    /// verbosity nuisance `alpha_i`, is `I_aa / (I_aa I_tt - I_at^2)`. This is the
-    /// same Hessian-based SE R quanteda reports as `se.theta`.
+    /// verbosity nuisance `alpha_i`, is `I_aa / (I_aa I_tt - I_at^2)`. This is a
+    /// Hessian-based observed-information SE comparable to quanteda's `se.theta` —
+    /// not guaranteed to equal it exactly: it profiles out `alpha_i` and folds in
+    /// the theta-prior precision, which quanteda's `se.theta` need not do. The R
+    /// parity harness (`parity/wordfish_r_compare.py`) reports the observed ratio.
     pub fn position_se(&self) -> Vec<f64> {
         let inv_var = if self.theta_prior_sd.is_finite() && self.theta_prior_sd > 0.0 {
             1.0 / (self.theta_prior_sd * self.theta_prior_sd)

--- a/src/wordfish.rs
+++ b/src/wordfish.rs
@@ -13,8 +13,10 @@
 //! on `beta` and `theta` for regularization. Identification is exact and applied
 //! every iteration: `theta` is standardized to mean 0 / unit variance (the scale is
 //! absorbed into `beta`, the location into `psi`), `psi` is centered (absorbed into
-//! `alpha`), and the sign is oriented to the anchors. The fit is deterministic — no
-//! RNG, fixed-order reductions — so it is bit-reproducible.
+//! `alpha`), and the sign is oriented to the anchors — or, with no anchors, to the
+//! first two authors (`theta[0] < theta[1]`), mirroring quanteda's default
+//! `dir = c(1, 2)`. The fit is deterministic — no RNG, fixed-order reductions — so
+//! it is bit-reproducible.
 
 /// A fitted Wordfish model. `theta` are the author positions (standardized);
 /// `beta`/`psi` are the per-word discrimination / intercept; `alpha` the per-author
@@ -455,8 +457,18 @@ fn center_psi(psi: &mut [f64], alpha: &mut [f64]) {
 }
 
 /// Orient the sign of the axis so it aligns with the anchors (positive correlation
-/// between anchored positions and their targets). No-op without anchors.
+/// between anchored positions and their targets). With no anchors, default-orient
+/// to the first two authors (`theta[0] < theta[1]`), mirroring quanteda's default
+/// `dir = c(1, 2)`, so the sign is reproducible against `textmodel_wordfish`
+/// instead of arbitrary.
 fn orient(theta: &mut [f64], beta: &mut [f64], anchors: &[(usize, f64)]) {
+    if anchors.is_empty() {
+        // No anchors: reproduce quanteda's `dir = c(1, 2)` (author 0 < author 1).
+        if theta.len() >= 2 && theta[0] > theta[1] {
+            flip(theta, beta);
+        }
+        return;
+    }
     if anchors.len() < 2 {
         // a single anchor: make its sign match its target's sign
         if let Some(&(i, target)) = anchors.first() {

--- a/tests/test_wordfish.py
+++ b/tests/test_wordfish.py
@@ -85,6 +85,17 @@ def test_anchors_orient_sign():
     assert pos["a0"] < pos["a39"], "anchors did not orient the axis"
 
 
+def test_default_orient_without_anchors():
+    # With no anchors, topica default-orients to the first two authors
+    # (theta[0] < theta[1]), mirroring quanteda's default dir = c(1, 2), so the
+    # sign is deterministic and reproducible rather than arbitrary.
+    docs, group, _, _ = _planted(seed=2)
+    m = topica.Wordfish(seed=1)
+    m.fit(docs, group=group)
+    pos = m.author_positions[:, 0]
+    assert pos[0] < pos[1], "default orientation should give theta[0] < theta[1]"
+
+
 def test_discriminating_words():
     docs, group, _, _ = _planted(seed=3)
     m = topica.Wordfish(seed=1)


### PR DESCRIPTION
Closes #505.

The Wordfish review (#505) confirmed the Newton EM, identification, and position SE are faithful to quanteda/austin, with positions R-parity-gated at `|r| >= 0.95`. This PR addresses the actionable findings. (#3, the prior-SD #481 guards, was already in the current code.)

## #1 — `position_se` docstring overclaimed exactness (honesty)

The docstrings said topica's SE is "the same Hessian-based SE R quanteda reports as `se.theta`". topica's SE profiles out the verbosity nuisance `alpha_i` (2x2 observed-information block) and folds in the theta-prior precision, which quanteda's `se.theta` need not do — so it is *comparable*, not guaranteed exactly equal (and arguably more correct). Softened in `src/wordfish.rs` and `src/python/wordfish.rs`, pointing at the parity harness for the observed ratio.

## #2 — unanchored axis sign was arbitrary (behavioral)

Without anchors the sign was deterministic but arbitrary (from the power-iteration init), so an unanchored topica axis could point opposite to quanteda, which always orients by its default `dir = c(1, 2)`. `orient()` now default-orients to the first two authors (`theta[0] < theta[1]`) when no anchors are given, mirroring quanteda. This is a likelihood-preserving sign flip (beta flips with theta), so positions, SE, and `|r|` are unchanged — only the sign convention is fixed. The anchor / single-anchor paths are untouched. Module and `author_positions` docstrings updated accordingly.

## #4 — R parity gated theta only (coverage)

`parity/wordfish_r_compare.py` printed the SE comparison but never gated it, and never compared `beta`. Now the R leg also emits `wf$beta`, and the harness gates:

- `|r(beta)| >= 0.95` (beta shares theta's identification, so a faithful scale recovers it)
- SE rank `|r| >= 0.90` and median ratio in `[0.5, 2.0]` (loose — SE is comparable, not equal)
- **signed** correlation of an unanchored topica fit vs quanteda `>= 0.95` — directly validating the #2 default orientation (not just the axis up to sign)

Observed on the synthetic leg (Rscript + quanteda.textmodels available locally):

```
topica Wordfish vs quanteda textmodel_wordfish : |r| = 1.0000
topica (unanchored, default dir) vs quanteda   :  r  = +1.0000
topica beta vs quanteda beta                   : |r| = 1.0000
topica position_se vs quanteda se.theta        : |r| = 1.0000 (median ratio 1.021)
PASS: topica Wordfish matches quanteda's scale (theta, beta, se)
```

The #5 robustness notes (exp overflow guard, step-halving, unregularized `delta`) are shared with the reference implementations and left as informational, per the review.

## Verification

- `pytest tests/test_wordfish.py` — 13 passed (incl. new `test_default_orient_without_anchors`)
- `cargo test --lib wordfish` — 3 passed
- `parity/wordfish_r_compare.py` — PASS (above); skips cleanly without Rscript
- `./scripts/preflight.sh` — fmt + clippy + #481 guard scan + table/stub sync all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)