### PR TITLE
fix(spectral): configurable projection threshold, default 10000 to match R stm (#542)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -473,6 +473,7 @@ class CTM:
         em_tol: Optional[float] = None,
         keep_eta_cov: bool = True,
         num_threads: Optional[int] = None,
+        spectral_projection_threshold: int = 10000,
     ) -> "CTM":
         """EM stops once the relative change in the variational bound falls below
         convergence_tol or after iters iterations, whichever comes first. Pass
@@ -650,6 +651,7 @@ class STM:
         covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
         keep_eta_cov: bool = True,
         num_threads: Optional[int] = None,
+        spectral_projection_threshold: int = 10000,
     ) -> "STM":
         """Fit. prevalence (or covariates, a symmetric alias) is (num_docs, F)
         covariates driving topic proportions (mu_d = X_d gamma; intercept

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -369,6 +369,7 @@ mod ctm_conformance_tests {
             GammaPrior::Pooled,
             true,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng,
         );
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -6427,9 +6427,15 @@ impl CTM {
     /// `em_tol` is the relative-bound tolerance for EM early stopping — the run
     /// stops when the relative change in the variational evidence bound falls below
     /// it (the criterion R `stm` uses).
+    /// `spectral_projection_threshold` is the vocabulary size above which the
+    /// spectral (anchor-word) init switches from the exact V*V co-occurrence to a
+    /// deterministic random projection. The default (10000) matches R `stm`, which
+    /// stays exact up to that size; lower it to force the cheaper approximate path
+    /// on smaller vocabularies. It only affects `init="spectral"` runs.
     #[pyo3(signature = (data, *, iters=500, convergence_tol=1e-5, inference="batch",
                         batch_size=256, tau=64.0, kappa=0.7, beta_init=None, em_tol=None,
-                        keep_eta_cov=true, num_threads=None))]
+                        keep_eta_cov=true, num_threads=None,
+                        spectral_projection_threshold=spectral::DEFAULT_PROJ_THRESHOLD))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -6445,6 +6451,7 @@ impl CTM {
         em_tol: Option<f64>,
         keep_eta_cov: bool,
         num_threads: Option<usize>,
+        spectral_projection_threshold: usize,
     ) -> PyResult<Py<Self>> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
@@ -6521,6 +6528,7 @@ impl CTM {
                         spectral,
                         keep_eta_cov,
                         diagonal,
+                        spectral_projection_threshold,
                         &mut rng,
                     )
                 } else {
@@ -6541,6 +6549,7 @@ impl CTM {
                         ctm::GammaPrior::Pooled,
                         keep_eta_cov,
                         diagonal,
+                        spectral_projection_threshold,
                         &mut rng,
                     )
                 }
@@ -7276,12 +7285,20 @@ impl STM {
     /// stopping — the run stops when the relative change in the variational evidence
     /// bound falls below it (the criterion R `stm` uses). `beta_init` is an optional
     /// initial topic-word matrix to warm-start from.
+    /// `spectral_projection_threshold` is the vocabulary size above which the
+    /// spectral (anchor-word) init switches from the exact V*V co-occurrence to a
+    /// deterministic random projection. The default (10000) matches R `stm`, which
+    /// stays exact up to that size, so at the default topica and `stm` take the same
+    /// exact init for any vocabulary at or below 10000 types. Lower it to force the
+    /// cheaper approximate path on smaller vocabularies (trading fidelity for
+    /// speed/memory). It has no effect when the constructor sets `init="random"`.
     #[pyo3(signature = (data, prevalence=None, *, prevalence_names=None,
                         content=None, content_names=None, content_time=None, content_smooth=1.0,
                         content_prior_var=0.5, content_prior="l2",
                         iters=500, convergence_tol=1e-5,
                         gamma_prior="pooled", gamma_enet=1.0, beta_init=None, em_tol=None,
-                        covariates=None, keep_eta_cov=true, num_threads=None))]
+                        covariates=None, keep_eta_cov=true, num_threads=None,
+                        spectral_projection_threshold=spectral::DEFAULT_PROJ_THRESHOLD))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -7304,6 +7321,7 @@ impl STM {
         covariates: Option<&Bound<'_, PyAny>>,
         keep_eta_cov: bool,
         num_threads: Option<usize>,
+        spectral_projection_threshold: usize,
     ) -> PyResult<Py<Self>> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
