### PR TITLE
feat(gsdmm): reject num_threads>1 — cluster discovery is inherently sequential (#566)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2436,7 +2436,14 @@ class GSDMM:
         alpha: float = 0.1,
         beta: float = 0.1,
         seed: int = 42,
-    ) -> None: ...
+        num_threads: int = 1,
+    ) -> None:
+        """num_threads must be 1. Unlike the other collapsed-Gibbs count models
+        (DMR, LabeledLDA, SeededLDA, BTM), GSDMM is not parallelized: its Movie
+        Group Process discovers the cluster count K via within-sweep reinforcement,
+        which approximate-parallel (AD-LDA) sampling would break, making K depend on
+        the thread count. Passing num_threads > 1 raises ValueError."""
+        ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -2444,11 +2451,15 @@ class GSDMM:
         iters: int = 30,
         progress_interval: int = 0,
         report_interval: Optional[int] = None,
+        num_threads: int = 1,
     ) -> "GSDMM":
         """Fit by the Movie Group Process. progress_interval controls the
         cluster-discovery trace (0 = auto ~50 points).
 
-        report_interval is a deprecated alias for progress_interval."""
+        report_interval is a deprecated alias for progress_interval.
+
+        num_threads must be 1; GSDMM is not parallelized (cluster-count discovery
+        is inherently sequential). num_threads > 1 raises ValueError."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -12323,6 +12323,25 @@ impl PT {
 // GSDMM: Gibbs Sampling Dirichlet Multinomial Mixture (short-text clustering)
 // ---------------------------------------------------------------------------
 
+/// GSDMM does not support approximate-parallel (AD-LDA) sampling: its Movie Group
+/// Process discovers the cluster count `K` via within-sweep reinforcement, which
+/// document-partitioned parallel sampling would break, making `K` thread-dependent.
+/// Accept only `num_threads == 1`; reject anything larger with a clear message
+/// (rather than a bare `TypeError`, since users arriving from the sibling count
+/// models reasonably expect the knob).
+fn gsdmm_reject_threads(num_threads: usize) -> PyResult<()> {
+    if num_threads > 1 {
+        return Err(PyValueError::new_err(
+            "GSDMM's Movie Group Process discovers the cluster count K sequentially \
+             (within-sweep reinforcement drives the collapse), so num_threads>1 would \
+             make K depend on the thread count. Only num_threads=1 is supported. Use \
+             num_threads>1 on the other collapsed-Gibbs count models (DMR, LabeledLDA, \
+             SeededLDA, BTM) instead.",
+        ));
+    }
+    Ok(())
+}
+
 /// GSDMM — the "Movie Group Process" (Yin & Wang 2014). A mixture model for
 /// **short texts** (tweets, survey answers, headlines) where each document
 /// belongs to exactly *one* topic, not a mixture. You set an upper bound `K` on
@@ -12391,6 +12410,8 @@ impl GSDMM {
         d.set_item("alpha", self.alpha)?;
         d.set_item("beta", self.beta)?;
         d.set_item("seed", self.seed)?;
+        // Always 1: GSDMM is intentionally not parallelized (see gsdmm_reject_threads).
+        d.set_item("num_threads", 1)?;
         Ok(d)
     }
 
