### PR TITLE
feat(btm): AD-LDA multithreading via num_threads (#566)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2544,10 +2544,23 @@ class BTM:
         window: int = 15,
         background: bool = False,
         seed: int = 42,
-    ) -> None: ...
+        num_threads: int = 1,
+    ) -> None:
+        """num_threads > 1 runs the biterm Gibbs sweep as MALLET-style
+        approximate-parallel (AD-LDA) sampling (partition the biterms, sample
+        against per-worker count copies, merge; deterministic for a fixed
+        num_threads+seed); 1 is the exact serial path. Override per call via
+        fit(num_threads=)."""
+        ...
     def fit(
-        self, data: Corpus | Sequence[Sequence[str]], *, iters: int | None = None
-    ) -> "BTM": ...
+        self, data: Corpus | Sequence[Sequence[str]], *, iters: int | None = None,
+        num_threads: int | None = None,
+    ) -> "BTM":
+        """num_threads overrides the constructor's worker count for this fit only
+        (None = constructor value); >1 runs the biterm sweep as approximate-parallel
+        AD-LDA (deterministic for a fixed num_threads+seed), 1 is the exact serial
+        path."""
+        ...
     def transform(
         self, data: Corpus | Sequence[Sequence[str]]
     ) -> numpy.typing.NDArray[numpy.float64]:

--- a/src/btm.rs
+++ b/src/btm.rs
@@ -16,6 +16,9 @@
 
 use crate::estimator::{Estimator, ModelFamily};
 use rand::Rng;
