### PR TITLE
feat(corpus): max_features cap + fixed vocabulary + Corpus.transform

### DIFF
--- a/docs/guides/preprocessing.md
+++ b/docs/guides/preprocessing.md
@@ -81,6 +81,51 @@ print(corpus.num_docs, corpus.num_words, corpus.total_tokens)
 The vocabulary is compiled in Rust, so even multi-gigabyte corpora build quickly.
 A `Corpus` can also load from disk (one document per line, or MALLET-style TSV).
 
+### Cap the vocabulary size (`max_features`)
+
+To keep only the most frequent terms, pass `max_features`. It caps the vocabulary
+to the N most frequent surviving word types, applied after the other filters, and
+matches scikit-learn's `CountVectorizer(max_features=)`:
+
+```python
+corpus = Corpus.from_documents(docs, max_features=10_000)   # keep the 10k most frequent terms
+```
+
+Ties are broken deterministically (by frequency, then by first appearance). Note
+that scikit-learn ranks by collection (total) frequency, while gensim's `keep_n`
+ranks by document frequency; topica follows scikit-learn.
+
+## Apply a fixed vocabulary, or vectorize held-out documents
+
+Two related tasks need the vocabulary held fixed rather than learned from the data.
+
+Pin the vocabulary to a predetermined, ordered term list with `vocabulary=`
+(scikit-learn's `vocabulary=`). Out-of-vocabulary tokens are dropped, the column
+order follows your list, and the frequency filters are not applied (so
+`vocabulary` cannot be combined with `min_doc_freq`, `max_features`, and friends):
+
+```python
+corpus = Corpus.from_documents(docs, vocabulary=["climate", "policy", "economy"])
+```
+
+To score held-out documents with a model you already fit, vectorize them against
+the training corpus with `transform`. The result shares the training vocabulary
+exactly (same terms, order, and ids, at full width), so the model's `topic_word`
+columns stay aligned:
+
+```python
+corpus = Corpus.from_documents(train_docs, min_doc_freq=5)
+model = topica.LDA(num_topics=20).fit(corpus)
+
+heldout = corpus.transform(test_docs)          # same vocabulary as `corpus`
+theta = model.transform(heldout)               # held-out document-topic mixtures
+```
+
+This is scikit-learn's `vectorizer.transform` and gensim's `doc2bow` on new text.
+A held-out document with no in-vocabulary tokens is dropped; its surviving index
+is recorded in `heldout.kept_indices`, so external labels can be realigned the
+same way as after pruning.
+
 ## Detect phrases
 
 Fixed expressions carry meaning together. Detect collocations and rewrite the

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -125,8 +125,9 @@ class Corpus:
 
     @property
     def preprocessing(self) -> dict | None:
-        """The vocabulary-filtering parameters Topica applied when this corpus
-        was built (min_doc_freq/max_doc_fraction/min_cf/rm_top), or None after load."""
+        """The vocabulary-filtering parameters Topica applied when this corpus was
+        built (min_doc_freq/max_doc_fraction/min_cf/rm_top/max_features, plus a
+        ``vocabulary`` flag for a fixed-vocabulary build), or None after load."""
         ...
 
     @staticmethod
@@ -140,6 +141,8 @@ class Corpus:
         max_doc_fraction: float = 1.0,
         min_cf: int = 0,
         rm_top: int = 0,
+        max_features: int | None = None,
+        vocabulary: list[str] | None = None,
     ) -> Corpus:
         """Build a Corpus from a list of token lists.
 
@@ -148,6 +151,31 @@ class Corpus:
         ``kept_indices`` (realign external covariates with ``X[corpus.kept_indices]``).
         ``min_cf`` drops words whose corpus frequency is below the threshold.
         ``rm_top`` removes the top-N most frequent words before any other pruning.
+        ``max_features`` then caps the vocabulary to the N most frequent surviving
+        terms (scikit-learn's ``CountVectorizer(max_features=)``); None is unbounded.
+        ``vocabulary`` pins the vocabulary to a fixed, ordered term list
+        (scikit-learn's ``vocabulary=``): out-of-vocabulary tokens are dropped and
+        the frequency filters are not applied, so it cannot be combined with them.
+        To vectorize held-out documents against an existing corpus, use
+        :meth:`transform`.
+        """
+        ...
+
+    def transform(
+        self,
+        documents: list[list[str]],
+        *,
+        doc_names: list[str] | None = None,
+        doc_labels: list[str] | None = None,
+    ) -> Corpus:
+        """Vectorize new documents against this corpus's vocabulary.
+
+        Returns a Corpus sharing this one's vocabulary exactly (same terms, order,
+        and ids, at full width), so a model fitted here keeps its ``topic_word``
+        columns aligned. Out-of-vocabulary tokens are dropped; documents left with
+        no in-vocabulary token are dropped, with the survivors' indices in the
+        result's ``kept_indices``. scikit-learn's ``vectorizer.transform`` /
+        gensim's ``doc2bow`` on held-out text. Raises if no document survives.
         """
         ...
 

