### PR TITLE
fix(dmr): faithful covariate prior + stable λ optimization vs tomotopy (#563)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`DMR` / `GDMR` covariate prior now faithfully reproduces `tomotopy`** (#563).
+  topica's Dirichlet-multinomial regression diverged from the `tomotopy` reference
+  on poliblog (K=10) at an aligned topic-word cosine of ~0.25, far below both
+  engines' own seed-to-seed ceiling of ~0.71, and topica's DMR disagreed with its
+  *own* LDA at 0.33 where `tomotopy`'s DMR matches its LDA at 0.99. The base Gibbs
+  sampler was faithful (plain LDA agrees with MALLET/`tomotopy` above their mutual
+  ceiling); the fault was in the λ covariate layer. Two causes: (1) the L-BFGS λ
+  optimizer took an unscaled first step (`x − ∇f`), so on the Dirichlet-multinomial
+  objective's large initial gradient it overshot and drove λ to ±100, collapsing
+  every document's topic prior toward uniform — the fix caps the first step by
+  `1/‖∇f‖` (standard L-BFGS initialization); and (2) topica used a zero-mean λ prior
+  (implicit baseline concentration 1.0) where `tomotopy` centers the λ prior at
+  `log(alpha)` with default `alpha=0.1`, so `DMR` now exposes `alpha` (default 0.1)
+  and `alpha_epsilon` (default 1e-10) matching the reference. After the fix,
+  topica↔`tomotopy` DMR aligned cosine is **0.81**, above the seed ceiling, and DMR
+  reduces to LDA for a weak covariate as it should. Pass `alpha=1.0` to recover the
+  old zero-mean-intercept behaviour. keyATM base/dynamic fits are unchanged; the
+  covariate fit shifts negligibly (R-gold keyword cosine 0.912 → 0.906, still far
+  above bar, sign agreement 1.00).
+
 ## [0.53.0] - 2026-07-26
 
 ### Fixed

--- a/paper/gen_validation_appendix.py
+++ b/paper/gen_validation_appendix.py
@@ -570,10 +570,14 @@ def leg_dmr(k):
     RESULTS["dmr"] = f"{cos:.2f} (ceil.\\ {ceiling:.2f})"
     intro = (r"The metadata covariate is the post's ideology (\code{rating}); DMR makes "
              rf"each document's topic prior log-linear in it. Aligned cosine "
-             rf"\textbf{{{cos:.3f}}} --- at the ceiling for independent DMR samplers: two "
-             rf"\pkg{{tomotopy}} runs from different seeds agree only {ceiling:.3f} with "
-             r"each other (these are random-initialized collapsed-Gibbs fits, so the "
-             r"dominant topics coincide while the diffuse tail differs run to run).")
+             rf"\textbf{{{cos:.3f}}}, above the reference's own seed-to-seed ceiling: two "
+             rf"\pkg{{tomotopy}} runs from different seeds agree {ceiling:.3f} with each "
+             r"other (these are random-initialized collapsed-Gibbs fits). As with plain "
+             r"LDA, the two engines agree at least as well as "
+             r"either agrees with itself. For this weak single covariate DMR reduces to "
+             r"LDA in both engines --- \pkg{topica}'s DMR matches its own LDA at 0.83 and "
+             r"\pkg{tomotopy}'s at 0.99 --- so the covariate-prior layer adds no "
+             r"cross-engine divergence.")
     return subsection(title, "\n\n".join([intro, table, feat]))
 
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -269,8 +269,10 @@ class DMR:
     """Dirichlet-Multinomial Regression topic model (Mimno & McCallum 2008).
 
     Like LDA, but the per-document topic prior is log-linear in document
-    features: alpha_{d,t} = exp(lambda_t . x_d). After fitting, the learned
-    weights are in `feature_effects`.
+    features: alpha_{d,t} = exp(lambda_t . x_d) + alpha_epsilon. The lambda prior
+    is centered at log(alpha) on the intercept, so with a null covariate the model
+    reduces to LDA with symmetric prior `alpha` (matching tomotopy's DMR default
+    0.1). After fitting, the learned weights are in `feature_effects`.
     """
     @property
     def settings(self) -> dict:
@@ -292,7 +294,9 @@ class DMR:
         optimize_interval: int = 50,
         burn_in: int = 200,
         seed: int = 42,
+        alpha: float = 0.1,
         prior_variance: float = 1.0,
+        alpha_epsilon: float = 1e-10,
         lbfgs_iters: int = 20,
         sampler: str = "sparse",
     ) -> None:

