### PR TITLE
feat(inspect): shared residual-dispersion diagnostic in topica-core (#543)

### DIFF
--- a/parity/residual_dispersion_r_compare.py
+++ b/parity/residual_dispersion_r_compare.py
@@ -1,0 +1,132 @@
+"""Cross-implementation validation: topica's residual dispersion vs. R `stm`'s
+`checkResiduals` (Taddy 2012).
+
+Unlike a fit comparison, this isolates the *metric*: we fit one STM model in R,
+call `stm::checkResiduals` on it, then export that model's exact `theta`, `beta`
+(= `exp(logbeta)`), and integer-coded documents and feed the identical arrays to
+topica-core's `inspect::residual_dispersion` (via `topica.check_residuals`'s
+binding). Because both sides consume the same fitted quantities, the dispersion,
+degrees of freedom, and chi-squared statistic should agree to floating-point
+noise. Any gap is a faithfulness bug in topica's port of stm's residual formula
+or its degrees-of-freedom accounting (`df = Nhat - V - n*(K-1) - K*(V-1)`).
+
+Shells out to `Rscript` with the `stm` package. Skips (exit 0) if R or `stm` is
+unavailable. Run directly:
+
+    python parity/residual_dispersion_r_compare.py
+"""
+
+from __future__ import annotations
+
+import csv
+import os
+import shutil
+import subprocess
+import tempfile
+
+import numpy as np
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.dirname(HERE)
+GADARIAN = os.path.join(ROOT, "examples", "gadarian.csv")
+STOPLIST = os.path.join(ROOT, "examples", "english-stoplist.txt")
+
+
+def r_stm_available() -> bool:
+    """True iff `Rscript` is on PATH and the `stm` package loads."""
+    if shutil.which("Rscript") is None:
+        return False
+    try:
+        out = subprocess.run(
+            ["Rscript", "-e", 'cat(requireNamespace("stm", quietly=TRUE))'],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return False
+    return out.stdout.strip().endswith("TRUE")
+
+
+R_SCRIPT = r"""
+suppressMessages(library(stm))
+args <- commandArgs(trailingOnly=TRUE)
+csv <- args[1]; stoplist <- args[2]; outdir <- args[3]
+d <- read.csv(csv, stringsAsFactors=FALSE)
+stops <- readLines(stoplist, warn=FALSE)
+proc <- textProcessor(d$open.ended.response, metadata=d,
+                      customstopwords=stops, verbose=FALSE)
+out <- prepDocuments(proc$documents, proc$vocab, proc$meta, verbose=FALSE)
+set.seed(2138)
+mod <- stm(out$documents, out$vocab, K=3, prevalence=~treatment,
+           data=out$meta, init.type="Spectral", max.em.its=25, verbose=FALSE)
+rc <- checkResiduals(mod, out$documents, tol=0.01)
+
+theta <- mod$theta                       # N x K
+beta  <- exp(mod$beta$logbeta[[1]])      # K x V
+write.table(theta, file.path(outdir, "theta.csv"), sep=",",
+            row.names=FALSE, col.names=FALSE)
+write.table(beta,  file.path(outdir, "beta.csv"),  sep=",",
+            row.names=FALSE, col.names=FALSE)
+# documents: one line per doc, space-separated 0-based token ids (repeated by count)
+con <- file(file.path(outdir, "docs.txt"), "w")
+for (doc in out$documents) {
+  ids <- rep(doc[1, ] - 1L, doc[2, ])
+  writeLines(paste(ids, collapse=" "), con)
+}
+close(con)
+writeLines(sprintf("%.10f %.10f %.10f", rc$dispersion, rc$df, rc$pvalue),
+           file.path(outdir, "rc.txt"))
+"""
+
+
+def main() -> int:
+    if not r_stm_available():
+        print("SKIP: Rscript or the `stm` package is unavailable.")
+        return 0
+    if not os.path.exists(GADARIAN):
+        print("SKIP: examples/gadarian.csv not found.")
+        return 0
+
+    from topica._topica import inspect_residual_dispersion
+    from topica.validation import _chisq_sf
+
+    with tempfile.TemporaryDirectory() as td:
+        script = os.path.join(td, "run.R")
+        with open(script, "w") as f:
+            f.write(R_SCRIPT)
+        proc = subprocess.run(
+            ["Rscript", script, GADARIAN, STOPLIST, td],
+            capture_output=True,
+            text=True,
+            timeout=600,
+        )
+        if proc.returncode != 0:
+            print("SKIP: R run failed:\n" + proc.stderr[-2000:])
+            return 0
+
+        theta = np.loadtxt(os.path.join(td, "theta.csv"), delimiter=",", ndmin=2)
+        beta = np.loadtxt(os.path.join(td, "beta.csv"), delimiter=",", ndmin=2)
+        with open(os.path.join(td, "docs.txt")) as f:
+            docs = [[int(x) for x in line.split()] for line in f if line.strip()]
+        with open(os.path.join(td, "rc.txt")) as f:
+            r_disp, r_df, r_pval = (float(x) for x in f.read().split())
+
+    disp, df, num_params, statistic, nhat = inspect_residual_dispersion(
+        beta.tolist(), theta.tolist(), docs, 0.01
+    )
+    pval = _chisq_sf(statistic, df) if df > 0 else float("nan")
+
+    print(f"R   stm::checkResiduals: dispersion={r_disp:.6f} df={r_df:.0f} pvalue={r_pval:.4g}")
+    print(f"topica residual_dispersion: dispersion={disp:.6f} df={df:.0f} pvalue={pval:.4g}")
+    ok_disp = np.isclose(disp, r_disp, rtol=1e-4, atol=1e-6)
+    ok_df = np.isclose(df, r_df, atol=0.5)
+    print(f"dispersion match: {ok_disp}   df match: {ok_df}")
+    if not (ok_disp and ok_df):
+        raise SystemExit("MISMATCH: topica residual dispersion diverges from stm.")
+    print("PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -93,6 +93,18 @@ def inspect_semantic_coherence(
     """stm-faithful per-topic semantic coherence (semCoh1beta) over top-m words (internal)."""
     ...
 
+def inspect_residual_dispersion(
+    beta: list[list[float]],
+    theta: list[list[float]],
+    docs: list[list[int]],
+    tol: float = 0.01,
+) -> tuple[float, float, float, float, float]:
+    """stm-faithful multinomial residual dispersion (checkResiduals / Taddy 2012).
+
+    Returns ``(dispersion, df, num_params, statistic, nhat)`` (internal).
+    """
+    ...
+
 def window_cooccurrence(
     docs: list[list[int]],
     num_relevant: int,

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1524,11 +1524,17 @@ def check_residuals(model, docs, *, tol=0.01):
 
     Returns a :class:`ResidualCheck` with ``dispersion`` (σ²), ``pvalue`` (χ²
     test of σ²=1 vs σ²>1), and ``df``.
+
+    The dispersion, ``df``, and χ² statistic come from the shared ``topica-core``
+    ``inspect::residual_dispersion`` implementation (the same port faSTM and the
+    Stata plugin consume), so every host reports one stm-faithful number. Only the
+    upper-tail χ² p-value is formed here.
     """
+    from ._topica import inspect_residual_dispersion
+
     phi = np.asarray(model.topic_word, dtype=np.float64)
     theta = np.asarray(model.doc_topic, dtype=np.float64)
     vocab = list(model.vocabulary)
-    k, v = phi.shape
     n = theta.shape[0]
     if len(docs) != n:
         raise ValueError(
@@ -1536,29 +1542,14 @@ def check_residuals(model, docs, *, tol=0.01):
             "pass the same documents used to fit the model"
         )
     vindex = {w: i for i, w in enumerate(vocab)}
+    docs_ids = [
+        [vindex[w] for w in doc if w in vindex] for doc in docs
+    ]
 
-    d_stat = 0.0
-    nhat = 0
-    for d in range(n):
-        q = np.clip(theta[d] @ phi, 1e-12, 1.0 - 1e-12)  # (V,) model word probs
-        x = np.zeros(v)
-        m = 0.0
-        for w in docs[d]:
-            i = vindex.get(w)
-            if i is not None:
-                x[i] += 1.0
-                m += 1.0
-        if m == 0:
-            continue
-        nhat += int(np.sum(q * m > tol))
-        first = np.sum((x * x - 2.0 * x * q * m) / (m * q * (1.0 - q)))
-        second = np.sum(m * q / (1.0 - q))
-        d_stat += float(first + second)
-
-    n_params = n * (k - 1) + k * (v - 1)
-    df = nhat - v - n_params
-    dispersion = d_stat / df if df > 0 else float("nan")
-    pvalue = _chisq_sf(d_stat, df) if df > 0 else float("nan")
+    dispersion, df, _n_params, statistic, _nhat = inspect_residual_dispersion(
+        phi.tolist(), theta.tolist(), docs_ids, float(tol)
+    )
+    pvalue = _chisq_sf(statistic, df) if df > 0 else float("nan")
     return ResidualCheck(dispersion=float(dispersion), pvalue=float(pvalue), df=float(df))
 
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -8390,6 +8390,29 @@ fn inspect_semantic_coherence(
     py.allow_threads(move || topica_core::inspect::semantic_coherence(&beta, &docs, m))
 }
 
+/// stm-faithful multinomial residual dispersion (`topica-core`
+/// `inspect::residual_dispersion`, stm's `checkResiduals` / Taddy 2012): the
+/// dispersion of the fitted model's multinomial residuals for judging whether K
+/// is too small. `beta` is the K×V topic-word matrix, `theta` the N×K per-document
+/// proportions, `docs` the token-id lists aligned to `theta`, `tol` Taddy's
+/// effective-count tolerance (stm default 1/100). Returns
+/// `(dispersion, df, num_params, statistic, nhat)`; the caller forms the χ²
+/// p-value from `statistic` and `df`. Internal: backs `topica.check_residuals`.
+#[pyfunction]
+#[pyo3(signature = (beta, theta, docs, tol=0.01))]
+fn inspect_residual_dispersion(
+    py: Python<'_>,
+    beta: Vec<Vec<f64>>,
+    theta: Vec<Vec<f64>>,
+    docs: Vec<Vec<u32>>,
+    tol: f64,
+) -> (f64, f64, f64, f64, f64) {
+    py.allow_threads(move || {
+        let r = topica_core::inspect::residual_dispersion(&beta, &theta, &docs, tol);
+        (r.dispersion, r.df, r.num_params, r.statistic, r.nhat)
+    })
+}
+
 /// Warn that a neighbor-preserving projection (UMAP / t-SNE) distorts global
 /// geometry, so PCA stays the distance-faithful default. UMAP is seeded and
 /// reproducible; t-SNE is additionally not reproducible (its optimizer is
@@ -14983,6 +15006,7 @@ fn _topica(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(inspect_score_scores, m)?)?;
     m.add_function(wrap_pyfunction!(inspect_exclusivity, m)?)?;
     m.add_function(wrap_pyfunction!(inspect_semantic_coherence, m)?)?;
+    m.add_function(wrap_pyfunction!(inspect_residual_dispersion, m)?)?;
     m.add_function(wrap_pyfunction!(project, m)?)?;
     m.add_function(wrap_pyfunction!(set_experimental, m)?)?;
     m.add_function(wrap_pyfunction!(experimental_is_enabled, m)?)?;

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -83,6 +83,28 @@ class TestCheckResiduals:
         with pytest.raises(ValueError):
             stm.check_residuals(m, docs[:10])
 
+    def test_backed_by_shared_core(self, two_topic):
+        # check_residuals delegates to topica-core inspect::residual_dispersion.
+        m, docs = two_topic
+        from topica._topica import inspect_residual_dispersion
+
+        phi = np.asarray(m.topic_word, dtype=np.float64)
+        theta = np.asarray(m.doc_topic, dtype=np.float64)
+        vocab = {w: i for i, w in enumerate(m.vocabulary)}
+        ids = [[vocab[w] for w in doc if w in vocab] for doc in docs]
+        dispersion, df, num_params, statistic, nhat = inspect_residual_dispersion(
+            phi.tolist(), theta.tolist(), ids, 0.01
+        )
+        rc = stm.check_residuals(m, docs)
+        assert np.isclose(rc.dispersion, dispersion, rtol=1e-9, atol=1e-12)
+        assert rc.df == df
+        assert dispersion > 0.0 and np.isfinite(dispersion)
+        # stm's d = n*(K-1) + K*(V-1); df = Nhat - V - d.
+        k, v = phi.shape
+        n = theta.shape[0]
+        assert num_params == n * (k - 1) + k * (v - 1)
+        assert np.isclose(df, nhat - v - num_params)
+
 
 class TestAlignment:
     def test_matches_swapped_topics(self, two_topic):

--- a/topica-core/src/inspect.rs
+++ b/topica-core/src/inspect.rs
@@ -265,6 +265,114 @@ pub fn exclusivity(beta: &[Vec<f64>], m: usize, frexw: f64) -> Vec<f64> {
     excl
 }
 
+/// Result of [`residual_dispersion`]: stm's `checkResiduals` return, split so the
+/// caller (Python / R / Stata) can form the chi-squared p-value from `statistic`
+/// and `df` with its own upper-tail routine.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ResidualDispersion {
+    /// Sample dispersion sigma^2 = D / df. Equals ~1 under the data-generating
+    /// process; > 1 is evidence K is too small (Taddy 2012). NaN when df <= 0.
+    pub dispersion: f64,
+    /// Residual degrees of freedom: `nhat - V - num_params` (stm's `df`).
+    pub df: f64,
+    /// Number of estimated parameters d = n*(K-1) + K*(V-1) (stm's `d`).
+    pub num_params: f64,
+    /// The aggregated squared-residual statistic D (stm's `D`), the chi-squared
+    /// test statistic for sigma^2 = 1 vs sigma^2 > 1.
+    pub statistic: f64,
+    /// Taddy's approximate effective count Nhat: expected counts exceeding `tol`,
+    /// summed over documents (stm's `Nhat`).
+    pub nhat: f64,
+}
+
+/// stm `checkResiduals` / Taddy (2012) multinomial residual dispersion: the
+/// dispersion of the fitted model's multinomial residuals, used to judge whether
+/// K is too small. Under a correct model the dispersion is ~1; a value well above
+/// 1 means the latent topics cannot absorb the overdispersion (too few topics).
+///
+/// `beta` is the K×V topic-word probability matrix, `theta` the N×K per-document
+/// topic proportions, `docs` the corpus token-id lists (one per document, aligned
+/// to `theta`'s rows). `tol` is Taddy's tolerance for the effective-count
+/// degrees-of-freedom approximation (stm default 1/100).
+///
+/// This is a faithful port of stm's `checkResiduals`: for each document with
+/// length `m`, the expected word probability is `q_w = sum_k theta_dk beta_kw`
+/// and the squared standardized (Pearson) multinomial residual summed over the
+/// full vocabulary is `sum_w (x_w - m q_w)^2 / (m q_w (1 - q_w))`, formed via
+/// stm's algebraic split `sum_w (x_w^2 - 2 x_w q_w m)/(m q_w (1-q_w)) + sum_w m
+/// q_w/(1-q_w)`. `D` sums that over documents; `Nhat` counts, per document, the
+/// words whose expected count `m q_w` exceeds `tol`; the parameter count is
+/// `d = n*(K-1) + K*(V-1)`; and `df = Nhat - V - d`, `dispersion = D / df`.
+/// `q_w` is clamped to `[1e-12, 1 - 1e-12]` to keep the `1 - q_w` denominators
+/// finite (smoothed beta stays well inside that range, so the clamp does not move
+/// stm's number).
+pub fn residual_dispersion(
+    beta: &[Vec<f64>],
+    theta: &[Vec<f64>],
+    docs: &[Vec<u32>],
+    tol: f64,
+) -> ResidualDispersion {
+    let k = beta.len();
+    let v = if k > 0 { beta[0].len() } else { 0 };
+    let n = theta.len();
+
+    let mut statistic = 0.0f64;
+    let mut nhat = 0.0f64;
+    for (d, doc) in docs.iter().enumerate().take(n) {
+        let th = &theta[d];
+        // q_w = sum_k theta_dk beta_kw, clamped to keep (1 - q) finite.
+        let mut q = vec![0.0f64; v];
+        for kk in 0..k {
+            let t = th.get(kk).copied().unwrap_or(0.0);
+            if t == 0.0 {
+                continue;
+            }
+            let row = &beta[kk];
+            for (vv, qv) in q.iter_mut().enumerate() {
+                *qv += t * row[vv];
+            }
+        }
+        for qv in q.iter_mut() {
+            *qv = qv.clamp(1e-12, 1.0 - 1e-12);
+        }
+
+        // Observed counts x_w and document length m from the token-id list.
+        let mut x = vec![0.0f64; v];
+        let mut m = 0.0f64;
+        for &tok in doc {
+            let w = tok as usize;
+            if w < v {
+                x[w] += 1.0;
+                m += 1.0;
+            }
+        }
+        if m == 0.0 {
+            continue;
+        }
+
+        for vv in 0..v {
+            let qv = q[vv];
+            if qv * m > tol {
+                nhat += 1.0;
+            }
+            let xv = x[vv];
+            let denom = m * qv * (1.0 - qv);
+            statistic += (xv * xv - 2.0 * xv * qv * m) / denom + m * qv / (1.0 - qv);
+        }
+    }
+
+    let num_params = (n as f64) * ((k as f64) - 1.0) + (k as f64) * ((v as f64) - 1.0);
+    let df = nhat - v as f64 - num_params;
+    let dispersion = if df > 0.0 { statistic / df } else { f64::NAN };
+    ResidualDispersion {
+        dispersion,
+        df,
+        num_params,
+        statistic,
+        nhat,
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -330,5 +438,76 @@ mod tests {
         let excl = exclusivity(&beta, 2, 0.7);
         assert_eq!(excl.len(), 2);
         assert!(excl.iter().all(|e| e.is_finite() && *e > 0.0));
+    }
+
+    // Two-cluster planted corpus: words {0,1,2} vs {3,4,5}. Docs 0-3 draw only
+    // from cluster A, docs 4-7 only from cluster B.
+    fn planted_corpus() -> Vec<Vec<u32>> {
+        let mut docs = Vec::new();
+        for _ in 0..4 {
+            docs.push(vec![0u32, 1, 2, 0, 1, 2, 0, 1, 2, 0, 1, 2]);
+        }
+        for _ in 0..4 {
+            docs.push(vec![3u32, 4, 5, 3, 4, 5, 3, 4, 5, 3, 4, 5]);
+        }
+        docs
+    }
+
+    #[test]
+    fn residual_dispersion_drops_as_k_reaches_truth() {
+        let docs = planted_corpus();
+        let n = docs.len();
+
+        // K = 1: a single averaged topic cannot represent the two clusters.
+        let beta1 = vec![vec![1.0 / 6.0; 6]];
+        let theta1 = vec![vec![1.0]; n];
+        let r1 = residual_dispersion(&beta1, &theta1, &docs, 0.01);
+
+        // K = 2: topics aligned to the true clusters, near-one-hot proportions.
+        let beta2 = vec![
+            vec![0.32, 0.32, 0.32, 0.013, 0.013, 0.014],
+            vec![0.013, 0.013, 0.014, 0.32, 0.32, 0.32],
+        ];
+        let mut theta2 = Vec::new();
+        for _ in 0..4 {
+            theta2.push(vec![0.98, 0.02]);
+        }
+        for _ in 0..4 {
+            theta2.push(vec![0.02, 0.98]);
+        }
+        let r2 = residual_dispersion(&beta2, &theta2, &docs, 0.01);
+
+        assert!(r1.df > 0.0 && r2.df > 0.0);
+        assert!(r1.dispersion.is_finite() && r2.dispersion.is_finite());
+        // Too-few-topics model is overdispersed relative to the well-specified one.
+        assert!(
+            r1.dispersion > r2.dispersion,
+            "K=1 dispersion {} should exceed K=2 dispersion {}",
+            r1.dispersion,
+            r2.dispersion
+        );
+        assert!(r1.dispersion > 1.0, "K=1 should be overdispersed (>1)");
+        // Parameter count matches stm's d = n*(K-1) + K*(V-1).
+        assert_eq!(r1.num_params, n as f64 * 0.0 + 1.0 * 5.0);
+        assert_eq!(r2.num_params, n as f64 * 1.0 + 2.0 * 5.0);
+    }
+
+    #[test]
+    fn residual_dispersion_is_deterministic() {
+        let docs = planted_corpus();
+        let beta = vec![
+            vec![0.32, 0.32, 0.32, 0.013, 0.013, 0.014],
+            vec![0.013, 0.013, 0.014, 0.32, 0.32, 0.32],
+        ];
+        let mut theta = Vec::new();
+        for _ in 0..4 {
+            theta.push(vec![0.98, 0.02]);
+        }
+        for _ in 0..4 {
+            theta.push(vec![0.02, 0.98]);
+        }
+        let a = residual_dispersion(&beta, &theta, &docs, 0.01);
+        let b = residual_dispersion(&beta, &theta, &docs, 0.01);
+        assert_eq!(a, b);
     }
 }


### PR DESCRIPTION
Closes #543.

## What

Adds R `stm::checkResiduals` / Taddy (2012) **multinomial residual dispersion** to the shared `topica-core` `inspect` module, so R, Python, and the Stata plugin (faSTM/fastm) all consume one stm-faithful implementation instead of reimplementing it per binding (per DESIGN.md).

`inspect::residual_dispersion(beta, theta, docs, tol) -> ResidualDispersion { dispersion, df, num_params, statistic, nhat }` sits alongside `semantic_coherence` / `exclusivity` / `frex_scores`.

## The metric (faithful to stm's `residuals.R`)

For each document `d` of length `m`, the expected word probability is `q_w = sum_k theta_dk * beta_kw`. The squared standardized (Pearson) multinomial residual, summed over the full vocabulary, is `sum_w (x_w - m q_w)^2 / (m q_w (1 - q_w))`, computed via stm's exact algebraic split `sum_w (x_w^2 - 2 x_w q_w m)/(m q_w (1-q_w)) + sum_w m q_w/(1-q_w)`. Then, matching stm exactly:

- `D` = that statistic summed over documents;
- `Nhat` = per-document count of words whose expected count `m q_w` exceeds `tol` (Taddy's effective-count approximation, stm default `tol = 1/100`);
- parameter count `d = n*(K-1) + K*(V-1)`;
- `df = Nhat - V - d`;
- `dispersion = D / df`.

`q_w` is clamped to `[1e-12, 1 - 1e-12]` to keep the `1 - q_w` denominators finite; smoothed beta stays well inside that range, so it does not move stm's number.

## Python surface

- Internal PyO3 fn `inspect_residual_dispersion(beta, theta, docs, tol=0.01)` returning `(dispersion, df, num_params, statistic, nhat)`.
- `topica.check_residuals` (already public) now **delegates** to the shared core — numbers unchanged — and only forms the chi-squared p-value in Python. `.pyi` stub updated.

## Verification

- **R parity (ran locally, exact):** `parity/residual_dispersion_r_compare.py` fits one STM in R, calls `stm::checkResiduals`, then feeds that model's exact `theta`/`beta`/documents to topica's core. On gadarian K=3: R `dispersion=2.188177, df=62452` vs topica `dispersion=2.188177, df=62452` — identical. Skips cleanly (exit 0) when `Rscript`/`stm` is unavailable; not imported by offline tests.
- **Rust unit tests:** on a planted two-cluster corpus, a too-few-topics (K=1) model is overdispersed (> 1) and its dispersion exceeds the well-specified (K=2) model's; plus a determinism check. `cargo test --lib -p topica-core` green.
- **Python test:** `tests/test_diagnostics.py::TestCheckResiduals::test_backed_by_shared_core` asserts `check_residuals` equals the direct binding and checks stm's df accounting. `pytest tests/test_stm.py tests/test_diagnostics.py` → 77 passed.
- **`scripts/preflight.sh`** (fmt + clippy + table/stub sync): all checks passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)