--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -31,6 +31,8 @@ def from_dataframe(
     max_doc_fraction=1.0,
     min_cf=0,
     rm_top=0,
+    max_features=None,
+    vocabulary=None,
 ):
     """Build a :class:`Corpus` from a pandas or Polars DataFrame, keeping
     per-document metadata aligned to the documents that survive pruning.
@@ -66,6 +68,14 @@ def from_dataframe(
         broken in a topic table), so pass a lemmatizing tokenizer here if you want
         to merge inflections while keeping readable surface forms. See the
         preprocessing guide ("Readable topic words: lemmatize, don't stem").
+    max_features : int, optional
+        Cap the vocabulary to the ``max_features`` most frequent surviving terms
+        (scikit-learn's ``CountVectorizer(max_features=)``). ``None`` leaves it
+        unbounded. Passed through to :meth:`Corpus.from_documents`.
+    vocabulary : sequence[str], optional
+        Pin the vocabulary to this fixed, ordered term list (scikit-learn's
+        ``vocabulary=``). Mutually exclusive with the frequency-pruning arguments
+        and ``max_features``; see :meth:`Corpus.from_documents`.
     """
     texts = list(df[text_col])  # pandas Series and Polars Series both iterate to values
     if tokenizer is None:
@@ -83,6 +93,8 @@ def from_dataframe(
         max_doc_fraction=max_doc_fraction,
         min_cf=min_cf,
         rm_top=rm_top,
+        max_features=max_features,
+        vocabulary=vocabulary,
     )
 
     cols = (

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -11,7 +11,7 @@ use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 
-use super::build_corpus_from_docs;
+use super::build_corpus_from_docs_ext;
 use super::error::io_err;
 use crate::corpus::{self, InputFormat, LoadOptions};
 
@@ -24,6 +24,12 @@ pub(crate) struct PrepInfo {
     pub max_doc_fraction: f64,
     pub min_cf: u32,
     pub rm_top: usize,
+    /// Cap on the vocabulary size (top-N by frequency); `None` when unlimited.
+    pub max_features: Option<usize>,
+    /// True when the corpus was built against a fixed, user-supplied vocabulary
+    /// (or produced by :meth:`Corpus.transform`), in which case the frequency
+    /// filters above were not applied.
+    pub vocabulary: bool,
 }
 
 /// A preprocessed, integer-encoded document collection.
@@ -67,17 +73,26 @@ impl Corpus {
     /// `min_doc_freq` (minimum document frequency) and `max_doc_fraction`
     /// (maximum fraction of documents), by `min_cf` (minimum collection/total
     /// frequency), and by `rm_top` (drop the N most frequent words) — matching
-    /// tomotopy's `min_df` / `min_cf` / `rm_top`.
+    /// tomotopy's `min_df` / `min_cf` / `rm_top`. `max_features` then caps the
+    /// vocabulary to the N most frequent surviving word types (scikit-learn's
+    /// `CountVectorizer(max_features=)`); `None` leaves it unbounded.
+    ///
+    /// `vocabulary` pins the vocabulary to a fixed, ordered term list
+    /// (scikit-learn's `vocabulary=`): tokens are mapped to those columns,
+    /// out-of-vocabulary tokens are dropped, and the frequency filters above are
+    /// not applied, so passing `vocabulary` together with any of them is an error.
+    /// To vectorize new documents against an *existing* corpus's vocabulary
+    /// (held-out data), prefer :meth:`Corpus.transform`.
     ///
     /// A document left with no tokens by pruning is dropped, so `num_docs` can be
     /// smaller than `len(documents)`. The surviving original indices are in
     /// `kept_indices`; realign any external covariate matrix with
-    /// `X[corpus.kept_indices]`. (An input document that is empty before any
-    /// pruning is retained.)
+    /// `X[corpus.kept_indices]`. (Without a fixed `vocabulary`, an input document
+    /// that is empty before any pruning is retained.)
     #[staticmethod]
     #[pyo3(signature = (documents, *, doc_names=None, doc_labels=None,
                         stopwords=None, min_doc_freq=1, max_doc_fraction=1.0,
-                        min_cf=0, rm_top=0))]
+                        min_cf=0, rm_top=0, max_features=None, vocabulary=None))]
     #[allow(clippy::too_many_arguments)]
     fn from_documents(
         documents: Vec<Vec<String>>,
@@ -88,9 +103,33 @@ impl Corpus {
         max_doc_fraction: f64,
         min_cf: u32,
         rm_top: usize,
+        max_features: Option<usize>,
+        vocabulary: Option<Vec<String>>,
     ) -> PyResult<Self> {
+        if let Some(mf) = max_features {
+            if mf == 0 {
+                return Err(PyValueError::new_err(
+                    "max_features must be a positive integer",
+                ));
+            }
+        }
+        if vocabulary.is_some()
+            && (min_doc_freq > 1
+                || max_doc_fraction != 1.0
+                || min_cf > 0
+                || rm_top > 0
+                || max_features.is_some())
+        {
+            return Err(PyValueError::new_err(
+                "vocabulary= pins a fixed vocabulary and cannot be combined with \
+                 frequency pruning (a non-default min_doc_freq, max_doc_fraction, \
+                 min_cf, rm_top, or max_features); drop those arguments or prune first \
+                 and pass the resulting corpus.vocabulary",
+            ));
+        }
+        let used_fixed_vocab = vocabulary.is_some();
         let stop: HashSet<String> = stopwords.unwrap_or_default().into_iter().collect();
-        let (inner, kept_indices) = build_corpus_from_docs(
+        let (inner, kept_indices) = build_corpus_from_docs_ext(
             documents,
             doc_names,
             doc_labels,
@@ -99,6 +138,8 @@ impl Corpus {
             max_doc_fraction,
             min_cf,
             rm_top,
+            max_features,
+            vocabulary,
         )?;
         Ok(Corpus {
             inner,
@@ -109,6 +150,56 @@ impl Corpus {
                 max_doc_fraction,
                 min_cf,
                 rm_top,
+                max_features,
+                vocabulary: used_fixed_vocab,
+            }),
+        })
+    }
+
+    /// Vectorize new documents against this corpus's vocabulary.
+    ///
+    /// The returned corpus shares this one's vocabulary exactly (same terms, same
+    /// order, same ids, at full width; terms absent from `documents` remain as
+    /// zero-frequency columns), so a model fitted on this corpus keeps its
+    /// `topic_word` columns aligned to the result. Out-of-vocabulary tokens are
+    /// dropped; `doc_freqs` / `word_counts` are recomputed over `documents`. This
+    /// is scikit-learn's `vectorizer.transform` / gensim's `doc2bow` on held-out
+    /// text.
+    ///
+    /// A document with no in-vocabulary tokens is dropped (as elsewhere in
+    /// topica); `kept_indices` on the result gives the surviving `documents`
+    /// indices so external labels/covariates can be realigned. `metadata` is not
+    /// carried over. Raises if no document retains any in-vocabulary token.
+    #[pyo3(signature = (documents, *, doc_names=None, doc_labels=None))]
+    fn transform(
+        &self,
+        documents: Vec<Vec<String>>,
+        doc_names: Option<Vec<String>>,
+        doc_labels: Option<Vec<String>>,
+    ) -> PyResult<Self> {
+        let (inner, kept_indices) = build_corpus_from_docs_ext(
+            documents,
+            doc_names,
+            doc_labels,
+            HashSet::new(),
+            1,
+            1.0,
+            0,
+            0,
+            None,
+            Some(self.inner.id_to_word.clone()),
+        )?;
+        Ok(Corpus {
+            inner,
+            kept_indices,
+            metadata: None,
+            preprocessing: Some(PrepInfo {
+                min_doc_freq: 1,
+                max_doc_fraction: 1.0,
+                min_cf: 0,
+                rm_top: 0,
+                max_features: None,
+                vocabulary: true,
             }),
         })
     }
@@ -172,6 +263,8 @@ impl Corpus {
                 max_doc_fraction,
                 min_cf: 0,
                 rm_top: 0,
+                max_features: None,
+                vocabulary: false,
             }),
         })
     }
