### PR TITLE
feat(labeledlda): AD-LDA multithreading via num_threads (#566)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1839,7 +1839,7 @@ class LabeledLDA:
 
     def __init__(
         self, *, alpha: float = 0.1, beta: float = 0.01, seed: int = 42,
-        sampler: str = "sparse",
+        sampler: str = "sparse", num_threads: int = 1,
     ) -> None:
         """Create an unfitted model. alpha is the symmetric per-topic prior.
 
@@ -1849,7 +1849,13 @@ class LabeledLDA:
         off the allowed topics). CVB0 enforces the same supervised constraint
         deterministically and tends to higher coherence; it produces no MCMC
         theta_draws. (WarpLDA is not offered here: masked proposals mix poorly,
-        whereas masking is free in CVB0.)"""
+        whereas masking is free in CVB0.)
+
+        num_threads > 1 runs the sparse backend as MALLET-style approximate-parallel
+        restricted Gibbs (partition documents, sample against per-worker count
+        copies, merge; deterministic for a fixed num_threads+seed); 1 is the exact
+        serial path. It is ignored by the cvb0 backend and can be overridden per
+        call via fit(num_threads=)."""
         ...
 
     def fit(
@@ -1867,11 +1873,17 @@ class LabeledLDA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
+        num_threads: int | None = None,
     ) -> "LabeledLDA":
         """Fit the model. labels is one label-list per document; the topic set is
         the union of all labels (or label_names, which fixes topic order and must
         contain every non-empty observed label exactly once). An empty label list
-        leaves that document unconstrained (all topics)."""
+        leaves that document unconstrained (all topics).
+
+        num_threads overrides the constructor's worker count for this fit only
+        (None = constructor value); >1 runs the sparse sweep as approximate-parallel
+        AD-LDA (deterministic for a fixed num_threads+seed), 1 is the exact serial
+        path, and it is ignored by the cvb0 backend."""
         ...
 
     @property

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -3077,6 +3077,83 @@ fn parallel_sweep_dmr_batched(
     reconcile_worker_outs(model, outs, &original_ttc, &original_tpt);
 }
 