@@ -7598,6 +7616,7 @@ impl STM {
                     gprior,
                     keep_eta_cov,
                     diagonal,
+                    spectral_projection_threshold,
                     &mut rng,
                 )
             });

--- a/tests/test_stm_model.py
+++ b/tests/test_stm_model.py
@@ -559,3 +559,58 @@ class TestSTMConvergence:
         m = STM(num_topics=2)
         with pytest.raises(RuntimeError):
             _ = m.bound
+
+
+# ---------------------------------------------------------------------------
+# spectral_projection_threshold (issue #542)
+# ---------------------------------------------------------------------------
+# The spectral (anchor-word) init switches from the exact V*V co-occurrence to a
+# deterministic random projection once the vocabulary exceeds the threshold. The
+# default (10000) matches R stm; lowering it forces the (different) projected path.
+
+
+class TestSpectralProjectionThreshold:
+    def test_default_matches_high_explicit_threshold(self, stm_corpus_and_x):
+        # This corpus's vocabulary (10 types) is well below the default 10000, so
+        # the default and any high explicit threshold both take the exact path and
+        # must be bit-for-bit identical.
+        docs, x_2d = stm_corpus_and_x
+        m_default = STM(num_topics=2, seed=1)
+        m_default.fit(docs, x_2d, prevalence_names=["x"], iters=8)
+        m_high = STM(num_topics=2, seed=1)
+        m_high.fit(
+            docs,
+            x_2d,
+            prevalence_names=["x"],
+            iters=8,
+            spectral_projection_threshold=100_000,
+        )
+        assert np.array_equal(m_default.topic_word, m_high.topic_word)
+
+    def test_low_threshold_changes_init_and_result(self, stm_corpus_and_x):
+        # Lowering the threshold below V (10) forces the approximate projected
+        # co-occurrence path, which yields a different init and hence a different
+        # fit from the exact (default) path.
+        docs, x_2d = stm_corpus_and_x
+        m_exact = STM(num_topics=2, seed=1)
+        m_exact.fit(docs, x_2d, prevalence_names=["x"], iters=8)
+        m_proj = STM(num_topics=2, seed=1)
+        m_proj.fit(
+            docs,
+            x_2d,
+            prevalence_names=["x"],
+            iters=8,
+            spectral_projection_threshold=1,
+        )
+        assert not np.array_equal(m_exact.topic_word, m_proj.topic_word)
+
+    def test_projected_path_is_deterministic(self, stm_corpus_and_x):
+        # A fixed (corpus, threshold) gives a reproducible projected init/fit.
+        docs, x_2d = stm_corpus_and_x
+        a = STM(num_topics=2, seed=1)
+        a.fit(docs, x_2d, prevalence_names=["x"], iters=8,
+              spectral_projection_threshold=1)
+        b = STM(num_topics=2, seed=1)
+        b.fit(docs, x_2d, prevalence_names=["x"], iters=8,
+              spectral_projection_threshold=1)
+        assert np.array_equal(a.topic_word, b.topic_word)

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -1100,6 +1100,12 @@ fn mu_from(x_d: &[f64], gamma: &[Vec<f64>], km1: usize) -> Vec<f64> {
 /// approximation (ν = diag(1/H_ii)), which skips the per-document Cholesky and
 /// inverse for a large E-step speedup at high K, at the cost of dropping the
 /// off-diagonal posterior covariance.
+///
+/// `spectral_proj_threshold` is the vocabulary size above which the spectral init
+/// switches from the exact V×V co-occurrence to a random projection (see
+/// [`crate::spectral::spectral_init_with_threshold`]); pass
+/// [`crate::spectral::DEFAULT_PROJ_THRESHOLD`] to match R `stm`. It only matters
+/// when `init_spectral` is set.
 #[allow(clippy::too_many_arguments)]
 pub fn fit_ctm<R: Rng>(
     docs: &[Vec<u32>],
@@ -1118,6 +1124,7 @@ pub fn fit_ctm<R: Rng>(
     gamma_prior: GammaPrior,
     keep_nu: bool,
     diagonal: bool,
+    spectral_proj_threshold: usize,
     rng: &mut R,
 ) -> CtmModel {
     let k = num_topics;
@@ -1184,7 +1191,12 @@ pub fn fit_ctm<R: Rng>(
     // computed base β (e.g. R `stm`'s exact spectral β) and reproduce that fit.
     let (mut beta, init_route): (Vec<Vec<f64>>, &'static str) = match init_beta {
         Some(b) => (b.iter().map(|row| row.to_vec()).collect(), "provided"),
-        None if init_spectral => match crate::spectral::spectral_init(docs, k, num_types) {
+        None if init_spectral => match crate::spectral::spectral_init_with_threshold(
+            docs,
+            k,
+            num_types,
+            spectral_proj_threshold,
+        ) {
             Some(b) => (b, "spectral"),
             None => (random_beta(rng), "random-fallback"),
         },
@@ -1519,6 +1531,10 @@ pub fn fit_ctm<R: Rng>(
 /// full-batch EM must touch every document each iteration; on moderate corpora
 /// the full-batch [`fit_ctm`] is preferable. Base model only — no prevalence or
 /// content covariates.
+///
+/// `spectral_proj_threshold` behaves as in [`fit_ctm`]: the vocabulary size above
+/// which the spectral init switches to a random projection (only relevant when
+/// `init_spectral` is set).
 #[allow(clippy::too_many_arguments)]
 pub fn fit_ctm_svi<R: Rng>(
     docs: &[Vec<u32>],
@@ -1533,6 +1549,7 @@ pub fn fit_ctm_svi<R: Rng>(
     init_spectral: bool,
     keep_nu: bool,
     diagonal: bool,
+    spectral_proj_threshold: usize,
     rng: &mut R,
 ) -> CtmModel {
     let k = num_topics;
@@ -1555,7 +1572,12 @@ pub fn fit_ctm_svi<R: Rng>(
         b
     };
     let (mut beta, init_route): (Vec<Vec<f64>>, &'static str) = if init_spectral {
-        match crate::spectral::spectral_init(docs, k, num_types) {
+        match crate::spectral::spectral_init_with_threshold(
+            docs,
+            k,
+            num_types,
+            spectral_proj_threshold,
+        ) {
             Some(b) => (b, "spectral"),
             None => (random_beta(rng), "random-fallback"),
         }
@@ -1894,6 +1916,7 @@ mod tests {
                 GammaPrior::Pooled,
                 true,
                 false,
+                crate::spectral::DEFAULT_PROJ_THRESHOLD,
                 &mut rng,
             )
         };
@@ -1976,7 +1999,20 @@ mod tests {
             })
             .collect();
         let m = fit_ctm_svi(
-            &docs, nb, v, 20, 32, 16.0, 0.7, 0.0, 0.0, false, true, false, &mut rng,
+            &docs,
+            nb,
+            v,
+            20,
+            32,
+            16.0,
+            0.7,
+            0.0,
+            0.0,
+            false,
+            true,
+            false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            &mut rng,
         );
         // Each planted block is the top of some topic.
         let mut covered = std::collections::HashSet::new();
@@ -2002,7 +2038,20 @@ mod tests {
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(7);
             fit_ctm_svi(
-                &docs, 3, 9, 10, 16, 16.0, 0.7, 0.0, 0.0, false, true, false, &mut rng,
+                &docs,
+                3,
+                9,
+                10,
+                16,
+                16.0,
+                0.7,
+                0.0,
+                0.0,
+                false,
+                true,
+                false,
+                crate::spectral::DEFAULT_PROJ_THRESHOLD,
+                &mut rng,
             )
             .beta
         };
@@ -2048,7 +2097,20 @@ mod tests {
             let docs = corr_docs();
             let mut rng = ChaCha8Rng::seed_from_u64(2);
             fit_ctm_svi(
-                &docs, 3, 9, 40, 16, 64.0, 0.7, shrink, 0.0, false, false, false, &mut rng,
+                &docs,
+                3,
+                9,
+                40,
+                16,
+                64.0,
+                0.7,
+                shrink,
+                0.0,
+                false,
+                false,
+                false,
+                crate::spectral::DEFAULT_PROJ_THRESHOLD,
+                &mut rng,
             )
         };
         let off0 = max_offdiag(&fit(0.0));
@@ -2089,7 +2151,20 @@ mod tests {
         }
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let model = fit_ctm_svi(
-            &docs, 2, 2, 40, 1, 64.0, 0.7, 0.0, 0.0, false, false, false, &mut rng,
+            &docs,
+            2,
+            2,
+            40,
+            1,
+            64.0,
+            0.7,
+            0.0,
+            0.0,
+            false,
+            false,
+            false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            &mut rng,
         );
         let max_w0 = (0..model.num_topics)
             .map(|t| model.beta[t][0])
@@ -2116,7 +2191,20 @@ mod tests {
         // ELBO trace has one entry per epoch.
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let full = fit_ctm_svi(
-            &docs, 3, 9, epochs, 16, 16.0, 0.7, 0.0, 0.0, false, false, false, &mut rng,
+            &docs,
+            3,
+            9,
+            epochs,
+            16,
+            16.0,
+            0.7,
+            0.0,
+            0.0,
+            false,
+            false,
+            false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            &mut rng,
         );
         assert!(!full.converged, "tol = 0 must not report convergence");
         assert_eq!(full.em_iters_run, epochs);
@@ -2125,7 +2213,20 @@ mod tests {
         // A loose tol early-stops well before the budget and reports `converged`.
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let early = fit_ctm_svi(
-            &docs, 3, 9, epochs, 16, 16.0, 0.7, 0.0, 1e-2, false, false, false, &mut rng,
+            &docs,
+            3,
+            9,
+            epochs,
+            16,
+            16.0,
+            0.7,
+            0.0,
+            1e-2,
+            false,
+            false,
+            false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            &mut rng,
         );
         assert!(early.converged, "a loose tol should early-stop");
         assert!(
@@ -2155,7 +2256,20 @@ mod tests {
         }
         let mut rng = ChaCha8Rng::seed_from_u64(2);
         let m = fit_ctm_svi(
-            &docs, 3, 9, 40, 1, 64.0, 0.7, 0.0, 0.0, false, false, false, &mut rng,
+            &docs,
+            3,
+            9,
+            40,
+            1,
+            64.0,
+            0.7,
+            0.0,
+            0.0,
+            false,
+            false,
+            false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            &mut rng,
         );
         let km1 = m.num_topics - 1;
         for i in 0..km1 {
@@ -2209,6 +2323,7 @@ mod tests {
             GammaPrior::Pooled,
             true,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng,
         );
         let theta = model.doc_topics();
@@ -2258,6 +2373,7 @@ mod tests {
             GammaPrior::Pooled,
             true,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng,
         );
         let cb = model.content_beta.expect("content_beta present");
@@ -2334,6 +2450,7 @@ mod tests {
                 GammaPrior::Pooled,
                 true,
                 false,
+                crate::spectral::DEFAULT_PROJ_THRESHOLD,
                 &mut rng,
             )
             .content_beta
@@ -2402,6 +2519,7 @@ mod tests {
             GammaPrior::Pooled,
             true,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng,
         );
         // The bound trajectory is (weakly) monotone increasing.
@@ -2436,6 +2554,7 @@ mod tests {
             GammaPrior::Pooled,
             true,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng2,
         );
         assert!(!capped.converged);
@@ -2477,6 +2596,7 @@ mod tests {
             GammaPrior::Pooled,
             true,
             true,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng,
         );
         assert!(model.diagonal, "model should record diagonal mode");
@@ -2736,6 +2856,7 @@ mod tests {
             GammaPrior::Pooled,
             true,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng,
         );
         let stored = m_keep.nu.clone(); // per-group E-step ν (keep_nu = true)
@@ -2760,6 +2881,7 @@ mod tests {
             GammaPrior::Pooled,
             false,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng2,
         );
         assert!(model.content_beta.is_some(), "content_beta present");
@@ -2844,6 +2966,7 @@ mod tests {
             GammaPrior::Pooled,
             true,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng,
         );
         let stored = m_keep.nu.clone();
@@ -2865,6 +2988,7 @@ mod tests {
             GammaPrior::Pooled,
             false,
             false,
+            crate::spectral::DEFAULT_PROJ_THRESHOLD,
             &mut rng2,
         );
         assert!(

--- a/topica-core/src/spectral.rs
+++ b/topica-core/src/spectral.rs
@@ -17,18 +17,26 @@ use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
 use std::collections::{BTreeMap, HashMap};
 
-/// Above this vocabulary size the dense V×V co-occurrence is replaced by a
-/// random projection to `PROJ_DIM` columns (Johnson-Lindenstrauss), turning the
-/// O(V²) anchor search into O(V·PROJ_DIM) — the same trick R's `stm` uses for
-/// large vocabularies. At or below it, the exact path runs (cheap and exact).
-/// The threshold sits well above `PROJ_DIM`: projecting only pays off once V is
-/// several times the target dimension (otherwise the projection overhead exceeds
-/// the savings), and it keeps the small/moderate-vocab behavior unchanged.
-const PROJ_THRESHOLD: usize = 3000;
+/// Default vocabulary size above which the dense V×V co-occurrence is replaced by
+/// a random projection to `PROJ_DIM` columns (Johnson-Lindenstrauss), turning the
+/// O(V²) anchor search into O(V·PROJ_DIM). At or below it, the exact path runs
+/// (cheap and exact). This default (10000) matches R `stm`, whose spectral init
+/// builds the exact co-occurrence Gram matrix up to a vocabulary of ~10000 types;
+/// below that boundary topica and `stm` take the same exact path. Above it, the
+/// projected path is an approximation `stm` does not use, so a corpus with a
+/// vocabulary larger than the threshold gets an init that only approximates the
+/// exact one. Callers can lower the threshold (see [`spectral_init_with_threshold`])
+/// to force the cheaper projected path sooner; the threshold should stay well above
+/// `PROJ_DIM`, since projecting only pays off once V is several times the target
+/// dimension (otherwise the projection overhead exceeds the savings).
+pub const DEFAULT_PROJ_THRESHOLD: usize = 10000;
 const PROJ_DIM: usize = 1024;
-/// Fixed seed for the projection so `spectral_init` stays a deterministic,
-/// seed-independent function of the corpus (the projection is an internal
-/// implementation detail, not a modeling choice).
+/// Fixed seed for the projection so the projected path stays a deterministic,
+/// seed-independent function of the corpus: the same corpus and threshold always
+/// yield the same init (the projection is an internal implementation detail, not a
+/// modeling choice). This determinism guarantee holds on both the exact and the
+/// projected path, so lowering the threshold changes *which* init you get but never
+/// makes it seed-dependent.
 const PROJ_SEED: u64 = 0x5EED_C0FFEE;
 
 /// Build the row-normalized co-occurrence matrix `Q̄` (V×V) and the word
@@ -336,14 +344,33 @@ fn cooccurrence_projected(
 /// Returns `None` when it is not applicable (corpus too small, fewer candidate
 /// words than topics, or degenerate co-occurrence) so the caller can fall back.
 ///
-/// For large vocabularies the dense V×V co-occurrence is replaced by a
-/// random-projected V×M one (see [`cooccurrence_projected`]); the downstream
-/// anchor search and recovery are dimension-agnostic and run unchanged.
+/// For vocabularies larger than [`DEFAULT_PROJ_THRESHOLD`] the dense V×V
+/// co-occurrence is replaced by a random-projected V×M one (see
+/// [`cooccurrence_projected`]); the downstream anchor search and recovery are
+/// dimension-agnostic and run unchanged. To make the switch-over point
+/// configurable, call [`spectral_init_with_threshold`].
 pub fn spectral_init(docs: &[Vec<u32>], k: usize, v: usize) -> Option<Vec<Vec<f64>>> {
+    spectral_init_with_threshold(docs, k, v, DEFAULT_PROJ_THRESHOLD)
+}
+
+/// [`spectral_init`] with the exact→projected switch-over vocabulary size given
+/// explicitly. Vocabularies with `v > proj_threshold` take the approximate
+/// random-projected path; at or below it the exact co-occurrence path runs. The
+/// default ([`DEFAULT_PROJ_THRESHOLD`]) matches R `stm`; lowering `proj_threshold`
+/// forces the cheaper projected path on smaller vocabularies (trading fidelity for
+/// speed/memory). The result is deterministic for a fixed `(docs, k, v,
+/// proj_threshold)` regardless of any RNG (the projection uses a fixed internal
+/// seed), on both paths.
+pub fn spectral_init_with_threshold(
+    docs: &[Vec<u32>],
+    k: usize,
+    v: usize,
+    proj_threshold: usize,
+) -> Option<Vec<Vec<f64>>> {
     if v < k {
         return None;
     }
-    let (qbar, p) = if v > PROJ_THRESHOLD {
+    let (qbar, p) = if v > proj_threshold {
         cooccurrence_projected(docs, v, PROJ_DIM)?
     } else {
         cooccurrence(docs, v)?
@@ -360,10 +387,11 @@ mod tests {
 
     #[test]
     fn projected_recovers_planted_topics_large_vocab() {
-        // Vocabulary above PROJ_THRESHOLD so the random-projection path runs.
-        // Ten disjoint blocks of 400 words each (V = 4000 > 3000); each doc
-        // draws from one block. Spectral init should still put each topic's
-        // top words on a single block via the projected co-occurrence.
+        // Force the random-projection path with an explicit low threshold (the
+        // default is now 10000, above this fixture's V). Ten disjoint blocks of
+        // 400 words each (V = 4000 > threshold 3000); each doc draws from one
+        // block. Spectral init should still put each topic's top words on a
+        // single block via the projected co-occurrence.
         let nb = 10usize;
         let bs = 400usize;
         let v = nb * bs; // 4000
@@ -377,7 +405,8 @@ mod tests {
             let doc: Vec<u32> = (0..10).map(|j| blk[(i * 7 + j * 37) % bs]).collect();
             docs.push(doc);
         }
-        let beta = spectral_init(&docs, nb, v).expect("projected spectral init");
+        let beta =
+            spectral_init_with_threshold(&docs, nb, v, 3000).expect("projected spectral init");
         // Each topic's top words should fall predominantly in one block.
         let mut covered = std::collections::HashSet::new();
         for t in 0..nb {
@@ -418,8 +447,8 @@ mod tests {
         // the corpus by construction. This asserts within-process reproducibility
         // (two inits on the same large-vocab corpus are bit-identical); it is a
         // smoke test rather than a proof, since whether an unordered sum actually
-        // diverges in its low bits is data-dependent. V = 4000 > PROJ_THRESHOLD
-        // forces the projected path.
+        // diverges in its low bits is data-dependent. An explicit threshold of
+        // 3000 < V = 4000 forces the projected path (the default is now 10000).
         let nb = 10usize;
         let bs = 400usize;
         let v = nb * bs;
@@ -434,9 +463,61 @@ mod tests {
             let doc: Vec<u32> = (0..25).map(|j| blk[(i * 13 + j * 41) % bs]).collect();
             docs.push(doc);
         }
-        let a = spectral_init(&docs, nb, v).expect("projected spectral init");
-        let b = spectral_init(&docs, nb, v).expect("projected spectral init");
+        let a = spectral_init_with_threshold(&docs, nb, v, 3000).expect("projected spectral init");
+        let b = spectral_init_with_threshold(&docs, nb, v, 3000).expect("projected spectral init");
         assert_eq!(a, b, "projected spectral init is not bit-reproducible");
+    }
+
+    #[test]
+    fn threshold_selects_exact_vs_projected_path_and_stays_deterministic() {
+        // #542: the switch-over vocabulary size is configurable. A mid-size
+        // vocabulary (3000 < V < DEFAULT_PROJ_THRESHOLD = 10000) takes the exact
+        // path at the default and the approximate projected path once the
+        // threshold is lowered below V. The two paths give measurably different
+        // inits (the projection is an approximation), and each is deterministic.
+        let nb = 8usize;
+        let bs = 500usize;
+        let v = nb * bs; // 4000: above 3000, below the 10000 default.
+        assert!(v > 3000 && v < DEFAULT_PROJ_THRESHOLD);
+        let blocks: Vec<Vec<u32>> = (0..nb)
+            .map(|b| (b * bs..b * bs + bs).map(|w| w as u32).collect())
+            .collect();
+        let mut docs = Vec::new();
+        for i in 0..(nb * 200) {
+            let blk = &blocks[i % nb];
+            let doc: Vec<u32> = (0..12).map(|j| blk[(i * 11 + j * 29) % bs]).collect();
+            docs.push(doc);
+        }
+
+        // Default threshold (10000): exact path, since V = 4000 <= 10000.
+        let exact_default = spectral_init(&docs, nb, v).expect("exact default");
+        // An explicit high threshold reproduces the exact path bit-for-bit.
+        let exact_explicit =
+            spectral_init_with_threshold(&docs, nb, v, DEFAULT_PROJ_THRESHOLD).expect("exact");
+        assert_eq!(
+            exact_default, exact_explicit,
+            "default threshold must equal DEFAULT_PROJ_THRESHOLD"
+        );
+
+        // Lowering the threshold below V forces the projected path.
+        let projected = spectral_init_with_threshold(&docs, nb, v, 3000).expect("projected");
+
+        // The projected path is an approximation, so it differs from the exact one.
+        assert_ne!(
+            exact_default, projected,
+            "lowering the threshold must switch to the (different) projected path"
+        );
+
+        // Both paths are deterministic for a fixed (docs, k, v, threshold).
+        let exact_again = spectral_init_with_threshold(&docs, nb, v, DEFAULT_PROJ_THRESHOLD)
+            .expect("exact again");
+        let projected_again =
+            spectral_init_with_threshold(&docs, nb, v, 3000).expect("projected again");
+        assert_eq!(exact_explicit, exact_again, "exact path not deterministic");
+        assert_eq!(
+            projected, projected_again,
+            "projected path not deterministic"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Closes #542.

## Problem

The spectral (anchor-word) init in the shared `topica-core` crate hardcoded a random-projection switch-over at a vocabulary of `PROJ_THRESHOLD = 3000` (`topica-core/src/spectral.rs`). Vocabularies between ~3000 and ~10000 types therefore received a **random-projected** (approximate) init, while R `stm`'s spectral init still builds the **exact** co-occurrence Gram matrix up to ~10000. The result was a different, less faithful init (and hence fit) for mid-size corpora. Because this lives in the shared engine, every binding inherited it.

## Change

Make the switch-over point configurable and **raise the default to 10000 to match R `stm`**.

- **`topica-core/src/spectral.rs`**: rename the hardcoded const to `pub const DEFAULT_PROJ_THRESHOLD = 10000`; add `spectral_init_with_threshold(docs, k, v, proj_threshold)` and keep `spectral_init` as a wrapper that passes the default. `PROJ_DIM` and `PROJ_SEED` are unchanged. Fixed the stale comment claiming the 3000 threshold matched `stm`, and documented the fixed-`PROJ_SEED` determinism guarantee (holds on both the exact and projected paths).
- **`topica-core/src/ctm.rs`**: thread a `spectral_proj_threshold` parameter through `fit_ctm` and `fit_ctm_svi` into the spectral-init call.
- **`src/python/mod.rs`**: expose it as an optional keyword on **`STM.fit`** and **`CTM.fit`**:
  - parameter name: **`spectral_projection_threshold`**, default **`10000`** (`spectral::DEFAULT_PROJ_THRESHOLD`).
- Updated the `python/topica/_topica.pyi` stub and `src/conformance.rs`.

The exact and projected code paths themselves are unchanged; only the switch-over point and its default move.

## Behavioral change

Raising the default from 3000 to 10000 changes the spectral init (hence the fit) for corpora with a vocabulary in the ~3000-10000 range: they now get the **exact** init, matching `stm`. Small-vocab (<3000) behavior is unchanged. **faSTM (R) and fastm (Stata) inherit the new default** when they update their vendored `topica-core` (and will need to pass the new `fit_ctm`/`fit_ctm_svi` argument).

The committed STM/CTM gold fixtures use a frozen poliblog subsample with a vocabulary of **2632 types** (< 3000), so they take the exact path both before and after this change — no gold shift, and both `test_stm_gold.py` and `test_ctm_gold.py` pass unchanged.

## Verification

- `cargo test --lib -p topica-core` — 44 passed (includes the new `threshold_selects_exact_vs_projected_path_and_stays_deterministic` plus the two existing projected-path tests, updated to force the projected path via an explicit low threshold).
- `cargo test --lib` — passed.
- `pytest tests/test_stm_gold.py tests/test_stm.py tests/test_stm_model.py tests/test_ctm_gold.py tests/test_ctm.py` — 190 passed (includes 3 new `TestSpectralProjectionThreshold` tests: default == high-explicit threshold, low threshold changes the result, projected path deterministic). Gold tests require `scipy`; they skip/error cleanly when the reference stack is absent.
- `./scripts/preflight.sh` — all checks passed (fmt, clippy, `#481` guard scan, model tables, `.pyi` stub sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)