### PR TITLE
fix(pt): warn when num_pseudo >= num_docs (#491 item 3)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2225,7 +2225,10 @@ class PT:
     ) -> None:
         """pseudo_doc_prior (lambda) is the symmetric Dirichlet prior on the
         pseudo-document mixture; it drives PTM's (m_p + lambda) rich-get-richer
-        aggregation (smaller = stronger popularity bias, larger flattens it)."""
+        aggregation (smaller = stronger popularity bias, larger flattens it).
+        PTM's regime is P << D: keep num_pseudo well below the corpus size.
+        Fitting with num_pseudo >= num_docs warns and collapses toward
+        per-document LDA."""
         ...
     def fit(
         self,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -11218,11 +11218,14 @@ impl PT {
 
     /// Create an unfitted model. `num_pseudo` is the number of pseudo-documents
     /// short texts are aggregated into (more = finer, fewer = more aggregation).
-    /// `num_topics` is the number of topics K; `alpha` is the document-topic
-    /// Dirichlet prior, `beta` the topic-word Dirichlet smoothing. `pseudo_doc_prior`
-    /// (λ) is the symmetric Dirichlet prior on the pseudo-document mixture — it
-    /// drives PTM's `(m_p + λ)` rich-get-richer aggregation (smaller = stronger
-    /// popularity bias; larger flattens it). `seed` seeds the Gibbs RNG.
+    /// PTM's regime is P << D, so keep `num_pseudo` well below the corpus size;
+    /// fitting with `num_pseudo >= num_docs` warns and collapses toward
+    /// per-document LDA. `num_topics` is the number of topics K; `alpha` is the
+    /// document-topic Dirichlet prior, `beta` the topic-word Dirichlet smoothing.
+    /// `pseudo_doc_prior` (λ) is the symmetric Dirichlet prior on the
+    /// pseudo-document mixture — it drives PTM's `(m_p + λ)` rich-get-richer
+    /// aggregation (smaller = stronger popularity bias; larger flattens it).
+    /// `seed` seeds the Gibbs RNG.
     #[new]
     #[pyo3(signature = (num_topics, *, num_pseudo=100, alpha=0.1, beta=0.01, pseudo_doc_prior=0.1, seed=42))]
     fn new(
@@ -11312,6 +11315,23 @@ impl PT {
         }
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
+        // PTM's regime is P << D: a few pseudo-documents pool many short texts so
+        // topic statistics are estimated from richer aggregated counts. When
+        // num_pseudo >= num_docs most pseudo-docs hold at most one real document,
+        // the (m_p + lambda) aggregation collapses toward per-document LDA, and
+        // PTM loses the very pooling it exists to provide (#491).
+        if slf.num_pseudo >= num_docs {
+            let msg = format!(
+                "num_pseudo ({}) >= number of documents ({}); PTM's regime is \
+                 P << D. With this many pseudo-documents each pools at most one \
+                 real document, so the pseudo-document aggregation collapses \
+                 toward per-document LDA. Use a num_pseudo well below the corpus \
+                 size.",
+                slf.num_pseudo, num_docs
+            );
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1("warn", (msg,))?;
+        }
         let (k, p, a, b, lam) = (
             slf.num_topics,
             slf.num_pseudo,

--- a/tests/test_extra_models.py
+++ b/tests/test_extra_models.py
@@ -52,6 +52,28 @@ class TestPT:
             topica.PT(num_topics=1)
         with pytest.raises(ValueError):
             topica.PT(num_topics=2, num_pseudo=0)
+        with pytest.raises(ValueError):
+            # pseudo_doc_prior must be finite and positive (#481-class guard).
+            topica.PT(num_topics=2, pseudo_doc_prior=0.0)
+
+    def test_warns_when_num_pseudo_exceeds_num_docs(self):
+        # PTM's regime is P << D; fitting with num_pseudo >= num_docs collapses
+        # the pseudo-document aggregation toward per-document LDA and should warn
+        # (not error). See issue #491.
+        docs = [["cat", "dog"], ["star", "moon"], ["cat", "pet"]]
+        m = topica.PT(num_topics=2, num_pseudo=10, seed=1)
+        with pytest.warns(UserWarning, match="num_pseudo"):
+            m.fit(docs, iters=20)
+
+    def test_no_warning_in_normal_regime(self):
+        # P << D: no aggregation warning.
+        import warnings
+
+        docs = _short_corpus()
+        m = topica.PT(num_topics=2, num_pseudo=10, seed=1)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            m.fit(docs, iters=20, keep_theta_draws=False)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Closes #491.

## Context: items 1 and 2 already shipped in #511

Before starting I verified the current state of `main`. The two headline
fidelity items from the #491 review were **already implemented and merged** in
PR #511 (commit `f3dc0b0`, merged 2026-07-24) via the **faithful restore** route:

- **Item 1 (popularity prior) — FAITHFUL RESTORE, already on main.** `PtmModel`
  carries `mp` (documents per pseudo-doc) and a `lambda` field; the constructor
  has a `pseudo_doc_prior` kwarg (default 0.1, validated `> 0` through the
  #481-class `finite_pos` guard); the assignment log-prob is
  `ln(m_p^{¬d} + λ) + content-fit`, with `mp` decremented/incremented
  leave-one-out alongside the token migration; λ is threaded through
  `PtState` (`#[serde(default)]`), `settings`, and the `.pyi` stub.
- **Item 2 (log-likelihood) — already on main.** `log_likelihood()` uses
  `log_gamma` (lgamma) for all four collapsed Dirichlet-multinomial terms, not
  `digamma`.

The issue was left open because #511 explicitly deferred the two minor notes.
This PR closes the remaining actionable one.

## This PR: item 3 — `num_pseudo >= num_docs` warning

PTM's regime is P << D: a few pseudo-documents pool many short texts so topic
statistics come from richer aggregated counts. When `num_pseudo >= num_docs`,
most pseudo-docs hold at most one real document and the `(m_p + λ)` aggregation
collapses toward per-document LDA. As #511 noted, this degeneracy is *more
salient* now that the faithful popularity prior actually aggregates.

- Emit a fit-time `UserWarning` (not an error) when `num_pseudo >= num_docs`.
- Document the P << D regime in the constructor docstring and the `.pyi` stub.

## Skips / not in scope

- The `transform` note from the review is informational only (held-out docs
  correctly infer θ over K topics against fixed φ with no held-out pseudo-doc
  layer, as the paper does not define one) — no change.

## Verification

- `cargo test --lib pt` — 16 passed, 0 failed.
- `pytest tests/test_extra_models.py::TestPT tests/test_pt_gold.py` — 9 passed
  (added: warns when `num_pseudo >= num_docs`; no warning in the normal regime;
  `pseudo_doc_prior=0.0` rejected).
- `pytest tests/test_model_settings.py tests/test_model_invariants.py -k PT` —
  6 passed, 1 skipped.
- `./scripts/preflight.sh` — all checks pass (fmt, clippy, #481 guard scan,
  model tables, stub sync). No `--no-verify`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)