### PR TITLE
fix(stm): guard content-prior scales, surface degenerate SE/bootstrap cases

### DIFF
--- a/python/topica/content.py
+++ b/python/topica/content.py
@@ -28,6 +28,7 @@ topic-word distribution ``topic_word_at(level)`` at a few sentiment levels
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 import numpy as np
@@ -703,14 +704,32 @@ def _bootstrap(corpus, fit_kwargs, cluster, B, seed, anchor_words, read_fn, shap
     docs = corpus.documents() if hasattr(corpus, "documents") else [list(d) for d in corpus]
     n = len(docs)
     rng = np.random.default_rng(seed)
+    B = int(B)
     reps = []
-    for _ in range(int(B)):
+    fails = 0
+    last_err = None
+    for _ in range(B):
         idx = _boot_indices(n, cluster, rng)
         try:
             m = _refit_stm(docs, idx, fit_kwargs)
             reps.append(read_fn(m))
-        except Exception:
-            continue  # a degenerate resample (e.g. a period drops out) is skipped
+        except Exception as exc:  # a degenerate resample (e.g. a period drops out) is skipped
+            fails += 1
+            last_err = exc
+    # A handful of degenerate resamples is expected; every replicate failing is
+    # not, and previously returned an all-NaN band with no signal. Surface it so a
+    # misassembled ``fit_kwargs`` (e.g. a dropped ``content_time``) is not read as
+    # "wide uncertainty."
     if not reps:
-        return np.full((1,) + tuple(shape), np.nan)
+        raise RuntimeError(
+            f"bootstrap produced no usable replicates: all {B} refits failed. "
+            f"Check that fit_kwargs reproduces the original STM fit (e.g. it must "
+            f"include content_time= for a trajectory model). Last error: {last_err!r}"
+        )
+    if fails > B // 2:
+        warnings.warn(
+            f"bootstrap: {fails} of {B} refits failed; the CI is based on only "
+            f"{len(reps)} replicates and may be unreliable. Last error: {last_err!r}",
+            stacklevel=2,
+        )
     return np.stack(reps, axis=0)

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -29,6 +29,7 @@ Nonlinear and interaction terms are built with :func:`spline` and
 
 from __future__ import annotations
 
+import warnings
 from dataclasses import dataclass
 
 import numpy as np
@@ -678,6 +679,26 @@ def estimate_effect(
             raise ValueError("weights must be finite and non-negative")
 
     p = X.shape[1]
+    # Cluster-robust SEs need many clusters. With G < 2 the sandwich meat
+    # collapses to ~0 (SEs spuriously near zero); with G <= p the cluster vcov is
+    # rank-deficient so some coefficients' SEs are understated. Previously silent.
+    if groups is not None:
+        n_g = len(groups)
+        if n_g < 2:
+            warnings.warn(
+                f"cluster-robust standard errors need at least 2 clusters; got {n_g}. "
+                f"The sandwich meat collapses and the reported SEs will be near zero "
+                f"(spuriously confident). Drop cluster= or use a coarser grouping.",
+                stacklevel=2,
+            )
+        elif n_g <= p:
+            warnings.warn(
+                f"cluster-robust standard errors have only {n_g} clusters for {p} "
+                f"coefficients: the cluster covariance is rank-deficient (G <= p), so "
+                f"some coefficients' SEs are unreliable (understated). Cluster-robust "
+                f"inference is trustworthy only with many clusters.",
+                stacklevel=2,
+            )
     if weights is None:
         XtX_inv = np.linalg.pinv(X.T @ X)
         hat = XtX_inv @ X.T  # (p, n)

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7349,6 +7349,20 @@ impl STM {
                 "STM needs prevalence and/or content covariates; use CTM for neither",
             ));
         }
+        // #481-class guard: the content-deviation prior scale flows into
+        // `1/content_prior_var` (the L2 precision, or the L1 rate under
+        // content_prior="l1"), so a NaN/+inf/zero/negative value silently yields
+        // NaN kappa and a NaN bound. Only meaningful with a content model.
+        if content.is_some() || content_time.is_some() {
+            ensure_finite_pos("content_prior_var", content_prior_var)?;
+        }
+        // `content_smooth` (the random-walk precision 1/tau^2) is gated as
+        // `content_smooth > 0.0`, so a NaN or negative value silently disables the
+        // smoothing the user asked for, and +inf poisons the RW penalty. 0 is legal
+        // (recovers the fully saturated content factor).
+        if content_time.is_some() {
+            ensure_finite_nonneg("content_smooth", content_smooth)?;
+        }
 
         // --- Prevalence design (optional) ---
         let mut prevalence_x: Option<Vec<Vec<f64>>> = None;

