### PR TITLE
feat(dmr): AD-LDA multithreading via num_threads (DMR + GDMR) (#566)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -299,6 +299,7 @@ class DMR:
         alpha_epsilon: float = 1e-10,
         lbfgs_iters: int = 20,
         sampler: str = "sparse",
+        num_threads: int = 1,
     ) -> None:
         """Create an unfitted DMR model. prior_variance is the Gaussian prior
         variance on the feature weights; lbfgs_iters caps L-BFGS steps per round.
@@ -312,7 +313,13 @@ class DMR:
         compute. As with plain LDA, warp is flat in K and overtakes sparse on
         speed around K~=50 (dominating at large K), while sparse keeps a small-K
         coherence edge and a convergence trace; the "warp"/"cvb0" paths record no
-        convergence trace, so convergence_tol has no effect there."""
+        convergence trace, so convergence_tol has no effect there.
+
+        num_threads > 1 runs MALLET-style approximate-parallel Gibbs on the
+        default sparse backend (partition documents, sample against per-worker
+        count copies, merge; deterministic for a fixed num_threads+seed); 1 is the
+        exact serial path. It is ignored by the warp/cvb0 backends and can be
+        overridden per call via fit(num_threads=)."""
         ...
 
     def fit(
@@ -332,6 +339,7 @@ class DMR:
         check_every: int = 10,
         covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
         offset: Optional[numpy.typing.NDArray[numpy.float64]] = None,
+        num_threads: int | None = None,
     ) -> "DMR":
         """Fit by collapsed Gibbs with the per-document Dirichlet prior
         alpha_{d,t} = exp(lambda_t . x_d + offset[d, t]). `features` (or

--- a/python/topica/gdmr.py
+++ b/python/topica/gdmr.py
@@ -269,6 +269,11 @@ class GDMR:
     sampler:
         Gibbs sampler variant: ``"sparse"`` (default), ``"warp"``, or
         ``"cvb0"``.  See ``topica.DMR`` for details.
+    num_threads:
+        Worker count for the inner ``DMR`` sparse Gibbs fit.  ``> 1`` enables
+        MALLET-style approximate-parallel sampling (deterministic for a fixed
+        ``num_threads`` + ``seed``); ``1`` is the exact serial path.  Ignored by
+        the ``"warp"``/``"cvb0"`` backends.
     """
 
     def __init__(
@@ -287,6 +292,7 @@ class GDMR:
         metadata_range: list[tuple[float, float]] | None = None,
         lbfgs_iters: int = 20,
         sampler: str = "sparse",
+        num_threads: int = 1,
     ) -> None:
         if num_topics < 1:
             raise ValueError("num_topics must be >= 1")
@@ -320,6 +326,7 @@ class GDMR:
         )
         self._lbfgs_iters = lbfgs_iters
         self._sampler = sampler
+        self._num_threads = num_threads
         # names of the D continuous metadata dimensions; set at fit
         self._metadata_names: list[str] | None = None
 
@@ -472,6 +479,7 @@ class GDMR:
             prior_variance=prior_variance,
             lbfgs_iters=self._lbfgs_iters,
             sampler=self._sampler,
+            num_threads=self._num_threads,
         )
 
         # Center the intercept (constant-term) prior at log(alpha) by adding a
@@ -677,6 +685,7 @@ class GDMR:
             ),
             "lbfgs_iters": self._lbfgs_iters,
             "sampler": self._sampler,
+            "num_threads": self._num_threads,
         }
 
     @property
@@ -968,6 +977,7 @@ class GDMR:
             "metadata_names": self._metadata_names,
             "lbfgs_iters": self._lbfgs_iters,
             "sampler": self._sampler,
+            "num_threads": self._num_threads,
             "recover_scales": self._recover_scales,
             "fitted": self._fitted,
         }
@@ -1003,6 +1013,7 @@ class GDMR:
             metadata_range=state["metadata_range"],
             lbfgs_iters=state["lbfgs_iters"],
             sampler=state["sampler"],
+            num_threads=state.get("num_threads", 1),
         )
         # Resolve the sidecar next to the wrapper file we are loading, so a moved
         # (wrapper + sidecar) pair loads from the new location rather than the

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -2889,7 +2889,6 @@ fn parallel_sweep_batched(
     let bits = model.topic_bits;
     let beta = model.beta;
     let beta_sum = model.beta_sum;
-    let v = model.num_types;
     let ranges = partition_ranges(docs.len(), num_threads);
 
     // Snapshot for reconciliation, and clone the shared read-only inputs.
@@ -2933,11 +2932,32 @@ fn parallel_sweep_batched(
         })
         .collect();
 
-    // --- Reconcile topic-word counts. Each worker started from `original` and
-    // only changed its own documents' tokens, so the exact global state is
-    //     final = Σ_w worker_w − (W−1)·original
-    // computed densely per word (in parallel, reusing a per-thread accumulator
-    // to avoid per-word allocation). Re-encode into the packed layout. ---
+    reconcile_worker_outs(model, outs, &original_ttc, &original_tpt);
+}
+
+/// Merge per-worker AD-LDA sampling results back into `model`. Each worker
+/// started from the shared `original_ttc`/`original_tpt` snapshot and only
+/// touched its own documents' tokens, so the exact global count state is
+///     final = Σ_w worker_w − (W−1)·original
+/// (topic-word counts and tokens-per-topic alike), and each worker's updated
+/// document topic assignments are written straight back into their slice. This
+/// is shared verbatim by every AD-LDA-style sweep (plain LDA and the per-document
+/// prior models like DMR), which differ only in how the workers *sample*, not in
+/// how their results reconcile.
+fn reconcile_worker_outs(
+    model: &mut TopicModel,
+    outs: Vec<WorkerOut>,
+    original_ttc: &[Vec<u32>],
+    original_tpt: &[u32],
+) {
+    let k = model.num_topics;
+    let mask = model.topic_mask;
+    let bits = model.topic_bits;
+    let v = model.num_types;
+
+    // --- Reconcile topic-word counts, computed densely per word (in parallel,
+    // reusing a per-thread accumulator to avoid per-word allocation), then
+    // re-encoded into the packed layout. ---
     let wm1 = (outs.len() as i64) - 1;
     let new_ttc: Vec<Vec<u32>> = (0..v)
         .into_par_iter()
@@ -2990,6 +3010,71 @@ fn parallel_sweep_batched(
             model.doc_topics[start + i] = row;
         }
     }
+}
+
+/// One approximate-parallel Gibbs sweep for a **per-document prior** model (DMR
+/// and the other DMR-family count models): identical AD-LDA partition-and-merge
+/// to [`parallel_sweep_batched`], but each worker samples its slice with
+/// [`dmr::run_sweep_dmr`], passing the matching slice of `doc_alpha`, so the only
+/// difference from plain LDA is that α varies by document. `batch` worker sweeps
+/// run against private count tables before the single exact reconciliation;
+/// `batch == 1` is the exact per-sweep path. Deterministic for a fixed
+/// `num_threads`/`batch`/`sweep_seed`: each worker seeds one RNG from `sweep_seed`.
+fn parallel_sweep_dmr_batched(
+    model: &mut TopicModel,
+    docs: &[Vec<u32>],
+    doc_alpha: &[Vec<f64>],
+    num_threads: usize,
+    sweep_seed: u64,
+    batch: usize,
+) {
+    let batch = batch.max(1);
+    let k = model.num_topics;
+    let mask = model.topic_mask;
+    let bits = model.topic_bits;
+    let beta = model.beta;
+    let beta_sum = model.beta_sum;
+    let ranges = partition_ranges(docs.len(), num_threads);
+
+    let original_ttc = model.type_topic_counts.clone();
+    let original_tpt = model.tokens_per_topic.clone();
+    let dt_all = &model.doc_topics;
+
+    let outs: Vec<WorkerOut> = ranges
+        .par_iter()
+        .enumerate()
+        .map(|(wid, &(start, end))| {
+            let mut ttc = original_ttc.clone();
+            let mut tpt = original_tpt.clone();
+            let mut dt: Vec<Vec<u32>> = dt_all[start..end].to_vec();
+            let mut rng = Pcg64Mcg::seed_from_u64(
+                sweep_seed ^ (wid as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
+            );
+            for _ in 0..batch {
+                dmr::run_sweep_dmr(
+                    &mut ttc,
+                    &mut tpt,
+                    &mut dt,
+                    &docs[start..end],
+                    &doc_alpha[start..end],
+                    beta,
+                    beta_sum,
+                    mask,
+                    bits,
+                    k,
+                    &mut rng,
+                );
+            }
+            WorkerOut {
+                ttc,
+                tpt,
+                start,
+                dt,
+            }
+        })
+        .collect();
+
+    reconcile_worker_outs(model, outs, &original_ttc, &original_tpt);
 }
 
 // ---------------------------------------------------------------------------
@@ -3693,6 +3778,10 @@ pub struct DMR {
     warp: bool,
     // CVB0 deterministic collapsed-variational inference (per-document α).
     cvb0: bool,
+    // Default worker count for the sparse Gibbs fit. `1` is the exact serial
+    // path; `>1` runs AD-LDA partition-and-merge (deterministic for a fixed
+    // num_threads+seed). Ignored by the warp/cvb0 backends.
+    num_threads: usize,
 
     fitted: bool,
     topic_names: Vec<String>,
@@ -3745,6 +3834,7 @@ impl DMR {
             "sparse"
         };
         d.set_item("sampler", sampler)?;
+        d.set_item("num_threads", self.num_threads)?;
         Ok(d)
     }
 
@@ -3767,7 +3857,12 @@ impl DMR {
     /// smoothing. λ is re-estimated by L-BFGS every `optimize_interval` sweeps once
     /// past `burn_in`. `seed` seeds the Gibbs RNG. `sampler` selects the inference
     /// backend: ``"sparse"`` (default), ``"warp"`` (WarpLDA), or ``"cvb0"``
-    /// (deterministic collapsed variational Bayes).
+    /// (deterministic collapsed variational Bayes). `num_threads` ``>1`` enables
+    /// MALLET-style approximate-parallel Gibbs on the default sparse backend
+    /// (partition documents, sample against per-worker count copies, merge;
+    /// deterministic for a fixed `num_threads`+`seed`); ``1`` is the exact serial
+    /// path. It is ignored by the warp/cvb0 backends. `fit(num_threads=)` overrides
+    /// it per call.
     ///
     /// Note: pass `alpha=1.0` to recover the pre-0.54 zero-mean-intercept behaviour
     /// (baseline concentration 1.0). Because topica uses intercept/reference coding
@@ -3779,7 +3874,7 @@ impl DMR {
     #[pyo3(signature = (num_topics, *, beta=0.01, optimize_interval=50,
                         burn_in=200, seed=42, alpha=0.1, prior_variance=1.0,
                         alpha_epsilon=1e-10, lbfgs_iters=20,
-                        sampler="sparse"))]
+                        sampler="sparse", num_threads=1))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
@@ -3792,6 +3887,7 @@ impl DMR {
         alpha_epsilon: f64,
         lbfgs_iters: usize,
         sampler: &str,
+        num_threads: usize,
     ) -> PyResult<Self> {
         if num_topics == 0 {
             return Err(PyValueError::new_err("num_topics must be >= 1"));
@@ -3832,6 +3928,7 @@ impl DMR {
             lbfgs_iters,
             warp,
             cvb0,
+            num_threads: num_threads.max(1),
             fitted: false,
             topic_names: Vec::new(),
             phi: None,
@@ -3880,7 +3977,7 @@ impl DMR {
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25,
                         convergence_tol=0.0_f64, check_every=10_usize, covariates=None,
-                        offset=None))]
+                        offset=None, num_threads=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -3899,7 +3996,11 @@ impl DMR {
         check_every: usize,
         covariates: Option<&Bound<'_, PyAny>>,
         offset: Option<&Bound<'_, PyAny>>,
+        num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
+        // num_threads: fit()-level value overrides the constructor default; the
+        // sparse Gibbs sweep runs AD-LDA partition-and-merge when this is >1.
+        let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
         // covariates= is a no-deprecation alias for features=
         let features: &Bound<'_, PyAny> = match (features, covariates) {
             (Some(_), Some(_)) => {
@@ -4029,6 +4130,10 @@ impl DMR {
         let beta = slf.beta;
         let warp = slf.warp;
         let cvb0_flag = slf.cvb0;
+        // Base seed for the approximate-parallel sparse sweep: per-sweep seeds are
+        // derived from it and the sweep index, so a fixed num_threads+seed run is
+        // deterministic and independent of when optimization/sampling phases start.
+        let seed_base = slf.seed;
         let (
             acc_phi,
             acc_theta,
@@ -4257,19 +4362,32 @@ impl DMR {
                 'outer: for iter in 1..=iters {
                     let doc_alpha =
                         dmr::compute_doc_alpha(&lambda, &feats, offset.as_deref(), alpha_epsilon);
-                    dmr::run_sweep_dmr(
-                        &mut model.type_topic_counts,
-                        &mut model.tokens_per_topic,
-                        &mut model.doc_topics,
-                        &corpus.docs,
-                        &doc_alpha,
-                        model.beta,
-                        model.beta_sum,
-                        model.topic_mask,
-                        model.topic_bits,
-                        k,
-                        &mut rng,
-                    );
+                    if num_threads <= 1 {
+                        dmr::run_sweep_dmr(
+                            &mut model.type_topic_counts,
+                            &mut model.tokens_per_topic,
+                            &mut model.doc_topics,
+                            &corpus.docs,
+                            &doc_alpha,
+                            model.beta,
+                            model.beta_sum,
+                            model.topic_mask,
+                            model.topic_bits,
+                            k,
+                            &mut rng,
+                        );
+                    } else {
+                        let s = seed_base
+                            .wrapping_add((iter as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+                        parallel_sweep_dmr_batched(
+                            &mut model,
+                            &corpus.docs,
+                            &doc_alpha,
+                            num_threads,
+                            s,
+                            1,
+                        );
+                    }
 
                     if optimize_interval > 0 && iter > burn_in && iter % optimize_interval == 0 {
                         let dtc = doc_topic_counts(&model.doc_topics, k);
@@ -4358,21 +4476,38 @@ impl DMR {
                 let mut acc_phi = vec![vec![0.0f64; k]; num_types];
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
 
+                // Continue the per-sweep seed sequence past the training sweeps so
+                // the sampling phase stays deterministic and non-overlapping.
+                let mut post_sweep: u64 = iters as u64;
                 for _ in 0..num_samples {
                     for _ in 0..sample_interval {
-                        dmr::run_sweep_dmr(
-                            &mut model.type_topic_counts,
-                            &mut model.tokens_per_topic,
-                            &mut model.doc_topics,
-                            &corpus.docs,
-                            &doc_alpha,
-                            model.beta,
-                            model.beta_sum,
-                            model.topic_mask,
-                            model.topic_bits,
-                            k,
-                            &mut rng,
-                        );
+                        post_sweep += 1;
+                        if num_threads <= 1 {
+                            dmr::run_sweep_dmr(
+                                &mut model.type_topic_counts,
+                                &mut model.tokens_per_topic,
+                                &mut model.doc_topics,
+                                &corpus.docs,
+                                &doc_alpha,
+                                model.beta,
+                                model.beta_sum,
+                                model.topic_mask,
+                                model.topic_bits,
+                                k,
+                                &mut rng,
+                            );
+                        } else {
+                            let s = seed_base
+                                .wrapping_add(post_sweep.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+                            parallel_sweep_dmr_batched(
+                                &mut model,
+                                &corpus.docs,
+                                &doc_alpha,
+                                num_threads,
+                                s,
+                                1,
+                            );
+                        }
                     }
                     accumulate_phi(&model, &mut acc_phi);
                     // DMR θ uses the per-document prior.
@@ -4841,6 +4976,9 @@ impl DMR {
             lbfgs_iters: s.lbfgs_iters,
             warp: false,
             cvb0: false,
+            // num_threads is a runtime resource knob, not fitted state; a loaded
+            // (already-fitted) model defaults to serial.
+            num_threads: 1,
             fitted: s.fitted,
             topic_names,
             phi: arr2_back(s.phi)?,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -3973,6 +3973,10 @@ impl DMR {
     /// A constant offset shifts the baseline Dirichlet concentration (e.g. GDMR
     /// passes `log(alpha)` to center the intercept prior at `log(alpha)`); `None`
     /// (default) leaves the prior unshifted.
+    /// `num_threads` overrides the constructor's worker count for this fit only
+    /// (`None` = constructor value); `>1` runs the sparse Gibbs sweep as
+    /// approximate-parallel AD-LDA (deterministic for a fixed `num_threads`+`seed`),
+    /// `1` is the exact serial path, and it is ignored by the warp/cvb0 backends.
     #[pyo3(signature = (data, features=None, *, feature_names=None, iters=1000,
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25,

--- a/tests/test_dmr_parallel.py
+++ b/tests/test_dmr_parallel.py
@@ -1,0 +1,110 @@
+"""DMR multi-threaded (AD-LDA) training mode — the num_threads knob (#566).
+
+DMR reuses LDA's sparse collapsed-Gibbs machinery, so it inherits the same
+MALLET-style approximate-parallel path: ``num_threads=1`` is the exact serial
+sampler; ``num_threads>1`` partitions documents across workers that sample
+against private count tables and reconciles once per sweep.
+
+Contract under test (identical to LDA's):
+- ``num_threads=1`` reproduces byte-for-byte across runs (exact serial path).
+- a fixed ``num_threads>1`` is deterministic across runs (same threads+seed →
+  identical ``topic_word``/``feature_effects``).
+- ``num_threads=0`` is clamped to 1 and matches the serial result.
+- ``fit(num_threads=)`` overrides the constructor value.
+- parallel training preserves the doc_topic simplex + shapes and recovers the
+  planted covariate-steered structure.
+- GDMR (a pure-Python wrapper over DMR) forwards the knob.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+from topica import DMR
+
+
+def _make_corpus(seed=0, D=400, V=120, tokens=30):
+    """Two document groups with group-biased vocabulary, plus a group covariate
+    so the DMR prior actually depends on the feature."""
+    rng = np.random.default_rng(seed)
+    vocab = [f"w{i}" for i in range(V)]
+    docs, feats = [], []
+    for d in range(D):
+        grp = d % 2
+        # each group draws mostly from its own half of the vocabulary
+        lo, hi = (0, V // 2) if grp == 0 else (V // 2, V)
+        idx = rng.integers(lo, hi, size=tokens)
+        docs.append([vocab[w] for w in idx])
+        feats.append([float(grp)])
+    return docs, np.asarray(feats)
+
+
+def _fit(docs, X, num_threads, seed=123, ctor_threads=None):
+    ctor = ctor_threads if ctor_threads is not None else num_threads
+    m = DMR(6, seed=seed, burn_in=20, num_threads=ctor)
+    kw = {} if ctor_threads is None else {"num_threads": num_threads}
+    m.fit(docs, X, iters=60, num_samples=3, progress=False, **kw)
+    return m
+
+
+def test_serial_is_reproducible():
+    docs, X = _make_corpus()
+    a = _fit(docs, X, 1)
+    b = _fit(docs, X, 1)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.feature_effects, b.feature_effects)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_fixed_thread_count_is_deterministic(nt):
+    docs, X = _make_corpus()
+    a = _fit(docs, X, nt)
+    b = _fit(docs, X, nt)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.feature_effects, b.feature_effects)
+
+
+def test_zero_threads_clamped_to_serial():
+    docs, X = _make_corpus()
+    serial = _fit(docs, X, 1)
+    clamped = _fit(docs, X, 0)
+    assert np.array_equal(serial.topic_word, clamped.topic_word)
+
+
+def test_fit_num_threads_overrides_constructor():
+    docs, X = _make_corpus()
+    # constructor says 1, fit says 4 -> must match a pure-4 run
+    override = _fit(docs, X, 4, ctor_threads=1)
+    pure4 = _fit(docs, X, 4)
+    assert np.array_equal(override.topic_word, pure4.topic_word)
+
+
+def test_parallel_preserves_invariants_and_structure():
+    docs, X = _make_corpus()
+    m = _fit(docs, X, 4)
+    dt = m.doc_topic
+    assert dt.shape == (len(docs), 6)
+    npt = np.testing
+    npt.assert_allclose(dt.sum(axis=1), 1.0, rtol=0, atol=1e-6)
+    assert m.topic_word.shape[0] == 6
+    # covariate steers topic prevalence: the two groups should have different
+    # mean topic distributions (structure recovered, not collapsed).
+    grp = X[:, 0].astype(bool)
+    assert not np.allclose(dt[grp].mean(0), dt[~grp].mean(0), atol=1e-3)
+
+
+def test_settings_report_num_threads():
+    m = DMR(6, num_threads=4)
+    assert m.settings["num_threads"] == 4
+
+
+def test_gdmr_forwards_num_threads():
+    docs, X = _make_corpus()
+    # 1-D continuous metadata for GDMR's Legendre basis.
+    meta = X  # single continuous column in [0,1]
+    a = topica.GDMR(6, degrees=[2], seed=5, burn_in=20, num_threads=4)
+    a.fit(docs, meta, iters=40, num_samples=2)
+    b = topica.GDMR(6, degrees=[2], seed=5, burn_in=20, num_threads=4)
+    b.fit(docs, meta, iters=40, num_samples=2)
+    assert a.settings["num_threads"] == 4
+    assert np.array_equal(a.topic_word, b.topic_word)


### PR DESCRIPTION
First slice of the multithreading roster (#569): extends LDA's MALLET-style approximate-parallel Gibbs (AD-LDA partition-and-merge) to **DMR** and, for free, **GDMR** (a pure-Python DMR wrapper). These were the highest-priority targets in #566 — both are benchmarked, and DMR reuses LDA's exact `sample_doc`/count-table machinery, so the threading is a direct reuse of a proven, determinism-safe path.

## What changed

- **Shared reconciliation.** Extracted the exact merge from LDA's `parallel_sweep_batched` into `reconcile_worker_outs` (`final = Σ_workers − (W−1)·original` for the topic-word + tokens-per-topic counts, plus the doc-topic writeback). The DMR-family and plain-LDA sweeps now differ *only* in how workers sample, not in how results reconcile — this is the shared helper the remaining #566 count models (LabeledLDA/PA/SeededLDA/GSDMM/BTM) will reuse.
- **`parallel_sweep_dmr_batched`.** Workers sample their document slice with `dmr::run_sweep_dmr` against private count tables, passing the matching `doc_alpha` slice (the only DMR difference: α varies by document), then reconcile once per sweep.
- **`num_threads` on DMR** — constructor + per-call `fit(num_threads=)` override + `settings`. Both the training loop and the posterior-sampling loop take the parallel path when `>1`, with per-sweep seeds derived from `seed_base` (non-overlapping across phases) so a fixed `num_threads`+`seed` is deterministic. `num_threads=1` is the exact serial path, byte-identical to before. Ignored by the warp/cvb0 backends.
- **GDMR** forwards `num_threads` through construct/fit and save/load; `.pyi` stub updated.

## Determinism contract (identical to LDA)

- `num_threads=1` reproduces **byte-for-byte** (serial path unchanged; new code is guarded behind `>1`).
- a fixed `num_threads>1` is **deterministic** across runs (same threads+seed → identical `topic_word`/`feature_effects`).
- `num_threads` across *different* thread counts intentionally differs — that is the AD-LDA approximation, same as LDA.

## Performance

Measured on 6k docs, V=500, K=20, 150 iters:

| threads | 1 | 2 | 4 | 8 |
|---|--|--|--|--|
| time | 5.36s | 3.29s | 2.20s | 1.47s |

~3.65x at 8 threads, in line with LDA's ~3.5x.

## Tests

- New `tests/test_dmr_parallel.py`: serial reproducibility, fixed-thread determinism at 2/4/8, zero-thread clamp, `fit()` override, doc_topic simplex + shape invariants, covariate-structure recovery, GDMR passthrough.
- 248 Rust + 281 DMR/GDMR Python + 175 LDA-threading regression tests pass; `./scripts/preflight.sh` green (fmt, clippy, stub sync, model tables).

Part of #569. Follow-ups: the same shared helper extends to the other count models in #566, then #567 (SupervisedLDA), #568 (NMF/LSA), #378 (VAE).

🤖 Generated with [Claude Code](https://claude.com/claude-code)