### PR TITLE
fix(stm): order content_time periods numerically, not lexically (#534)

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7454,15 +7454,30 @@ impl STM {
                         num_docs
                     )));
                 }
-                // Ordered periods: sorted unique labels (pass sortable labels, e.g.
-                // years or zero-padded strings, so the order is chronological).
+                // Ordered periods: unique labels sorted chronologically. When every
+                // label parses as a number, sort numerically so integer-like periods
+                // (1,2,3,10,11,12) order 1<2<...<10<... rather than lexically
+                // (1,10,11,12,2,3) — the latter would tie the wrong chronological
+                // neighbors in the random walk (#534). Falls back to lexical order for
+                // non-numeric labels. This matches the numeric ordering the Python
+                // trajectory reader (content.py) already uses.
                 let mut periods: Vec<String> = times_str
                     .iter()
                     .cloned()
                     .collect::<HashSet<_>>()
                     .into_iter()
                     .collect();
-                periods.sort();
+                if periods.iter().all(|p| p.trim().parse::<f64>().is_ok()) {
+                    periods.sort_by(|a, b| {
+                        let (na, nb) = (
+                            a.trim().parse::<f64>().unwrap(),
+                            b.trim().parse::<f64>().unwrap(),
+                        );
+                        na.total_cmp(&nb).then_with(|| a.cmp(b))
+                    });
+                } else {
+                    periods.sort();
+                }
                 let pindex: HashMap<&str, usize> = periods
                     .iter()
                     .enumerate()

--- a/tests/test_content_trajectory.py
+++ b/tests/test_content_trajectory.py
@@ -133,3 +133,18 @@ def test_to_frame(fit):
     df = tr.to_frame()
     assert list(df.columns) == ["word", "period", "estimate"]
     assert len(df) == 4  # 1 word x 4 periods
+
+
+def test_content_time_periods_order_numerically_not_lexically():
+    # Integer-like periods of non-uniform width must order chronologically
+    # (1,2,3,10,11,12), not lexically (1,10,11,12,2,3), or the random walk ties the
+    # wrong neighbors (#534). 4-digit years happen to be safe; these labels are the
+    # regression case.
+    docs, grp, per = [], [], []
+    for t in [1, 2, 3, 10, 11, 12]:
+        for _ in range(6):
+            docs.append(["econ", "jobs", "climate", "border"]); grp.append("Dem"); per.append(t)
+            docs.append(["econ", "jobs", "border", "climate"]); grp.append("Rep"); per.append(t)
+    m = topica.STM(num_topics=2, seed=1).fit(docs, content=grp, content_time=per, iters=5)
+    dem = [g.split("@")[1] for g in m.groups if g.startswith("Dem@")]
+    assert dem == ["1", "2", "3", "10", "11", "12"], dem


### PR DESCRIPTION
Closes #534.

The `content_time` random-walk tied periods in the order of a **lexical** sort of the (stringified) period labels. Integer-like labels of non-uniform width were ordered wrong — `[1,2,3,10,11,12]` became `1,10,11,12,2,3`, so the RW smoothed the wrong chronological neighbors (period 12 pulled toward 2, period 1 toward 10). Four-digit years happened to be safe (lexical == numeric), which is why the existing tests missed it, and the bug was **silent**: the Python trajectory reader sorts numerically, so the read-back axis looked correct while the underlying fit had smoothed the wrong cells.

## Fix
Sort periods numerically when every label parses as a number, else fall back to lexical — matching the numeric ordering `content.py` already uses for the read layer.

## Verification
- New `test_content_time_periods_order_numerically_not_lexically`: fits with periods `[1,2,3,10,11,12]` and asserts the group axis orders `1,2,3,10,11,12` (was `1,10,11,12,2,3`).
- `pytest tests/test_content_trajectory.py` — 11 passed
- `./scripts/preflight.sh` — green

Found by the adversarial review of topica's faSTM-beyond-STM extensions. Note: faSTM's own R path orders periods via R `factor()`, which sorts numeric covariates numerically, so faSTM's documented numeric usage is unaffected (only string-labeled periods would hit the same class there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)