### PR TITLE
release: 0.51.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.51.0] - 2026-07-25
+
+### Added
+
+- **Vocabulary control on `Corpus` for scikit-learn / gensim parity** (#553).
+  `Corpus.from_documents` (and `from_dataframe`) gain `max_features`, capping the
+  vocabulary to the N most frequent surviving terms (scikit-learn's
+  `CountVectorizer(max_features=)`), and `vocabulary=`, pinning the vocabulary to a
+  fixed, ordered term list (scikit-learn's `vocabulary=`). A new
+  `Corpus.transform(documents)` vectorizes held-out documents against an existing
+  corpus's vocabulary (scikit-learn's `vectorizer.transform` / gensim's `doc2bow`
+  on new text), sharing the vocabulary at full width so a fitted model's
+  `topic_word` columns stay aligned. Out-of-vocabulary tokens are dropped; a
+  document left with no in-vocabulary token is dropped and recorded in
+  `kept_indices`.
+
 ## [0.50.0] - 2026-07-25
 
 ### Changed

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.50.0
+version: 0.51.0
 date-released: 2026-07-25
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.50.0"
+version = "0.51.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.50.0"
+version = "0.51.0"
 edition = "2021"
 description = "Fast, all-purpose topic modeling for Python, with a Rust core"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.50.0"
+version = "0.51.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cut 0.51.0 from `main`.

## Version bump
- `Cargo.toml`, `Cargo.lock`, `pyproject.toml`, `CITATION.cff` → 0.51.0
- `CHANGELOG.md` entry added

## Included since 0.50.0
- **#553** — scikit-learn / gensim vocabulary parity on `Corpus`: `max_features` (vocabulary cap), a fixed `vocabulary=`, and `Corpus.transform(documents)` for vectorizing held-out documents against an existing corpus's vocabulary.

No code changes in this PR beyond the version/changelog bump. `test_version_consistency` passes; mkdocs `--strict` builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)