--- a/tests/test_content_trajectory.py
+++ b/tests/test_content_trajectory.py
@@ -133,3 +133,44 @@ def test_to_frame(fit):
     df = tr.to_frame()
     assert list(df.columns) == ["word", "period", "estimate"]
     assert len(df) == 4  # 1 word x 4 periods
+
+
+def test_content_prior_var_guard():
+    # content_prior_var flows into 1/content_prior_var (the L2 precision / L1 rate),
+    # so a zero/negative/non-finite value silently produced NaN kappa and a NaN
+    # bound. It must be rejected at fit (issue: faSTM-extension guard review).
+    docs, grp, per, _ = _drift_corpus(per_cell=8)
+    for bad in (0.0, -1.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="content_prior_var"):
+            topica.STM(num_topics=3, seed=1).fit(
+                docs, content=grp, content_prior_var=bad, iters=5
+            )
+
+
+def test_content_smooth_guard():
+    # content_smooth (the RW precision 1/tau^2) was gated as `> 0.0`, so a NaN or
+    # negative value silently disabled smoothing; +inf poisons the RW penalty.
+    # 0.0 is legal (recovers the fully saturated content factor).
+    docs, grp, per, _ = _drift_corpus(per_cell=8)
+    for bad in (-1.0, float("nan"), float("inf")):
+        with pytest.raises(ValueError, match="content_smooth"):
+            topica.STM(num_topics=3, seed=1).fit(
+                docs, content=grp, content_time=per, content_smooth=bad, iters=5
+            )
+    # 0.0 is accepted and fits.
+    topica.STM(num_topics=3, seed=1).fit(
+        docs, content=grp, content_time=per, content_smooth=0.0, iters=5
+    )
+
+
+def test_bootstrap_all_failures_raise_not_silent_nan(fit):
+    # A fit_kwargs that cannot reproduce the model (here: content_time dropped, so
+    # every refit reads a non-content_time surface and raises) previously returned
+    # an all-NaN band with no signal. It must now surface the failure.
+    m, docs, grp, per = fit
+    fk_broken = dict(num_topics=3, seed=1, content=grp, iters=20)  # no content_time
+    with pytest.raises(RuntimeError, match="no usable replicates"):
+        content.content_divergence(
+            m, groups=("Dem", "Rep"), anchor_words=ANCHOR,
+            ci=True, corpus=docs, fit_kwargs=fk_broken, B=4, seed=3,
+        )

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -150,6 +150,34 @@ def test_composition_effect_inflates_over_ols():
         assert moc[t].se[1] >= ols[t].se[1] - 1e-9
 
 