+use rand::SeedableRng;
+use rand_pcg::Pcg64Mcg;
+use rayon::prelude::*;
 
 /// A fitted Biterm Topic Model.
 pub struct BtmModel {
@@ -170,8 +173,171 @@ pub fn infer_doc(
     pz_d
 }
 
+/// One collapsed-Gibbs sweep over a contiguous block of biterms. `biterms` and
+/// `z_assign` are the (possibly sliced) parallel arrays for this block, indexed by
+/// the same local index; `nb_z`/`nwz` are the (possibly per-worker private) count
+/// tables. `pz` is a reused length-K scratch buffer. The per-biterm conditional is
+/// identical to the original inline loop.
+#[allow(clippy::too_many_arguments)]
+fn run_sweep_btm_range<R: Rng>(
+    nb_z: &mut [i64],
+    nwz: &mut [Vec<i64>],
+    z_assign: &mut [usize],
+    biterms: &[(u32, u32)],
+    pw_b: &[f64],
+    alpha: f64,
+    beta: f64,
+    vbeta: f64,
+    denom_z: f64,
+    k: usize,
+    background: bool,
+    pz: &mut [f64],
+    rng: &mut R,
+) {
+    for bi in 0..biterms.len() {
+        let (w1, w2) = (biterms[bi].0 as usize, biterms[bi].1 as usize);
+        let z_old = z_assign[bi];
+        // Remove this biterm's contribution.
+        nb_z[z_old] -= 1;
+        nwz[z_old][w1] -= 1;
+        nwz[z_old][w2] -= 1;
+
+        // Conditional p(z|b) ∝ p(z) p(w1|z) p(w2|z), matching compute_pz_b
+        // (note the asymmetric +1 in the second word's denominator).
+        for z in 0..k {
+            let nbz = nb_z[z] as f64;
+            let (pw1, pw2) = if background && z == 0 {
+                (pw_b[w1], pw_b[w2])
+            } else {
+                (
+                    (nwz[z][w1] as f64 + beta) / (2.0 * nbz + vbeta),
+                    (nwz[z][w2] as f64 + beta) / (2.0 * nbz + 1.0 + vbeta),
+                )
+            };
+            let pk = (nbz + alpha) / denom_z;
+            pz[z] = pk * pw1 * pw2;
+        }
+        let z_new = mult_sample(pz, rng);
+        z_assign[bi] = z_new;
+        nb_z[z_new] += 1;
+        nwz[z_new][w1] += 1;
+        nwz[z_new][w2] += 1;
+    }
+}
+
+/// Contiguous, non-overlapping ranges partitioning `0..n` into `parts` blocks
+/// (clamped so the block count never exceeds `n`). Local mirror of the binding's
+/// `partition_ranges`.
+fn partition_ranges(n: usize, parts: usize) -> Vec<(usize, usize)> {
+    let parts = parts.max(1).min(n.max(1));
+    let base = n / parts;
+    let rem = n % parts;
+    let mut ranges = Vec::with_capacity(parts);
+    let mut start = 0;
+    for i in 0..parts {
+        let len = base + if i < rem { 1 } else { 0 };
+        ranges.push((start, start + len));
+        start += len;
+    }
+    ranges
+}
+
+/// One approximate-parallel (AD-LDA) sweep over the biterm topic assignments.
+/// Biterms are globally exchangeable and carry no per-document state, so the flat
+/// biterm array is partitioned across workers; each samples its slice against a
+/// private clone of `nb_z`/`nwz`, then both tables are reconciled by the exact
+/// additive merge `Σ_workers − (W−1)·original` (clamped ≥ 0 to keep the sampling
+/// numerators/denominators positive under staleness). Each worker's `z_assign`
+/// slice is written straight back (biterms are disjoint). Deterministic for a
+/// fixed `sweep_seed`/`num_threads`.
+#[allow(clippy::too_many_arguments)]
+fn parallel_sweep_btm(
+    nb_z: &mut [i64],
+    nwz: &mut [Vec<i64>],
+    z_assign: &mut [usize],
+    biterms: &[(u32, u32)],
+    pw_b: &[f64],
+    alpha: f64,
+    beta: f64,
+    vbeta: f64,
+    denom_z: f64,
+    k: usize,
+    background: bool,
+    num_threads: usize,
+    sweep_seed: u64,
+) {
+    let v = nwz.first().map_or(0, |row| row.len());
+    let ranges = partition_ranges(biterms.len(), num_threads);
+    let orig_nb_z = nb_z.to_vec();
+    let orig_nwz = nwz.to_vec();
+    let z_ro: &[usize] = z_assign;
+
+    struct BtmWorkerOut {
+        nb_z: Vec<i64>,
+        nwz: Vec<Vec<i64>>,
+        z: Vec<usize>,
+        start: usize,
+    }
+
+    let outs: Vec<BtmWorkerOut> = ranges
+        .par_iter()
+        .enumerate()
+        .map(|(wid, &(start, end))| {
+            let mut wnb = orig_nb_z.clone();
+            let mut wnwz = orig_nwz.clone();
+            let mut wz: Vec<usize> = z_ro[start..end].to_vec();
+            let mut rng = Pcg64Mcg::seed_from_u64(
+                sweep_seed ^ (wid as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
+            );
+            let mut pz = vec![0.0f64; k];
+            run_sweep_btm_range(
+                &mut wnb,
+                &mut wnwz,
+                &mut wz,
+                &biterms[start..end],
+                pw_b,
+                alpha,
+                beta,
+                vbeta,
+                denom_z,
+                k,
+                background,
+                &mut pz,
+                &mut rng,
+            );
+            BtmWorkerOut {
+                nb_z: wnb,
+                nwz: wnwz,
+                z: wz,
+                start,
+            }
+        })
+        .collect();
+
+    // --- Reconcile both count tables: final = Σ_workers − (W−1)·original,
+    // clamped ≥ 0 so a stale-driven negative never poisons the sampling CDF. ---
+    let wm1 = (outs.len() as i64) - 1;
+    for z in 0..k {
+        let sum_b: i64 = outs.iter().map(|o| o.nb_z[z]).sum();
+        nb_z[z] = (sum_b - wm1 * orig_nb_z[z]).max(0);
+        for w in 0..v {
+            let sum_w: i64 = outs.iter().map(|o| o.nwz[z][w]).sum();
+            nwz[z][w] = (sum_w - wm1 * orig_nwz[z][w]).max(0);
+        }
+    }
+
+    // --- Write back each worker's biterm topic assignments (disjoint slices). ---
+    for out in outs {
+        for (i, zi) in out.z.into_iter().enumerate() {
+            z_assign[out.start + i] = zi;
+        }
+    }
+}
+
 /// Fit BTM on the given token-id documents with collapsed Gibbs sampling over
-/// biterm topic assignments.
+/// biterm topic assignments. `num_threads` `1` runs the exact serial sweep; `>1`
+/// runs MALLET-style approximate-parallel (AD-LDA) sampling over the biterms,
+/// deterministic for a fixed `num_threads` + seed.
 #[allow(clippy::too_many_arguments)]
 pub fn fit_btm<R: Rng>(
     docs: &[Vec<u32>],
@@ -182,6 +348,7 @@ pub fn fit_btm<R: Rng>(
     iters: usize,
     window: usize,
     background: bool,
+    num_threads: usize,
     rng: &mut R,
 ) -> BtmModel {
     let k = num_topics;
@@ -217,34 +384,42 @@ pub fn fit_btm<R: Rng>(
     let mut pz = vec![0.0f64; k];
 
     for _ in 0..iters {
-        for bi in 0..b {
-            let (w1, w2) = (biterms[bi].0 as usize, biterms[bi].1 as usize);
-            let z_old = z_assign[bi];
-            // Remove this biterm's contribution.
-            nb_z[z_old] -= 1;
-            nwz[z_old][w1] -= 1;
-            nwz[z_old][w2] -= 1;
-
-            // Conditional p(z|b) ∝ p(z) p(w1|z) p(w2|z), matching compute_pz_b
-            // (note the asymmetric +1 in the second word's denominator).
-            for z in 0..k {
-                let nbz = nb_z[z] as f64;
-                let (pw1, pw2) = if background && z == 0 {
-                    (pw_b[w1], pw_b[w2])
-                } else {
-                    (
-                        (nwz[z][w1] as f64 + beta) / (2.0 * nbz + vbeta),
-                        (nwz[z][w2] as f64 + beta) / (2.0 * nbz + 1.0 + vbeta),
-                    )
-                };
-                let pk = (nbz + alpha) / denom_z;
-                pz[z] = pk * pw1 * pw2;
-            }
-            let z_new = mult_sample(&pz, rng);
-            z_assign[bi] = z_new;
-            nb_z[z_new] += 1;
-            nwz[z_new][w1] += 1;
-            nwz[z_new][w2] += 1;
+        if num_threads <= 1 {
+            // Exact serial path — byte-identical to the pre-threading loop.
+            run_sweep_btm_range(
+                &mut nb_z,
+                &mut nwz,
+                &mut z_assign,
+                &biterms,
+                &pw_b,
+                alpha,
+                beta,
+                vbeta,
+                denom_z,
+                k,
+                background,
+                &mut pz,
+                rng,
+            );
+        } else {
+            // Approximate-parallel AD-LDA over the biterms. One per-sweep seed from
+            // the main RNG keeps it deterministic for a fixed num_threads + seed.
+            let sweep_seed = rng.gen::<u64>();
+            parallel_sweep_btm(
+                &mut nb_z,
+                &mut nwz,
+                &mut z_assign,
+                &biterms,
+                &pw_b,
+                alpha,
+                beta,
+                vbeta,
+                denom_z,
+                k,
+                background,
+                num_threads,
+                sweep_seed,
+            );
         }
     }
 
@@ -364,7 +539,18 @@ mod tests {
         let (k, block) = (3, 6);
         let (docs, v) = planted(k, block, 150, 5, 42);
         let mut rng = ChaCha8Rng::seed_from_u64(7);
-        let m = fit_btm(&docs, k, v, 50.0 / k as f64, 0.01, 200, 15, false, &mut rng);
+        let m = fit_btm(
+            &docs,
+            k,
+            v,
+            50.0 / k as f64,
+            0.01,
+            200,
+            15,
+            false,
+            1,
+            &mut rng,
+        );
 
         assert_eq!(m.topic_word.len(), k);
         assert_eq!(m.topic_word[0].len(), v);
@@ -391,7 +577,7 @@ mod tests {
         let (docs, v) = planted(k, block, 60, 4, 123);
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(99);
-            fit_btm(&docs, k, v, 1.0, 0.01, 80, 15, false, &mut rng)
+            fit_btm(&docs, k, v, 1.0, 0.01, 80, 15, false, 1, &mut rng)
         };
         let a = run();
         let b = run();

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -22,6 +22,10 @@ pub struct BTM {
     window: usize,
     background: bool,
     seed: u64,
+    // Default worker count for the biterm Gibbs fit. `1` is the exact serial path;
+    // `>1` runs AD-LDA partition-and-merge (deterministic for a fixed
+    // num_threads+seed).
+    num_threads: usize,
     fitted: bool,
     topic_names: Vec<String>,
     model: Option<crate::btm::BtmModel>,
@@ -111,6 +115,7 @@ impl BTM {
         d.set_item("window", self.window)?;
         d.set_item("background", self.background)?;
         d.set_item("seed", self.seed)?;
+        d.set_item("num_threads", self.num_threads)?;
         Ok(d)
     }
 
@@ -120,10 +125,13 @@ impl BTM {
     /// common words (drawn from the biterm-participation word distribution), leaving
     /// `num_topics - 1` content topics; its reported `topic_word` row is emitted from
     /// the biterm counts it accumulated, not the background distribution it sampled
-    /// from.
+    /// from. `num_threads` `>1` runs the biterm Gibbs sweep as MALLET-style
+    /// approximate-parallel (AD-LDA) sampling (partition the biterms, sample against
+    /// per-worker count copies, merge; deterministic for a fixed `num_threads`+`seed`);
+    /// `1` is the exact serial path. `fit(num_threads=)` overrides it per call.
     #[new]
     #[pyo3(signature = (num_topics, *, alpha=None, beta=0.01, iters=1000,
-                        window=15, background=false, seed=42))]
+                        window=15, background=false, seed=42, num_threads=1))]
     #[allow(clippy::too_many_arguments)]
     fn new(
         num_topics: usize,
@@ -133,6 +141,7 @@ impl BTM {
         window: usize,
         background: bool,
         seed: u64,
+        num_threads: usize,
     ) -> PyResult<Self> {
         if num_topics < 2 {
             return Err(PyValueError::new_err("num_topics must be >= 2"));
@@ -156,6 +165,7 @@ impl BTM {
             iters,
             window,
             background,
+            num_threads: num_threads.max(1),
             seed,
             fitted: false,
             topic_names: Vec::new(),
@@ -164,13 +174,18 @@ impl BTM {
         })
     }
 
-    /// Fit the model on a corpus or list of token lists.
-    #[pyo3(signature = (data, *, iters=None))]
+    /// Fit the model on a corpus or list of token lists. `num_threads` overrides
+    /// the constructor's worker count for this fit only (`None` = constructor
+    /// value); `>1` runs the biterm Gibbs sweep as approximate-parallel AD-LDA
+    /// (deterministic for a fixed `num_threads`+`seed`), `1` is the exact serial
+    /// path.
+    #[pyo3(signature = (data, *, iters=None, num_threads=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
+        num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -197,6 +212,8 @@ impl BTM {
             ));
         }
         let iters = iters.unwrap_or(slf.iters);
+        // fit()-level num_threads overrides the constructor default for this run.
+        let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
         let alpha = slf.alpha.unwrap_or(50.0 / slf.num_topics as f64);
         let (k, beta, window, background, seed) = (
             slf.num_topics,
@@ -217,6 +234,7 @@ impl BTM {
                 iters,
                 window,
                 background,
+                num_threads,
                 &mut rng,
             );
             (m, corpus)
@@ -419,6 +437,9 @@ impl BTM {
             window: s.window,
             background: s.background,
             seed: s.seed,
+            // num_threads is a runtime resource knob, not fitted state; a loaded
+            // (already-fitted) model defaults to serial.
+            num_threads: 1,
             fitted: s.fitted,
             topic_names: s.topic_names,
             model,

--- a/tests/test_btm_parallel.py
+++ b/tests/test_btm_parallel.py
@@ -1,0 +1,89 @@
+"""BTM multi-threaded (AD-LDA) training — the num_threads knob (#566).
+
+BTM's sampling unit is the biterm (a within-window word pair), not the document,
+and it keeps no per-document state during fit. So its AD-LDA path partitions the
+flat biterm array across workers that sample against private nb_z/nwz count
+tables, reconciling both once per sweep. num_threads=1 is the exact serial sweep.
+
+Contract under test:
+- num_threads=1 reproduces byte-for-byte across runs.
+- a fixed num_threads>1 is deterministic across runs (topic_word and theta).
+- num_threads=0 clamps to serial; fit(num_threads=) overrides the constructor.
+- topic recovery holds under threading: on a planted block corpus each block's
+  vocabulary concentrates in a single, distinct topic.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+L = 3            # planted blocks / topics
+Vp = 15          # vocabulary words per block
+D = 720
+
+
+def _make_corpus(seed=0):
+    rng = np.random.default_rng(seed)
+    # Short texts (6 tokens) drawn from a single block — BTM's target regime.
+    return [[f"b{d % L}w{rng.integers(Vp)}" for _ in range(6)] for d in range(D)]
+
+
+def _fit(docs, num_threads, seed=42, ctor_threads=None):
+    ctor = ctor_threads if ctor_threads is not None else num_threads
+    m = topica.BTM(L, seed=seed, iters=80, num_threads=ctor)
+    kw = {} if ctor_threads is None else {"num_threads": num_threads}
+    m.fit(docs, **kw)
+    return m
+
+
+def test_serial_is_reproducible():
+    docs = _make_corpus()
+    a = _fit(docs, 1)
+    b = _fit(docs, 1)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.theta, b.theta)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_fixed_thread_count_is_deterministic(nt):
+    docs = _make_corpus()
+    a = _fit(docs, nt)
+    b = _fit(docs, nt)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.theta, b.theta)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+def test_zero_threads_clamped_to_serial():
+    docs = _make_corpus()
+    serial = _fit(docs, 1)
+    clamped = _fit(docs, 0)
+    assert np.array_equal(serial.topic_word, clamped.topic_word)
+
+
+def test_fit_num_threads_overrides_constructor():
+    docs = _make_corpus()
+    override = _fit(docs, 4, ctor_threads=1)
+    pure4 = _fit(docs, 4)
+    assert np.array_equal(override.topic_word, pure4.topic_word)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_topic_recovery_under_threading(nt):
+    docs = _make_corpus()
+    m = _fit(docs, nt)
+    tw = m.topic_word  # (K, V)
+    idx = {w: i for i, w in enumerate(m.vocabulary)}
+    # Each block's total topic_word mass should peak in one topic, and the three
+    # blocks should map to three distinct topics.
+    winners = []
+    for blk in range(L):
+        wids = [idx[f"b{blk}w{i}"] for i in range(Vp) if f"b{blk}w{i}" in idx]
+        winners.append(int(np.argmax(tw[:, wids].sum(axis=1))))
+    assert len(set(winners)) == L, winners
+
+
+def test_settings_report_num_threads():
+    m = topica.BTM(L, num_threads=4)
+    assert m.settings["num_threads"] == 4


### PR DESCRIPTION
Fourth count model in the #569/#566 threading roster: **BTM**. This one is the cleanest AD-LDA of the set.

## Why BTM threads cleanly

BTM's sampling unit is the **biterm** (a within-window word pair), not the document, and it keeps **no per-document state** during fit (`doc_topic` is inferred post-hoc). So the parallel path just partitions the flat biterm array across workers and reconciles the two dense count tables — no `ndk`/doc-topic bookkeeping.

## Approach

- **Extract** the per-biterm sweep into `run_sweep_btm_range` (sliceable — `biterms`/`z_assign` share one local index). The serial call over all biterms is byte-identical to the pre-threading loop.
- **`parallel_sweep_btm`**: partition biterms; each worker clones `nb_z` + `nwz`, owns its `z_assign` slice, samples with a per-sweep `Pcg64Mcg` seed; then reconcile **both** tables by `Σ_workers − (W−1)·original`, each **clamped ≥0** so a stale-driven negative can't poison `mult_sample`'s inverse-CDF (Gemini's plan-review refinement). `z_assign` slice written straight back.

Plan reviewed by **Gemini before implementation** (verdict PLAN SOUND, clamp-both-tables its key refinement).

## Determinism + performance

- `num_threads=1` reproduces byte-for-byte; a fixed `num_threads>1` is deterministic (topic_word, theta, doc_topic).
- ~**4.6x at 8 threads** (40k short docs, K=12): 4.25s → 0.93s — best scaling of the count models (biterms are numerous).

## Tests

New `tests/test_btm_parallel.py`: serial reproducibility, fixed-thread determinism at 2/4/8, zero-clamp, `fit()` override, `settings`, and topic recovery under threading (each planted block → a distinct topic). The 4 Rust BTM tests (incl. recovery+conformance = serial byte-identity) pass unchanged.

248 Rust + full Python suite (3929 passed, 32 skipped) green; `./scripts/preflight.sh` clean.

Part of #569. Next: GSDMM (last count model), then the #567/#568 knob PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)