@@ -12405,13 +12426,23 @@ impl GSDMM {
     /// `num_topics` getter and is usually smaller. `alpha` controls the pull
     /// toward populous clusters; `beta` is the word-Dirichlet smoothing.
     /// `seed` seeds the Movie Group Process Gibbs RNG.
+    ///
+    /// `num_threads` must be `1`. Unlike the other collapsed-Gibbs count models
+    /// (`DMR`, `LabeledLDA`, `SeededLDA`, `BTM`), GSDMM is **not** parallelized:
+    /// its Movie Group Process discovers the cluster count `K` through *within-sweep*
+    /// reinforcement (once a document births a cluster, later documents in the same
+    /// sweep join it), and approximate-parallel (AD-LDA) sampling would break that
+    /// reinforcement and make the discovered `K` depend on the thread count — an
+    /// unacceptable dependence for a headline structural output. Passing
+    /// `num_threads > 1` raises `ValueError`.
     #[new]
-    #[pyo3(signature = (num_topics, *, alpha=0.1, beta=0.1, seed=42))]
+    #[pyo3(signature = (num_topics, *, alpha=0.1, beta=0.1, seed=42, num_threads=1))]
     fn new(
         #[pyo3(from_py_with = "py_num_topics")] num_topics: usize,
         alpha: f64,
         beta: f64,
         seed: u64,
+        num_threads: usize,
     ) -> PyResult<Self> {
         if num_topics < 2 {
             return Err(PyValueError::new_err(
@@ -12421,6 +12452,7 @@ impl GSDMM {
         if !finite_pos(alpha) || !finite_pos(beta) {
             return Err(PyValueError::new_err("alpha and beta must be > 0"));
         }
+        gsdmm_reject_threads(num_threads)?;
         Ok(GSDMM {
             k_max: num_topics,
             alpha,
@@ -12443,7 +12475,11 @@ impl GSDMM {
     /// (`cluster_count_history` / `log_likelihood_history`): 0 = auto (~50
     /// points), a positive value records every that-many sweeps.
     /// `report_interval` is a deprecated alias for `progress_interval`.
-    #[pyo3(signature = (data, *, iters=30, progress_interval=0, report_interval=None))]
+    /// `num_threads` must be `1`; GSDMM is not parallelized (its cluster-count
+    /// discovery is inherently sequential — see the constructor). `num_threads > 1`
+    /// raises `ValueError`.
+    #[pyo3(signature = (data, *, iters=30, progress_interval=0, report_interval=None,
+                        num_threads=1))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -12451,7 +12487,9 @@ impl GSDMM {
         iters: usize,
         progress_interval: usize,
         report_interval: Option<usize>,
+        num_threads: usize,
     ) -> PyResult<Py<Self>> {
+        gsdmm_reject_threads(num_threads)?;
         let progress_interval = if let Some(old_val) = report_interval {
             let warnings = py.import_bound("warnings")?;
             warnings.call_method1(

--- a/tests/test_gsdmm_no_threading.py
+++ b/tests/test_gsdmm_no_threading.py
@@ -1,0 +1,44 @@
+"""GSDMM intentionally does NOT support AD-LDA threading (#566).
+
+Unlike the sibling collapsed-Gibbs count models (DMR, LabeledLDA, SeededLDA, BTM),
+GSDMM's Movie Group Process discovers the cluster count K through within-sweep
+reinforcement — once a document births a cluster, later documents in the same
+sweep join it, driving the collapse. Approximate-parallel (AD-LDA) sampling would
+break that reinforcement and make K depend on the thread count, which is
+unacceptable for a headline structural output. GSDMM therefore accepts only
+num_threads=1 and rejects num_threads>1 with a clear ValueError (rather than a
+bare TypeError) so users arriving from the sibling models get an explanation.
+"""
+
+import pytest
+
+import topica
+
+DOCS = [["a", "b", "c"], ["a", "b"], ["x", "y", "z"], ["x", "y"]] * 20
+
+
+def test_num_threads_1_is_accepted():
+    # Default and explicit num_threads=1 both fit.
+    topica.GSDMM(6, seed=1).fit(DOCS, iters=20)
+    topica.GSDMM(6, seed=1, num_threads=1).fit(DOCS, iters=20, num_threads=1)
+
+
+def test_settings_reports_num_threads_1():
+    assert topica.GSDMM(6).settings["num_threads"] == 1
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_constructor_rejects_multithreading(nt):
+    with pytest.raises(ValueError, match="sequentially"):
+        topica.GSDMM(6, num_threads=nt)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_fit_rejects_multithreading(nt):
+    with pytest.raises(ValueError, match="sequentially"):
+        topica.GSDMM(6).fit(DOCS, num_threads=nt)
+
+
+def test_error_message_points_to_sibling_models():
+    with pytest.raises(ValueError, match="DMR, LabeledLDA, SeededLDA, BTM"):
+        topica.GSDMM(6, num_threads=2)


### PR DESCRIPTION
Closes out the count-model sweep of #566. GSDMM is the one model here that **should not** get AD-LDA threading, and this PR makes that explicit and friendly.

## Why GSDMM isn't threaded

GSDMM's Movie Group Process discovers the cluster count **K** through *within-sweep reinforcement*: once a document births a cluster, later documents in the same sweep see it populated and join it — that feedback is what drives the collapse to a small stable K. AD-LDA partitions documents across workers that each sample against the *same start-of-sweep snapshot*, so multiple workers independently birth the same empty cluster with no cross-worker reinforcement, **inflating K as a function of `num_threads`**.

The distinction from the four models that were threaded (DMR/GDMR #570, LabeledLDA #571, SeededLDA #573, BTM #574): there, AD-LDA only perturbs *soft* topic-word distributions (already stochastic). GSDMM's headline output is a *discrete discovered integer K*, which must not depend on the thread count. A plan review (independent Gemini 3.1-pro, cross-family) reached the same not-threadable conclusion unprompted.

## What shipped

- `num_threads=1` accepted (API consistency with the sibling count models); `num_threads>1` raises a clear `ValueError` at **both** constructor and `fit()`, explaining the sequential-discovery reason and pointing to the threaded models — rather than a bare `TypeError` for users arriving from those models.
- `settings` reports `num_threads: 1`; docstrings + `.pyi` updated.
- `tests/test_gsdmm_no_threading.py` (9 tests): num_threads=1 accepted, settings, and >1 rejected at ctor + fit with the explanatory message.

**No sampling code changed** — this is a binding-level guard, so there's no algorithm to adversarially verify; CI + preflight are the gate.

Full Python suite (3938 passed, 32 skipped) + `./scripts/preflight.sh` green.

Part of #569. Remaining in #566: PA (bespoke two-level merge) and the harder Gibbs models. Next up: the #567/#568 knob PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)