### PR TITLE
fix(embedding): non-lossy EmbeddingLDA save/load; drop dead EmbeddingKeyATM (#502)

### DIFF
--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -29,6 +29,7 @@ and the matching vocabulary list; it does the clustering and seeding.
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 from typing import Sequence
 
@@ -379,6 +380,49 @@ class EmbeddingLDA:
         """The underlying fitted :class:`~topica.SeededLDA`."""
         return self._model
 
+    # Persistence. EmbeddingLDA is a Python-layer composition, so ``__getattr__``
+    # would delegate ``save``/``load`` to the underlying SeededLDA and silently
+    # drop the embedding layer (centroids, seeds, doc-anchor). We define our own
+    # pair: the SeededLDA core is saved by its own serializer, and the
+    # embedding-layer state goes to a sidecar ``<path>.embedding.npz`` so a
+    # fresh save -> load round-trip reproduces ``document_topic_prior`` and the
+    # full delegated surface.
+    _SIDE_SUFFIX = ".embedding.npz"
+
+    def save(self, path) -> None:
+        """Save the model. Writes the SeededLDA core to ``path`` and the
+        embedding-layer state (centroids, seeds, and the topic-word/doc-anchor
+        hyperparameters) to a companion ``<path>.embedding.npz``. Both files are
+        needed to reload; :meth:`load` reads them together."""
+        self._model.save(str(path))
+        np.savez(
+            str(path) + self._SIDE_SUFFIX,
+            centroids=np.asarray(self._centroids, dtype=float),
+            num_topics=np.asarray(self.num_topics),
+            top_m=np.asarray(self.top_m),
+            alpha=np.asarray(self.alpha, dtype=float),
+            doc_anchor=np.asarray(self.doc_anchor, dtype=float),
+            seeds=np.asarray(json.dumps(self.seeds)),
+        )
+
+    @staticmethod
+    def load(path) -> "EmbeddingLDA":
+        """Reload a model saved by :meth:`save`, restoring both the SeededLDA core
+        and the embedding layer so ``document_topic_prior`` and the delegated
+        surface work exactly as before the save."""
+        from . import SeededLDA
+
+        obj = EmbeddingLDA.__new__(EmbeddingLDA)
+        obj._model = SeededLDA.load(str(path))
+        with np.load(str(path) + EmbeddingLDA._SIDE_SUFFIX, allow_pickle=False) as data:
+            obj._centroids = data["centroids"]
+            obj.num_topics = int(data["num_topics"])
+            obj.top_m = int(data["top_m"])
+            obj.alpha = float(data["alpha"])
+            obj.doc_anchor = float(data["doc_anchor"])
+            obj.seeds = json.loads(str(data["seeds"]))
+        return obj
+
     def __getattr__(self, name):
         # Delegate the fitted-model API (topic_word, top_words, ...) to SeededLDA.
         model = self.__dict__.get("_model")
@@ -391,160 +435,4 @@ class EmbeddingLDA:
         return (
             f"EmbeddingLDA(num_topics={self.num_topics}, top_m={self.top_m}, "
             f"{seeded} topics seeded)"
-        )
-
-
-def _topic_anchors(seeds, vocabulary, embeddings, num_topics, topic_embeddings):
-    """Per-topic unit anchor vectors (or ``None``). By default a keyword topic's
-    anchor is the mean embedding of its in-vocabulary keywords; residual topics
-    have none. An explicit ``topic_embeddings`` row (finite) overrides a topic's
-    anchor, which also lets residual topics be anchored.
-
-    Returns a list of length ``num_topics`` whose entries are unit-norm
-    ``(E,)`` arrays or ``None``."""
-    emb = np.asarray(embeddings, dtype=np.float64)
-    index = {str(w): i for i, w in enumerate(vocabulary)}
-    anchors: list = [None] * num_topics
-    # Keyword topics come first, in dict order (matching topica's topic order).
-    for t, words in enumerate(seeds.values()):
-        rows = [index[str(w)] for w in words if str(w) in index]
-        if rows:
-            anchors[t] = emb[rows].mean(axis=0)
-
-    if topic_embeddings is not None:
-        te = np.asarray(topic_embeddings, dtype=np.float64)
-        if te.shape != (num_topics, emb.shape[1]):
-            raise ValueError(
-                f"topic_embeddings must be ({num_topics}, {emb.shape[1]}); got {te.shape}"
-            )
-        for t in range(num_topics):
-            if np.all(np.isfinite(te[t])) and np.linalg.norm(te[t]) > 0:
-                anchors[t] = te[t]
-
-    # Normalize to unit length so the offset is a cosine.
-    out = []
-    for a in anchors:
-        if a is None:
-            out.append(None)
-            continue
-        n = np.linalg.norm(a)
-        out.append(a / n if n > 0 else None)
-    return out
-
-
-class EmbeddingKeyATM:
-    """keyATM whose document-topic prior is anchored by document embeddings.
-
-    This is the covariate keyATM (``α_{d,k} = exp(x_d · λ_k)``) with one extra
-    term: a fixed embedding offset added inside the exponent,
-
-        α_{d,k} = exp(x_d · λ_k + doc_anchor · max(cos(emb_d, anchor_k), 0)).
-
-    Each keyword topic's ``anchor_k`` is, by default, the mean embedding of its
-    keywords, so a document leans toward the keyword topics it is semantically
-    near even when it is too short for word co-occurrence to place it. The
-    covariate coefficients ``λ`` are still estimated, so you keep keyATM's
-    effect estimation (``feature_effects``, ``by_strata``) on top of the anchor.
-    Pass ``covariates`` to estimate effects; omit them to use the anchor alone
-    (an intercept-only design is synthesized).
-
-    Unlike a hard embedding clustering, the embedding here is a prior the word
-    likelihood can override, and ``doc_anchor`` dials how much it is trusted.
-
-    Parameters
-    ----------
-    seeds : dict[str, list[str]]
-        Keyword topics, as for :class:`~topica.KeyATM`.
-    num_topics : int
-        Total topics (keyword topics first, then residual topics).
-    embeddings : array (V, E)
-        Word-embedding matrix aligned with ``vocabulary`` (for the keyword-mean
-        anchors).
-    vocabulary : sequence of str
-        Words aligned row-for-row with ``embeddings``.
-    topic_embeddings : array (num_topics, E), optional
-        Explicit per-topic anchor vectors. A finite row overrides that topic's
-        keyword-mean anchor (and can anchor a residual topic); leave a row
-        non-finite to keep the default.
-    doc_anchor : float
-        Strength of the embedding offset.
-    seed : int
-        Random seed for the underlying sampler.
-    """
-
-    def __init__(
-        self,
-        seeds,
-        num_topics: int,
-        *,
-        embeddings,
-        vocabulary: Sequence[str],
-        topic_embeddings=None,
-        doc_anchor: float = 5.0,
-        seed: int = 42,
-        **keyatm_kwargs,
-    ) -> None:
-        from . import KeyATM
-
-        if len(vocabulary) != np.asarray(embeddings).shape[0]:
-            raise ValueError("vocabulary length must match the number of embedding rows")
-        if num_topics < len(seeds):
-            raise ValueError("num_topics cannot be smaller than the number of keyword topics")
-        if doc_anchor < 0:
-            raise ValueError("doc_anchor must be >= 0")
-
-        self.seeds = dict(seeds)
-        self.num_topics = num_topics
-        self.doc_anchor = doc_anchor
-        self._E = np.asarray(embeddings, dtype=np.float64).shape[1]
-        self._anchors = _topic_anchors(
-            self.seeds, vocabulary, embeddings, num_topics, topic_embeddings
-        )
-        self._model = KeyATM(self.seeds, num_topics=num_topics, seed=seed, **keyatm_kwargs)
-
-    def document_topic_offset(self, doc_embeddings) -> np.ndarray:
-        """The fixed offset matrix ``s_{d,k} = doc_anchor · max(cos(emb_d,
-        anchor_k), 0)``, shape ``(num_docs, num_topics)``. Topics without an
-        anchor (residual topics, by default) get a zero column."""
-        de = np.asarray(doc_embeddings, dtype=np.float64)
-        if de.ndim != 2 or de.shape[1] != self._E:
-            raise ValueError(
-                "doc_embeddings must be (num_docs, E) with E matching the word embeddings"
-            )
-        norms = np.linalg.norm(de, axis=1, keepdims=True)
-        norms[norms == 0.0] = 1.0
-        den = de / norms
-        offset = np.zeros((de.shape[0], self.num_topics))
-        for t, a in enumerate(self._anchors):
-            if a is not None:
-                offset[:, t] = self.doc_anchor * np.maximum(den @ a, 0.0)
-        return offset
-
-    def fit(self, data, *, doc_embeddings=None, covariates=None, iters: int = 1500, **fit_kwargs):
-        """Fit on ``data``. If ``doc_embeddings`` is given (same space as the
-        word embeddings), each document's topic prior is anchored toward the
-        keyword topics it is closest to. ``covariates`` (and other keyATM
-        ``fit`` kwargs) are passed through, so effects are estimated jointly."""
-        offset = self.document_topic_offset(doc_embeddings) if doc_embeddings is not None else None
-        self._model.fit(
-            data, iters=iters, covariates=covariates, prior_offset=offset, **fit_kwargs
-        )
-        return self
-
-    @property
-    def model(self):
-        """The underlying fitted :class:`~topica.KeyATM`."""
-        return self._model
-
-    def __getattr__(self, name):
-        model = self.__dict__.get("_model")
-        if model is None:
-            raise AttributeError(name)
-        return getattr(model, name)
-
-    def __repr__(self) -> str:
-        anchored = sum(1 for a in self._anchors if a is not None)
-        return (
-            f"EmbeddingKeyATM(num_topics={self.num_topics}, "
-            f"{anchored} topics anchored, doc_anchor={self.doc_anchor})"
         )

--- a/tests/test_embedding_save_load.py
+++ b/tests/test_embedding_save_load.py
@@ -59,6 +59,63 @@ def test_save_requires_fitted(tmp_path):
         topica.BERTopic(min_cluster_size=5).save(str(tmp_path / "x.tt"))
 
 
+def _embedding_lda_corpus(seed=0, n_blocks=3, per_block=8, e_dim=16, n_docs=200):
+    """A blocky vocabulary (each block clusters in embedding space) plus a corpus
+    and matching per-document embeddings, for EmbeddingLDA round-trip tests."""
+    rng = np.random.default_rng(seed)
+    blocks = [[f"{chr(97 + b)}{i}" for i in range(per_block)] for b in range(n_blocks)]
+    vocab = [w for blk in blocks for w in blk]
+    centers = rng.normal(size=(n_blocks, e_dim)) * 3
+    emb = np.zeros((len(vocab), e_dim))
+    for i in range(len(vocab)):
+        emb[i] = centers[i // per_block] + rng.normal(size=e_dim) * 0.5
+    docs, doc_emb = [], []
+    for d in range(n_docs):
+        b = d % n_blocks
+        docs.append(list(rng.choice(blocks[b], 6)))
+        doc_emb.append(centers[b] + rng.normal(size=e_dim) * 0.5)
+    return vocab, emb, docs, np.asarray(doc_emb)
+
+
+def test_embedding_lda_save_load_round_trip(tmp_path):
+    """EmbeddingLDA save -> load must restore the embedding layer, not just the
+    SeededLDA core (issue #502): the delegated surface AND the embedding-derived
+    document prior must be identical after a round-trip."""
+    vocab, emb, docs, doc_emb = _embedding_lda_corpus()
+    m = topica.EmbeddingLDA(
+        num_topics=3, embeddings=emb, vocabulary=vocab, top_m=5, doc_anchor=2.0, seed=1
+    )
+    m.fit(docs, doc_embeddings=doc_emb, iters=200)
+
+    p = str(tmp_path / "elda")
+    m.save(p)
+    loaded = topica.EmbeddingLDA.load(p)
+
+    # SeededLDA-delegated surface round-trips.
+    assert loaded.num_topics == m.num_topics
+    assert np.allclose(loaded.topic_word, m.topic_word)
+    assert np.allclose(loaded.doc_topic, m.doc_topic)
+
+    # Embedding-layer state round-trips (this is what the delegate dropped).
+    assert loaded.top_m == m.top_m
+    assert loaded.alpha == m.alpha
+    assert loaded.doc_anchor == m.doc_anchor
+    assert loaded.seeds == m.seeds
+    assert np.allclose(loaded._centroids, m._centroids)
+
+    # The embedding-dependent inference is reproducible after load.
+    assert np.allclose(
+        loaded.document_topic_prior(doc_emb), m.document_topic_prior(doc_emb)
+    )
+
+
+def test_embedding_lda_save_delegates_would_drop_state(tmp_path):
+    """Guard the fix: EmbeddingLDA defines its own save/load rather than letting
+    __getattr__ delegate to SeededLDA (which would lose the embedding layer)."""
+    assert "save" in vars(topica.EmbeddingLDA)
+    assert "load" in vars(topica.EmbeddingLDA)
+
+
 def test_add_ngrams_basic():
     docs = [["machine", "learning", "model"], ["deep", "learning", "model"]]
     out = topica.add_ngrams(docs, ngram_range=(1, 2))


### PR DESCRIPTION
Closes #502.

The review flagged two items in the EmbeddingLDA composition (`python/topica/embedding.py`). Both are addressed here.

## 1. Non-lossy `EmbeddingLDA` save/load

EmbeddingLDA defined no `save`/`load` of its own, so `m.save(path)` fell through `__getattr__` to `SeededLDA.save` and persisted only the sampler core. The embedding-layer state (`_centroids`, `seeds`, `top_m`, `alpha`, `doc_anchor`) was silently dropped, and there was no class-level `load`, so a save -> load round-trip returned a bare SeededLDA that could no longer reproduce `document_topic_prior`.

The fix adds `EmbeddingLDA.save`/`load`: the SeededLDA core is written by its own serializer to `path`, and the embedding-layer state goes to a companion `<path>.embedding.npz`. `load` reads both and reconstructs the wrapper, so the SeededLDA-delegated surface (`topic_word`, `doc_topic`, ...) and the embedding-derived document prior are identical after a round-trip. EmbeddingLDA is a pure Python-layer composition, so this needs no Rust serde change (the `#[serde(default)]` guidance applies to Rust `*State` structs; there is no Rust state here).

## 2. Remove dead `EmbeddingKeyATM`

`EmbeddingKeyATM` (and its sole helper `_topic_anchors`) was unexported, unvalidated dead code. Verified before deleting: it appeared only in its own definition and repr within `embedding.py`, was absent from `python/topica/__init__.py` and every `.pyi` stub, and was referenced by no test, doc, or parity script. It was unreachable as `topica.EmbeddingKeyATM`. Removed.

## Skipped

The issue's two checkbox items are both done. The review's section-3 minor/doc notes (KeyATM `prior_offset` stub wording, registry description, k-means empty-cluster note, calibration notes) are out of scope for this fix and not part of issue #502's two items.

## Verification

- `pytest tests/test_embedding_lda.py tests/test_embedding_save_load.py -q` -> 18 passed. New tests: `test_embedding_lda_save_load_round_trip` (fits with document embeddings, saves, loads, asserts `topic_word`/`doc_topic`/`top_m`/`alpha`/`doc_anchor`/`seeds`/`_centroids`/`document_topic_prior` all identical after round-trip) and `test_embedding_lda_save_delegates_would_drop_state`.
- `./scripts/preflight.sh` -> all checks passed (cargo fmt --check, clippy -D warnings, #481 guard scan, model tables in sync, stub sync 78 passed). No binding signature changed, so no `.pyi` edit was needed.
- Release build via maturin `--release --features python` succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)