### PR TITLE
fix(stm): make content_prior="l1" a pure Laplace prior, not L1+L2 (#532)

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7253,13 +7253,17 @@ impl STM {
     /// random walk, the temporal generalization of `content`. `content_smooth`
     /// controls that random-walk penalty strength (``1/tau^2``); larger values tie
     /// adjacent periods more tightly. `content_prior` selects the prior on the
-    /// content (SAGE κ) deviation blocks: ``"l2"`` (default) is a Gaussian ridge that
-    /// keeps every `kappa_topic`, while ``"l1"`` puts a sparse Laplace prior (FISTA,
-    /// exact zeros) that recovers sparse content contrasts, matching R `stm`'s sparse
-    /// content model. `content_prior_var` is the L2 prior variance on those content
-    /// deviations (default ``0.5``); larger loosens regularization (more group-driven
-    /// contrast), smaller tightens it toward the shared baseline. The ``"l2"`` path
-    /// with `content_time=None` is bit-for-bit identical to the prior release.
+    /// content (SAGE κ) deviation blocks: ``"l2"`` (default) is a Gaussian ridge on
+    /// the deviations, while ``"l1"`` puts a *pure* sparse Laplace prior (FISTA, exact
+    /// zeros) on them — recovering sparse content contrasts, matching R `stm`'s sparse
+    /// content model. Under ``"l1"`` the deviation blocks carry the Laplace prior only
+    /// (not an additional ridge); the topic baseline `kappa_topic` keeps its L2 either
+    /// way. `content_prior_var` (default ``0.5``) sets the deviation-prior scale: under
+    /// ``"l2"`` it is the Gaussian prior variance, under ``"l1"`` the Laplace scale (the
+    /// L1 rate is ``1/content_prior_var``). Larger loosens regularization (more
+    /// group-driven contrast), smaller tightens it toward the shared baseline. The
+    /// ``"l2"`` path with `content_time=None` is bit-for-bit identical to the prior
+    /// release.
     /// `convergence_tol` is the relative-bound tolerance for EM early
     /// stopping — the run stops when the relative change in the variational evidence
     /// bound falls below it (the criterion R `stm` uses). `beta_init` is an optional

--- a/tests/test_stm_content.py
+++ b/tests/test_stm_content.py
@@ -548,3 +548,40 @@ class TestSTMContentRecomputeEtaCov:
         # Identical under the fix (both use the current fit's β); under the bug the
         # reused instance recomputes against the stale first-fit β and diverges.
         npt.assert_allclose(a, b, rtol=0, atol=1e-5)
+
+
+def test_l1_content_prior_is_pure_laplace_not_elastic_net():
+    # Under content_prior="l1" the deviation blocks (kappa_cov / kappa_interaction)
+    # must carry a *pure* Laplace prior, not a coupled L1+L2 elastic net (#532): the
+    # surviving (nonzero) deviations are therefore not ridge-shrunk, so they run
+    # larger in magnitude than the l2 fit's deviations at the same content_prior_var.
+    # The baseline kappa_topic keeps its L2 (stays dense) under both priors.
+    rng = np.random.default_rng(0)
+    A = [f"a{i}" for i in range(8)]; B = [f"b{i}" for i in range(8)]; F = [f"f{i}" for i in range(8)]
+    docs, grp = [], []
+    for _ in range(120):
+        docs.append(list(rng.choice(A + F, 20))); grp.append("A")
+        docs.append(list(rng.choice(B + F, 20))); grp.append("B")
+
+    def fit(prior):
+        m = STM(num_topics=2, seed=1).fit(
+            docs, content=grp, content_prior=prior, content_prior_var=0.5, iters=60
+        )
+        ck = m.content_kappa
+        dev = np.concatenate([np.ravel(v) for k, v in ck.items() if k != "kappa_topic"])
+        base = np.ravel(ck["kappa_topic"])
+        return dev, base
+
+    d_l1, base_l1 = fit("l1")
+    d_l2, _ = fit("l2")
+
+    # l1 sparsifies the deviations (exact zeros); l2 does not.
+    assert (d_l1 == 0).sum() > 0, "l1 should produce exact zeros on the deviations"
+    assert (d_l2 == 0).sum() == 0, "l2 should not force zeros"
+    # baseline is L2-regularized (dense) under l1, not sparsified.
+    assert (base_l1 == 0).sum() == 0, "kappa_topic must keep its L2 (stay dense) under l1"
+    # pure Laplace: surviving deviations are not additionally ridge-shrunk, so their
+    # mean magnitude exceeds the (fully ridge-shrunk) l2 deviations.
+    mean_l1 = np.abs(d_l1[d_l1 != 0]).mean()
+    mean_l2 = np.abs(d_l2).mean()
+    assert mean_l1 > mean_l2, f"l1 survivors should exceed l2 magnitudes: {mean_l1:.3f} vs {mean_l2:.3f}"

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -644,7 +644,13 @@ fn optimize_content(
                 }
             }
         }
-        for (i, &xi) in flat.iter().enumerate() {
+        // Gaussian (L2) prior. Under the sparse content prior (content_l1 > 0) the
+        // deviation blocks κ_cov / κ_interaction (indices >= n_t) are regularized by
+        // the L1 prox in FISTA instead, so they carry NO L2 here — only the baseline
+        // κ_topic keeps L2. This makes content_prior="l1" a genuine Laplace prior on
+        // the deviations rather than a coupled L1+L2 elastic net (#532).
+        let l2_end = if content_l1 > 0.0 { n_t } else { flat.len() };
+        for (i, &xi) in flat.iter().enumerate().take(l2_end) {
             value -= 0.5 * inv_var * xi * xi;
             grad[i] -= inv_var * xi;
         }


### PR DESCRIPTION
Closes #532.

## Problem
Under `content_prior="l1"`, the smooth objective applied the Gaussian (L2) prior to **every** content coordinate (`topica-core/src/ctm.rs`), and the FISTA prox then added L1 on the deviation blocks — so `kappa_cov` / `kappa_interaction` carried **both** penalties at the same coupled rate `1/content_prior_var`. That is a (coupled) elastic net, while the docstrings advertised a pure sparse Laplace / SAGE prior, and the "l1→l2 limit" was unreachable (one knob drove both rates).

## Fix
Skip the L2 term on the penalized deviation coordinates when `content_l1 > 0`, so the deviations carry the Laplace (L1) prior **only**; the baseline `kappa_topic` keeps its L2 either way. `content_prior="l2"` and the no-content path are untouched (bit-exact).

Because this is the **shared `topica-core` fitting core**, faSTM inherits the corrected prior automatically (its `content_prior="l1"` calls the same `fit_ctm`).

## Effect (verified)
On a strongly group-separated corpus at `content_prior_var=0.5`:
- l1 deviations: sparse (77/168 nonzero), mean |nonzero| ≈ **2.10** — survivors no longer ridge-shrunk
- l2 deviations: dense (168/168), mean |dev| ≈ **1.09**
- l1 baseline `kappa_topic`: dense (keeps L2) ✓

## Docs
Clarified that `content_prior_var` is the Gaussian **variance** under `"l2"` and the Laplace **scale** (rate `1/content_prior_var`) under `"l1"`.

## Verification
- New `test_l1_content_prior_is_pure_laplace_not_elastic_net` (sparsity, dense baseline, l1 survivors > l2 magnitudes)
- `cargo test --lib -p topica-core` — 43 passed
- `pytest` STM + content + gold + R-compare — 149 + 71 passed, no pinned-value regressions
- `./scripts/preflight.sh` — green

Found by the adversarial review of topica's faSTM-beyond-STM extensions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)