@@ -288,6 +381,8 @@ impl Corpus {
                 d.set_item("max_doc_fraction", p.max_doc_fraction)?;
                 d.set_item("min_cf", p.min_cf)?;
                 d.set_item("rm_top", p.rm_top)?;
+                d.set_item("max_features", p.max_features)?;
+                d.set_item("vocabulary", p.vocabulary)?;
                 Ok(Some(d))
             }
         }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -638,6 +638,45 @@ pub(super) fn build_corpus_from_docs(
     min_cf: u32,
     rm_top: usize,
 ) -> PyResult<(corpus::Corpus, Vec<usize>)> {
+    build_corpus_from_docs_ext(
+        docs_in,
+        doc_names_in,
+        doc_labels_in,
+        stopwords,
+        min_doc_freq,
+        max_doc_fraction,
+        min_cf,
+        rm_top,
+        None,
+        None,
+    )
+}
+
+/// Extended corpus builder backing [`build_corpus_from_docs`].
+///
+/// `max_features` caps the pruned vocabulary to the N most frequent word types
+/// (by total collection frequency, ties broken by ascending vocab id, the same
+/// convention as `rm_top`), applied *after* the `min_doc_freq` / `max_doc_fraction`
+/// / `min_cf` / `rm_top` filters, matching scikit-learn's `CountVectorizer`.
+///
+/// `fixed_vocab`, when `Some`, pins the vocabulary to the given term list in the
+/// given order: tokens are mapped to those ids, out-of-vocabulary tokens are
+/// dropped, and the frequency filters (`min_doc_freq`, …, `max_features`) are
+/// ignored. See [`build_with_fixed_vocab`]. This is scikit-learn's `vocabulary=`
+/// and the machinery behind [`Corpus::transform`].
+#[allow(clippy::too_many_arguments)]
+pub(super) fn build_corpus_from_docs_ext(
+    docs_in: Vec<Vec<String>>,
+    doc_names_in: Option<Vec<String>>,
+    doc_labels_in: Option<Vec<String>>,
+    stopwords: HashSet<String>,
+    min_doc_freq: u32,
+    max_doc_fraction: f64,
+    min_cf: u32,
+    rm_top: usize,
+    max_features: Option<usize>,
+    fixed_vocab: Option<Vec<String>>,
+) -> PyResult<(corpus::Corpus, Vec<usize>)> {
     let n = docs_in.len();
     if let Some(names) = &doc_names_in {
         if names.len() != n {
@@ -658,6 +697,14 @@ pub(super) fn build_corpus_from_docs(
         }
     }
 
+    // Fixed-vocabulary path: map against a predetermined term list, dropping
+    // out-of-vocabulary tokens and all frequency filters. Kept separate from the
+    // dynamic path so the latter's "retain an already-empty input document"
+    // contract is untouched.
+    if let Some(vocab_list) = fixed_vocab {
+        return build_with_fixed_vocab(docs_in, doc_names_in, doc_labels_in, stopwords, vocab_list);
+    }
+
     let mut vocab: HashMap<String, usize> = HashMap::new();
     let mut id_to_word: Vec<String> = Vec::new();
     let mut total_freqs: Vec<u32> = Vec::new();
@@ -668,7 +715,9 @@ pub(super) fn build_corpus_from_docs(
         let mut token_ids: Vec<u32> = Vec::with_capacity(tokens.len());
         let mut seen: HashSet<usize> = HashSet::new();
         for tok in tokens {
-            if stopwords.contains(tok) {
+            // An empty string is not a word; skip it so it never becomes a
+            // vocabulary type (which a later fixed-vocab `transform` would reject).
+            if tok.is_empty() || stopwords.contains(tok) {
                 continue;
             }
             let id = if let Some(&eid) = vocab.get(tok) {
@@ -719,7 +768,7 @@ pub(super) fn build_corpus_from_docs(
     } else {
         HashSet::new()
     };
-    let keep: Vec<bool> = (0..num_types)
+    let mut keep: Vec<bool> = (0..num_types)
         .map(|id| {
             doc_freqs[id] >= min_doc_freq
                 && doc_freqs[id] <= max_df
@@ -727,6 +776,20 @@ pub(super) fn build_corpus_from_docs(
                 && !drop_top.contains(&id)
         })
         .collect();
+
+    // `max_features`: after the df/cf/rm_top filters, keep only the N most
+    // frequent survivors (by total frequency, ties broken by ascending id — the
+    // same ordering `rm_top` uses). Matches scikit-learn's CountVectorizer, which
+    // also applies max_features last. `None` = unlimited.
+    if let Some(mf) = max_features {
+        let mut surviving: Vec<usize> = (0..num_types).filter(|&id| keep[id]).collect();
+        if surviving.len() > mf {
+            surviving.sort_by(|&a, &b| total_freqs[b].cmp(&total_freqs[a]).then(a.cmp(&b)));
+            for &id in &surviving[mf..] {
+                keep[id] = false;
+            }
+        }
+    }
 
     if keep.iter().all(|&k| k) {
         let n = docs.len();
@@ -799,6 +862,98 @@ pub(super) fn build_corpus_from_docs(
         doc_labels: final_labels,
         doc_freqs: new_doc_freqs,
         total_freqs: new_total_freqs,
+    };
+    Ok((corpus, kept_indices))
+}
+
+/// Build a corpus against a fixed, predetermined vocabulary (scikit-learn's
+/// `vocabulary=` / gensim's `doc2bow` on new text). Tokens are mapped to the ids
+/// implied by `vocab_list` order; out-of-vocabulary tokens are dropped; no
+/// frequency filtering is applied.
+///
+/// The vocabulary is preserved at full width and in the given order (terms that
+/// never appear in `docs_in` remain as columns with frequency zero), so a model
+/// trained on the source corpus keeps its `topic_word` columns aligned. Documents
+/// left empty (every token out-of-vocabulary) are dropped, with `doc_names` /
+/// `doc_labels` kept aligned and the surviving original indices returned in the
+/// second tuple field (topica's usual `kept_indices` contract). `stopwords` are
+/// still honoured, so a caller may drop extra tokens even if they are in the
+/// vocabulary.
+fn build_with_fixed_vocab(
+    docs_in: Vec<Vec<String>>,
+    doc_names_in: Option<Vec<String>>,
+    doc_labels_in: Option<Vec<String>>,
+    stopwords: HashSet<String>,
+    vocab_list: Vec<String>,
+) -> PyResult<(corpus::Corpus, Vec<usize>)> {
+    if vocab_list.is_empty() {
+        return Err(PyValueError::new_err("vocabulary must not be empty"));
+    }
+    let num_types = vocab_list.len();
+    let mut word_to_id: HashMap<&str, u32> = HashMap::with_capacity(num_types);
+    for (i, w) in vocab_list.iter().enumerate() {
+        if w.is_empty() {
+            return Err(PyValueError::new_err(
+                "vocabulary contains an empty-string term",
+            ));
+        }
+        if word_to_id.insert(w.as_str(), i as u32).is_some() {
+            return Err(PyValueError::new_err(format!(
+                "vocabulary contains a duplicate term: {:?}",
+                w
+            )));
+        }
+    }
+
+    let n = docs_in.len();
+    let doc_names: Vec<String> =
+        doc_names_in.unwrap_or_else(|| (0..n).map(|i| format!("doc_{}", i)).collect());
+    let doc_labels: Vec<String> = doc_labels_in.unwrap_or_else(|| vec![String::new(); n]);
+
+    let mut total_freqs = vec![0u32; num_types];
+    let mut doc_freqs = vec![0u32; num_types];
+    let mut final_docs: Vec<Vec<u32>> = Vec::new();
+    let mut final_names: Vec<String> = Vec::new();
+    let mut final_labels: Vec<String> = Vec::new();
+    let mut kept_indices: Vec<usize> = Vec::new();
+
+    for (idx, tokens) in docs_in.into_iter().enumerate() {
+        let mut token_ids: Vec<u32> = Vec::with_capacity(tokens.len());
+        let mut seen: HashSet<usize> = HashSet::new();
+        for tok in &tokens {
+            if tok.is_empty() || stopwords.contains(tok) {
+                continue;
+            }
+            if let Some(&id) = word_to_id.get(tok.as_str()) {
+                total_freqs[id as usize] += 1;
+                token_ids.push(id);
+                seen.insert(id as usize);
+            }
+        }
+        if !token_ids.is_empty() {
+            for id in seen {
+                doc_freqs[id] += 1;
+            }
+            final_docs.push(token_ids);
+            final_names.push(doc_names[idx].clone());
+            final_labels.push(doc_labels[idx].clone());
+            kept_indices.push(idx);
+        }
+    }
+
+    if final_docs.is_empty() {
+        return Err(PyValueError::new_err(
+            "no documents survived: none of the tokens matched the fixed vocabulary",
+        ));
+    }
+
+    let corpus = corpus::Corpus {
+        id_to_word: vocab_list,
+        docs: final_docs,
+        doc_names: final_names,
+        doc_labels: final_labels,
+        doc_freqs,
+        total_freqs,
     };
     Ok((corpus, kept_indices))
 }

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -259,7 +259,8 @@ class TestPreprocessingGetter:
             [["a", "b", "c"], ["b", "c", "d"]],
             min_doc_freq=1, max_doc_fraction=1.0, min_cf=0, rm_top=2)
         assert c.preprocessing == {
-            "min_doc_freq": 1, "max_doc_fraction": 1.0, "min_cf": 0, "rm_top": 2}
+            "min_doc_freq": 1, "max_doc_fraction": 1.0, "min_cf": 0, "rm_top": 2,
+            "max_features": None, "vocabulary": False}
 
     def test_none_after_load(self, tmp_path):
         c = Corpus.from_documents([["a", "b"], ["b", "c", "a"]])

--- a/tests/test_corpus_vocab.py
+++ b/tests/test_corpus_vocab.py
@@ -1,0 +1,204 @@
+"""Vocabulary control on Corpus: ``max_features``, a fixed ``vocabulary=``, and
+``Corpus.transform`` for held-out documents (scikit-learn / gensim parity)."""
+
+import numpy as np
+import pytest
+
+import topica
+
+
+# --- max_features ---------------------------------------------------------
+
+
+def test_max_features_keeps_top_n_by_total_frequency():
+    # totals: cat=5, dog=4, fish=3, bird=1, tree=1
+    docs = [
+        ["cat", "cat", "dog", "fish"],
+        ["dog", "dog", "bird"],
+        ["cat", "fish", "fish", "tree"],
+        ["dog", "cat", "cat"],
+    ]
+    c = topica.Corpus.from_documents(docs, max_features=3)
+    assert set(c.vocabulary) == {"cat", "dog", "fish"}
+    assert c.num_words == 3
+
+
+def test_max_features_larger_than_vocab_is_a_noop():
+    docs = [["a", "b"], ["b", "c"]]
+    c = topica.Corpus.from_documents(docs, max_features=100)
+    assert set(c.vocabulary) == {"a", "b", "c"}
+
+
+def test_max_features_tie_break_is_deterministic_first_appearance():
+    # "alpha" and "omega" both have total frequency 1; "alpha" appears first, so
+    # with max_features=1 it wins the tie (ties break by ascending vocab id).
+    docs = [["alpha", "omega"]]
+    c = topica.Corpus.from_documents(docs, max_features=1)
+    assert c.vocabulary == ["alpha"]
+
+
+def test_max_features_applies_after_rm_top():
+    # totals: the=10, cat=4, dog=3, fish=2. rm_top=1 removes "the"; max_features=2
+    # then keeps the top 2 survivors: cat, dog.
+    docs = [
+        ["the"] * 10,
+        ["cat"] * 4,
+        ["dog"] * 3,
+        ["fish"] * 2,
+    ]
+    c = topica.Corpus.from_documents(docs, rm_top=1, max_features=2)
+    assert set(c.vocabulary) == {"cat", "dog"}
+
+
+def test_max_features_zero_raises():
+    with pytest.raises(ValueError, match="positive"):
+        topica.Corpus.from_documents([["a"]], max_features=0)
+
+
+def test_preprocessing_reports_max_features():
+    c = topica.Corpus.from_documents([["a", "b"], ["b", "c"]], max_features=2)
+    assert c.preprocessing["max_features"] == 2
+    assert c.preprocessing["vocabulary"] is False
+
+
+# --- fixed vocabulary -----------------------------------------------------
+
+
+def test_fixed_vocabulary_preserves_order_and_full_width():
+    docs = [["dog", "cat"], ["cat", "cat"]]
+    V = ["dog", "cat", "zebra"]  # "zebra" never appears
+    c = topica.Corpus.from_documents(docs, vocabulary=V)
+    assert c.vocabulary == V  # order preserved, full width kept
+    # word_counts parallel to vocabulary: dog=1, cat=3, zebra=0
+    assert list(c.word_counts) == [1, 3, 0]
+    assert c.preprocessing["vocabulary"] is True
+
+
+def test_fixed_vocabulary_drops_oov_and_empty_docs_with_kept_indices():
+    docs = [["dog", "xxx"], ["yyy", "zzz"], ["cat"]]
+    c = topica.Corpus.from_documents(docs, vocabulary=["dog", "cat"])
+    # doc 1 is all out-of-vocabulary and is dropped; alignment via kept_indices
+    assert c.num_docs == 2
+    assert c.kept_indices == [0, 2]
+
+
+def test_fixed_vocabulary_all_oov_raises():
+    with pytest.raises(ValueError, match="none of the tokens"):
+        topica.Corpus.from_documents([["xxx"], ["yyy"]], vocabulary=["dog", "cat"])
+
+
+def test_fixed_vocabulary_validation():
+    with pytest.raises(ValueError, match="empty"):
+        topica.Corpus.from_documents([["a"]], vocabulary=[])
+    with pytest.raises(ValueError, match="duplicate"):
+        topica.Corpus.from_documents([["a"]], vocabulary=["a", "a"])
+    with pytest.raises(ValueError, match="empty-string"):
+        topica.Corpus.from_documents([["a"]], vocabulary=["a", ""])
+
+
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        {"min_doc_freq": 2},
+        {"max_doc_fraction": 0.5},
+        {"min_cf": 3},
+        {"rm_top": 1},
+        {"max_features": 5},
+    ],
+)
+def test_fixed_vocabulary_mutually_exclusive_with_pruning(kwargs):
+    with pytest.raises(ValueError, match="fixed vocabulary"):
+        topica.Corpus.from_documents([["a", "b"]], vocabulary=["a", "b"], **kwargs)
+
+
+@pytest.mark.parametrize("frac", [2.0, float("inf"), float("nan")])
+def test_fixed_vocabulary_rejects_out_of_range_max_doc_fraction(frac):
+    # A non-default max_doc_fraction (including nan/inf/>1) alongside vocabulary=
+    # is still a conflict, not silently ignored. (Codex review, finding 2.)
+    with pytest.raises(ValueError, match="fixed vocabulary"):
+        topica.Corpus.from_documents([["a", "b"]], vocabulary=["a", "b"], max_doc_fraction=frac)
+
+
+def test_empty_string_token_never_enters_vocabulary():
+    # An empty-string "token" is not a word and must not become a vocab type, so a
+    # later transform against that vocabulary does not spuriously fail.
+    # (Codex review, finding 1.)
+    c = topica.Corpus.from_documents([["", "a"], ["a", "b"]])
+    assert "" not in c.vocabulary
+    held = c.transform([["a"]])  # would raise if "" were a vocab term
+    assert held.vocabulary == c.vocabulary
+
+
+def test_fixed_vocabulary_allows_default_pruning_args():
+    # Passing the *default* pruning values alongside vocabulary is a no-op, not an
+    # error (only a meaningfully-active pruning argument conflicts).
+    c = topica.Corpus.from_documents(
+        [["a", "b"]], vocabulary=["a", "b"], min_doc_freq=1, max_doc_fraction=1.0
+    )
+    assert c.vocabulary == ["a", "b"]
+
+
+# --- transform (held-out) -------------------------------------------------
+
+
+def test_transform_shares_vocabulary_exactly():
+    corpus = topica.Corpus.from_documents([["a", "b", "c"], ["b", "c", "d"]])
+    held = corpus.transform([["a", "zzz"], ["d"]])
+    assert held.vocabulary == corpus.vocabulary  # same terms, order, and width
+
+
+def test_transform_drops_oov_tokens_and_empty_docs():
+    corpus = topica.Corpus.from_documents([["dog", "cat"]])
+    held = corpus.transform([["dog"], ["xxx", "yyy"], ["cat", "dog"]])
+    assert held.num_docs == 2  # the all-OOV middle doc is dropped
+    assert held.kept_indices == [0, 2]
+
+
+def test_transform_all_oov_raises():
+    corpus = topica.Corpus.from_documents([["dog", "cat"]])
+    with pytest.raises(ValueError, match="none of the tokens"):
+        corpus.transform([["xxx"], ["yyy"]])
+
+
+def test_transform_keeps_topic_word_alignment():
+    train = [["dog", "cat", "fish"] * 3, ["bird", "dog", "cat"] * 3, ["fish", "fish", "tree"] * 3]
+    corpus = topica.Corpus.from_documents(train)
+    model = topica.LDA(num_topics=2, seed=0).fit(corpus)
+    held = corpus.transform([["dog", "cat"], ["fish", "tree"]])
+    # topic_word columns align to the transformed corpus vocabulary...
+    assert model.topic_word.shape[1] == held.num_words
+    # ...so the fitted model can score the held-out documents.
+    theta = model.transform(held)
+    assert theta.shape == (held.num_docs, 2)
+    assert np.allclose(theta.sum(axis=1), 1.0)
+
+
+def test_zero_frequency_vocab_column_keeps_coherence_finite():
+    # A fixed vocabulary can carry a term that never appears (doc_freq 0). Fitting
+    # and scoring must not divide by zero / take log(0). (Gemini review, open q b.)
+    docs = [["dog", "cat", "fish"] * 3, ["cat", "fish", "bird"] * 3, ["dog", "dog", "tree"] * 3]
+    c = topica.Corpus.from_documents(docs, vocabulary=["dog", "cat", "fish", "bird", "tree", "ghost"])
+    assert c.word_counts[c.vocabulary.index("ghost")] == 0
+    model = topica.LDA(num_topics=2, seed=0).fit(c)
+    assert np.isfinite(model.coherence()).all()
+
+
+# --- from_dataframe passthrough -------------------------------------------
+
+
+def test_from_dataframe_max_features_and_vocabulary_passthrough():
+    pd = pytest.importorskip("pandas")
+    df = pd.DataFrame(
+        {
+            "text": ["cat cat dog", "dog dog bird", "cat fish fish", "dog cat cat"],
+            "year": [2000, 2001, 2002, 2003],
+        }
+    )
+    c = topica.from_dataframe(df, text_col="text", max_features=2)
+    assert c.num_words == 2
+
+    cv = topica.from_dataframe(df, text_col="text", vocabulary=["cat", "dog"])
+    assert cv.vocabulary == ["cat", "dog"]
+    # metadata stays aligned to the surviving rows
+    assert cv.metadata is not None
+    assert len(cv.metadata) == cv.num_docs

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -75,7 +75,8 @@ def test_captures_seed_and_preprocessing(fitted):
     rec = record_fit(model, corpus, privacy="aggregate", iters=50)
     assert rec.model["seed"] == 99
     assert rec.corpus["description"]["preprocessing"] == {
-        "min_doc_freq": 1, "max_doc_fraction": 1.0, "min_cf": 0, "rm_top": 1}
+        "min_doc_freq": 1, "max_doc_fraction": 1.0, "min_cf": 0, "rm_top": 1,
+        "max_features": None, "vocabulary": False}
 
 
 def test_models_expose_seed(fitted):


### PR DESCRIPTION
## What

Closes the two remaining scikit-learn / gensim text-processing parity gaps at the corpus/vectorizer level. No model `fit()` signatures change.

- **`max_features`** on `Corpus.from_documents` / `from_dataframe` — cap the vocabulary to the N most frequent surviving terms (scikit-learn `CountVectorizer(max_features=)`). Applied *after* the `min_doc_freq` / `max_doc_fraction` / `min_cf` / `rm_top` filters; ties broken by ascending vocab id (the same convention `rm_top` uses). We match scikit-learn's collection-frequency ranking; gensim's `keep_n` ranks by document frequency, noted in the docs.
- **`vocabulary=`** — pin the vocabulary to a fixed, ordered term list (scikit-learn `vocabulary=`). Out-of-vocabulary tokens are dropped, column order follows the list, and the frequency filters are not applied. Passing it together with any active pruning argument is a `ValueError` (topica surfaces the conflict rather than silently ignoring it, as sklearn does).
- **`Corpus.transform(docs)`** — vectorize held-out documents against an existing corpus's vocabulary (scikit-learn `vectorizer.transform` / gensim `doc2bow` on new text). The result shares the source vocabulary exactly — same terms, order, and ids, at full width (terms absent from the new docs remain as zero-frequency columns) — so a model fitted on the source corpus keeps its `topic_word` columns aligned and can score the held-out set directly.

Fixed-vocab and `transform` drop all-OOV documents and record `kept_indices` (topica's existing alignment idiom), and raise if no document survives.

## Scope / non-goals

- The MALLET-style `Corpus.from_text_file` loader keeps its existing options (it already lacks `min_cf`/`rm_top`); extending it to full parity is a clean follow-up.
- No scipy/`csr_matrix` interchange and no general `TfidfVectorizer` — separate decisions.

## Review

Plan was reviewed adversarially by Gemini (via the antigravity skill) before implementation — that pass flipped the row-handling design to "drop empty docs + `kept_indices`" (uniform with topica's idiom, avoids empty-doc crashes in STM/CTM/GSDMM) and added an explicit zero-token guard. The implemented diff was then reviewed by Codex (gpt-5.6-sol), which surfaced two Low-severity items now fixed: empty-string tokens no longer enter a vocabulary (so a later `transform` can't spuriously reject it), and the mutual-exclusion check catches a non-default `max_doc_fraction` of `nan`/`inf`/`>1`.

## Tests

New `tests/test_corpus_vocab.py` (max_features top-N + tie-break + ordering after `rm_top`; fixed-vocab validation, OOV/empty-doc drop, full-width preservation; transform held-out alignment against a fitted LDA; zero-frequency column keeps coherence finite; from_dataframe passthrough). Two existing exact-dict `preprocessing` assertions updated for the two new keys.

Gates: `cargo test` (244), full `pytest` (3876 passed), `clippy -D warnings`, `fmt`, `mkdocs --strict`, `preflight.sh` (stub/table sync) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)