+def test_cluster_robust_warns_on_too_few_clusters():
+    # With < 2 clusters the CR1 sandwich meat collapses to ~0 (SEs spuriously near
+    # zero); with G <= p the cluster vcov is rank-deficient. Both used to be silent.
+    _, corpus, x = _planted()
+    m = topica.LDA(2, seed=1)
+    m.fit(corpus, iters=250, keep_theta_draws=False)
+    X = x[:, None]
+    n = X.shape[0]
+    # one cluster -> collapse warning
+    with pytest.warns(UserWarning, match="at least 2 clusters"):
+        topica.estimate_effect(
+            m.doc_topic, X, feature_names=["x"], cluster=np.zeros(n, dtype=int)
+        )
+    # G == p (2 clusters, 2 coefficients incl. intercept) -> rank-deficient warning
+    with pytest.warns(UserWarning, match="rank-deficient"):
+        topica.estimate_effect(
+            m.doc_topic, X, feature_names=["x"], cluster=(np.arange(n) % 2)
+        )
+    # many clusters -> no warning
+    import warnings as _w
+
+    with _w.catch_warnings():
+        _w.simplefilter("error")
+        topica.estimate_effect(
+            m.doc_topic, X, feature_names=["x"], cluster=(np.arange(n) % 40)
+        )
+
+
 def test_composition_self_sufficient_for_gibbs_and_rejects_embedding():
     # A fitted LDA/keyATM/SeededLDA retains its own per-document lengths (issue
     # #32), so even with draws disabled the Dirichlet fallback needs no corpus=.

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -1120,7 +1120,18 @@ pub fn fit_ctm<R: Rng>(
     let nf = prevalence.map(|x| x[0].len());
     let groups = content.map(|(g, _)| g);
     let num_groups = content.map_or(1, |(_, ng)| ng);
-    if let Some((nb, nt, _)) = content_time_rw {
+    // Content-prior scale guards (shared by every front-end: topica's PyO3 layer
+    // and faSTM's extendr layer both reach the core here, so guarding at the source
+    // protects both). `content_prior_var` feeds `1/content_prior_var` — the L2
+    // precision, or the L1 rate under a sparse content prior — so a non-finite,
+    // zero, or negative value would silently produce NaN kappa and a NaN bound.
+    if content.is_some() {
+        assert!(
+            content_prior_var.is_finite() && content_prior_var > 0.0,
+            "content_prior_var must be finite and > 0; got {content_prior_var}"
+        );
+    }
+    if let Some((nb, nt, smooth)) = content_time_rw {
         assert!(
             content.is_some(),
             "content_time_rw requires a content covariate"
@@ -1129,6 +1140,12 @@ pub fn fit_ctm<R: Rng>(
             nb * nt,
             num_groups,
             "content_time_rw: num_base*num_times must equal the saturated num_groups"
+        );
+        // The random-walk precision (1/tau^2). Non-finite/negative would poison the
+        // RW penalty; 0.0 is legal (recovers the fully saturated content factor).
+        assert!(
+            smooth.is_finite() && smooth >= 0.0,
+            "content_smooth must be finite and >= 0; got {smooth}"
         );
     }
 


### PR DESCRIPTION
Adversarial review of topica's **faSTM-beyond-STM extensions** (the content L1 prior, the temporal content covariate, and `estimate_effect`) surfaced several issues. This PR lands the three clear guard/robustness fixes (findings 1–3); findings 4–5 are filed as separate issues (docs/behavior decisions), and the high-severity lexical-period-ordering bug is tracked separately.

All fixes are confirmed with reproductions and change nothing for valid inputs.

## 1. Unguarded content-prior scales → silent NaN / silent no-op (#481-class)
- `content_prior_var` flows into `1/content_prior_var` (the L2 precision, or the L1 rate under `content_prior="l1"`). `content_prior_var=0.0` returned a fitted model with **all-NaN `content_kappa` and a NaN `bound`, no error**; negatives gave anti-shrinkage. Now rejected via `ensure_finite_pos` when a content model is used.
- `content_smooth` (the RW precision `1/tau^2`) was gated `> 0.0`, so a NaN/negative value **silently disabled** the smoothing the user requested, and `+inf` poisons the RW penalty. Now `ensure_finite_nonneg` when `content_time` is given (`0.0` stays legal = fully saturated content factor).

## 2. Bootstrap returned a silent all-NaN band when every refit failed
`content_divergence`/`content_trajectory` with `ci=True` wrapped each refit in a bare `except: continue`. A `fit_kwargs` that can't reproduce the fit (e.g. drops `content_time`) makes **every** replicate fail, and the old code returned an all-NaN CI with no signal — read as "wide uncertainty" rather than "the bootstrap never ran." Now raises `RuntimeError` on zero usable replicates and warns when >half fail.

## 3. Cluster-robust SEs silently degenerate with too few clusters
`estimate_effect(cluster=)` with `< 2` clusters collapses the CR1 sandwich meat to ~0 (SEs spuriously near zero); with `G <= p` the cluster vcov is rank-deficient (understated SEs). Both were silent. Now warns in both cases.

## What the review verified CORRECT (no change)
The hard algorithmic machinery all checked out against references/derivation: the FISTA prox + penalize-mask, the **entire elastic-net gamma solver**, the RW penalty/gradient (correct discrete Laplacian, within-base tying, saturated/pooled limits), the **CR1 sandwich / WLS / REML / AME / Rubin pooling** (cross-checked against statsmodels to machine precision), and the **bootstrap topic-alignment across replicates** (anchor re-resolution — the concern that would have been most damaging).

## Verification
- `pytest tests/test_content_trajectory.py tests/test_standard_errors.py` — 44 passed (new: `test_content_prior_var_guard`, `test_content_smooth_guard`, `test_bootstrap_all_failures_raise_not_silent_nan`, `test_cluster_robust_warns_on_too_few_clusters`)
- `pytest tests/test_stm*.py tests/test_content.py` — 190 passed
- `./scripts/preflight.sh` — fmt + clippy + #481 scan + table/stub sync all green

🤖 Generated with [Claude Code](https://claude.com/claude-code)