### PR TITLE
feat(seededlda): AD-LDA multithreading via num_threads (#566)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3145,6 +3145,7 @@ class SeededLDA:
         sampler: str = "sparse",
         seed_match: str = "fixed",
         case_insensitive: bool = False,
+        num_threads: int = 1,
     ) -> None:
         """seed_match selects how each seed pattern is matched to the vocabulary:
         "fixed" (default) exact literal equality; "glob" reads `*`/`?` wildcards
@@ -3170,7 +3171,13 @@ class SeededLDA:
         SeededLDA's sparse sweep scores all K topics per token, so "warp" is
         dramatically faster at large K (e.g. ~40x at K=500 on a 2,000-document
         corpus) at comparable coherence. The "warp" and "cvb0" paths do not yet
-        support doc_topic_prior."""
+        support doc_topic_prior.
+
+        num_threads > 1 runs the default sparse backend as MALLET-style
+        approximate-parallel (AD-LDA) seeded Gibbs (partition documents, sample
+        against per-worker count copies, merge; deterministic for a fixed
+        num_threads+seed); 1 is the exact serial path. It is ignored by the
+        warp/cvb0 backends and can be overridden per call via fit(num_threads=)."""
         ...
     def fit(
         self,
@@ -3182,12 +3189,18 @@ class SeededLDA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
+        num_threads: int | None = None,
     ) -> "SeededLDA":
         """Fit the seeded model. `convergence_tol` (default 0.0, disabled) enables
         opt-in log-likelihood early stopping on the default ("sparse") sampler,
         recording the `fit_history` trace every `check_every` sweeps; the "cvb0"
         and "warp" backends ignore both (no per-iteration trace, `converged`
-        stays False)."""
+        stays False).
+
+        num_threads overrides the constructor's worker count for this fit only
+        (None = constructor value); >1 runs the sparse sweep as approximate-parallel
+        AD-LDA (deterministic for a fixed num_threads+seed), 1 is the exact serial
+        path, and it is ignored by the warp/cvb0 backends."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -12982,6 +12982,10 @@ pub struct SeededLDA {
     warp: bool,
     // CVB0 deterministic collapsed-variational inference (seeded β).
     cvb0: bool,
+    // Default worker count for the default sparse seeded-Gibbs fit. `1` is the
+    // exact serial path; `>1` runs AD-LDA partition-and-merge (deterministic for a
+    // fixed num_threads+seed). Ignored by the warp/cvb0 backends.
+    num_threads: usize,
     fitted: bool,
     topic_names: Vec<String>,
     phi: Option<Array2<f64>>,
@@ -13033,6 +13037,7 @@ impl SeededLDA {
             "sparse"
         };
         d.set_item("sampler", sampler)?;
+        d.set_item("num_threads", self.num_threads)?;
         Ok(d)
     }
 
@@ -13057,6 +13062,11 @@ impl SeededLDA {
     ///
     /// `sampler` selects the inference backend: ``"sparse"`` (default), ``"warp"``
     /// (WarpLDA), or ``"cvb0"`` (deterministic collapsed variational Bayes).
+    /// `num_threads` ``>1`` runs the default sparse backend as MALLET-style
+    /// approximate-parallel (AD-LDA) seeded Gibbs (partition documents, sample
+    /// against per-worker count copies, merge; deterministic for a fixed
+    /// `num_threads`+`seed`); ``1`` is the exact serial path. It is ignored by the
+    /// warp/cvb0 backends. `fit(num_threads=)` overrides it per call.
     ///
     /// `seed_match` chooses how each seed pattern is matched to the vocabulary:
     /// ``"fixed"`` (default) is exact literal equality; ``"glob"`` reads `*`/`?`
@@ -13072,7 +13082,7 @@ impl SeededLDA {
     #[new]
     #[pyo3(signature = (seed_words, *, residual=0, alpha=0.5, beta=0.1, weight=0.01, seed=42,
                         seed_prior="frequency", sampler="sparse", seed_match="fixed",
-                        case_insensitive=false))]
+                        case_insensitive=false, num_threads=1))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         seed_words: &Bound<'_, PyDict>,
@@ -13085,6 +13095,7 @@ impl SeededLDA {
         sampler: &str,
         seed_match: &str,
         case_insensitive: bool,
+        num_threads: usize,
     ) -> PyResult<Self> {
         let (names, words) = parse_seed_dict(seed_words)?;
         if !finite_pos(alpha) || !finite_pos(beta) {
@@ -13134,6 +13145,7 @@ impl SeededLDA {
             seed,
             warp,
             cvb0,
+            num_threads: num_threads.max(1),
             fitted: false,
             topic_names: Vec::new(),
             phi: None,
@@ -13163,9 +13175,13 @@ impl SeededLDA {
     /// snapshots in `theta_draws`, the cross-sweep posterior samples
     /// `composition_theta` prefers over the Dirichlet approximation; set it False to
     /// save memory.
+    /// `num_threads` overrides the constructor's worker count for this fit only
+    /// (`None` = constructor value); `>1` runs the sparse seeded-Gibbs sweep as
+    /// approximate-parallel AD-LDA (deterministic for a fixed `num_threads`+`seed`),
+    /// `1` is the exact serial path, and it is ignored by the warp/cvb0 backends.
     #[pyo3(signature = (data, *, iters=2000, doc_topic_prior=None,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize))]
+                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -13176,7 +13192,11 @@ impl SeededLDA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
+        num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
+        // num_threads: fit()-level value overrides the constructor default; the
+        // sparse seeded-Gibbs sweep runs AD-LDA partition-and-merge when >1.
+        let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -13384,6 +13404,7 @@ impl SeededLDA {
                 draws_opts,
                 convergence_tol,
                 check_every,
+                num_threads,
                 &mut rng,
             );
             (m, ll, conv, corpus)
@@ -13612,6 +13633,9 @@ impl SeededLDA {
             seed: s.seed,
             warp: s.warp,
             cvb0: s.cvb0,
+            // num_threads is a runtime resource knob, not fitted state; a loaded
+            // (already-fitted) model defaults to serial.
+            num_threads: 1,
             fitted: s.fitted,
             topic_names: s.topic_names,
             phi: arr2_back(s.phi)?,

--- a/src/seeded.rs
+++ b/src/seeded.rs
@@ -35,6 +35,10 @@
 
 use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 use rand::Rng;
+use rand::SeedableRng;
+use rand_pcg::Pcg64Mcg;
+use rayon::prelude::*;
+use std::collections::HashMap;
 
 // ---------------------------------------------------------------------------
 // Model struct
@@ -316,6 +320,176 @@ fn seeded_theta_snapshot(
         .collect()
 }
 
+/// One restricted collapsed-Gibbs sweep over a contiguous block of documents.
+///
+/// `ndk`, `z`, `docs`, and `doc_alpha` (when present) are all indexed by the same
+/// local document index `0..docs.len()`, so a caller can pass the whole corpus
+/// (serial) or a `[start..end]` partition (one AD-LDA worker). `nkw`/`nk` are the
+/// (possibly per-worker private) count tables; `scores` is a reused length-K
+/// scratch buffer. The per-token math is identical to the original inline loop.
+#[allow(clippy::too_many_arguments)]
+fn run_sweep_seeded_range<R: Rng>(
+    nkw: &mut [Vec<u32>],
+    nk: &mut [u32],
+    ndk: &mut [Vec<u32>],
+    z: &mut [Vec<usize>],
+    docs: &[Vec<u32>],
+    doc_alpha: Option<&[Vec<f64>]>,
+    mass_map: &[HashMap<usize, f64>],
+    beta_sum_k: &[f64],
+    beta: f64,
+    alpha: f64,
+    k: usize,
+    scores: &mut [f64],
+    rng: &mut R,
+) {
+    for d in 0..docs.len() {
+        let doc = &docs[d];
+        // The document's α row: per-document when supplied, else symmetric.
+        let a_row: Option<&Vec<f64>> = doc_alpha.map(|da| &da[d]);
+        for i in 0..doc.len() {
+            let w = doc[i] as usize;
+            let old = z[d][i];
+
+            // Remove token from counts.
+            nkw[old][w] -= 1;
+            nk[old] -= 1;
+            ndk[d][old] -= 1;
+
+            // Compute unnormalised sampling probabilities.
+            for t in 0..k {
+                let beta_tw = beta + mass_map[t].get(&w).copied().unwrap_or(0.0);
+                let a_t = a_row.map_or(alpha, |r| r[t]);
+                scores[t] = (a_t + ndk[d][t] as f64) * (beta_tw + nkw[t][w] as f64)
+                    / (beta_sum_k[t] + nk[t] as f64);
+            }
+
+            // Sample new topic and update counts.
+            let new_t = sample_index(scores, rng);
+            nkw[new_t][w] += 1;
+            nk[new_t] += 1;
+            ndk[d][new_t] += 1;
+            z[d][i] = new_t;
+        }
+    }
+}
+
+/// Contiguous, non-overlapping document ranges — one per worker (clamped so the
+/// worker count never exceeds the document count). Mirrors the binding's
+/// `partition_ranges`, kept local so the core stays self-contained.
+fn partition_ranges(n: usize, parts: usize) -> Vec<(usize, usize)> {
+    let parts = parts.max(1).min(n.max(1));
+    let base = n / parts;
+    let rem = n % parts;
+    let mut ranges = Vec::with_capacity(parts);
+    let mut start = 0;
+    for i in 0..parts {
+        let len = base + if i < rem { 1 } else { 0 };
+        ranges.push((start, start + len));
+        start += len;
+    }
+    ranges
+}
+
+/// One approximate-parallel (AD-LDA) sweep over the dense SeededLDA count tables.
+/// Documents are partitioned across workers; each worker samples its slice against
+/// a private clone of the global `nkw`/`nk`, owning copies of its `z`/`ndk` slice,
+/// then the results are reconciled: `nkw` is the exact additive merge
+/// `Σ_workers − (W−1)·original` (accumulated in `i64`, clamped ≥ 0), `nk` is
+/// **recomputed** from the merged `nkw` rows so `nk[k] == Σ_w nkw[k][w]` holds
+/// exactly (no zero-clamp drift), and each worker's `z`/`ndk` slice is written
+/// straight back (documents are disjoint). The seeded asymmetric prior `β_{k,w}`
+/// is a fixed pseudocount that never enters `nkw`, so the merge is unaffected by
+/// it. Deterministic for a fixed `sweep_seed`/`num_threads`.
+#[allow(clippy::too_many_arguments)]
+fn parallel_sweep_seeded(
+    nkw: &mut [Vec<u32>],
+    nk: &mut [u32],
+    ndk: &mut [Vec<u32>],
+    z: &mut [Vec<usize>],
+    docs: &[Vec<u32>],
+    doc_alpha: Option<&[Vec<f64>]>,
+    mass_map: &[HashMap<usize, f64>],
+    beta_sum_k: &[f64],
+    beta: f64,
+    alpha: f64,
+    k: usize,
+    num_threads: usize,
+    sweep_seed: u64,
+) {
+    struct SeededWorkerOut {
+        nkw: Vec<Vec<u32>>,
+        z: Vec<Vec<usize>>,
+        ndk: Vec<Vec<u32>>,
+        start: usize,
+    }
+
+    let v = nkw.first().map_or(0, |row| row.len());
+    let ranges = partition_ranges(docs.len(), num_threads);
+    let orig_nkw = nkw.to_vec();
+    let orig_nk = nk.to_vec();
+    // Read-only views so workers can copy their slices inside the parallel map.
+    let z_ro: &[Vec<usize>] = z;
+    let ndk_ro: &[Vec<u32>] = ndk;
+
+    let outs: Vec<SeededWorkerOut> = ranges
+        .par_iter()
+        .enumerate()
+        .map(|(wid, &(start, end))| {
+            let mut wnkw = orig_nkw.clone();
+            let mut wnk = orig_nk.clone();
+            let mut wz: Vec<Vec<usize>> = z_ro[start..end].to_vec();
+            let mut wndk: Vec<Vec<u32>> = ndk_ro[start..end].to_vec();
+            let da_slice = doc_alpha.map(|da| &da[start..end]);
+            let mut rng = Pcg64Mcg::seed_from_u64(
+                sweep_seed ^ (wid as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
+            );
+            let mut scores = vec![0.0f64; k];
+            run_sweep_seeded_range(
+                &mut wnkw,
+                &mut wnk,
+                &mut wndk,
+                &mut wz,
+                &docs[start..end],
+                da_slice,
+                mass_map,
+                beta_sum_k,
+                beta,
+                alpha,
+                k,
+                &mut scores,
+                &mut rng,
+            );
+            SeededWorkerOut {
+                nkw: wnkw,
+                z: wz,
+                ndk: wndk,
+                start,
+            }
+        })
+        .collect();
+
+    // --- Reconcile nkw: final = Σ_workers − (W−1)·original, clamped ≥ 0. ---
+    let wm1 = (outs.len() as i64) - 1;
+    for t in 0..k {
+        for w in 0..v {
+            let sum_w: i64 = outs.iter().map(|o| o.nkw[t][w] as i64).sum();
+            let val = sum_w - wm1 * orig_nkw[t][w] as i64;
+            nkw[t][w] = val.max(0) as u32;
+        }
+        // Recompute nk from the merged nkw row so the two stay exactly consistent.
+        nk[t] = nkw[t].iter().map(|&c| c as u64).sum::<u64>() as u32;
+    }
+
+    // --- Write back each worker's per-document z / ndk slice (disjoint docs). ---
+    for out in outs {
+        for (i, (zrow, ndkrow)) in out.z.into_iter().zip(out.ndk).enumerate() {
+            z[out.start + i] = zrow;
+            ndk[out.start + i] = ndkrow;
+        }
+    }
+}
+
 /// Fit a Seeded-LDA model by collapsed Gibbs sampling.
 ///
 /// # Arguments
@@ -338,6 +512,9 @@ fn seeded_theta_snapshot(
 /// * `draws`            — thinned θ-draw retention schedule (issue #31).
 /// * `convergence_tol`  — relative-change tolerance for early stopping (0 = off).
 /// * `check_every`      — LL-trace cadence in sweeps (0 = no trace).
+/// * `num_threads`      — `1` runs the exact serial sweep; `>1` runs MALLET-style
+///                        approximate-parallel (AD-LDA) sampling, deterministic
+///                        for a fixed `num_threads` + seed.
 /// * `rng`              — random-number source; deterministic for a fixed seed.
 ///
 /// Returns `(model, ll_history, converged)` where `ll_history` is a vector of
@@ -357,6 +534,7 @@ pub fn fit_seeded_lda<R: Rng>(
     draws: crate::keyatm::ThetaDrawOpts,
     convergence_tol: f64,
     check_every: usize,
+    num_threads: usize,
     rng: &mut R,
 ) -> (SeededModel, Vec<(usize, f64)>, bool) {
     let k = num_topics;
@@ -491,34 +669,42 @@ pub fn fit_seeded_lda<R: Rng>(
 
     for it in 0..iters {
         let iter = it + 1;
-        for d in 0..d_count {
-            let doc = &docs[d];
-            // The document's α row: per-document when supplied, else symmetric.
-            let a_row: Option<&Vec<f64>> = doc_alpha.as_ref().map(|da| &da[d]);
-            for i in 0..doc.len() {
-                let w = doc[i] as usize;
-                let old = z[d][i];
-
-                // Remove token from counts.
-                nkw[old][w] -= 1;
-                nk[old] -= 1;
-                ndk[d][old] -= 1;
-
-                // Compute unnormalised sampling probabilities.
-                for t in 0..k {
-                    let beta_tw = beta + mass_map[t].get(&w).copied().unwrap_or(0.0);
-                    let a_t = a_row.map_or(alpha, |r| r[t]);
-                    scores[t] = (a_t + ndk[d][t] as f64) * (beta_tw + nkw[t][w] as f64)
-                        / (beta_sum_k[t] + nk[t] as f64);
-                }
-
-                // Sample new topic and update counts.
-                let new_t = sample_index(&scores, rng);
-                nkw[new_t][w] += 1;
-                nk[new_t] += 1;
-                ndk[d][new_t] += 1;
-                z[d][i] = new_t;
-            }
+        if num_threads <= 1 {
+            // Exact serial path — byte-identical to the pre-threading loop.
+            run_sweep_seeded_range(
+                &mut nkw,
+                &mut nk,
+                &mut ndk,
+                &mut z,
+                docs,
+                doc_alpha.as_deref(),
+                &mass_map,
+                &beta_sum_k,
+                beta,
+                alpha,
+                k,
+                &mut scores,
+                rng,
+            );
+        } else {
+            // Approximate-parallel AD-LDA. One per-sweep seed drawn from the main
+            // RNG keeps it deterministic for a fixed num_threads + seed.
+            let sweep_seed = rng.gen::<u64>();
+            parallel_sweep_seeded(
+                &mut nkw,
+                &mut nk,
+                &mut ndk,
+                &mut z,
+                docs,
+                doc_alpha.as_deref(),
+                &mass_map,
+                &beta_sum_k,
+                beta,
+                alpha,
+                k,
+                num_threads,
+                sweep_seed,
+            );
         }
         if draws.thin > 0 && iter % draws.thin == 0 {
             theta_draw_buf.push(seeded_theta_snapshot(&ndk, doc_alpha.as_ref(), alpha, k));
@@ -654,6 +840,7 @@ mod tests {
             crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
             0.0,
             0,
+            1,
             &mut rng,
         );
 
@@ -716,6 +903,7 @@ mod tests {
             crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
             0.0,
             0,
+            1,
             &mut rng,
         );
 
@@ -778,6 +966,7 @@ mod tests {
             crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
             0.0,
             0,
+            1,
             &mut r1,
         );
         let (m2, _, _) = fit_seeded_lda(
@@ -794,6 +983,7 @@ mod tests {
             crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
             0.0,
             0,
+            1,
             &mut r2,
         );
 
@@ -833,6 +1023,7 @@ mod tests {
             crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
             0.0,
             0,
+            1,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);

--- a/tests/test_seeded_parallel.py
+++ b/tests/test_seeded_parallel.py
@@ -1,0 +1,100 @@
+"""SeededLDA multi-threaded (AD-LDA) training — the num_threads knob (#566).
+
+SeededLDA uses dense count tables (nkw / nk / ndk), so unlike DMR/LabeledLDA it
+cannot reuse the packed reconcile helper — it has its own dense AD-LDA merge. The
+knob behaves the same: num_threads=1 is the exact serial seeded-Gibbs sweep;
+num_threads>1 partitions documents across workers that sample against private
+count tables and reconciles once per sweep. The seeded asymmetric prior beta_{k,w}
+is a fixed pseudocount that never enters nkw, so it does not affect the merge.
+
+Contract under test:
+- num_threads=1 reproduces byte-for-byte across runs.
+- a fixed num_threads>1 is deterministic across runs (phi and theta).
+- num_threads=0 clamps to serial; fit(num_threads=) overrides the constructor.
+- the seeding still works under threading: each seed word is top-weighted in its
+  own topic.
+- doc_topic rows sum to 1.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+L = 3            # seeded topics
+Vp = 20          # vocabulary words per block
+D = 480
+
+
+def _make_corpus(seed=0):
+    rng = np.random.default_rng(seed)
+    docs = [[f"b{d % L}w{rng.integers(Vp)}" for _ in range(30)] for d in range(D)]
+    seed_words = {f"topic{b}": [f"b{b}w0"] for b in range(L)}
+    return docs, seed_words
+
+
+def _fit(docs, seed_words, num_threads, seed=42, ctor_threads=None):
+    ctor = ctor_threads if ctor_threads is not None else num_threads
+    m = topica.SeededLDA(seed_words, seed=seed, num_threads=ctor)
+    kw = {} if ctor_threads is None else {"num_threads": num_threads}
+    m.fit(docs, iters=80, keep_theta_draws=False, **kw)
+    return m
+
+
+def test_serial_is_reproducible():
+    docs, sw = _make_corpus()
+    a = _fit(docs, sw, 1)
+    b = _fit(docs, sw, 1)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_fixed_thread_count_is_deterministic(nt):
+    docs, sw = _make_corpus()
+    a = _fit(docs, sw, nt)
+    b = _fit(docs, sw, nt)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+def test_zero_threads_clamped_to_serial():
+    docs, sw = _make_corpus()
+    serial = _fit(docs, sw, 1)
+    clamped = _fit(docs, sw, 0)
+    assert np.array_equal(serial.topic_word, clamped.topic_word)
+
+
+def test_fit_num_threads_overrides_constructor():
+    docs, sw = _make_corpus()
+    override = _fit(docs, sw, 4, ctor_threads=1)
+    pure4 = _fit(docs, sw, 4)
+    assert np.array_equal(override.topic_word, pure4.topic_word)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_seeding_holds_under_threading(nt):
+    # The point of SeededLDA: each seed word steers its topic. Threading must not
+    # break that — the seed word bXw0 must have its highest probability in its own
+    # seeded topic X (topics are created in seed_words insertion order). This is
+    # the same "seeds steer topics" invariant the Rust unit test checks.
+    docs, sw = _make_corpus()
+    m = _fit(docs, sw, nt)
+    tw = m.topic_word  # (K, V)
+    idx = {w: i for i, w in enumerate(m.vocabulary)}
+    for b in range(L):
+        wi = idx[f"b{b}w0"]
+        assert int(np.argmax(tw[:, wi])) == b, (b, tw[:, wi].tolist())
+
+
+def test_parallel_preserves_simplex():
+    docs, sw = _make_corpus()
+    m = _fit(docs, sw, 4)
+    dt = m.doc_topic
+    np.testing.assert_allclose(dt.sum(axis=1), 1.0, rtol=0, atol=1e-6)
+
+
+def test_settings_report_num_threads():
+    _, sw = _make_corpus()
+    m = topica.SeededLDA(sw, num_threads=4)
+    assert m.settings["num_threads"] == 4


### PR DESCRIPTION
Third count model in the #569/#566 threading roster: **SeededLDA**. This one is the harder shape and needed a new dense reconcile rather than the shared helper.

## Why it's different from DMR/LabeledLDA

Those use the packed `TopicModel` + the shared `reconcile_worker_outs`. SeededLDA uses **dense** count tables (`nkw` K×V, `nk`, `ndk` D×K), and its fit (`fit_seeded_lda`) is monolithic — no per-sweep function and no packed tables to reconcile.

## Approach

- **Extract** the inner per-token sweep into `run_sweep_seeded_range` (sliceable — `ndk`/`z`/`docs`/`doc_alpha` share one local document index). The serial call over the whole corpus is byte-identical to the pre-threading loop.
- **`parallel_sweep_seeded`**: partition documents; each worker clones `nkw`/`nk` and owns its `z`/`ndk` slice, samples with a per-sweep `Pcg64Mcg` seed; then a **dense reconcile** — `nkw = Σ_workers − (W−1)·original` (i64, clamped ≥0), and `nk` is **recomputed from the merged `nkw` rows** so `nk[k] == Σ_w nkw[k][w]` exactly (guards against zero-clamp drift — Gemini's plan-review refinement). `z`/`ndk` slices written straight back (disjoint docs).

## Fidelity

The seeded asymmetric prior `β_{k,w}` is a fixed pseudocount that **never enters `nkw`**, so the additive merge is unaffected and koheiw/seededlda parity holds. `num_threads=1` is byte-identical serial; the warp/cvb0 backends ignore it.

Plan was reviewed by **Gemini before implementation** (verdict PLAN SOUND, with the `nk`-recompute guard as its key refinement).

## Determinism + performance

- `num_threads=1` reproduces byte-for-byte; a fixed `num_threads>1` is deterministic (phi and theta).
- ~**3.8x at 8 threads** (12k docs, K=12): 6.41s → 1.70s.

## Tests

New `tests/test_seeded_parallel.py`: serial reproducibility, fixed-thread determinism at 2/4/8, zero-clamp, `fit()` override, doc_topic simplex, `settings`, and the key invariant — **seeding still steers each seed word to its own topic under threading**. The existing 95 seeded Python + 5 Rust gold/parity tests (serial byte-identity) pass unchanged.

248 Rust + full Python suite (3919 passed, 32 skipped) green; `./scripts/preflight.sh` clean.

Part of #569. Next: BTM → GSDMM, then the #567/#568 knob PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)