### PR TITLE
release: 0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-07-26
+
+### Fixed
+
+- **UMAP reducer no longer collapses on real embeddings** (#555). The in-house
+  UMAP became the default `reducer` for `BERTopic`/`Top2Vec` in 0.50.0, but on real
+  sentence embeddings it collapsed to ~2 topics on the large majority of seeds for
+  small-to-moderate corpora. The cause was `find_ab_params` under-converging: it fit
+  the low-dimensional membership curve with plain gradient descent that stalled far
+  from the least-squares optimum at the `min_dist=0.0` default (`a≈1.58` where the
+  reference is `a≈1.93`), giving too-weak short-range attraction so the layout never
+  opened the density valleys HDBSCAN needs. It now uses a damped Gauss-Newton solve
+  matching SciPy `curve_fit` to four decimals across `min_dist`. Validated against
+  the reference `umap-learn`/`bertopic` on 20 Newsgroups, congressional bills, and a
+  synthetic corpus (collapse rate 88% to 0%; topic counts and ARI on par with the
+  reference).
+
+### Changed
+
+- **`BERTopic.fit` is dramatically faster on medium and large corpora** (#557). The
+  `approximate_distribution` step that builds the soft document-topic distribution
+  (`doc_topic`) was `O(docs · windows · topics · vocabulary)` and single-threaded,
+  dominating fit time — a 5000-document fit spent over an hour in it. It now keeps
+  only each window's nonzero tokens (reducing the per-window cosine from the full
+  vocabulary to the window size), precomputes each topic's norm once, and
+  parallelizes across documents. The output `doc_topic` is bit-identical to before;
+  the same 5000-document fit drops from ~72 minutes to a few seconds.
+
 ## [0.51.0] - 2026-07-25
 
 ### Added

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.51.0
-date-released: 2026-07-25
+version: 0.52.0
+date-released: 2026-07-26
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than two

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.51.0"
+version = "0.52.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.51.0"
+version = "0.52.0"
 edition = "2021"
 description = "Fast, all-purpose topic modeling for Python, with a Rust core"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.51.0"
+version = "0.52.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## 0.52.0

Bumps `Cargo.toml`, `pyproject.toml`, `CITATION.cff`, `Cargo.lock` and adds the `CHANGELOG.md` entry. Two changes landed since 0.51.0:

### Fixed
- **UMAP reducer no longer collapses on real embeddings** (#555 / #556). `find_ab_params` under-converged at the `min_dist=0.0` default (`a≈1.58` vs the reference `a≈1.93`), giving too-weak attraction so the default `BERTopic`/`Top2Vec` UMAP path collapsed to ~2 topics on most seeds for small-to-moderate corpora. Now a damped Gauss-Newton solve matching SciPy `curve_fit`. Validated vs `umap-learn`/`bertopic` on 20NG, congressional bills, and a synthetic corpus (collapse 88%→0%).

### Changed
- **`BERTopic.fit` dramatically faster on medium/large corpora** (#557 / #558). `approximate_distribution` was `O(docs·windows·topics·vocabulary)` single-threaded and dominated fit time. Now sparse per-window + precomputed norms + rayon; `doc_topic` is bit-identical. A 5000-doc fit drops from ~72 min to a few seconds.

Version consistency test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)