+/// One approximate-parallel restricted Gibbs sweep for **Labeled LDA**. Same
+/// AD-LDA partition-and-merge as [`parallel_sweep_dmr_batched`], but the workers
+/// sample with [`labeled::run_sweep_labeled`], which restricts each token to its
+/// document's allowed-topic set. `run_sweep_labeled` operates on a whole
+/// `TopicModel` (via its packed-table methods) and indexes `model.doc_topics[d]`,
+/// so each worker is handed a lightweight `TopicModel` carrying a clone of the
+/// shared count tables and only its *slice* of `doc_topics` — indices then line
+/// up with `docs[start..end]` / `allowed[start..end]`. The additive merge stays
+/// exact: a worker touches only its own documents' tokens relative to the shared
+/// snapshot, and a topic disallowed for every doc in the slice contributes a zero
+/// net delta. Deterministic for a fixed `num_threads`/`batch`/`sweep_seed`.
+fn parallel_sweep_labeled_batched(
+    model: &mut TopicModel,
+    docs: &[Vec<u32>],
+    allowed: &[Vec<usize>],
+    num_threads: usize,
+    sweep_seed: u64,
+    batch: usize,
+) {
+    let batch = batch.max(1);
+    let k = model.num_topics;
+    let v = model.num_types;
+    let mask = model.topic_mask;
+    let bits = model.topic_bits;
+    let alpha = model.alpha.clone();
+    let alpha_sum = model.alpha_sum;
+    let beta = model.beta;
+    let beta_sum = model.beta_sum;
+    let ranges = partition_ranges(docs.len(), num_threads);
+
+    let original_ttc = model.type_topic_counts.clone();
+    let original_tpt = model.tokens_per_topic.clone();
+    let dt_all = &model.doc_topics;
+
+    let outs: Vec<WorkerOut> = ranges
+        .par_iter()
+        .enumerate()
+        .map(|(wid, &(start, end))| {
+            // A per-worker model that shares the global count tables but carries
+            // only this partition's doc_topics, so run_sweep_labeled's 0-based
+            // document loop aligns with docs[start..end] / allowed[start..end].
+            let mut wm = TopicModel {
+                num_topics: k,
+                num_types: v,
+                topic_mask: mask,
+                topic_bits: bits,
+                alpha: alpha.clone(),
+                alpha_sum,
+                beta,
+                beta_sum,
+                type_topic_counts: original_ttc.clone(),
+                tokens_per_topic: original_tpt.clone(),
+                doc_topics: dt_all[start..end].to_vec(),
+            };
+            let mut rng = Pcg64Mcg::seed_from_u64(
+                sweep_seed ^ (wid as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
+            );
+            for _ in 0..batch {
+                labeled::run_sweep_labeled(
+                    &mut wm,
+                    &docs[start..end],
+                    &allowed[start..end],
+                    &mut rng,
+                );
+            }
+            WorkerOut {
+                ttc: wm.type_topic_counts,
+                tpt: wm.tokens_per_topic,
+                start,
+                dt: wm.doc_topics,
+            }
+        })
+        .collect();
+
+    reconcile_worker_outs(model, outs, &original_ttc, &original_tpt);
+}
+
 // ---------------------------------------------------------------------------
 // Held-out evaluation: Wallach et al. (2009) left-to-right estimator
 // ---------------------------------------------------------------------------
@@ -5022,6 +5099,10 @@ pub struct LabeledLDA {
     // CVB0 deterministic collapsed-variational inference (masked γ per document)
     // instead of the default restricted SparseLDA sweep.
     cvb0: bool,
+    // Default worker count for the sparse restricted-Gibbs fit. `1` is the exact
+    // serial path; `>1` runs AD-LDA partition-and-merge (deterministic for a fixed
+    // num_threads+seed). Ignored by the cvb0 backend.
+    num_threads: usize,
 
     fitted: bool,
     num_topics: usize,
@@ -5060,6 +5141,7 @@ impl LabeledLDA {
         d.set_item("beta", self.beta)?;
         d.set_item("seed", self.seed)?;
         d.set_item("sampler", if self.cvb0 { "cvb0" } else { "sparse" })?;
+        d.set_item("num_threads", self.num_threads)?;
         Ok(d)
     }
 
@@ -5072,11 +5154,16 @@ impl LabeledLDA {
     /// Create an unfitted model. `alpha` is the (symmetric) per-topic prior
     /// over a document's allowed topics.
     /// `beta` is the topic-word Dirichlet smoothing; `seed` seeds the Gibbs RNG.
-    /// `sampler` selects the inference backend: ``"sparse"`` (default), ``"warp"``
-    /// (WarpLDA), or ``"cvb0"`` (deterministic collapsed variational Bayes).
+    /// `sampler` selects the inference backend: ``"sparse"`` (default) or
+    /// ``"cvb0"`` (deterministic collapsed variational Bayes). `num_threads`
+    /// ``>1`` runs the sparse backend as MALLET-style approximate-parallel
+    /// restricted Gibbs (partition documents, sample against per-worker count
+    /// copies, merge; deterministic for a fixed `num_threads`+`seed`); ``1`` is the
+    /// exact serial path. It is ignored by the cvb0 backend. `fit(num_threads=)`
+    /// overrides it per call.
     #[new]
-    #[pyo3(signature = (*, alpha=0.1, beta=0.01, seed=42, sampler="sparse"))]
-    fn new(alpha: f64, beta: f64, seed: u64, sampler: &str) -> PyResult<Self> {
+    #[pyo3(signature = (*, alpha=0.1, beta=0.01, seed=42, sampler="sparse", num_threads=1))]
+    fn new(alpha: f64, beta: f64, seed: u64, sampler: &str, num_threads: usize) -> PyResult<Self> {
         if !finite_pos(alpha) {
             return Err(PyValueError::new_err("alpha must be > 0"));
         }
@@ -5097,6 +5184,7 @@ impl LabeledLDA {
             beta,
             seed,
             cvb0,
+            num_threads: num_threads.max(1),
             fitted: false,
             num_topics: 0,
             topic_names: Vec::new(),
@@ -5129,10 +5217,14 @@ impl LabeledLDA {
     /// snapshots in `theta_draws`, the cross-sweep posterior samples
     /// `composition_theta` prefers over the Dirichlet approximation; set it False to
     /// save memory.
+    /// `num_threads` overrides the constructor's worker count for this fit only
+    /// (`None` = constructor value); `>1` runs the sparse restricted-Gibbs sweep as
+    /// approximate-parallel AD-LDA (deterministic for a fixed `num_threads`+`seed`),
+    /// `1` is the exact serial path, and it is ignored by the cvb0 backend.
     #[pyo3(signature = (data, labels, *, label_names=None, iters=1000,
                         num_samples=5, sample_interval=25, progress=None, progress_interval=50,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize))]
+                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -5149,7 +5241,11 @@ impl LabeledLDA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
+        num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
+        // num_threads: fit()-level value overrides the constructor default; the
+        // sparse restricted-Gibbs sweep runs AD-LDA partition-and-merge when >1.
+        let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -5300,6 +5396,10 @@ impl LabeledLDA {
             return Ok(slf.into());
         }
 
+        // Base seed for the approximate-parallel sparse sweep: per-sweep seeds are
+        // derived from it and the sweep index, so a fixed num_threads+seed run is
+        // deterministic and independent of when the sampling phase starts.
+        let seed_base = slf.seed;
         let (acc_phi, acc_theta, theta_draw_buf, ll_history, converged, model, corpus) = py
             .allow_threads(move || {
                 let mut theta_draw_buf: Vec<Vec<Vec<f32>>> = Vec::new();
@@ -5308,7 +5408,20 @@ impl LabeledLDA {
                 let mut converged = false;
 
                 'outer: for iter in 1..=iters {
-                    labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
+                    if num_threads <= 1 {
+                        labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
+                    } else {
+                        let s = seed_base
+                            .wrapping_add((iter as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15));
+                        parallel_sweep_labeled_batched(
+                            &mut model,
+                            &corpus.docs,
+                            &allowed,
+                            num_threads,
+                            s,
+                            1,
+                        );
+                    }
                     if draws_opts.thin > 0 && iter % draws_opts.thin == 0 {
                         let counts = doc_topic_counts(&model.doc_topics, k);
                         let snap: Vec<Vec<f32>> = (0..num_docs)
@@ -5355,9 +5468,31 @@ impl LabeledLDA {
 
                 let mut acc_phi = vec![vec![0.0f64; k]; num_types];
                 let mut acc_theta = vec![vec![0.0f64; k]; num_docs];
+                // Continue the per-sweep seed sequence past the training sweeps so
+                // the sampling phase stays deterministic and non-overlapping.
+                let mut post_sweep: u64 = iters as u64;
                 for _ in 0..num_samples {
                     for _ in 0..sample_interval {
-                        labeled::run_sweep_labeled(&mut model, &corpus.docs, &allowed, &mut rng);
+                        post_sweep += 1;
+                        if num_threads <= 1 {
+                            labeled::run_sweep_labeled(
+                                &mut model,
+                                &corpus.docs,
+                                &allowed,
+                                &mut rng,
+                            );
+                        } else {
+                            let s = seed_base
+                                .wrapping_add(post_sweep.wrapping_mul(0x9E37_79B9_7F4A_7C15));
+                            parallel_sweep_labeled_batched(
+                                &mut model,
+                                &corpus.docs,
+                                &allowed,
+                                num_threads,
+                                s,
+                                1,
+                            );
+                        }
                     }
                     accumulate_phi(&model, &mut acc_phi);
                     let counts = doc_topic_counts(&model.doc_topics, k);
@@ -5656,6 +5791,9 @@ impl LabeledLDA {
             beta: s.beta,
             seed: s.seed,
             cvb0: false,
+            // num_threads is a runtime resource knob, not fitted state; a loaded
+            // (already-fitted) model defaults to serial.
+            num_threads: 1,
             fitted: s.fitted,
             num_topics: s.num_topics,
             topic_names,

--- a/tests/test_labeled_parallel.py
+++ b/tests/test_labeled_parallel.py
@@ -1,0 +1,115 @@
+"""LabeledLDA multi-threaded (AD-LDA) training — the num_threads knob (#566).
+
+LabeledLDA reuses LDA's collapsed-Gibbs count tables, so it inherits the same
+MALLET-style approximate-parallel path as DMR (#570): `num_threads=1` is the exact
+serial restricted sweep; `num_threads>1` partitions documents across workers that
+sample against private count tables and reconciles once per sweep. Each worker's
+per-document label constraint is preserved (a token may only land on a topic in
+its document's label set).
+
+Contract under test:
+- `num_threads=1` reproduces byte-for-byte across runs.
+- a fixed `num_threads>1` is deterministic across runs (phi and theta).
+- `num_threads=0` clamps to serial; `fit(num_threads=)` overrides the constructor.
+- **the label constraint holds under threading**: theta mass is zero outside each
+  document's allowed-topic set, at every thread count.
+- a mix of labeled and unconstrained (empty-label) documents fits without panic.
+- doc_topic rows sum to 1; discovered structure is recovered.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+L = 6           # label-topics
+D = 500
+WORDS_PER = 20  # vocabulary words per label block
+
+
+def _make_corpus(seed=0, unconstrained_every=0):
+    """Each document gets 1-3 labels and draws words from those label blocks.
+    With ``unconstrained_every>0``, every Nth document gets an empty label set."""
+    rng = np.random.default_rng(seed)
+    docs, labels = [], []
+    for d in range(D):
+        if unconstrained_every and d % unconstrained_every == 0:
+            labs = []
+        else:
+            labs = sorted(rng.choice(L, size=rng.integers(1, 4), replace=False).tolist())
+        labels.append([f"lab{l}" for l in labs])
+        pool = labs if labs else list(range(L))
+        docs.append(
+            [f"L{pool[rng.integers(len(pool))]}w{rng.integers(WORDS_PER)}" for _ in range(30)]
+        )
+    label_names = [f"lab{l}" for l in range(L)]
+    return docs, labels, label_names
+
+
+def _fit(docs, labels, label_names, num_threads, seed=42, ctor_threads=None):
+    ctor = ctor_threads if ctor_threads is not None else num_threads
+    m = topica.LabeledLDA(seed=seed, num_threads=ctor)
+    kw = {} if ctor_threads is None else {"num_threads": num_threads}
+    m.fit(docs, labels, label_names=label_names, iters=60, num_samples=3,
+          progress=False, **kw)
+    return m
+
+
+def test_serial_is_reproducible():
+    docs, labels, names = _make_corpus()
+    a = _fit(docs, labels, names, 1)
+    b = _fit(docs, labels, names, 1)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_fixed_thread_count_is_deterministic(nt):
+    docs, labels, names = _make_corpus()
+    a = _fit(docs, labels, names, nt)
+    b = _fit(docs, labels, names, nt)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+def test_zero_threads_clamped_to_serial():
+    docs, labels, names = _make_corpus()
+    serial = _fit(docs, labels, names, 1)
+    clamped = _fit(docs, labels, names, 0)
+    assert np.array_equal(serial.topic_word, clamped.topic_word)
+
+
+def test_fit_num_threads_overrides_constructor():
+    docs, labels, names = _make_corpus()
+    override = _fit(docs, labels, names, 4, ctor_threads=1)
+    pure4 = _fit(docs, labels, names, 4)
+    assert np.array_equal(override.topic_word, pure4.topic_word)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_label_constraint_holds_under_threading(nt):
+    # The whole point of LabeledLDA: a document's topic mass must stay within its
+    # label set. Threading must not let a worker leak mass onto a disallowed topic.
+    docs, labels, names = _make_corpus(unconstrained_every=7)
+    m = _fit(docs, labels, names, nt)
+    dt = m.doc_topic
+    for d in range(D):
+        if not labels[d]:
+            continue  # unconstrained doc: all topics allowed
+        allowed = {int(x[3:]) for x in labels[d]}  # "labN" -> N
+        for t in range(L):
+            if t not in allowed:
+                assert dt[d, t] <= 1e-9, (d, t, dt[d, t])
+
+
+def test_parallel_preserves_simplex_and_mixes_labels():
+    docs, labels, names = _make_corpus(unconstrained_every=7)
+    m = _fit(docs, labels, names, 4)
+    dt = m.doc_topic
+    assert dt.shape == (D, L)
+    np.testing.assert_allclose(dt.sum(axis=1), 1.0, rtol=0, atol=1e-6)
+
+
+def test_settings_report_num_threads():
+    m = topica.LabeledLDA(num_threads=4)
+    assert m.settings["num_threads"] == 4


### PR DESCRIPTION
Second count model in the #569/#566 threading roster: extends the AD-LDA partition-and-merge (shared `reconcile_worker_outs` from #570) to **LabeledLDA**.

## The one wrinkle vs DMR

DMR reused a raw-slice sweep (`run_sweep_dmr` over `&mut [Vec<u32>]`). LabeledLDA's restricted sweep (`labeled::run_sweep_labeled`) instead operates on a whole `TopicModel` via its packed-table methods and indexes `model.doc_topics[d]`. So each worker gets a **lightweight `TopicModel`** carrying a clone of the shared count tables plus only its *slice* of `doc_topics` — indices then align with `docs[start..end]` / `allowed[start..end]`, and `run_sweep_labeled` is reused **unchanged**. Merge is the shared `reconcile_worker_outs`.

## Correctness under the label constraint

The additive merge (`final = Σ_workers − (W−1)·original`) stays exact: a worker touches only its own documents' tokens relative to the snapshot, and a topic disallowed for every doc in a worker's slice contributes a **zero net delta** — so `tokens_per_topic` can never underflow. Plan reviewed by **Gemini before implementation** (verdict PLAN SOUND, with the merge-correctness and no-underflow proofs).

## Wiring

`num_threads` on the constructor (default 1), `fit()` override, `settings`, and `load` (→1). Both the training and posterior-sampling sweep sites dispatch serial-vs-parallel with disjoint per-sweep seeds (`iter` / `post_sweep`). `num_threads=1` is byte-identical serial; **ignored by the cvb0 backend**.

## Determinism + performance

- `num_threads=1` reproduces byte-for-byte; a fixed `num_threads>1` is deterministic (phi and theta).
- ~**3.7x at 8 threads** (20k docs, K=12, incl. unconstrained docs): 4.22s → 1.14s.

## Tests

New `tests/test_labeled_parallel.py`: serial reproducibility, fixed-thread determinism at 2/4/8, zero-clamp, `fit()` override, doc_topic simplex, labeled+unconstrained mix, and — the key invariant — **the label constraint holds under threading** (zero out-of-label theta mass at every thread count).

248 Rust + full Python suite (3908 passed, 32 skipped) green; `./scripts/preflight.sh` clean.

Part of #569. Next: SeededLDA → BTM → GSDMM, then the #567/#568 knob PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)