### PR TITLE
release: 0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,23 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
-## [0.52.0] - 2026-07-26
+## [0.53.0] - 2026-07-26
+
+### Fixed
+
+- **`STS` default now faithfully reproduces the reference model** (#560). topica's
+  Structural Topic and Sentiment-Discourse model diverged from Chen & Mankad (2024)
+  on its default fit, aligning to the authors' poliblog reference at a topic-word
+  cosine of 0.85 where the reference expects the mid-0.90s. The reference-init path
+  was not a faithful port: it approximated the prevalence latents from a phi
+  log-ratio and built the prior covariance from the init-eta variance. R's `STS.R`
+  seeds from `stm(max.em.its=0)`, which returns `eta = 0` and `invsigma = diag(1/20)`,
+  so the prevalence latents start at 0 and the prior covariance is `diag(20)` across
+  all latent dimensions. The default fit now uses that initialization and the
+  reference's `lasso` kappa estimator (was topica-native `ridge`; ridge remains
+  available via `kappa_estimation="ridge"`). The default `STS(...).fit(...)` now
+  reproduces the reference at cosine 0.94, and on this corpus the lasso default is
+  also faster than ridge.
 
 ### Fixed
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.52.0
+version: 0.53.0
 date-released: 2026-07-26
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -722,7 +722,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.52.0"
+version = "0.53.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.52.0"
+version = "0.53.0"
 edition = "2021"
 description = "Fast, all-purpose topic modeling for Python, with a Rust core"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.52.0"
+version = "0.53.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
## 0.53.0

Bumps `Cargo.toml`, `pyproject.toml`, `CITATION.cff`, `Cargo.lock` and adds the `CHANGELOG.md` entry. One change since 0.52.0:

### Fixed
- **`STS` default now faithfully reproduces the reference model** (#560 / #561). The reference-init path was not a faithful port of R's `STS.R` — it approximated the prevalence latents (phi log-ratio) and the prior covariance (init-eta variance). R seeds from `stm(max.em.its=0)` → `eta=0`, `invsigma=diag(1/20)`, so the faithful init is prevalence latents at 0 and Σ=diag(20). The default now uses that init and the reference `lasso` κ estimator (ridge stays opt-in). Default `STS(...).fit(...)` aligns to R-STS at **0.94** (was 0.85); the validation leg is green.

Cut so the STS result can go into the paper. Version-consistency test green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)