### PR TITLE
fix(party-embeddings): reject +inf sample, guard core panics, sync stub (#508)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -5108,7 +5108,15 @@ class PartyEmbeddings:
     @property
     def num_authors(self) -> int: ...
     @property
-    def author_positions(self) -> numpy.typing.NDArray[numpy.float64]: ...
+    def author_positions(self) -> numpy.typing.NDArray[numpy.float64]:
+        """Party placements as (num_authors, num_dims): the leading principal
+        components of the party vectors, standardized to mean 0 / unit variance
+        (column 0 is the left-right scale). Identifiability: without anchors the
+        sign of each dimension is arbitrary (PCA fixes the axes by variance, so
+        each column is identified only up to sign); pass anchors to fit() to fix
+        the signs. Columns are standardized independently, so the relative scale
+        of the components is not preserved; read author_vectors if you need it."""
+        ...
     @property
     def author_names(self) -> list[str]: ...
     @property

--- a/src/party_embeddings.rs
+++ b/src/party_embeddings.rs
@@ -149,6 +149,13 @@ pub fn fit_pvdm(
     cfg: &PvdmConfig,
     seed: u64,
 ) -> PartyEmbeddingsModel {
+    // Preconditions the binding already enforces (window >= 1 in the constructor,
+    // vocabulary >= 2 words after pruning). Assert them here so a direct core caller
+    // fails with a clear message rather than an opaque `% 0` or `last().unwrap()`
+    // panic in the training loop (issue #508).
+    assert!(cfg.window >= 1, "window must be >= 1");
+    assert!(num_words >= 1, "num_words must be >= 1");
+
     let m = cfg.vector_size;
     let num_tags = num_groups + num_controls;
     let mut rng = ChaCha8Rng::seed_from_u64(seed);

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -161,17 +161,12 @@ impl PartyEmbeddings {
         if negative < 1 {
             return Err(PyValueError::new_err("negative must be >= 1"));
         }
-        if !learning_rate.is_finite() || learning_rate <= 0.0 {
-            return Err(PyValueError::new_err("learning_rate must be > 0"));
-        }
+        ensure_finite_pos("learning_rate", learning_rate)?;
         // #481-class guard: a NaN `sample` makes every keep-probability NaN, so every
-        // token is dropped and the model trains on nothing yet returns "fitted".
-        // Keep `0.0` legal — it is the documented "subsampling off" value.
-        if sample.is_nan() || sample < 0.0 {
-            return Err(PyValueError::new_err(format!(
-                "sample must be >= 0 (0 disables subsampling); got {sample}"
-            )));
-        }
+        // token is dropped and the model trains on nothing yet returns "fitted", and a
+        // non-finite `sample` is a nonsensical threshold. Keep `0.0` legal — it is the
+        // documented "subsampling off" value — so this is the non-negative guard.
+        ensure_finite_nonneg("sample", sample)?;
         Ok(PartyEmbeddings {
             num_dims,
             vector_size,

--- a/tests/test_party_embeddings.py
+++ b/tests/test_party_embeddings.py
@@ -145,6 +145,43 @@ def test_bad_params():
         m.fit([["a", "b"], ["c", "d"]], group=["x"])  # wrong length
 
 
+@pytest.mark.parametrize("bad", [float("nan"), float("inf"), -1.0])
+def test_sample_guard(bad):
+    # #481-class guard: a non-finite or negative subsampling threshold must be
+    # rejected at construction (a NaN sample would drop every token and return a
+    # fitted-looking-but-untrained model; +inf is a nonsensical threshold).
+    with pytest.raises(ValueError):
+        topica.PartyEmbeddings(sample=bad)
+
+
+def test_sample_zero_is_legal():
+    # 0.0 means "subsampling off" and must be accepted.
+    m = topica.PartyEmbeddings(vector_size=8, window=3, min_count=1, negative=2,
+                               sample=0.0, seed=1)
+    m.fit([["a", "b"], ["b", "a"]], group=["x", "y"], iters=2)
+    assert m.author_positions.shape[0] == 2
+
+
+@pytest.mark.parametrize(
+    "docs, groups, kw",
+    [
+        ([], [], {}),                                   # empty corpus
+        ([["a", "b", "c"]], ["x"], {}),                 # one group
+        ([["a"], ["a"]], ["x", "y"], {}),               # vocabulary < 2 words
+        ([[], []], ["x", "y"], {}),                     # no in-vocabulary tokens
+        ([["a", "b"], ["c", "d"]], ["x", "y"], {"min_count": 99}),  # pruned to nothing
+    ],
+)
+def test_degenerate_inputs_raise_cleanly(docs, groups, kw):
+    # Each degenerate input must raise a clean ValueError, never a Rust panic
+    # (PanicException, which is a BaseException and not caught by `except ValueError`).
+    opts = {"vector_size": 8, "window": 3, "min_count": 1, "negative": 2,
+            "sample": 0.0, "seed": 1, **kw}
+    m = topica.PartyEmbeddings(**opts)
+    with pytest.raises(ValueError):
+        m.fit(docs, group=groups, iters=2)
+
+
 def test_unfitted_raises():
     m = topica.PartyEmbeddings()
     with pytest.raises(Exception):


### PR DESCRIPTION
Closes #508.

Follow-up hardening for `PartyEmbeddings` from the #508 review. The PV-DM +
negative-sampling core is faithful to gensim and parity-gated; this PR does not
touch the learning algorithm. It closes the remaining actionable items.

## Changes

- **`sample` guard tightened to reject `+inf` (#481 class).** The constructor
  already rejected `NaN`/negative `sample`, but a hand-rolled check let `+inf`
  (a nonsensical subsampling threshold) through silently. Routed both `sample`
  and `learning_rate` through the shared `ensure_finite_nonneg` /
  `ensure_finite_pos` helpers so every non-finite value is rejected with a clean
  `ValueError`. `sample=0.0` (subsampling off) stays legal.
- **Core precondition asserts (defense-in-depth).** Added `window >= 1` and
  `num_words >= 1` asserts at the top of `fit_pvdm` so a direct core caller fails
  with a clear message instead of the opaque `% 0` (`:215`) or
  `last().unwrap()` (`:107`) panic the review flagged. Both are unreachable from
  the Python API (the constructor guards `window >= 1`, `fit` guards vocabulary
  `>= 2`), so this is core-robustness, not a user-facing fix.
- **Stub docstring for `author_positions`.** The binding getter documents the
  sign identifiability (axis identified only up to sign without `anchors`); the
  `.pyi` stub carried a bare `...`. Mirrored the note into the stub so the two
  stay in sync.

## Skipped (already landed / not open)

- **Sign identifiability in the binding docstring (item 1)** — already documented
  in the `author_positions` getter by #512; only the stub was out of sync.
- **`sample` NaN/negative guard (item 2)** — already added by #510; this PR only
  extends it to `+inf` via the shared helper.
- **Degenerate/empty-input panics (item 5)** — every Python-reachable degenerate
  input (empty corpus, one group, vocabulary < 2, all-empty docs, everything
  pruned by `min_count`) already raises a clean `ValueError`; verified
  empirically and now locked in by tests. The two core panics were the only
  remnant, addressed by the asserts above.
- **Items 3 (LR floor / default `sample` vs gensim) and 4 (standardized-column
  scale)** — informational/schedule notes; item 4's honesty caveat is already
  in the getter docstring. No behavior change warranted.

## Verification

- `pytest tests/test_party_embeddings.py -q` -> 20 passed (new: `sample` guard
  for NaN/inf/negative, `sample=0.0` legal, degenerate-input parametrization).
- `cargo test --lib party` -> 2 passed.
- `scripts/preflight.sh` -> all checks passed (fmt, clippy -D warnings, no
  NaN-admitting `<= 0.0` guards, model tables, stub sync 78 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)