### PR TITLE
fix(estimate_effect): GLM robust SEs use HC0, not HC1 (#533)

### DIFF
--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -544,8 +544,9 @@ def estimate_effect(
       bounds where OLS can wander outside them (Papke & Wooldridge). Non-identity
       links report heteroskedasticity- or cluster-robust standard errors; the
       heteroskedasticity-robust GLM SE is HC0 (no ``n/(n-p)`` factor), matching
-      statsmodels' GLM sandwich and the Papke–Wooldridge convention, while the
-      identity link uses HC1 and the cluster path uses CR1.
+      statsmodels' GLM sandwich and the Papke–Wooldridge convention. The identity
+      link without ``cluster`` reports classical OLS standard errors; under
+      ``cluster`` both links use the CR1 cluster-robust sandwich.
     - ``weights`` — a length-``num_docs`` array of (survey) weights, or a column
       name in ``data``. Switches to weighted least squares: documents enter the
       regression in proportion to their weight, so a weighted sample (e.g. a

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -173,18 +173,25 @@ def _link_inv(eta, link):
     return eta
 
 
-def _sandwich(X, bread, score_resid, groups, n, p, weights=None):
+def _sandwich(X, bread, score_resid, groups, n, p, weights=None, *, hc1=True):
     """Robust covariance ``bread · meat · bread``. With `groups` (a list of index
-    arrays) the cluster-robust CR1 estimator; otherwise heteroskedasticity-robust
-    HC1. `score_resid` is the estimating-equation residual (y−μ). With `weights`
+    arrays) the cluster-robust CR1 estimator; otherwise heteroskedasticity-robust.
+    `score_resid` is the estimating-equation residual (y−μ). With `weights`
     (survey weights), the score rows become ``w_i · X_i · resid_i`` and `bread` is
     the weighted ``(X'WX)^-1`` the caller supplies — matching faSTM's weighted
-    cluster-robust meat."""
+    cluster-robust meat.
+
+    `hc1` applies the ``n/(n-p)`` finite-sample factor to the heteroskedasticity-
+    robust (non-cluster) meat: use it for the linear model (matches statsmodels
+    HC1), and turn it off for a GLM, whose robust SE convention is HC0 — statsmodels
+    treats HC0/HC1 identically for a GLM, and the Papke–Wooldridge fractional-logit
+    robust SE is HC0 (no df factor). The cluster CR1 factor is unaffected."""
     sr = score_resid if weights is None else weights * score_resid
     if groups is None:
         meat = X.T @ (X * (sr ** 2)[:, None])
         cov = bread @ meat @ bread
-        cov *= n / max(n - p, 1)                       # HC1 small-sample factor
+        if hc1:
+            cov *= n / max(n - p, 1)                   # HC1 small-sample factor
     else:
         g_count = len(groups)
         meat = np.zeros((p, p))
@@ -244,7 +251,9 @@ def _fit_one(y, X, *, link, groups, hat, XtX_inv, dof, weights=None):
         beta, W = _glm_irls(y, X, link, sw=weights)
         bread = np.linalg.pinv(X.T @ (X * W[:, None]))
         mu = _link_inv(X @ beta, link)
-        cov = _sandwich(X, bread, y - mu, groups, n, p, weights=weights)  # ψ_i = w_i X_i(y_i−μ_i)
+        # GLM robust SE is HC0 (no n/(n-p) factor): matches statsmodels' GLM
+        # sandwich and the Papke–Wooldridge fractional-logit convention (#533).
+        cov = _sandwich(X, bread, y - mu, groups, n, p, weights=weights, hc1=False)  # ψ_i = w_i X_i(y_i−μ_i)
     tss = float(((y - y.mean()) ** 2).sum())
     r2 = 1.0 - float(((y - mu) ** 2).sum()) / tss if tss > 0 else 0.0
     return beta, cov, r2
@@ -533,7 +542,10 @@ def estimate_effect(
       binomial quasi-likelihood), or ``"log"`` (quasi-Poisson). Because topic
       proportions live in ``[0, 1]``, the logit link keeps fitted values in
       bounds where OLS can wander outside them (Papke & Wooldridge). Non-identity
-      links report heteroskedasticity- or cluster-robust standard errors.
+      links report heteroskedasticity- or cluster-robust standard errors; the
+      heteroskedasticity-robust GLM SE is HC0 (no ``n/(n-p)`` factor), matching
+      statsmodels' GLM sandwich and the Papke–Wooldridge convention, while the
+      identity link uses HC1 and the cluster path uses CR1.
     - ``weights`` — a length-``num_docs`` array of (survey) weights, or a column
       name in ``data``. Switches to weighted least squares: documents enter the
       regression in proportion to their weight, so a weighted sample (e.g. a

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -289,3 +289,53 @@ def test_bootstrap_via_refit_hook():
     res = topica.standard_errors(m, corpus, of="prevalence", method="bootstrap",
                                  n_boot=20, topn=5, refit=refit, seed=0)
     assert len(res) == 2 and all(r.reliable for r in res)
+
+
+def test_sandwich_hc1_flag_toggles_df_factor():
+    # #533: the heteroskedasticity-robust meat carries the n/(n-p) HC1 factor only
+    # when hc1=True (linear model); with hc1=False it is HC0 (GLM / Papke-Wooldridge
+    # convention). The cluster path is unaffected by this flag.
+    from topica.stm import _sandwich
+
+    rng = np.random.default_rng(0)
+    n, p = 40, 3
+    X = np.column_stack([np.ones(n), rng.normal(size=(n, p - 1))])
+    bread = np.linalg.inv(X.T @ X)
+    resid = rng.normal(size=n)
+
+    hc0 = _sandwich(X, bread, resid, None, n, p, hc1=False)
+    hc1 = _sandwich(X, bread, resid, None, n, p, hc1=True)
+
+    # HC0 is exactly bread @ meat @ bread with no small-sample factor.
+    meat = X.T @ (X * (resid ** 2)[:, None])
+    np.testing.assert_allclose(hc0, bread @ meat @ bread, rtol=1e-12)
+    # HC1 = HC0 * n/(n-p).
+    np.testing.assert_allclose(hc1, hc0 * (n / (n - p)), rtol=1e-12)
+    assert not np.allclose(hc0, hc1)  # the factor is non-trivial here
+
+
+def test_fit_one_glm_reports_hc0_not_hc1():
+    # #533 wiring: _fit_one's GLM (non-identity) branch must report the HC0 robust
+    # covariance, not the HC1-inflated one the identity path uses. Reconstruct the
+    # HC0 sandwich from the same IRLS fit and require an exact match.
+    from topica.stm import _fit_one, _glm_irls, _sandwich, _link_inv
+
+    rng = np.random.default_rng(1)
+    n, p = 60, 3
+    X = np.column_stack([np.ones(n), rng.normal(size=(n, p - 1))])
+    y = rng.uniform(0.05, 0.95, size=n)  # fractional response for a logit link
+    XtX_inv = np.linalg.inv(X.T @ X)
+    hat = XtX_inv @ X.T
+
+    _, cov, _ = _fit_one(
+        y, X, link="logit", groups=None, hat=hat, XtX_inv=XtX_inv, dof=max(n - p, 1)
+    )
+
+    beta, W = _glm_irls(y, X, "logit")
+    bread = np.linalg.pinv(X.T @ (X * W[:, None]))
+    mu = _link_inv(X @ beta, "logit")
+    hc0 = _sandwich(X, bread, y - mu, None, n, p, hc1=False)
+
+    np.testing.assert_allclose(cov, hc0, rtol=1e-10)
+    # Guard the regression direction: it must NOT be the old HC1-inflated value.
+    assert not np.allclose(cov, hc0 * (n / (n - p)))


### PR DESCRIPTION
Closes #533.

## Problem
`_sandwich` (`python/topica/stm.py`) applied the finite-sample factor `n/max(n-p,1)` unconditionally. For the linear model that matches statsmodels **HC1** (verified). But for a **GLM** (fractional logit / quasi-Poisson), statsmodels treats HC0 and HC1 identically (no df factor), and the classic **Papke–Wooldridge** fractional-logit robust SE is **HC0**. So topica's GLM robust SE was a constant `sqrt(n/(n-p))` too large (≈1.0127× at n=120, p=3).

## Fix
Add an `hc1=` flag to `_sandwich` (default `True`) that gates the `n/(n-p)` factor on the heteroskedasticity-robust (non-cluster) meat, and pass `hc1=False` from the GLM branch of `_fit_one`. 

- Identity-link **HC1** and cluster-robust **CR1** paths are unchanged (both already matched statsmodels exactly).
- No change to point estimates; only the GLM non-cluster robust SE changes (removes the spurious inflation).
- Documented the convention in the `estimate_effect` docstring: GLM heteroskedasticity-robust SE is HC0, identity is HC1, cluster is CR1.

## Verification
- New `test_sandwich_hc1_flag_toggles_df_factor` (HC0 == bread·meat·bread, HC1 == HC0·n/(n-p)) and `test_fit_one_glm_reports_hc0_not_hc1` (the GLM path reports HC0, reconstructed from the same IRLS fit; guards against the HC1 regression).
- `pytest -k "stm or content or standard_error or effect or estimate"` — 1791 passed, 29 skipped, no pinned-value regressions.
- `./scripts/preflight.sh` — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)