### PR TITLE
fix(sts): faithful STS.R initialization; default reproduces R (#560)

### DIFF
--- a/parity/sts_r_compare.py
+++ b/parity/sts_r_compare.py
@@ -202,9 +202,14 @@ def run(verbose: bool = True) -> dict:
     K = r_sts.shape[0]
     X = rating.reshape(-1, 1)
     sts = STS(num_topics=K, init="spectral")
+    # reference="paper" replicates Chen & Mankad's STS.R init faithfully: prevalence
+    # latents at 0 and Σ = diag(20) (their stm(max.em.its=0) returns eta=0,
+    # invsigma=diag(1/20)), the "lasso" (plain group-mean) κ estimator, and the
+    # centered-seed sentiment init. This is the profile the reference RDS was produced
+    # with, so it is what we validate against.
     sts.fit(docs, sentiment_seed=rating.tolist(), prevalence=X,
             prevalence_names=["rating"],
-            iters=50, kappa_estimation="lasso")  # match the reference's kappa estimator
+            iters=50, kappa_estimation="lasso", reference="paper")
     stm = STM(num_topics=K, init="spectral")
     stm.fit(docs, X, prevalence_names=["rating"], iters=80)
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -916,17 +916,20 @@ class STS:
 
         EM stops once the relative change in the variational bound falls below
         convergence_tol or after iters iterations. kappa_estimation chooses the
-        topic-word estimator: None (default) uses the topica-native "ridge" unless a
-        reference profile overrides it; "ridge" (fast, topica-native; kappa_ridge
-        sets the ridge), "lasso" (an L1 Poisson path with AIC-selected penalty),
-        or "adjusted" (the CRAN sts public default: the same L1/AIC solve with a
-        phi-mass-weighted sentiment aggregation).
+        topic-word estimator: None (default) uses "lasso" -- R STS.R's default --
+        unless a reference profile overrides it; "lasso" (an L1 Poisson path with
+        AIC-selected penalty, the reference opt.kappa.R glmnet default), "ridge"
+        (topica-native ridge-penalized Poisson; kappa_ridge sets the ridge, an opt-in
+        for large-K regimes where it is faster), or "adjusted" (the CRAN sts public
+        default: the same L1/AIC solve with a phi-mass-weighted sentiment aggregation).
 