--- a/python/topica/gdmr.py
+++ b/python/topica/gdmr.py
@@ -21,10 +21,11 @@ Reference implementations (both by the paper's first author, ``bab2min``):
 tomotopy ``GDMRModel`` and the ``bab2min/g-dmr`` experiment repo.
 
 Note: the constant term's prior is centered at ``log(alpha)`` in both reference
-implementations; topica's inner DMR currently uses a zero-mean prior on the
-intercept (implicit ``alpha = 1``). That intercept-mean difference is tracked
-separately (issue #426); the ``sigma``/``sigma0`` roles and the per-dimension
-decay implemented here match the references.
+implementations. g-DMR realizes that centering with an explicit ``log(alpha)``
+predictor offset (see ``fit``), which is why the inner ``DMR`` is constructed with
+``alpha=1.0`` (zero-mean intercept prior) — DMR's own ``log(alpha)`` centering
+(added in 0.54, #563) would otherwise double-apply. The ``sigma``/``sigma0`` roles
+and the per-dimension decay implemented here match the references.
 """
 
 from __future__ import annotations
@@ -455,13 +456,19 @@ class GDMR:
         # own intercept, so hand it the non-intercept names only.
         feature_names = _basis_feature_names(self._degrees, self._metadata_names)[1:]
 
-        # Build inner DMR
+        # Build inner DMR. Since 0.54 DMR itself centers the intercept prior at
+        # log(alpha) (#563), but g-DMR realizes that centering via its own `offset`
+        # below (so the constant-term prior interacts correctly with the Legendre
+        # basis / decay scaling). Pin the inner DMR to alpha=1.0 (log(1)=0, zero-mean
+        # intercept prior) so log(alpha) is applied exactly once, here, and NOT
+        # doubled by DMR's native centering.
         self._dmr = DMR(
             self._num_topics,
             beta=self._beta,
             optimize_interval=self._optimize_interval,
             burn_in=self._burn_in,
             seed=self._seed,
+            alpha=1.0,
             prior_variance=prior_variance,
             lbfgs_iters=self._lbfgs_iters,
             sampler=self._sampler,

--- a/src/dmr.rs
+++ b/src/dmr.rs
@@ -28,7 +28,7 @@ use crate::sampler::sample_doc;
 /// (~1.4e217) is astronomically larger than any meaningful α yet leaves ample
 /// headroom below `f64::MAX` even summed over many topics, so this bites only
 /// pathological inputs and never a realistic fit.
-const PREDICTOR_CLAMP: f64 = 500.0;
+pub(crate) const PREDICTOR_CLAMP: f64 = 500.0;
 
 /// `exp` of the DMR linear predictor with the [`PREDICTOR_CLAMP`] guard.
 #[inline]
@@ -36,16 +36,20 @@ fn predictor_exp(dot: f64, off: f64) -> f64 {
     (dot + off).clamp(-PREDICTOR_CLAMP, PREDICTOR_CLAMP).exp()
 }
 
-/// Per-document, per-topic prior `α_{d,t} = exp(λ_t · x_d + s_{d,t})`.
+/// Per-document, per-topic prior `α_{d,t} = exp(λ_t · x_d + s_{d,t}) + ε`.
 ///
 /// `lambda` is `[num_topics][num_features]`, `features` is
 /// `[num_docs][num_features]`; returns `[num_docs][num_topics]`. The optional
 /// `offset` is a fixed `[num_docs][num_topics]` term added inside the exponent
 /// (the embedding anchor `s_{d,t}`); pass `None` for the plain DMR prior.
+/// `alpha_epsilon` is a small additive floor on α (tomotopy's `alpha_epsilon`,
+/// default `1e-10`) that keeps α strictly away from 0 so `logΓ`/`digamma` stay
+/// finite; pass `0.0` to recover the bare `exp` prior.
 pub fn compute_doc_alpha(
     lambda: &[Vec<f64>],
     features: &[Vec<f64>],
     offset: Option<&[Vec<f64>]>,
+    alpha_epsilon: f64,
 ) -> Vec<Vec<f64>> {
     features
         .iter()
@@ -57,7 +61,7 @@ pub fn compute_doc_alpha(
                 .map(|(t, lt)| {
                     let dot: f64 = lt.iter().zip(x).map(|(l, xi)| l * xi).sum();
                     let off = offset.map_or(0.0, |o| o[d][t]);
-                    predictor_exp(dot, off)
+                    predictor_exp(dot, off) + alpha_epsilon
                 })
                 .collect()
         })
@@ -130,15 +134,23 @@ pub fn run_sweep_dmr<R: Rng>(
 /// ```text
 ///   L = Σ_d [ logΓ(α_{d,·}) − logΓ(N_d + α_{d,·})
 ///             + Σ_t ( logΓ(n_{d,t} + α_{d,t}) − logΓ(α_{d,t}) ) ]
-///       − 1/(2σ²) Σ_{t,f} λ_{t,f}²
+///       − 1/(2σ²) Σ_{t,f} (λ_{t,f} − μ_f)²
 /// ```
-/// with `α_{d,t} = exp(λ_t · x_d + s_{d,t})` and `α_{d,·} = Σ_t α_{d,t}`. The
+/// with `α_{d,t} = exp(λ_t · x_d + s_{d,t}) + ε` and `α_{d,·} = Σ_t α_{d,t}`. The
 /// optional `offset` `s` is a fixed `[num_docs][num_topics]` term added inside
-/// the exponent; since it is constant in `λ`, the gradient still uses
-/// `∂α_{d,t}/∂λ_{t,f} = α_{d,t} · x_{d,f}`.
+/// the exponent; since it is constant in `λ`, the gradient uses
+/// `∂α_{d,t}/∂λ_{t,f} = exp(λ_t·x_d + s) · x_{d,f} = (α_{d,t} − ε) · x_{d,f}` —
+/// the additive floor `ε` drops out of the derivative but shifts the value.
+///
+/// `prior_mean` is the per-feature Gaussian prior mean `μ` (length
+/// `num_features`); the DMR baseline concentration is set by centring the
+/// intercept column at `log(alpha)` (tomotopy centres every λ at `log(alpha)`;
+/// in topica's intercept coding that is `μ = [log(alpha), 0, …, 0]`). Passing
+/// all-zeros recovers the old zero-mean prior (implicit `alpha = 1`).
 ///
 /// `doc_topic_counts` is `[num_docs][num_topics]`. Returns `(value, gradient)`
 /// where `gradient` matches the shape of `lambda` (`[num_topics][num_features]`).
+#[allow(clippy::too_many_arguments)]
 pub fn dmr_objective_and_gradient(
     lambda: &[Vec<f64>],
     features: &[Vec<f64>],
@@ -146,19 +158,26 @@ pub fn dmr_objective_and_gradient(
     num_topics: usize,
     num_features: usize,
     prior_variance: f64,
+    prior_mean: &[f64],
+    alpha_epsilon: f64,
     offset: Option<&[Vec<f64>]>,
 ) -> (f64, Vec<Vec<f64>>) {
     let mut value = 0.0f64;
     let mut grad = vec![vec![0.0f64; num_features]; num_topics];
 
     let mut alpha = vec![0.0f64; num_topics];
+    // The linear part exp(λ·x + s) without the ε floor: this is ∂α/∂(λ·x), so it
+    // (not α) multiplies x in the gradient chain (#563).
+    let mut alpha_lin = vec![0.0f64; num_topics];
 
     for (d, x) in features.iter().enumerate() {
         let mut alpha_sum = 0.0f64;
         for t in 0..num_topics {
             let dot: f64 = lambda[t].iter().zip(x).map(|(l, xi)| l * xi).sum();
             let off = offset.map_or(0.0, |o| o[d][t]);
-            let a = predictor_exp(dot, off);
+            let a_lin = predictor_exp(dot, off);
+            let a = a_lin + alpha_epsilon;
+            alpha_lin[t] = a_lin;
             alpha[t] = a;
             alpha_sum += a;
         }
@@ -175,9 +194,9 @@ pub fn dmr_objective_and_gradient(
             let n = counts[t];
             value += log_gamma(a + n) - log_gamma(a);
 
-            // ∂L/∂α_{d,t}, then chain through ∂α/∂λ = α · x.
+            // ∂L/∂α_{d,t}, then chain through ∂α/∂λ = exp(λ·x+s) · x = α_lin · x.
             let dl_da = dg_alpha_sum - dg_alpha_sum_n + digamma(a + n) - digamma(a);
-            let coef = dl_da * a;
+            let coef = dl_da * alpha_lin[t];
             let gt = &mut grad[t];
             for f in 0..num_features {
                 gt[f] += coef * x[f];
@@ -185,12 +204,13 @@ pub fn dmr_objective_and_gradient(
         }
     }
 
-    // Gaussian prior N(0, σ²) on every weight.
+    // Gaussian prior N(μ_f, σ²) on every weight (μ centres the DMR baseline).
     let inv_var = 1.0 / prior_variance;
     for t in 0..num_topics {
         for f in 0..num_features {
-            value -= 0.5 * inv_var * lambda[t][f] * lambda[t][f];
-            grad[t][f] -= inv_var * lambda[t][f];
+            let dev = lambda[t][f] - prior_mean[f];
+            value -= 0.5 * inv_var * dev * dev;
+            grad[t][f] -= inv_var * dev;
         }
     }
 
@@ -206,13 +226,16 @@ pub fn dmr_objective_and_gradient(
 /// normalizer `α_{d,·}`, so the Hessian is not block-diagonal across topics; per
 /// document `d` it is
 /// ```text
-///   ∂²L_d/∂λ_{t,f}∂λ_{u,g} = x_{d,f} x_{d,g} ( c_d a_t a_u + [t=u] a_t b_t )
+///   ∂²L_d/∂λ_{t,f}∂λ_{u,g} = x_{d,f} x_{d,g} ( c_d ℓ_t ℓ_u + [t=u] ℓ_t b_t )
 /// ```
-/// with `a_t = α_{d,t}`, `c_d = ψ'(α_{d,·}) − ψ'(α_{d,·}+N_d)`,
+/// with `ℓ_t = exp(λ_t·x_d + s_{d,t})` the linear part of α (so `α_{d,t} = ℓ_t + ε`
+/// and `∂α/∂λ = ℓ_t·x`), `a_t = α_{d,t} = ℓ_t + ε`,
+/// `c_d = ψ'(α_{d,·}) − ψ'(α_{d,·}+N_d)`,
 /// `g_t = ψ(α_·) − ψ(α_·+N_d) + ψ(a_t+n_t) − ψ(a_t)`, and
-/// `b_t = a_t(ψ'(a_t+n_t) − ψ'(a_t)) + g_t`. The observed information is
+/// `b_t = ℓ_t(ψ'(a_t+n_t) − ψ'(a_t)) + g_t`. The observed information is
 /// `J = (1/σ²)I − Σ_d H_d` (a `(T·F)×(T·F)` SPD matrix); the SE of `λ_{t,f}` is
 /// `sqrt(diag(J^{-1}))`. Returns `[num_topics][num_features]`, aligned to `lambda`.
+#[allow(clippy::too_many_arguments)]
 pub fn dmr_lambda_se(
     lambda: &[Vec<f64>],
     features: &[Vec<f64>],
@@ -220,6 +243,7 @@ pub fn dmr_lambda_se(
     num_topics: usize,
     num_features: usize,
     prior_variance: f64,
+    alpha_epsilon: f64,
     offset: Option<&[Vec<f64>]>,
 ) -> Vec<Vec<f64>> {
     let t = num_topics;
@@ -232,6 +256,7 @@ pub fn dmr_lambda_se(
         num_topics,
         num_features,
         prior_variance,
+        alpha_epsilon,
         offset,
     );
     (0..t)
@@ -257,6 +282,7 @@ pub fn dmr_lambda_se(
 /// square root of its diagonal. The full matrix is needed when `λ` is later
 /// transformed by a non-diagonal map (e.g. keyATM's standardization Jacobian),
 /// which mixes the within-topic covariance entries.
+#[allow(clippy::too_many_arguments)]
 pub fn dmr_lambda_cov(
     lambda: &[Vec<f64>],
     features: &[Vec<f64>],
@@ -264,6 +290,7 @@ pub fn dmr_lambda_cov(
     num_topics: usize,
     num_features: usize,
     prior_variance: f64,
+    alpha_epsilon: f64,
     offset: Option<&[Vec<f64>]>,
 ) -> Vec<f64> {
     use crate::linalg::{make_diagonally_dominant, spd_inverse};
@@ -273,8 +300,12 @@ pub fn dmr_lambda_cov(
     let f = num_features;
     let p = t * f;
     // Observed information J, assembled as (1/σ²)I − Σ_d H_d (row-major p x p).
+    // The α floor ε enters as a value shift only: ∂α/∂λ = exp(λ·x+s) = a_lin,
+    // so the x_f·x_g chain uses `a_lin` while the ψ/ψ' terms take the full
+    // α = a_lin + ε as argument (#563). The prior enters the Hessian only through
+    // its (1/σ²)I diagonal, so the prior *mean* does not appear here.
     let mut info = vec![0.0f64; p * p];
-    let mut a = vec![0.0f64; t];
+    let mut a_lin = vec![0.0f64; t];
     let mut b = vec![0.0f64; t];
 
     for (d, x) in features.iter().enumerate() {
@@ -282,8 +313,8 @@ pub fn dmr_lambda_cov(
         for tt in 0..t {
             let dot: f64 = lambda[tt].iter().zip(x).map(|(l, xi)| l * xi).sum();
             let off = offset.map_or(0.0, |o| o[d][tt]);
-            a[tt] = predictor_exp(dot, off);
-            alpha_sum += a[tt];
+            a_lin[tt] = predictor_exp(dot, off);
+            alpha_sum += a_lin[tt] + alpha_epsilon;
         }
         let counts = &doc_topic_counts[d];
         let n_d: f64 = counts.iter().sum();
@@ -291,17 +322,17 @@ pub fn dmr_lambda_cov(
         let dg_asum = digamma(alpha_sum);
         let dg_asum_n = digamma(alpha_sum + n_d);
         for tt in 0..t {
-            let at = a[tt];
+            let at = a_lin[tt] + alpha_epsilon;
             let n = counts[tt];
             let g_t = dg_asum - dg_asum_n + digamma(at + n) - digamma(at);
-            b[tt] = at * (trigamma(at + n) - trigamma(at)) + g_t;
+            b[tt] = a_lin[tt] * (trigamma(at + n) - trigamma(at)) + g_t;
         }
-        // Add −H_d = −x_f x_g ( c_d a_t a_u + [t=u] a_t b_t ) into J.
+        // Add −H_d = −x_f x_g ( c_d a_lin_t a_lin_u + [t=u] a_lin_t b_t ) into J.
         for tt in 0..t {
             for uu in 0..t {
-                let mut coef = -c_d * a[tt] * a[uu];
+                let mut coef = -c_d * a_lin[tt] * a_lin[uu];
                 if tt == uu {
-                    coef -= a[tt] * b[tt];
+                    coef -= a_lin[tt] * b[tt];
                 }
                 if coef == 0.0 {
                     continue;
@@ -333,7 +364,7 @@ pub fn dmr_lambda_cov(
 }
 
 use crate::mathfun::log_gamma;
-use crate::variational::lbfgs_minimize_status;
+use crate::variational::{lbfgs_minimize_status, lbfgs_minimize_status_capped};
 
 /// Optimize `lambda` in place to maximize the penalized DMR likelihood for the
 /// current topic counts (one L-BFGS run, used periodically during sampling).
@@ -344,6 +375,7 @@ use crate::variational::lbfgs_minimize_status;
 /// optimum, so a run that hit `max_iter` (or was given `max_iter == 0`) reports
 /// `false` and no SE is emitted (#419).
 #[must_use]
+#[allow(clippy::too_many_arguments)]
 pub fn optimize_lambda(
     lambda: &mut [Vec<f64>],
     features: &[Vec<f64>],
@@ -351,41 +383,50 @@ pub fn optimize_lambda(
     num_topics: usize,
     num_features: usize,
     prior_variance: f64,
+    prior_mean: &[f64],
+    alpha_epsilon: f64,
     max_iter: usize,
     offset: Option<&[Vec<f64>]>,
+    cap_first_step: bool,
 ) -> bool {
     let mut x0 = Vec::with_capacity(num_topics * num_features);
     for lt in lambda.iter() {
         x0.extend_from_slice(lt);
     }
 
-    let (x, converged) = lbfgs_minimize_status(
-        x0,
-        |flat| {
-            let mut lam = vec![vec![0.0f64; num_features]; num_topics];
-            for t in 0..num_topics {
-                lam[t].copy_from_slice(&flat[t * num_features..(t + 1) * num_features]);
-            }
-            // We minimize, so negate the (maximization) objective and gradient.
-            let (val, grad) = dmr_objective_and_gradient(
-                &lam,
-                features,
-                doc_topic_counts,
-                num_topics,
-                num_features,
-                prior_variance,
-                offset,
-            );
-            let mut g = Vec::with_capacity(num_topics * num_features);
-            for gt in &grad {
-                g.extend(gt.iter().map(|v| -v));
-            }
-            (-val, g)
-        },
-        max_iter,
-        7,
-        1e-5,
-    );
+    let obj = |flat: &[f64]| -> (f64, Vec<f64>) {
+        let mut lam = vec![vec![0.0f64; num_features]; num_topics];
+        for t in 0..num_topics {
+            lam[t].copy_from_slice(&flat[t * num_features..(t + 1) * num_features]);
+        }
+        // We minimize, so negate the (maximization) objective and gradient.
+        let (val, grad) = dmr_objective_and_gradient(
+            &lam,
+            features,
+            doc_topic_counts,
+            num_topics,
+            num_features,
+            prior_variance,
+            prior_mean,
+            alpha_epsilon,
+            offset,
+        );
+        let mut g = Vec::with_capacity(num_topics * num_features);
+        for gt in &grad {
+            g.extend(gt.iter().map(|v| -v));
+        }
+        (-val, g)
+    };
+
+    // Standalone DMR (`cap_first_step = true`) caps the first L-BFGS step to stop the
+    // λ objective's large initial gradient from overshooting (#563); keyATM passes
+    // `false` to keep its optimizer trajectory bit-identical (it standardizes
+    // features and clamps λ, so it never had the runaway).
+    let (x, converged) = if cap_first_step {
+        lbfgs_minimize_status_capped(x0, obj, max_iter, 7, 1e-5)
+    } else {
+        lbfgs_minimize_status(x0, obj, max_iter, 7, 1e-5)
+    };
 
     for t in 0..num_topics {
         lambda[t].copy_from_slice(&x[t * num_features..(t + 1) * num_features]);
@@ -403,6 +444,7 @@ pub fn optimize_lambda(
 /// computed from the post-sampling counts, which have drifted away from the counts
 /// `lambda` was fit to, so it was not `J^{-1}` at the optimum for the returned
 /// `lambda`.
+#[allow(clippy::too_many_arguments)]
 pub fn dmr_lambda_se_checked(
     lambda: &[Vec<f64>],
     features: &[Vec<f64>],
@@ -410,6 +452,8 @@ pub fn dmr_lambda_se_checked(
     num_topics: usize,
     num_features: usize,
     prior_variance: f64,
+    prior_mean: &[f64],
+    alpha_epsilon: f64,
     offset: Option<&[Vec<f64>]>,
 ) -> Option<Vec<Vec<f64>>> {
     let (value, grad) = dmr_objective_and_gradient(
@@ -419,6 +463,8 @@ pub fn dmr_lambda_se_checked(
         num_topics,
         num_features,
         prior_variance,
+        prior_mean,
+        alpha_epsilon,
         offset,
     );
     if !value.is_finite() || grad.iter().flatten().any(|g| !g.is_finite()) {
@@ -431,6 +477,7 @@ pub fn dmr_lambda_se_checked(
         num_topics,
         num_features,
         prior_variance,
+        alpha_epsilon,
         offset,
     );
     if se.iter().flatten().any(|v| !v.is_finite()) {
@@ -462,6 +509,11 @@ mod tests {
             vec![2.0f64, 0.0, 1.0],
         ];
         let sigma2 = 10.0;
+        // Exercise the new paths: a nonzero per-feature prior mean and a non-trivial
+        // additive α floor, so the FD check covers the (λ−μ) prior term and the
+        // a_lin-vs-α split in the gradient chain (#563).
+        let prior_mean = vec![0.1_f64.ln(), 0.0]; // [ln(0.1), 0]
+        let alpha_epsilon = 0.05_f64;
 
         let (_, grad) = dmr_objective_and_gradient(
             &lambda,
@@ -470,6 +522,8 @@ mod tests {
             num_topics,
             num_features,
             sigma2,
+            &prior_mean,
+            alpha_epsilon,
             None,
         );
 
@@ -487,6 +541,8 @@ mod tests {
                     num_topics,
                     num_features,
                     sigma2,
+                    &prior_mean,
+                    alpha_epsilon,
                     None,
                 );
                 let (vm, _) = dmr_objective_and_gradient(
@@ -496,6 +552,8 @@ mod tests {
                     num_topics,
                     num_features,
                     sigma2,
+                    &prior_mean,
+                    alpha_epsilon,
                     None,
                 );
                 let numeric = (vp - vm) / (2.0 * eps);
@@ -535,13 +593,25 @@ mod tests {
             vec![1.0f64, 3.0, 2.0],
         ];
         let sigma2 = 10.0;
+        let alpha_epsilon = 0.05_f64; // exercise the a_lin-vs-α split in the Hessian
+        let prior_mean = vec![0.0_f64; f]; // SE is prior-mean-independent
         let p = t * f;
 
         // Analytic observed information J from the same assembly the SE uses.
         // Rebuild J by inverting the SE-derived covariance is circular, so instead
         // FD the gradient: H[i,j] = d g_i / d lambda_j, and J = -H + (1/sigma2)I.
         let grad_flat = |lam: &[Vec<f64>]| -> Vec<f64> {
-            let (_, g) = dmr_objective_and_gradient(lam, &features, &counts, t, f, sigma2, None);
+            let (_, g) = dmr_objective_and_gradient(
+                lam,
+                &features,
+                &counts,
+                t,
+                f,
+                sigma2,
+                &prior_mean,
+                alpha_epsilon,
+                None,
+            );
             let mut out = vec![0.0; p];
             for tt in 0..t {
                 for ff in 0..f {
@@ -569,7 +639,16 @@ mod tests {
             let cov = spd_inverse(&j_fd, p).expect("FD info not invertible");
             (0..p).map(|i| cov[i * p + i].sqrt()).collect()
         };
-        let se = dmr_lambda_se(&lambda, &features, &counts, t, f, sigma2, None);
+        let se = dmr_lambda_se(
+            &lambda,
+            &features,
+            &counts,
+            t,
+            f,
+            sigma2,
+            alpha_epsilon,
+            None,
+        );
         for tt in 0..t {
             for ff in 0..f {
                 let analytic = se[tt][ff];
@@ -603,8 +682,8 @@ mod tests {
         };
         let (fs, cs) = mk(40);
         let (fl, cl) = mk(400);
-        let se_small = dmr_lambda_se(&lambda, &fs, &cs, t, f, 100.0, None);
-        let se_large = dmr_lambda_se(&lambda, &fl, &cl, t, f, 100.0, None);
+        let se_small = dmr_lambda_se(&lambda, &fs, &cs, t, f, 100.0, 1e-10, None);
+        let se_large = dmr_lambda_se(&lambda, &fl, &cl, t, f, 100.0, 1e-10, None);
         for tt in 0..t {
             for ff in 0..f {
                 assert!(
@@ -638,6 +717,7 @@ mod tests {
             }
         }
         let mut lambda = vec![vec![0.0f64; num_features]; num_topics];
+        let prior_mean = vec![0.0f64; num_features];
         let converged = optimize_lambda(
             &mut lambda,
             &features,
@@ -645,8 +725,11 @@ mod tests {
             num_topics,
             num_features,
             100.0,
+            &prior_mean,
+            1e-10,
             100,
             None,
+            true,
         );
         assert!(converged, "L-BFGS should reach a stationary point here");
 
@@ -659,6 +742,68 @@ mod tests {
         );
     }
 
+    // #563: a nonzero prior mean pulls the fitted intercept toward log(alpha). With
+    // a null covariate and a tight prior, the fitted intercept must land near μ
+    // rather than near 0 (the old zero-mean behavior).
+    #[test]
+    fn prior_mean_pulls_intercept_toward_log_alpha() {
+        // Intercept-only design (single feature = intercept), two topics, balanced
+        // counts so the data likelihood is flat in the intercept and the prior mean
+        // decides where λ settles.
+        let (t, f) = (2usize, 1usize);
+        let mut features = Vec::new();
+        let mut counts = Vec::new();
+        for _ in 0..50 {
+            features.push(vec![1.0]);
+            counts.push(vec![4.0, 4.0]);
+        }
+        let ln_alpha = 0.1f64.ln();
+        let prior_mean = vec![ln_alpha];
+        // A tight prior (small variance) so the prior mean dominates.
+        let mut lambda = vec![vec![0.0f64; f]; t];
+        let converged = optimize_lambda(
+            &mut lambda,
+            &features,
+            &counts,
+            t,
+            f,
+            0.01,
+            &prior_mean,
+            1e-10,
+            200,
+            None,
+            true,
+        );
+        assert!(converged);
+        for lt in &lambda {
+            assert!(
+                (lt[0] - ln_alpha).abs() < 0.3,
+                "intercept {} should sit near ln(alpha)={ln_alpha}",
+                lt[0]
+            );
+        }
+        // Sanity: the zero-mean prior would instead pull the intercept toward 0.
+        let mut lambda0 = vec![vec![0.0f64; f]; t];
+        let zero_mean = vec![0.0f64; f];
+        let _ = optimize_lambda(
+            &mut lambda0,
+            &features,
+            &counts,
+            t,
+            f,
+            0.01,
+            &zero_mean,
+            1e-10,
+            200,
+            None,
+            true,
+        );
+        assert!(
+            lambda0[0][0].abs() < (lambda[0][0] - 0.0).abs(),
+            "zero-mean prior keeps the intercept nearer 0 than the ln(alpha)-centered prior"
+        );
+    }
+
     // #419: optimize_lambda reports non-convergence when it cannot take a real step
     // (max_iter = 0), which the SE guard uses to withhold an invalid covariance.
     #[test]
@@ -666,7 +811,20 @@ mod tests {
         let features = vec![vec![1.0, 1.0], vec![1.0, -1.0], vec![1.0, 0.5]];
         let counts = vec![vec![5.0, 1.0], vec![1.0, 5.0], vec![3.0, 3.0]];
         let mut lambda = vec![vec![0.0f64; 2]; 2];
-        let converged = optimize_lambda(&mut lambda, &features, &counts, 2, 2, 100.0, 0, None);
+        let prior_mean = vec![0.0f64; 2];
+        let converged = optimize_lambda(
+            &mut lambda,
+            &features,
+            &counts,
+            2,
+            2,
+            100.0,
+            &prior_mean,
+            1e-10,
+            0,
+            None,
+            true,
+        );
         assert!(
             !converged,
             "max_iter=0 leaves lambda un-optimized, so it must not report convergence"
@@ -690,9 +848,32 @@ mod tests {
             vec![4.0, 6.0],
         ];
         let mut lambda = vec![vec![0.0f64; 2]; 2];
-        let converged = optimize_lambda(&mut lambda, &features, &counts, 2, 2, 100.0, 200, None);
+        let prior_mean = vec![0.0f64; 2];
+        let converged = optimize_lambda(
+            &mut lambda,
+            &features,
+            &counts,
+            2,
+            2,
+            100.0,
+            &prior_mean,
+            1e-10,
+            200,
+            None,
+            true,
+        );
         assert!(converged);
-        let se = dmr_lambda_se_checked(&lambda, &features, &counts, 2, 2, 100.0, None);
+        let se = dmr_lambda_se_checked(
+            &lambda,
+            &features,
+            &counts,
+            2,
+            2,
+            100.0,
+            &prior_mean,
+            1e-10,
+            None,
+        );
         let se = se.expect("SE should be available at a converged optimum");
         assert!(se.iter().flatten().all(|v| v.is_finite() && *v > 0.0));
 
@@ -703,9 +884,18 @@ mod tests {
             vec![6.0, 4.0],
             vec![4.0, 6.0],
         ];
-        assert!(
-            dmr_lambda_se_checked(&lambda, &features, &bad_counts, 2, 2, 100.0, None).is_none()
-        );
+        assert!(dmr_lambda_se_checked(
+            &lambda,
+            &features,
+            &bad_counts,
+            2,
+            2,
+            100.0,
+            &prior_mean,
+            1e-10,
+            None
+        )
+        .is_none());
     }
 
     #[test]

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -330,8 +330,9 @@ impl KeyAtmModel {
         // Covariate model: per-document, per-topic α from the regression
         // (plus the fixed embedding offset, when present).
         if let (Some(lambda), Some(features)) = (&self.lambda, &self.features) {
+            // keyATM keeps the bare exp() prior (no α floor) and a zero-mean λ prior.
             let doc_alpha =
-                crate::dmr::compute_doc_alpha(lambda, features, self.prior_offset.as_deref());
+                crate::dmr::compute_doc_alpha(lambda, features, self.prior_offset.as_deref(), 0.0);
             return self
                 .ndk
                 .iter()
@@ -387,7 +388,12 @@ impl KeyAtmModel {
                 .collect();
         }
         if let (Some(lambda), Some(features)) = (&self.lambda, &self.features) {
-            return crate::dmr::compute_doc_alpha(lambda, features, self.prior_offset.as_deref());
+            return crate::dmr::compute_doc_alpha(
+                lambda,
+                features,
+                self.prior_offset.as_deref(),
+                0.0,
+            );
         }
         let row = self
             .alpha_vec
@@ -1738,6 +1744,7 @@ fn covariate_lambda_se(
         t,
         f,
         prior_variance,
+        0.0,
         offset,
     );
     // Per-topic Jacobian M (F×F), identical across topics: row 0 maps the
@@ -1853,7 +1860,10 @@ pub fn fit_keyatm_cov<R: Rng>(
     );
 
     let mut lambda = vec![vec![0.0f64; num_features]; num_topics];
-    let mut doc_alpha = crate::dmr::compute_doc_alpha(&lambda, &features_std, offset);
+    // keyATM keeps DMR's original zero-mean λ prior and bare exp() prior (no α
+    // floor); the #563 baseline-α centering is DMR-specific.
+    let km_prior_mean = vec![0.0f64; num_features];
+    let mut doc_alpha = crate::dmr::compute_doc_alpha(&lambda, &features_std, offset, 0.0);
     let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
     // So the log-likelihood trace uses the covariate doc-topic prior: doc_topic()
     // takes the (lambda, features) path only when both are set on the model. While
@@ -1891,8 +1901,13 @@ pub fn fit_keyatm_cov<R: Rng>(
                 num_topics,
                 num_features,
                 prior_variance,
+                &km_prior_mean,
+                0.0,
                 lbfgs_iters,
                 offset,
+                // keyATM keeps the plain first step (bit-identical to pre-#563): it
+                // standardizes features and clamps λ, so it never had DMR's runaway.
+                false,
             );
             // Snapshot the counts this optimization ran against (before the next
             // sweep mutates them); only a converged run yields a valid SE optimum.
@@ -1908,7 +1923,7 @@ pub fn fit_keyatm_cov<R: Rng>(
                     *v = v.clamp(-LAMBDA_BOUND, LAMBDA_BOUND);
                 }
             }
-            doc_alpha = crate::dmr::compute_doc_alpha(&lambda, &features_std, offset);
+            doc_alpha = crate::dmr::compute_doc_alpha(&lambda, &features_std, offset, 0.0);
         }
         draws.maybe_collect(&mut theta_draw_buf, it + 1, &model.ndk, &doc_alpha);
         if record_ll(it + 1, ll_interval, iters) {
@@ -2586,8 +2601,8 @@ mod tests {
                 row
             })
             .collect();
-        let a_std = crate::dmr::compute_doc_alpha(&lambda_std, &fstd, None);
-        let a_orig = crate::dmr::compute_doc_alpha(&lambda_orig, &features, None);
+        let a_std = crate::dmr::compute_doc_alpha(&lambda_std, &fstd, None, 0.0);
+        let a_orig = crate::dmr::compute_doc_alpha(&lambda_orig, &features, None, 0.0);
         for d in 0..features.len() {
             for k in 0..lambda_std.len() {
                 assert!(
@@ -2635,7 +2650,7 @@ mod tests {
         // Reference: full p×p covariance in std space, transformed by the full
         // block-diagonal Jacobian J (each topic block = M), SE = sqrt(diag).
         let p = t * f;
-        let cov = crate::dmr::dmr_lambda_cov(&lambda_std, &fstd, &counts, t, f, sigma2, None);
+        let cov = crate::dmr::dmr_lambda_cov(&lambda_std, &fstd, &counts, t, f, sigma2, 0.0, None);
         // M (F×F): row 0 = [1, -mean_g/sd_g...]; row g≥1 = e_g / sd_g.
         let mut m = vec![vec![0.0f64; f]; f];
         m[0][0] = 1.0;

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -156,6 +156,12 @@ struct LdaState {
     #[serde(default)]
     theta_draws: Option<Arr3f32>,
 }
+/// Legacy DMR saves predate the baseline-α prior (#563); they were fit with an
+/// implicit symmetric prior of 1.0, so a missing `alpha` deserializes to 1.0 (see
+/// the field note below on the bincode `serde(default)` limitation).
+fn dmr_legacy_alpha() -> f64 {
+    1.0
+}
 #[derive(serde::Serialize, serde::Deserialize)]
 struct DmrState {
     num_topics: usize,
@@ -183,6 +189,15 @@ struct DmrState {
     // SE of the feature weights (num_topics, num_features); absent in old saves.
     #[serde(default)]
     feature_effect_se: Option<Arr2>,
+    // Baseline concentration + α floor (#563), appended last. Same pre-v1.0 caveat
+    // as the other trailing fields: `serde(default)` fills these only for a save
+    // whose stream is otherwise structurally current; a pre-0.54 bincode payload is
+    // positionally shorter and will not round-trip (documented, not supported —
+    // only the author has saved models). A same-version round-trip is exact.
+    #[serde(default = "dmr_legacy_alpha")]
+    alpha: f64,
+    #[serde(default)]
+    alpha_epsilon: f64,
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct LabeledState {
@@ -3658,6 +3673,11 @@ pub struct DMR {
     burn_in: usize,
     seed: u64,
     prior_variance: f64,
+    // Baseline Dirichlet concentration: the λ prior is centred at ln(alpha) on the
+    // intercept, matching tomotopy's DMR `alpha` (default 0.1). See #563.
+    alpha: f64,
+    // Additive floor on α (tomotopy's `alpha_epsilon`, default 1e-10) keeping α > 0.
+    alpha_epsilon: f64,
     lbfgs_iters: usize,
     // WarpLDA cache-efficient sampler (per-document-α doc phase) instead of the
     // default SparseLDA DMR sweep. Recommended for large K.
@@ -3705,6 +3725,8 @@ impl DMR {
         d.set_item("burn_in", self.burn_in)?;
         d.set_item("seed", self.seed)?;
         d.set_item("prior_variance", self.prior_variance)?;
+        d.set_item("alpha", self.alpha)?;
+        d.set_item("alpha_epsilon", self.alpha_epsilon)?;
         d.set_item("lbfgs_iters", self.lbfgs_iters)?;
         let sampler = if self.warp {
             "warp"
@@ -3723,8 +3745,13 @@ impl DMR {
         self.seed
     }
 
-    /// Create an unfitted DMR model. `prior_variance` is the Gaussian prior
-    /// variance σ² on the feature weights λ (smaller = stronger shrinkage);
+    /// Create an unfitted DMR model. `alpha` is the baseline Dirichlet
+    /// concentration: the λ Gaussian prior is centred at `ln(alpha)` on the
+    /// intercept, so with a null covariate the model reduces to LDA with symmetric
+    /// prior `alpha` (matching tomotopy's DMR `alpha`, default 0.1). `prior_variance`
+    /// is the Gaussian prior variance σ² on λ (smaller = stronger shrinkage; equals
+    /// tomotopy `sigma²`, default 1.0). `alpha_epsilon` is a small additive floor on
+    /// α keeping it strictly positive (tomotopy `alpha_epsilon`, default 1e-10).
     /// `lbfgs_iters` caps the L-BFGS steps per optimization round.
     ///
     /// `num_topics` is the number of topics K; `beta` is the topic-word Dirichlet
@@ -3732,17 +3759,28 @@ impl DMR {
     /// past `burn_in`. `seed` seeds the Gibbs RNG. `sampler` selects the inference
     /// backend: ``"sparse"`` (default), ``"warp"`` (WarpLDA), or ``"cvb0"``
     /// (deterministic collapsed variational Bayes).
+    ///
+    /// Note: pass `alpha=1.0` to recover the pre-0.54 zero-mean-intercept behaviour
+    /// (baseline concentration 1.0). Because topica uses intercept/reference coding
+    /// rather than tomotopy's one-hot metadata, the prior *mean* matches tomotopy
+    /// exactly while the prior *covariance* differs benignly (non-reference levels
+    /// carry 2σ² prior variance and share σ² with the intercept); this does not
+    /// affect the baseline concentration.
     #[new]
     #[pyo3(signature = (num_topics, *, beta=0.01, optimize_interval=50,
-                        burn_in=200, seed=42, prior_variance=1.0, lbfgs_iters=20,
+                        burn_in=200, seed=42, alpha=0.1, prior_variance=1.0,
+                        alpha_epsilon=1e-10, lbfgs_iters=20,
                         sampler="sparse"))]
+    #[allow(clippy::too_many_arguments)]
     fn new(
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
         beta: f64,
         optimize_interval: usize,
         burn_in: usize,
         seed: u64,
+        alpha: f64,
         prior_variance: f64,
+        alpha_epsilon: f64,
         lbfgs_iters: usize,
         sampler: &str,
     ) -> PyResult<Self> {
@@ -3752,8 +3790,16 @@ impl DMR {
         if !finite_pos(beta) {
             return Err(PyValueError::new_err("beta must be > 0"));
         }
+        if !finite_pos(alpha) {
+            return Err(PyValueError::new_err("alpha must be > 0"));
+        }
         if !finite_pos(prior_variance) {
             return Err(PyValueError::new_err("prior_variance must be > 0"));
+        }
+        if !alpha_epsilon.is_finite() || alpha_epsilon < 0.0 {
+            return Err(PyValueError::new_err(
+                "alpha_epsilon must be finite and >= 0",
+            ));
         }
         let (warp, cvb0) = match sampler {
             "sparse" => (false, false),
@@ -3772,6 +3818,8 @@ impl DMR {
             burn_in,
             seed,
             prior_variance,
+            alpha,
+            alpha_epsilon,
             lbfgs_iters,
             warp,
             cvb0,
@@ -3944,8 +3992,19 @@ impl DMR {
             }
         };
 
-        // λ starts at zero -> α ≡ 1 (symmetric) before optimization kicks in.
+        // The λ Gaussian prior is centred at ln(alpha) on the intercept (feature 0)
+        // and at 0 on the covariates, so before/without covariate steering the
+        // baseline concentration is `alpha` (matching tomotopy's DMR default 0.1),
+        // not the old implicit 1.0. λ starts at its prior mean (#563).
+        let alpha = slf.alpha;
+        let alpha_epsilon = slf.alpha_epsilon;
+        let ln_alpha = alpha.ln();
+        let mut prior_mean = vec![0.0f64; nf];
+        prior_mean[0] = ln_alpha; // feature 0 is the prepended intercept
         let mut lambda = vec![vec![0.0f64; nf]; k];
+        for lt in lambda.iter_mut() {
+            lt[0] = ln_alpha;
+        }
         let mut model = TopicModel::new(k, k as f64, slf.beta, num_types);
         let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         // The sparse path initializes `model` inside its branch below; the warp
@@ -3983,7 +4042,8 @@ impl DMR {
                 // λ, not at counts that drifted afterwards (#419).
                 let mut se_counts: Option<Vec<Vec<f64>>> = None;
                 for iter in 1..=iters {
-                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
+                    let doc_alpha =
+                        dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref(), alpha_epsilon);
                     cv.set_doc_alpha(doc_alpha);
                     cv.sweep();
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
@@ -3995,8 +4055,11 @@ impl DMR {
                             k,
                             nf,
                             prior_variance,
+                            &prior_mean,
+                            alpha_epsilon,
                             lbfgs_iters,
                             offset.as_deref(),
+                            true, // standalone DMR caps the first L-BFGS step (#563)
                         );
                         se_counts = if converged { Some(dtc) } else { None };
                     }
@@ -4013,6 +4076,8 @@ impl DMR {
                         k,
                         nf,
                         prior_variance,
+                        &prior_mean,
+                        alpha_epsilon,
                         offset.as_deref(),
                     )
                 });
@@ -4042,7 +4107,8 @@ impl DMR {
                 let mut se_counts: Option<Vec<Vec<f64>>> = None;
 
                 for iter in 1..=iters {
-                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
+                    let doc_alpha =
+                        dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref(), alpha_epsilon);
                     ws.set_doc_alpha(doc_alpha);
                     ws.sweep(&corpus, &mut rng);
 
@@ -4055,15 +4121,22 @@ impl DMR {
                             k,
                             nf,
                             prior_variance,
+                            &prior_mean,
+                            alpha_epsilon,
                             lbfgs_iters,
                             offset.as_deref(),
+                            true, // standalone DMR caps the first L-BFGS step (#563)
                         );
                         se_counts = if converged { Some(dtc) } else { None };
                     }
 
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
-                        let doc_alpha_snap =
-                            dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
+                        let doc_alpha_snap = dmr::compute_doc_alpha(
+                            &lambda,
+                            &feats,
+                            offset.as_deref(),
+                            alpha_epsilon,
+                        );
                         let snap: Vec<Vec<f32>> = ws
                             .doc_topics()
                             .iter()
@@ -4093,6 +4166,8 @@ impl DMR {
                                 k,
                                 nf,
                                 prior_variance,
+                                &prior_mean,
+                                alpha_epsilon,
                                 offset.as_deref(),
                             );
                             let llpt = ll / total_tokens;
@@ -4104,7 +4179,8 @@ impl DMR {
                 }
 
                 // Sampling phase: λ (and thus α per doc) fixed.
-                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
+                let doc_alpha =
+                    dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref(), alpha_epsilon);
                 ws.set_doc_alpha(doc_alpha.clone());
                 let mut acc_phi = vec![vec![0.0f64; k]; num_types];
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
@@ -4141,6 +4217,8 @@ impl DMR {
                         k,
                         nf,
                         prior_variance,
+                        &prior_mean,
+                        alpha_epsilon,
                         offset.as_deref(),
                     )
                 });
@@ -4168,7 +4246,8 @@ impl DMR {
                 let mut se_counts: Option<Vec<Vec<f64>>> = None;
 
                 'outer: for iter in 1..=iters {
-                    let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
+                    let doc_alpha =
+                        dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref(), alpha_epsilon);
                     dmr::run_sweep_dmr(
                         &mut model.type_topic_counts,
                         &mut model.tokens_per_topic,
@@ -4192,16 +4271,23 @@ impl DMR {
                             k,
                             nf,
                             prior_variance,
+                            &prior_mean,
+                            alpha_epsilon,
                             lbfgs_iters,
                             offset.as_deref(),
+                            true, // standalone DMR caps the first L-BFGS step (#563)
                         );
                         se_counts = if converged { Some(dtc) } else { None };
                     }
 
                     // Snapshot θ = (n_dk + α_dk) / (N_d + Σα_d) every thin sweeps.
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
-                        let doc_alpha_snap =
-                            dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
+                        let doc_alpha_snap = dmr::compute_doc_alpha(
+                            &lambda,
+                            &feats,
+                            offset.as_deref(),
+                            alpha_epsilon,
+                        );
                         let snap: Vec<Vec<f32>> = model
                             .doc_topics
                             .iter()
@@ -4231,6 +4317,8 @@ impl DMR {
                                 k,
                                 nf,
                                 prior_variance,
+                                &prior_mean,
+                                alpha_epsilon,
                                 offset.as_deref(),
                             );
                             let llpt = ll / total_tokens;
@@ -4256,7 +4344,8 @@ impl DMR {
                 }
 
                 // Sampling phase: λ is now fixed, so α per doc is fixed too.
-                let doc_alpha = dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref());
+                let doc_alpha =
+                    dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref(), alpha_epsilon);
                 let mut acc_phi = vec![vec![0.0f64; k]; num_types];
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
 
@@ -4308,6 +4397,8 @@ impl DMR {
                         k,
                         nf,
                         prior_variance,
+                        &prior_mean,
+                        alpha_epsilon,
                         offset.as_deref(),
                     )
                 });
@@ -4407,15 +4498,22 @@ impl DMR {
     }
 
     /// The baseline document-topic Dirichlet prior α, shape ``(num_topics,)``:
-    /// ``exp(λ_intercept)``, the per-topic prior at covariates = 0. DMR's prior is
-    /// per-document (``α_{d,k} = exp(λ_k · x_d)``), so this is the baseline; it
-    /// marks DMR as a Dirichlet model for :func:`topica.effects.composition_theta`.
+    /// ``exp(λ_intercept) + alpha_epsilon``, the per-topic prior at covariates = 0.
+    /// DMR's prior is per-document (``α_{d,k} = exp(λ_k · x_d) + alpha_epsilon``), so
+    /// this is the baseline; it marks DMR as a Dirichlet model for
+    /// :func:`topica.effects.composition_theta`.
     #[getter]
     fn alpha<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         self.require_fitted()?;
         // feature_effects is (num_topics, num_features); column 0 is the intercept.
+        // Match the training prior: clamp the predictor then add the α floor.
         let lam = self.feature_effects.as_ref().unwrap();
-        let a: Vec<f64> = lam.column(0).iter().map(|&l| l.exp()).collect();
+        let eps = self.alpha_epsilon;
+        let a: Vec<f64> = lam
+            .column(0)
+            .iter()
+            .map(|&l| l.clamp(-dmr::PREDICTOR_CLAMP, dmr::PREDICTOR_CLAMP).exp() + eps)
+            .collect();
         Ok(Array1::from(a).to_pyarray_bound(py))
     }
 
@@ -4621,6 +4719,7 @@ impl DMR {
                     )));
                 }
                 check_all_finite_arr2("features", &x)?;
+                let eps = self.alpha_epsilon;
                 (0..docs_usize.len())
                     .map(|d| {
                         (0..k)
@@ -4629,14 +4728,24 @@ impl DMR {
                                 for f in 1..nf {
                                     s += eff[[t, f]] * x[[d, f - 1]];
                                 }
-                                s.exp()
+                                // Match the training prior exactly: clamp the linear
+                                // predictor (dmr::PREDICTOR_CLAMP) then add the α floor.
+                                s.clamp(-dmr::PREDICTOR_CLAMP, dmr::PREDICTOR_CLAMP).exp() + eps
                             })
                             .collect()
                     })
                     .collect()
             }
             None => {
-                let base: Vec<f64> = (0..k).map(|t| eff[[t, 0]].exp()).collect();
+                let eps = self.alpha_epsilon;
+                let base: Vec<f64> = (0..k)
+                    .map(|t| {
+                        eff[[t, 0]]
+                            .clamp(-dmr::PREDICTOR_CLAMP, dmr::PREDICTOR_CLAMP)
+                            .exp()
+                            + eps
+                    })
+                    .collect();
                 vec![base; docs_usize.len()]
             }
         };
@@ -4685,6 +4794,8 @@ impl DMR {
                 seed: self.seed,
                 prior_variance: self.prior_variance,
                 lbfgs_iters: self.lbfgs_iters,
+                alpha: self.alpha,
+                alpha_epsilon: self.alpha_epsilon,
                 fitted: self.fitted,
                 phi: arr2_opt(&self.phi),
                 theta: arr2_opt(&self.theta),
@@ -4716,6 +4827,8 @@ impl DMR {
             burn_in: s.burn_in,
             seed: s.seed,
             prior_variance: s.prior_variance,
+            alpha: s.alpha,
+            alpha_epsilon: s.alpha_epsilon,
             lbfgs_iters: s.lbfgs_iters,
             warp: false,
             cvb0: false,

--- a/tests/test_dmr.py
+++ b/tests/test_dmr.py
@@ -95,6 +95,70 @@ class TestDMRConstructor:
         with pytest.raises(ValueError):
             DMR(2, prior_variance=-1.0)
 
+    def test_alpha_zero_raises(self):
+        with pytest.raises(ValueError):
+            DMR(2, alpha=0.0)
+
+    def test_alpha_negative_raises(self):
+        with pytest.raises(ValueError):
+            DMR(2, alpha=-0.1)
+
+    def test_alpha_epsilon_negative_raises(self):
+        with pytest.raises(ValueError):
+            DMR(2, alpha_epsilon=-1e-9)
+
+    def test_default_alpha_and_epsilon(self):
+        d = DMR(2)
+        assert d.settings["alpha"] == 0.1
+        assert d.settings["alpha_epsilon"] == 1e-10
+
+
+class TestCovariatePriorFaithfulness:
+    """#563: the covariate prior must not over-steer. For a *null* covariate,
+    DMR must reduce to LDA at the same baseline concentration (the λ optimizer
+    used to diverge to |λ|~100, collapsing θ toward uniform)."""
+
+    def _null_cov_corpus(self, n=300, doc_length=12, seed=0):
+        rng = np.random.default_rng(seed)
+        docs = []
+        for i in range(n):
+            vocab = _VOCAB_A if i % 2 == 0 else _VOCAB_B
+            docs.append(rng.choice(vocab, size=doc_length).tolist())
+        # A covariate that carries NO signal about the text.
+        x = rng.normal(size=(n, 1))
+        return docs, x
+
+    def test_lambda_stays_bounded_under_optimization(self):
+        docs, x = self._null_cov_corpus(seed=1)
+        m = DMR(num_topics=2, seed=1)
+        m.fit(docs, x, feature_names=["null"], iters=600)
+        fe = np.asarray(m.feature_effects)
+        # Pre-fix this ran to |lambda| ~ 40-100; a faithful fit keeps it O(1).
+        assert np.abs(fe).max() < 10.0, f"lambda diverged: max|λ|={np.abs(fe).max()}"
+
+    def test_dmr_reduces_to_lda_for_null_covariate(self):
+        from topica import LDA
+
+        docs, x = self._null_cov_corpus(seed=2)
+        d = DMR(num_topics=2, seed=1)
+        d.fit(docs, x, feature_names=["null"], iters=600)
+        lda = LDA(num_topics=2, seed=1)
+        lda.fit(docs, iters=600)
+
+        # Align topic-word rows across the shared vocabulary and require a high
+        # aligned cosine (DMR with a null covariate ≈ LDA).
+        dv = {w: i for i, w in enumerate(lda.vocabulary)}
+        shared = [w for w in d.vocabulary if w in dv]
+        Pd = np.asarray(d.topic_word)[:, [i for i, w in enumerate(d.vocabulary) if w in dv]]
+        Pl = np.asarray(lda.topic_word)[:, [dv[w] for w in shared]]
+        Pd = Pd / np.linalg.norm(Pd, axis=1, keepdims=True)
+        Pl = Pl / np.linalg.norm(Pl, axis=1, keepdims=True)
+        best = max(
+            np.mean([Pd[i] @ Pl[p[i]] for i in range(2)])
+            for p in [(0, 1), (1, 0)]
+        )
+        assert best > 0.7, f"DMR diverges from LDA for a null covariate: cos={best:.3f}"
+
 
 # ---------------------------------------------------------------------------
 # Unfitted access raises RuntimeError

--- a/topica-core/src/variational/lbfgs.rs
+++ b/topica-core/src/variational/lbfgs.rs
@@ -20,12 +20,49 @@ where
 /// standard errors from the result need this: the observed-information inverse is
 /// only a valid covariance at an optimum, so a run that hit `max_iter` (or was
 /// given `max_iter == 0`) must not be treated as converged.
+///
+/// Uses the plain backtracking line search (unit initial step). This is the exact
+/// pre-#563 behaviour; every existing caller (DTM, ETM, SAGE, STS, IdealPoint,
+/// keyATM) routes here and is bit-identical.
 pub fn lbfgs_minimize_status<F>(
+    x0: Vec<f64>,
+    f: F,
+    max_iter: usize,
+    history: usize,
+    tol: f64,
+) -> (Vec<f64>, bool)
+where
+    F: FnMut(&[f64]) -> (f64, Vec<f64>),
+{
+    lbfgs_core(x0, f, max_iter, history, tol, false)
+}
+
+/// As [`lbfgs_minimize_status`], but caps the *first* step's magnitude by `1/‖g‖`
+/// when the initial gradient is large. Opt-in (#563): standalone DMR does not
+/// standardize covariates, so its Dirichlet-multinomial λ objective can present an
+/// initial gradient of O(1e3), and the plain unit first step (`x − ∇f`) overshoots
+/// to |λ|~100, collapsing the per-document prior. Only DMR requests this; keeping it
+/// separate leaves every other caller's trajectory untouched.
+pub fn lbfgs_minimize_status_capped<F>(
+    x0: Vec<f64>,
+    f: F,
+    max_iter: usize,
+    history: usize,
+    tol: f64,
+) -> (Vec<f64>, bool)
+where
+    F: FnMut(&[f64]) -> (f64, Vec<f64>),
+{
+    lbfgs_core(x0, f, max_iter, history, tol, true)
+}
+
+fn lbfgs_core<F>(
     x0: Vec<f64>,
     mut f: F,
     max_iter: usize,
     history: usize,
     tol: f64,
+    cap_first_step: bool,
 ) -> (Vec<f64>, bool)
 where
     F: FnMut(&[f64]) -> (f64, Vec<f64>),
@@ -39,7 +76,7 @@ where
     let mut rho_list: Vec<f64> = Vec::new();
     let mut converged = false;
 
-    for _ in 0..max_iter {
+    for iter_idx in 0..max_iter {
         if g.iter().map(|v| v * v).sum::<f64>().sqrt() < tol {
             converged = true;
             break;
@@ -83,8 +120,26 @@ where
         }
         let dg = dot(&d, &g);
 
-        // Backtracking Armijo line search.
-        let mut step = 1.0;
+        // Backtracking Armijo line search. Only on the very first iteration there is
+        // no curvature history, so `d = -g` (steepest descent) and a unit step moves
+        // by `|g|`, which overshoots catastrophically when the gradient is large
+        // (e.g. DMR's Dirichlet-multinomial λ objective, whose initial gradient can
+        // be O(1e3) on concentrated topic counts; #563). Cap that first step so its
+        // magnitude is ≲ 1 — `min(1, 1/‖g‖₂)` — which leaves well-scaled problems
+        // (‖g‖ ≤ 1) and near-optimum warm starts untouched (step stays 1) and only
+        // shrinks a large-gradient first step. Backtracking + the curvature scaling
+        // take over afterwards. The cap is gated on `iter_idx == 0`, NOT on `m == 0`:
+        // when no curvature pair is ever stored (`s·y ≤ 1e-10`) `m` stays 0 every
+        // iteration, and capping every step would stall a steepest-descent optimizer
+        // whose steps are legitimately large. It is also opt-in per caller
+        // (`cap_first_step`) so only DMR is affected.
+        let capped_first = cap_first_step && iter_idx == 0;
+        let mut step = if capped_first {
+            let gnorm = g.iter().map(|v| v * v).sum::<f64>().sqrt();
+            (1.0 / gnorm).min(1.0)
+        } else {
+            1.0
+        };
         let mut x_new = x.clone();
         // Assigned on every loop iteration before they are read; the line search
         // always runs the body at least once, so no initial value is needed.
@@ -135,11 +190,15 @@ where
             y_list.push(y);
         }
 
+        // A deliberately-shrunk first step can make a tiny relative function change
+        // look "converged" while the gradient is still large (e.g. an objective with
+        // a large constant offset). Don't accept function-change convergence on that
+        // capped step; the gradient-norm test at the loop top still applies (#563).
         let fx_converged = (fx - fx_new).abs() < tol * (1.0 + fx.abs());
         x = x_new;
         fx = fx_new;
         g = g_new;
-        if fx_converged {
+        if fx_converged && !capped_first {
             converged = true;
             break;
         }
@@ -164,6 +223,31 @@ mod tests {
         assert!(
             (x[0] - 3.0).abs() < 1e-4 && (x[1] + 2.0).abs() < 1e-4,
             "{x:?}"
+        );
+    }
+
+    // #563: a large initial gradient must not overshoot. On a well-conditioned
+    // quadratic scaled so ‖∇f(x0)‖ ≈ 2000, the unscaled first step (x - g) would
+    // fling x ~2000 away from the min; the first-step cap keeps it converging.
+    #[test]
+    fn large_initial_gradient_does_not_overshoot() {
+        // f(x) = 1000*(x-3)^2, ∇f = 2000*(x-3); at x0=0, ∇f = -6000.
+        let f = |x: &[f64]| -> (f64, Vec<f64>) {
+            let a = x[0] - 3.0;
+            (1000.0 * a * a, vec![2000.0 * a])
+        };
+        let (x, converged) = lbfgs_minimize_status_capped(vec![0.0], f, 100, 7, 1e-10);
+        assert!(converged, "should converge, not diverge: {x:?}");
+        assert!(
+            (x[0] - 3.0).abs() < 1e-3,
+            "should reach the min at 3: {x:?}"
+        );
+
+        // The uncapped path is unchanged and still converges on this benign case.
+        let (xu, cu) = lbfgs_minimize_status(vec![0.0], f, 100, 7, 1e-10);
+        assert!(
+            cu && (xu[0] - 3.0).abs() < 1e-3,
+            "uncapped still converges: {xu:?}"
         );
     }
 

--- a/topica-core/src/variational/mod.rs
+++ b/topica-core/src/variational/mod.rs
@@ -5,7 +5,7 @@
 //! family trait.
 
 pub mod lbfgs;
-pub use lbfgs::{lbfgs_minimize, lbfgs_minimize_status};
+pub use lbfgs::{lbfgs_minimize, lbfgs_minimize_status, lbfgs_minimize_status_capped};
 
 pub mod sparse;
 pub use sparse::doc_sparse;


### PR DESCRIPTION
## Summary

Fixes #563. topica's `DMR`/`GDMR` diverged from the `tomotopy` reference on poliblog (K=10) at an aligned topic-word cosine of **~0.25**, far below both engines' **~0.71** seed-to-seed ceiling. Diagnostic localization (the dive the issue asked for):

| comparison | before | after |
|---|--:|--:|
| tomotopy DMR ↔ tomotopy LDA | 0.988 | — |
| **topica DMR ↔ topica LDA** | **0.327** | **0.826** |
| topica LDA ↔ tomotopy LDA | 0.884 | (base faithful) |
| **topica DMR ↔ tomotopy DMR** | **0.278** | **0.813** (ceiling 0.714) |

The base Gibbs sampler was already faithful (plain LDA agrees with MALLET/`tomotopy` *above* their mutual ceiling). The fault was entirely in the λ covariate layer, which was over-steering: topica's DMR disagreed with its **own** LDA (0.33) where `tomotopy`'s DMR ≈ its LDA (0.99).

## Root cause (two bugs)

**1. L-BFGS first-step overshoot (dominant).** `lbfgs_minimize_status` took an unscaled first step: with no curvature history the direction is `-∇f`, so a unit step moves λ by `‖∇f‖`. On the Dirichlet-multinomial λ objective the initial gradient is O(1e3) on concentrated topic counts, so λ ran away to **±100**, collapsing every document's topic prior toward uniform → blurred, systematically different topics. Confirmed by isolating the objective: topica's exact DMR objective optimized by *scipy* L-BFGS on the same counts gives λ ∈ [-1.2, 1.2] (≈ tomotopy's [-2.0, 0.75]); topica's own optimizer gave λ ∈ [-100, +92]. Fix: cap the first step by `1/‖∇f‖₂` (standard L-BFGS initialization). Well-scaled problems and near-optimum warm starts are untouched (step stays 1). This was a **regression** — the `log_gamma` tiny-argument `+inf` (fixed in #434/#439) had been implicitly capping λ.

**2. Prior mean / baseline concentration.** topica used a zero-mean λ prior (implicit baseline α = 1.0); `tomotopy` centers the λ prior at `log(alpha)` (default `alpha=0.1`) and adds an `alpha_epsilon` floor (verified against `tomotopy` `DMRModel.hpp`). `DMR` now exposes `alpha` (default 0.1) and `alpha_epsilon` (default 1e-10), centers the intercept prior at `ln(alpha)`, inits λ there, and threads a per-feature prior mean + the α floor (with the `a_lin` vs `α` split in the derivative chain) through the objective/gradient/Hessian.

Pass `alpha=1.0` to recover the pre-fix zero-mean behaviour.

## Faithfulness review (Google Gemini, pre-implementation)

An independent Gemini pass verified the prior-mean equivalence (`exp(log α + dev·x) = α·exp(dev·x)`), the intercept-only centering, and the α-floor gradient chain against `tomotopy`'s source, and caught the **g-DMR double-offset hazard**: g-DMR already realizes `log(alpha)` via its own predictor `offset`, so its inner DMR is now pinned to `alpha=1.0` to apply the centering exactly once. It also noted (documented, benign) that intercept/reference coding gives a prior *covariance* asymmetry vs `tomotopy`'s one-hot coding while the prior *mean* matches exactly.

## keyATM impact

`keyatm` shares `lbfgs_minimize_status` (it standardizes features and clamps λ, so it never had the runaway). Measured before/after against the committed R gold:

| keyATM model | before | after | R self |
|---|--:|--:|--:|
| base | 0.8828 | 0.8828 | 0.9125 |
| covariate | 0.9122 | 0.9061 | 0.9323 |
| dynamic | 0.9127 | 0.9127 | 0.8867 |

Base/dynamic bit-unchanged; covariate shifts −0.006 (negligible, margin +0.12, sign agreement 1.00).

## Tests

- Rust: FD gradient + FD-Hessian with nonzero prior mean and α floor; prior mean pulls the intercept toward `ln(alpha)`; L-BFGS large-initial-gradient regression (`f=1000(x-3)²`, ∇=−6000, must not overshoot).
- Python: `alpha`/`alpha_epsilon` validation + defaults; λ stays bounded under optimization; DMR ≈ LDA for a null covariate.
- Full `cargo test --lib` (245), DMR/GDMR/keyATM pytest (432), gold+parity (156) green; preflight (fmt/clippy/stub/tables) green.

## Paper

The appendix generator prose is de-overclaimed (0.278 "at the ceiling" → 0.81 *above* the 0.71 ceiling, plus the DMR≈LDA framing). The generated `paper/generated/validation_appendix.tex` is **not** regenerated here to avoid clobbering in-progress paper edits in the working tree; regenerating it will restore the ~0.82 numbers the committed appendix already carried before the regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01RfP5qetE6FhpoJYmpDQzuQ