### PR TITLE
fix(guards): route FASTopic/InfoCTM *_tol through ensure_finite_nonneg (#517)

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13261,8 +13261,10 @@ impl FASTopic {
         ensure_finite_pos("tw_alpha", tw_alpha)?;
         ensure_finite_pos("lr", lr)?;
         // Guard-parity with the other *_tol params (#517): these feed only
-        // comparison-based early-stops (a NaN/+inf merely disables early stopping),
-        // so this is a consistency guard, not a #481 NaN-topic hazard.
+        // comparison-based early-stops (NaN disables early stopping; +inf would
+        // instead trip it after one step), so this is a consistency guard, not a
+        // #481 NaN-topic hazard. The fit-time `convergence_tol` override is guarded
+        // the same way below.
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         ensure_finite_nonneg("sinkhorn_tol", sinkhorn_tol)?;
         Ok(FASTopic {
@@ -13297,6 +13299,11 @@ impl FASTopic {
         iters: Option<usize>,
         convergence_tol: Option<f64>,
     ) -> PyResult<Py<Self>> {
+        if let Some(t) = convergence_tol {
+            // Guard-parity (#517): the fit-time override must satisfy the same
+            // finite/non-negative contract as the constructor value.
+            ensure_finite_nonneg("convergence_tol", t)?;
+        }
         let tol = convergence_tol.unwrap_or(slf.em_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13260,6 +13260,11 @@ impl FASTopic {
         ensure_finite_pos("dt_alpha", dt_alpha)?;
         ensure_finite_pos("tw_alpha", tw_alpha)?;
         ensure_finite_pos("lr", lr)?;
+        // Guard-parity with the other *_tol params (#517): these feed only
+        // comparison-based early-stops (a NaN/+inf merely disables early stopping),
+        // so this is a consistency guard, not a #481 NaN-topic hazard.
+        ensure_finite_nonneg("convergence_tol", convergence_tol)?;
+        ensure_finite_nonneg("sinkhorn_tol", sinkhorn_tol)?;
         Ok(FASTopic {
             num_topics,
             lr,

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -1587,6 +1587,10 @@ impl InfoCTM {
         // pos_threshold silently mis-densifies the alignment mask.
         ensure_finite_pos("mi_weight", mi_weight)?;
         ensure_finite_pos("lr", lr)?;
+        // Guard-parity with the other *_tol params (#517): convergence_tol feeds only
+        // a comparison-based early-stop (a NaN/+inf merely disables it), so this is a
+        // consistency guard, not a #481 NaN-topic hazard.
+        ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         if hidden_size < 1 {
             return Err(PyValueError::new_err("hidden_size must be >= 1"));
         }

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -1588,8 +1588,8 @@ impl InfoCTM {
         ensure_finite_pos("mi_weight", mi_weight)?;
         ensure_finite_pos("lr", lr)?;
         // Guard-parity with the other *_tol params (#517): convergence_tol feeds only
-        // a comparison-based early-stop (a NaN/+inf merely disables it), so this is a
-        // consistency guard, not a #481 NaN-topic hazard.
+        // a comparison-based early-stop (NaN disables it; +inf would instead trip it
+        // after one step), so this is a consistency guard, not a #481 NaN-topic hazard.
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         if hidden_size < 1 {
             return Err(PyValueError::new_err("hidden_size must be >= 1"));

--- a/tests/test_fastopic.py
+++ b/tests/test_fastopic.py
@@ -104,3 +104,7 @@ def test_errors():
         _ = m.topic_word  # not fitted
     with pytest.raises(ValueError):
         m.fit(docs, doc_emb[:10])  # row/doc mismatch
+    # #517 guard-parity: the fit-time convergence_tol override is guarded too.
+    for bad in (float("nan"), float("inf"), -1.0):
+        with pytest.raises(ValueError):
+            m.fit(docs, doc_emb, convergence_tol=bad)

--- a/tests/test_fastopic.py
+++ b/tests/test_fastopic.py
@@ -93,6 +93,12 @@ def test_errors():
         topica.FASTopic(num_topics=1)
     with pytest.raises(ValueError):
         topica.FASTopic(num_topics=3, theta_temp=0.0)
+    # #517 guard-parity: the *_tol params must be finite and >= 0.
+    for bad in (float("nan"), float("inf"), -1.0):
+        with pytest.raises(ValueError):
+            topica.FASTopic(num_topics=3, convergence_tol=bad)
+        with pytest.raises(ValueError):
+            topica.FASTopic(num_topics=3, sinkhorn_tol=bad)
     m = topica.FASTopic(num_topics=3, seed=1)
     with pytest.raises(Exception):
         _ = m.topic_word  # not fitted

--- a/tests/test_infoctm.py
+++ b/tests/test_infoctm.py
@@ -143,6 +143,10 @@ def test_construction_validation():
         topica.InfoCTM(num_topics=3, mi_temperature=0.0)
     with pytest.raises(ValueError):
         topica.InfoCTM(num_topics=3, dropout=1.0)
+    # #517 guard-parity: convergence_tol must be finite and >= 0.
+    for bad in (float("nan"), float("inf"), -1.0):
+        with pytest.raises(ValueError):
+            topica.InfoCTM(num_topics=3, convergence_tol=bad)
 
 
 def test_unknown_lang_raises():


### PR DESCRIPTION
Closes #517.

Follow-up from the #510 review — a guard-parity consistency gap, **not** a correctness bug. #510 added `ensure_finite_nonneg("convergence_tol", ...)` to IdealPointTM, IdealPointSentenceTM, and Wordfish, but three sibling `*_tol` params stayed unguarded:

- `FASTopic.convergence_tol` and `FASTopic.sinkhorn_tol` (`src/python/mod.rs`)
- `InfoCTM.convergence_tol` (`src/python/neural.rs`)

These feed only comparison-based early-stops (`if tol > 0.0`, `rel < tol`, and the Sinkhorn `err < tol`), so a NaN/+inf value merely disabled early-stopping and the fit ran to max iters — no NaN topics, unlike the true #481 class. This routes all three through `ensure_finite_nonneg` at construction for parity. Cheap, no behavior change for valid inputs.

## Verification

- `pytest tests/test_fastopic.py tests/test_infoctm.py` — 20 passed (construction-validation cases extended to reject NaN / +inf / negative `*_tol`)
- `./scripts/preflight.sh` — fmt + clippy + #481 guard scan + table/stub sync all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)