-        reference selects a reference-fidelity profile: "none" (default, honors
-        kappa_estimation), "paper" (Chen & Mankad 2024: STM-derived spectral-eta /
-        sentiment-prior-variance-20 init, the "lasso" estimator, no kappa damping),
-        or "cran" (CRAN sts: same init, the "adjusted" estimator, reference
-        half-step kappa damping). A reference profile forces its own estimator, so
+        reference selects a reference-fidelity profile: "none" (default: the
+        reference STS.R init -- prevalence latents at 0 and prior covariance diag(20)
+        -- honoring kappa_estimation, so the default lasso fit reproduces the
+        reference), "paper" (Chen & Mankad 2024: their stm(max.em.its=0)
+        seed -- prevalence latents at 0 and prior covariance diag(20) -- the "lasso"
+        estimator, no kappa damping), or "cran" (CRAN sts: same init, the "adjusted"
+        estimator, reference half-step kappa damping). A reference profile forces its own estimator, so
         pairing it with any explicit kappa_estimation that differs (including an
         explicit "ridge") raises.
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -8930,20 +8930,25 @@ impl STS {
     /// `convergence_tol` or `iters` iterations are reached.
     ///
     /// `kappa_estimation` chooses the topic-word (κ) estimator. Left unset
-    /// (``None``, the default) it resolves to ``"ridge"`` unless a `reference`
-    /// profile overrides it; passing it explicitly pins the estimator and, under a
-    /// reference profile, is checked for conflict (see below). ``"ridge"``
-    /// is a fast ridge-penalized Poisson fit (`kappa_ridge` sets the
-    /// ridge) — topica-native, not a reference target. ``"lasso"`` is an L1
-    /// Poisson path with AIC-selected penalty (the paper replication code's
-    /// default). ``"adjusted"`` is the CRAN `sts` public default: the same L1/AIC
-    /// solve but with the aggregated sentiment column formed as a φ-mass-weighted
-    /// group mean of ``α^(s)`` (the reference `weighted_alpha` reweighting).
+    /// (``None``, the default) it resolves to ``"lasso"`` — R `STS.R`'s default
+    /// estimator — unless a `reference` profile overrides it; passing it explicitly
+    /// pins the estimator and, under a reference profile, is checked for conflict
+    /// (see below). ``"lasso"`` is an L1 Poisson path with AIC-selected penalty (the
+    /// reference `opt.kappa.R` glmnet default). ``"ridge"`` is a ridge-penalized
+    /// Poisson fit (`kappa_ridge` sets the ridge) — topica-native, an opt-in for
+    /// regimes where it is faster (large K). ``"adjusted"`` is the CRAN `sts` public
+    /// default: the same L1/AIC solve but with the aggregated sentiment column formed
+    /// as a φ-mass-weighted group mean of ``α^(s)`` (the reference `weighted_alpha`
+    /// reweighting).
     ///
     /// `reference` selects a reference-fidelity fitting profile. ``"none"``
-    /// (default) is topica-native and honors `kappa_estimation` as given.
-    /// ``"paper"`` reproduces Chen & Mankad (2024) (STM-derived spectral-eta /
-    /// sentiment-prior-variance-20 init, the ``"lasso"`` estimator, no κ damping).
+    /// (default) uses the reference `STS.R` initialization (prevalence latents at 0,
+    /// prior covariance ``diag(20)``) and honors `kappa_estimation` as given, so the
+    /// default fit (lasso) reproduces the reference; pass `kappa_estimation="ridge"`
+    /// for the topica-native estimator with the same init.
+    /// ``"paper"`` reproduces Chen & Mankad (2024) (their `stm(max.em.its=0)` seed:
+    /// prevalence latents at 0 and prior covariance ``diag(20)``, the ``"lasso"``
+    /// estimator, no κ damping).
     /// ``"cran"`` reproduces CRAN `sts` (the same init, the ``"adjusted"``
     /// estimator, and the reference half-step κ damping). A reference profile
     /// forces its own estimator, so pairing it with any explicit
@@ -9004,13 +9009,14 @@ impl STS {
             (None, Some(c)) => Some(c),
             (None, None) => None,
         };
-        // `kappa_estimation` is a sentinel Option so an explicit "ridge" (the
-        // topica-native default estimator) is distinguishable from "unset". This
-        // matters for the reference-profile conflict check below: reference="cran"
-        // paired with an explicit kappa_estimation="ridge" must raise, not be
-        // silently overwritten with the profile's estimator.
+        // `kappa_estimation` is a sentinel Option so an explicit estimator is
+        // distinguishable from "unset". This matters for the reference-profile
+        // conflict check below: reference="cran" paired with an explicit
+        // kappa_estimation="ridge" must raise, not be silently overwritten with the
+        // profile's estimator. The default is "lasso" — R `STS.R`'s default
+        // (`opt.kappa.R` glmnet), so the out-of-the-box fit reproduces the reference.
         let user_set_kappa = kappa_estimation.is_some();
-        let kappa_estimation: &str = kappa_estimation.unwrap_or("ridge");
+        let kappa_estimation: &str = kappa_estimation.unwrap_or("lasso");
         let lasso = sts::KappaEst::Lasso {
             nlambda: 100,
             lambda_min_ratio: 0.001,
@@ -9037,11 +9043,17 @@ impl STS {
         //             group-mean aggregation, no κ damping).
         //   "cran"  — CRAN `sts` public default (`kappaEstimation="adjusted"`,
         //             φ-mass-weighted aggregation, half-step κ damping).
-        //   "none"  — topica-native; honors kappa_estimation as given (ridge default).
+        //   "none"  — reference STS.R init (diag(20)); honors kappa_estimation (lasso default).
         // A reference profile forces its estimator, so pairing it with a conflicting
         // explicit kappa_estimation is an error (including an explicit "ridge").
+        //
+        // Every profile enables `reference_init` (the faithful STS.R seed: prevalence
+        // latents at 0, prior covariance diag(20)). The `reference_init = false`
+        // path (Sigma = identity) is intentionally not exposed to Python — it is a
+        // strictly less faithful init with no principled use for an STS port — but is
+        // kept in `fit_sts` and exercised by the Rust conformance tests.
         let (kappa_est, reference_init, kappa_damping) = match reference {
-            "none" => (kappa_est, false, false),
+            "none" => (kappa_est, true, false),
             "paper" => {
                 if user_set_kappa && kappa_estimation != "lasso" {
                     return Err(PyValueError::new_err(format!(

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -863,11 +863,12 @@ fn damp_kappa_halfstep(new: &mut [Vec<f64>], prev: &[Vec<f64>]) {
 /// [`opt_kappa`]). Aggregation groups for the `κ` step are the distinct levels of
 /// `sentiment_seed`, which also seeds the initial `α^(s)`.
 ///
-/// `reference_init` and `kappa_damping` select the CRAN `sts` reference-fidelity
-/// behavior: `reference_init` starts the prevalence latents `α^(topic)` at the
-/// spectral solution and sets the sentiment-block prior variance to 20 (the
-/// reference `diag(1/20)` precision); `kappa_damping` applies the reference
-/// half-step κ update `(κ_new + κ_old)/2` on every M-step and at initialization.
+/// `reference_init` and `kappa_damping` select reference-fidelity behavior.
+/// `reference_init` reproduces `STS.R`'s `stm(..., max.em.its = 0)` seed: on that
+/// init STM returns `eta = 0` and `invsigma = diag(1/20)`, so the prevalence
+/// latents start at 0 and the prior covariance is `diag(20)` across all `2K-1`
+/// dims (`Sigma_Inv = diag(1/20)`). `kappa_damping` applies the CRAN half-step κ
+/// update `(κ_new + κ_old)/2` on every M-step and at initialization.
 #[allow(clippy::too_many_arguments)]
 pub fn fit_sts<R: Rng>(
     docs: &[Vec<u32>],
@@ -1002,35 +1003,19 @@ pub fn fit_sts<R: Rng>(
         kappa_s = ks;
     }
 
-    // Reference-compatible latent/covariance init (item #5). The prevalence latents
-    // start at the spectral solution (`α^(topic)_d = log θ_d − log θ_{d,K}`, the
-    // softmax-basis analog of STM's `mod.out$eta`) instead of 0, and the
-    // sentiment-block prior variance is set to 20 (the reference `diag(1/20)`
-    // precision). This is the documented statistically-equivalent substitute for
-    // STM's spectral eta / invsigma initialization, not a byte-identical STM port.
+    // Reference-compatible latent/covariance init. The reference `STS.R` seeds STS
+    // from `stm(..., max.em.its = 0)`: on this init STM returns `eta = 0` and
+    // `invsigma = diag(1/20)` (verified against the poliblog corpus), so the
+    // prevalence latents start at 0 (already set above) and the prior covariance is
+    // `diag(20)` across all `2K-1` latent dims (`Sigma_Inv = diag(1/20)`). The
+    // sentiment latents are the centered seed (set above), matching
+    // `alpha.est[,1:K+K-1] <- X_seed - mean(X_seed)`. An earlier build approximated
+    // `eta` from a phi log-ratio and the covariance from the init-eta variance; the
+    // reference does neither, so we drop both to make this a faithful port.
     let mut sigma = vec![0.0f64; n * n];
+    let init_var = if reference_init { 20.0 } else { 1.0 };
     for i in 0..n {
-        sigma[i * n + i] = 1.0;
-    }
-    if reference_init {
-        for di in 0..d {
-            let sum: f64 = phi_d[di].iter().sum::<f64>().max(1e-12);
-            let ref_log = (phi_d[di][k - 1] / sum).max(1e-8).ln();
-            for t in 0..(k - 1) {
-                alpha[di][t] = (phi_d[di][t] / sum).max(1e-8).ln() - ref_log;
-            }
-        }
-        // Topic-block prior covariance ≈ sample variance of the init eta (the STM
-        // invsigma analog), floored for conditioning; sentiment block at variance 20.
-        for t in 0..(k - 1) {
-            let mean: f64 = alpha.iter().map(|a| a[t]).sum::<f64>() / d as f64;
-            let var: f64 =
-                alpha.iter().map(|a| (a[t] - mean).powi(2)).sum::<f64>() / (d.max(1) as f64);
-            sigma[t * n + t] = var.max(1e-2);
-        }
-        for i in (k - 1)..n {
-            sigma[i * n + i] = 20.0;
-        }
+        sigma[i * n + i] = init_var;
     }
 
     let mut gamma: Option<Vec<Vec<f64>>> = nf.map(|f| vec![vec![0.0f64; n]; f]);


### PR DESCRIPTION
## Summary

topica's `STS` default fit diverged from the Chen & Mankad (2024) reference, aligning to the authors' poliblog fit at a topic-word cosine of **0.849** where the reference expects the mid-0.90s — the validation leg (`parity/sts_r_compare.py`) had begun failing. This makes the default fit a **faithful port** of R's `STS.R`, so `topica.STS(...).fit(...)` reproduces the reference out of the box.

## Root cause (verified against the R source)

The reference-init path was not faithful. It *approximated* the prevalence latents from a phi log-ratio and built Σ from the init-eta variance. I dumped what R's `STS.R` actually seeds from — `stm(..., max.em.its = 0)` on the poliblog corpus — and it returns **`eta = 0`** and **`invsigma = diag(1/20)`** exactly. So the faithful init is simply: prevalence latents at **0**, Σ = **diag(20)** across all `2K−1` dims, sentiment latents = centered seed, then the κ warm-start. The old default also used Σ=identity (variance 1, not 20) and the topica-native **ridge** κ estimator — R uses **lasso**.

## Changes
- **`src/sts.rs`** — `reference_init` rewritten to R's exact seed (η=0, Σ=diag(20)); phi-approximation removed.
- **`src/python/mod.rs` / `.pyi`** — the default fit now uses the reference init, and the default κ estimator is **`lasso`** (R `STS.R`'s default) instead of ridge. Ridge stays an opt-in (`kappa_estimation="ridge"`) for large-K regimes. Docstrings corrected.
- **`parity/sts_r_compare.py`** — validates against the faithful profile.

## Result (real R, end-to-end)

| | before | after |
|---|--:|--:|
| default `topica.STS(...)` ↔ R-STS | 0.849 | **0.942** |
| topica-STM ↔ R stm (baseline) | 0.959 | 0.959 |
| leg status | FAIL | **OK** |

The alignment is a *consequence* of replicating R's init, not tuning to the threshold. On this corpus lasso is also ~3× faster than ridge (144s vs 464s/fit), so the faithful default is faster here too.

## Verification
- 302 Rust tests + 29 Python STS tests pass; `./scripts/preflight.sh` green.
- Diagnosis is grounded in the reference `Code/STS.R`, `opt.kappa.R`, and a direct dump of `stm(max.em.its=0)$eta`/`$invsigma`.

## Notes / follow-ups
- Corrects the record on #560: an earlier bisect wrongly blamed #474 (which is innocent — tested at 0.930). The exact commit that regressed 0.930→0.849 is a later non-STS change and is now moot, since the default is faithful by construction.
- The paper's `parity`-generated validation files need one regen to pick up the fixed STS + the 0.52.0 stamp (separate).

Refs #560

🤖 Generated with [Claude Code](https://claude.com/claude-code)