### PR TITLE
feat(pa): AD-LDA multithreading via num_threads (#566)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3142,7 +3142,14 @@ class PA:
         alpha: float = 0.1,
         beta: float = 0.01,
         seed: int = 42,
-    ) -> None: ...
+        num_threads: int = 1,
+    ) -> None:
+        """num_threads > 1 runs the collapsed-Gibbs sweep as MALLET-style
+        approximate-parallel AD-LDA (documents partitioned across workers sampling
+        private sub-topic-word count copies, then merged; deterministic for a fixed
+        num_threads+seed); 1 is the exact serial path. Overridden per call via
+        fit(num_threads=)."""
+        ...
     def fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -3152,6 +3159,7 @@ class PA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 10,
+        num_threads: int | None = None,
     ) -> "PA": ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]:

--- a/src/pa.rs
+++ b/src/pa.rs
@@ -51,6 +51,9 @@
 
 use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 use rand::Rng;
+use rand::SeedableRng;
+use rand_pcg::Pcg64Mcg;
+use rayon::prelude::*;
 
 /// A fitted Pachinko Allocation model (four-level, two-tier).
 pub struct PamModel {
@@ -232,68 +235,236 @@ fn sample_index<R: Rng>(probs: &[f64], rng: &mut R) -> usize {
     probs.len() - 1
 }
 
-impl PamModel {
-    /// Draw a `(super, sub)` pair for token (d, i)=w from the current state (the
-    /// token's counts must already be removed) and add the token back under the
-    /// chosen pair.
-    fn assign_token<R: Rng>(
-        &mut self,
-        d: usize,
-        i: usize,
-        w: usize,
-        probs: &mut [f64],
-        rng: &mut R,
-    ) {
-        let v = self.num_types;
-        let s_count = self.num_super;
-        let k = self.num_sub;
-        let n_d: u32 = self.nds[d].iter().sum();
-        // The doc→super normalizer (n_d + S·alpha) cancels across pairs, but we
-        // include it for clarity/numeric scaling.
-        let super_norm = n_d as f64 + s_count as f64 * self.alpha;
+/// One collapsed-Gibbs sweep over a contiguous slice of documents. Per-document
+/// tables (`nds`, `ndsk`, `zs`, `zk`) are indexed 0-based within the slice and must
+/// align with `docs`; the global sub-topic→word counts (`nkw`, `nk`) are the only
+/// state shared across documents. `probs` is a reusable `S·K` scratch buffer. The
+/// arithmetic and per-token RNG draw order are exactly those of the original
+/// `PamModel::sweep`/`assign_token`, so the serial call site stays byte-identical.
+#[allow(clippy::too_many_arguments)]
+fn run_sweep_pam_range<R: Rng>(
+    nds: &mut [Vec<u32>],
+    ndsk: &mut [Vec<Vec<u32>>],
+    zs: &mut [Vec<usize>],
+    zk: &mut [Vec<usize>],
+    nkw: &mut [Vec<u32>],
+    nk: &mut [u32],
+    docs: &[Vec<u32>],
+    alpha_sk: &[Vec<f64>],
+    alpha: f64,
+    beta: f64,
+    num_super: usize,
+    num_sub: usize,
+    num_types: usize,
+    probs: &mut [f64],
+    rng: &mut R,
+) {
+    let v = num_types;
+    let s_count = num_super;
+    let k = num_sub;
+    for d in 0..docs.len() {
+        let doc = &docs[d];
+        for i in 0..doc.len() {
+            let w = doc[i] as usize;
+            let s_old = zs[d][i];
+            let k_old = zk[d][i];
+            nds[d][s_old] -= 1;
+            ndsk[d][s_old][k_old] -= 1;
+            nkw[k_old][w] -= 1;
+            nk[k_old] -= 1;
 
-        // `probs` is a reusable scratch buffer (one allocation per sweep, not per
-        // token); the s_count·k entries are all overwritten below.
-        for s in 0..s_count {
-            let nds = self.nds[d][s] as f64;
-            let super_term = (nds + self.alpha) / super_norm;
-            let alpha_sum: f64 = self.alpha_sk[s].iter().sum();
-            let sub_norm = nds + alpha_sum;
-            for sub in 0..k {
-                let sub_super = (self.ndsk[d][s][sub] as f64 + self.alpha_sk[s][sub]) / sub_norm;
-                let emit = (self.nkw[sub][w] as f64 + self.beta)
-                    / (self.nk[sub] as f64 + v as f64 * self.beta);
-                probs[s * k + sub] = super_term * sub_super * emit;
+            // The doc→super normalizer (n_d + S·alpha) cancels across pairs, but we
+            // include it for clarity/numeric scaling.
+            let n_d: u32 = nds[d].iter().sum();
+            let super_norm = n_d as f64 + s_count as f64 * alpha;
+            for s in 0..s_count {
+                let nds_s = nds[d][s] as f64;
+                let super_term = (nds_s + alpha) / super_norm;
+                let alpha_sum: f64 = alpha_sk[s].iter().sum();
+                let sub_norm = nds_s + alpha_sum;
+                for sub in 0..k {
+                    let sub_super = (ndsk[d][s][sub] as f64 + alpha_sk[s][sub]) / sub_norm;
+                    let emit = (nkw[sub][w] as f64 + beta) / (nk[sub] as f64 + v as f64 * beta);
+                    probs[s * k + sub] = super_term * sub_super * emit;
+                }
             }
+
+            let g = sample_index(probs, rng);
+            let s = g / k;
+            let sub = g % k;
+            nds[d][s] += 1;
+            ndsk[d][s][sub] += 1;
+            nkw[sub][w] += 1;
+            nk[sub] += 1;
+            zs[d][i] = s;
+            zk[d][i] = sub;
         }
+    }
+}
 
-        let g = sample_index(probs, rng);
-        let s = g / k;
-        let sub = g % k;
+/// Contiguous, non-overlapping document ranges — one per worker (clamped so the
+/// worker count never exceeds the document count). Mirrors the binding's
+/// `partition_ranges`, kept local so the core stays self-contained.
+fn partition_ranges(n: usize, parts: usize) -> Vec<(usize, usize)> {
+    let parts = parts.max(1).min(n.max(1));
+    let base = n / parts;
+    let rem = n % parts;
+    let mut ranges = Vec::with_capacity(parts);
+    let mut start = 0;
+    for i in 0..parts {
+        let len = base + if i < rem { 1 } else { 0 };
+        ranges.push((start, start + len));
+        start += len;
+    }
+    ranges
+}
 
-        self.nds[d][s] += 1;
-        self.ndsk[d][s][sub] += 1;
-        self.nkw[sub][w] += 1;
-        self.nk[sub] += 1;
-        self.zs[d][i] = s;
-        self.zk[d][i] = sub;
+/// One approximate-parallel (AD-LDA) sweep over the PAM count tables. Documents are
+/// partitioned across workers; each worker samples its slice against a private clone
+/// of the global `nkw`/`nk`, owning copies of its per-document `nds`/`ndsk`/`zs`/`zk`
+/// slice (documents are disjoint), then the results are reconciled: `nkw` is the
+/// exact additive merge `Σ_workers − (W−1)·original` (accumulated in `i64`, clamped
+/// ≥ 0) and `nk` is **recomputed** from the merged `nkw` rows so
+/// `nk[k] == Σ_w nkw[k][w]` holds exactly (no zero-clamp drift). Only the sub-topic
+/// index of the sampled `(super, sub)` pair touches `nkw`, so word-token counts stay
+/// conserved per worker and the standard AD-LDA merge applies unchanged. `alpha_sk`
+/// is read-only during the sweep (it is adapted serially by `estimate_alpha_sk`
+/// after the merge). Deterministic for a fixed `sweep_seed`/`num_threads`.
+#[allow(clippy::too_many_arguments)]
+fn parallel_sweep_pam(
+    nds: &mut [Vec<u32>],
+    ndsk: &mut [Vec<Vec<u32>>],
+    zs: &mut [Vec<usize>],
+    zk: &mut [Vec<usize>],
+    nkw: &mut [Vec<u32>],
+    nk: &mut [u32],
+    docs: &[Vec<u32>],
+    alpha_sk: &[Vec<f64>],
+    alpha: f64,
+    beta: f64,
+    num_super: usize,
+    num_sub: usize,
+    num_types: usize,
+    num_threads: usize,
+    sweep_seed: u64,
+) {
+    struct PamWorkerOut {
+        nkw: Vec<Vec<u32>>,
+        nds: Vec<Vec<u32>>,
+        ndsk: Vec<Vec<Vec<u32>>>,
+        zs: Vec<Vec<usize>>,
+        zk: Vec<Vec<usize>>,
+        start: usize,
     }
 
-    /// One full Gibbs sweep over every token.
+    let v = num_types;
+    let k = num_sub;
+    let ranges = partition_ranges(docs.len(), num_threads);
+    let orig_nkw = nkw.to_vec();
+    let orig_nk = nk.to_vec();
+    // Read-only views so workers can copy their slices inside the parallel map.
+    let nds_ro: &[Vec<u32>] = nds;
+    let ndsk_ro: &[Vec<Vec<u32>>] = ndsk;
+    let zs_ro: &[Vec<usize>] = zs;
+    let zk_ro: &[Vec<usize>] = zk;
+
+    let outs: Vec<PamWorkerOut> = ranges
+        .par_iter()
+        .enumerate()
+        .map(|(wid, &(start, end))| {
+            let mut wnkw = orig_nkw.clone();
+            let mut wnk = orig_nk.clone();
+            let mut wnds: Vec<Vec<u32>> = nds_ro[start..end].to_vec();
+            let mut wndsk: Vec<Vec<Vec<u32>>> = ndsk_ro[start..end].to_vec();
+            let mut wzs: Vec<Vec<usize>> = zs_ro[start..end].to_vec();
+            let mut wzk: Vec<Vec<usize>> = zk_ro[start..end].to_vec();
+            let mut rng = Pcg64Mcg::seed_from_u64(
+                sweep_seed ^ (wid as u64).wrapping_mul(0x9E37_79B9_7F4A_7C15),
+            );
+            let mut probs = vec![0.0f64; num_super * num_sub];
+            run_sweep_pam_range(
+                &mut wnds,
+                &mut wndsk,
+                &mut wzs,
+                &mut wzk,
+                &mut wnkw,
+                &mut wnk,
+                &docs[start..end],
+                alpha_sk,
+                alpha,
+                beta,
+                num_super,
+                num_sub,
+                num_types,
+                &mut probs,
+                &mut rng,
+            );
+            PamWorkerOut {
+                nkw: wnkw,
+                nds: wnds,
+                ndsk: wndsk,
+                zs: wzs,
+                zk: wzk,
+                start,
+            }
+        })
+        .collect();
+
+    // --- Reconcile nkw: final = Σ_workers − (W−1)·original, clamped ≥ 0. ---
+    let wm1 = (outs.len() as i64) - 1;
+    for t in 0..k {
+        for w in 0..v {
+            let sum_w: i64 = outs.iter().map(|o| o.nkw[t][w] as i64).sum();
+            let val = sum_w - wm1 * orig_nkw[t][w] as i64;
+            nkw[t][w] = val.max(0) as u32;
+        }
+        // Recompute nk from the merged nkw row so the two stay exactly consistent.
+        nk[t] = nkw[t].iter().map(|&c| c as u64).sum::<u64>() as u32;
+    }
+
+    // --- Write back each worker's per-document slices (documents are disjoint). ---
+    for out in outs {
+        let start = out.start;
+        for (i, (((ndsr, ndskr), zsr), zkr)) in out
+            .nds
+            .into_iter()
+            .zip(out.ndsk)
+            .zip(out.zs)
+            .zip(out.zk)
+            .enumerate()
+        {
+            nds[start + i] = ndsr;
+            ndsk[start + i] = ndskr;
+            zs[start + i] = zsr;
+            zk[start + i] = zkr;
+        }
+    }
+}
+
+impl PamModel {
+    /// One full Gibbs sweep over every token, delegating to the shared, range-based
+    /// [`run_sweep_pam_range`] over the whole corpus. Disjoint `&mut self.field`
+    /// borrows in a single call are permitted, so a single copy of the sampling
+    /// logic is used by both the serial path and each AD-LDA worker (no drift).
     fn sweep<R: Rng>(&mut self, docs: &[Vec<u32>], rng: &mut R) {
         let mut probs = vec![0.0f64; self.num_super * self.num_sub];
-        for (d, doc) in docs.iter().enumerate() {
-            for (i, &w) in doc.iter().enumerate() {
-                let w = w as usize;
-                let s_old = self.zs[d][i];
-                let k_old = self.zk[d][i];
-                self.nds[d][s_old] -= 1;
-                self.ndsk[d][s_old][k_old] -= 1;
-                self.nkw[k_old][w] -= 1;
-                self.nk[k_old] -= 1;
-                self.assign_token(d, i, w, &mut probs, rng);
-            }
-        }
+        run_sweep_pam_range(
+            &mut self.nds,
+            &mut self.ndsk,
+            &mut self.zs,
+            &mut self.zk,
+            &mut self.nkw,
+            &mut self.nk,
+            docs,
+            &self.alpha_sk,
+            self.alpha,
+            self.beta,
+            self.num_super,
+            self.num_sub,
+            self.num_types,
+            &mut probs,
+            rng,
+        );
     }
 
     /// Re-estimate each super-topic's asymmetric sub-topic prior `α_s` by moment
@@ -395,6 +566,7 @@ pub fn fit_pam<R: Rng>(
         crate::keyatm::ThetaDrawOpts::new(false, 0, 0),
         0.0,
         0,
+        1,
         rng,
     );
     model
@@ -403,6 +575,11 @@ pub fn fit_pam<R: Rng>(
 /// Fit a PAM with thinned θ snapshots (sub-topic proportions, marginalized over
 /// super-topics) collected every `thin` sweeps, ring-buffered to `cap` draws.
 /// `cap=0` disables collection entirely.
+///
+/// `num_threads` selects the sampler: `1` (or `0`) runs the exact serial sweep,
+/// byte-identical to the pre-threading path; `>1` runs MALLET-style
+/// approximate-parallel (AD-LDA) sampling, deterministic for a fixed
+/// `num_threads` + seed.
 ///
 /// Returns `(model, ll_history, converged)`.
 #[allow(clippy::too_many_arguments)]
@@ -417,6 +594,7 @@ pub fn fit_pam_with_draws<R: Rng>(
     opts: crate::keyatm::ThetaDrawOpts,
     convergence_tol: f64,
     check_every: usize,
+    num_threads: usize,
     rng: &mut R,
 ) -> (PamModel, Vec<(usize, f64)>, bool) {
     let d = docs.len();
@@ -477,7 +655,31 @@ pub fn fit_pam_with_draws<R: Rng>(
     let mut converged = false;
 
     for it in 0..iters {
-        model.sweep(docs, rng);
+        if num_threads <= 1 {
+            // Exact serial path — byte-identical to the pre-threading loop.
+            model.sweep(docs, rng);
+        } else {
+            // Approximate-parallel AD-LDA. One per-sweep seed drawn from the main
+            // RNG keeps it deterministic for a fixed num_threads + seed.
+            let sweep_seed = rng.gen::<u64>();
+            parallel_sweep_pam(
+                &mut model.nds,
+                &mut model.ndsk,
+                &mut model.zs,
+                &mut model.zk,
+                &mut model.nkw,
+                &mut model.nk,
+                docs,
+                &model.alpha_sk,
+                model.alpha,
+                model.beta,
+                model.num_super,
+                model.num_sub,
+                model.num_types,
+                num_threads,
+                sweep_seed,
+            );
+        }
         if it >= adapt_after {
             model.estimate_alpha_sk();
         }
@@ -695,8 +897,101 @@ mod tests {
         let opts = crate::keyatm::ThetaDrawOpts { cap: 0, thin: 1 };
         let mut rng = ChaCha8Rng::seed_from_u64(3);
         let (model, _, _) =
-            fit_pam_with_draws(&docs, 12, 2, 3, 0.1, 0.01, 5, opts, 0.0, 0, &mut rng);
+            fit_pam_with_draws(&docs, 12, 2, 3, 0.1, 0.01, 5, opts, 0.0, 0, 1, &mut rng);
         // Collection stays disabled: nothing pushed despite thin=1.
         assert!(model.theta_draws.is_empty());
+    }
+
+    /// Helper: a small corpus with enough documents to partition across workers.
+    fn threading_corpus() -> (Vec<Vec<u32>>, usize) {
+        let v = 16;
+        let docs: Vec<Vec<u32>> = (0..60)
+            .map(|d| (0..12).map(|i| ((i * 5 + d * 3) % v) as u32).collect())
+            .collect();
+        (docs, v)
+    }
+
+    fn fit_threaded(
+        docs: &[Vec<u32>],
+        v: usize,
+        iters: usize,
+        num_threads: usize,
+        seed: u64,
+    ) -> PamModel {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed);
+        let opts = crate::keyatm::ThetaDrawOpts::new(false, 0, 0);
+        let (m, _, _) = fit_pam_with_draws(
+            docs,
+            v,
+            3,
+            4,
+            0.1,
+            0.01,
+            iters,
+            opts,
+            0.0,
+            0,
+            num_threads,
+            &mut rng,
+        );
+        m
+    }
+
+    #[test]
+    fn num_threads_one_is_bit_identical_to_serial() {
+        // num_threads=1 must never draw the per-sweep seed and must reproduce the
+        // pre-threading serial path exactly.
+        let (docs, v) = threading_corpus();
+        let mut r_serial = ChaCha8Rng::seed_from_u64(99);
+        let serial = fit_pam(&docs, v, 3, 4, 0.1, 0.01, 40, &mut r_serial);
+        let threaded1 = fit_threaded(&docs, v, 40, 1, 99);
+        assert_eq!(serial.nkw, threaded1.nkw, "nkw differs at num_threads=1");
+        assert_eq!(serial.nk, threaded1.nk, "nk differs at num_threads=1");
+        assert_eq!(serial.zs, threaded1.zs, "zs differs at num_threads=1");
+        assert_eq!(serial.zk, threaded1.zk, "zk differs at num_threads=1");
+        assert_eq!(serial.nds, threaded1.nds, "nds differs at num_threads=1");
+        assert_eq!(serial.ndsk, threaded1.ndsk, "ndsk differs at num_threads=1");
+    }
+
+    #[test]
+    fn threaded_is_deterministic_for_fixed_threads_and_seed() {
+        // A fixed num_threads>1 with a fixed seed reproduces exactly across runs.
+        let (docs, v) = threading_corpus();
+        let a = fit_threaded(&docs, v, 40, 4, 123);
+        let b = fit_threaded(&docs, v, 40, 4, 123);
+        assert_eq!(a.nkw, b.nkw);
+        assert_eq!(a.nk, b.nk);
+        assert_eq!(a.nds, b.nds);
+        assert_eq!(a.ndsk, b.ndsk);
+        assert_eq!(a.topic_word(), b.topic_word());
+    }
+
+    #[test]
+    fn threaded_nk_matches_merged_nkw_and_token_total() {
+        // The AD-LDA merge recomputes nk from the merged nkw rows, so nk[k] must
+        // equal Σ_w nkw[k][w] exactly, and the grand total must equal the corpus
+        // token count (no tokens lost or duplicated in the partition-and-merge).
+        let (docs, v) = threading_corpus();
+        let m = fit_threaded(&docs, v, 40, 4, 7);
+        for t in 0..m.num_sub {
+            let row_sum: u32 = m.nkw[t].iter().sum();
+            assert_eq!(m.nk[t], row_sum, "nk[{t}] != Σ_w nkw[{t}][w]");
+        }
+        let total_tokens: usize = docs.iter().map(|d| d.len()).sum();
+        let nk_total: u32 = m.nk.iter().sum();
+        assert_eq!(nk_total as usize, total_tokens, "token count not conserved");
+    }
+
+    #[test]
+    fn threaded_handles_more_workers_than_docs() {
+        // partition_ranges clamps the worker count to the document count, so an
+        // oversized num_threads must run cleanly without empty-chunk corruption.
+        let docs: Vec<Vec<u32>> = (0..3)
+            .map(|d| (0..6).map(|i| ((i + d) % 8) as u32).collect())
+            .collect();
+        let m = fit_threaded(&docs, 8, 20, 16, 5);
+        let total_tokens: usize = docs.iter().map(|d| d.len()).sum();
+        let nk_total: u32 = m.nk.iter().sum();
+        assert_eq!(nk_total as usize, total_tokens);
     }
 }

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -35,6 +35,15 @@ struct PaState {
     log_likelihood_history: Vec<(usize, f64)>,
     #[serde(default)]
     converged: bool,
+    // Appended last with a default so older self-describing saves still load; the
+    // positional bincode format cannot round-trip a genuine pre-threading save
+    // regardless (see the `doc_super` note above), so this is only a soft default.
+    #[serde(default = "default_num_threads")]
+    num_threads: usize,
+}
+
+fn default_num_threads() -> usize {
+    1
 }
 #[derive(serde::Serialize, serde::Deserialize)]
 struct HldaState {
@@ -79,6 +88,9 @@ pub struct PA {
     alpha: f64,
     beta: f64,
     seed: u64,
+    // Default AD-LDA worker count; `fit(num_threads=)` overrides it per call.
+    // `1` is the exact serial path.
+    num_threads: usize,
     fitted: bool,
     topic_names: Vec<String>,
     phi: Option<Array2<f64>>,       // num_sub × V
@@ -123,6 +135,7 @@ impl PA {
         d.set_item("alpha", self.alpha)?;
         d.set_item("beta", self.beta)?;
         d.set_item("seed", self.seed)?;
+        d.set_item("num_threads", self.num_threads)?;
         Ok(d)
     }
 
@@ -130,15 +143,20 @@ impl PA {
     /// sub-topics (the sub-topics are the word-level topics).
     /// `alpha` is the symmetric Dirichlet prior on each document's distribution
     /// over super-topics; `beta` is the topic-word Dirichlet smoothing; `seed`
-    /// seeds the Gibbs RNG.
+    /// seeds the Gibbs RNG. `num_threads` `>1` runs the collapsed-Gibbs sweep as
+    /// MALLET-style approximate-parallel AD-LDA (documents partitioned across
+    /// workers sampling private sub-topic→word count copies, then merged;
+    /// deterministic for a fixed `num_threads`+`seed`); `1` is the exact serial
+    /// path. `fit(num_threads=)` overrides it per call.
     #[new]
-    #[pyo3(signature = (num_super, num_sub, *, alpha=0.1, beta=0.01, seed=42))]
+    #[pyo3(signature = (num_super, num_sub, *, alpha=0.1, beta=0.01, seed=42, num_threads=1))]
     fn new(
         #[pyo3(from_py_with = "py_num_super")] num_super: usize,
         #[pyo3(from_py_with = "py_num_sub")] num_sub: usize,
         alpha: f64,
         beta: f64,
         seed: u64,
+        num_threads: usize,
     ) -> PyResult<Self> {
         if num_super < 1 || num_sub < 2 {
             return Err(PyValueError::new_err(
@@ -154,6 +172,7 @@ impl PA {
             alpha,
             beta,
             seed,
+            num_threads: num_threads.max(1),
             fitted: false,
             topic_names: Vec::new(),
             phi: None,
@@ -181,8 +200,12 @@ impl PA {
     /// heuristic on the log-likelihood trace, not a guarantee the Gibbs chain has
     /// mixed. `check_every` is how often, in sweeps, the log-likelihood is recorded
     /// and the `convergence_tol` test is applied.
+    /// `num_threads` overrides the constructor's worker count for this fit only
+    /// (`None` = constructor value); `>1` runs the collapsed-Gibbs sweep as
+    /// approximate-parallel AD-LDA (deterministic for a fixed `num_threads`+`seed`),
+    /// `1` is the exact serial path.
     #[pyo3(signature = (data, *, iters=1000, keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize))]
+                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -192,6 +215,7 @@ impl PA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
+        num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -217,6 +241,8 @@ impl PA {
         let num_docs = corpus.num_docs();
         let num_types = corpus.num_types();
         let (s, k, a, b) = (slf.num_super, slf.num_sub, slf.alpha, slf.beta);
+        // fit()-level num_threads overrides the constructor default for this run.
+        let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
 
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
@@ -234,6 +260,7 @@ impl PA {
                 draws_opts,
                 convergence_tol,
                 check_every,
+                num_threads,
                 &mut rng,
             );
             (m, hist, conv, corpus)
@@ -423,6 +450,7 @@ impl PA {
                 topic_names: self.topic_names.clone(),
                 log_likelihood_history: self.log_likelihood_history.clone(),
                 converged: self.converged,
+                num_threads: self.num_threads,
             },
         )
     }
@@ -441,6 +469,7 @@ impl PA {
             alpha: s.alpha,
             beta: s.beta,
             seed: s.seed,
+            num_threads: s.num_threads.max(1),
             fitted: s.fitted,
             topic_names,
             phi: arr2_back(s.phi)?,

--- a/tests/test_pa_parallel.py
+++ b/tests/test_pa_parallel.py
@@ -1,0 +1,130 @@
+"""Pachinko Allocation multi-threaded (AD-LDA) training — the num_threads knob (#566).
+
+PAM's collapsed Gibbs sampler shares only the sub-topic->word counts (nkw / nk)
+across documents; the per-document two-level tables (nds, ndsk) and the per-token
+super/sub assignments are disjoint by document. So the knob follows the same dense
+AD-LDA pattern as SeededLDA: num_threads=1 is the exact serial sweep;
+num_threads>1 partitions documents across workers sampling against private nkw/nk
+copies, then merges (nkw additively, nk recomputed from the merged rows) and writes
+each worker's per-document slices straight back.
+
+Contract under test:
+- num_threads=1 reproduces byte-for-byte across runs.
+- a fixed num_threads>1 is deterministic across runs (topic_word and doc_topic).
+- num_threads=0 clamps to serial; fit(num_threads=) overrides the constructor.
+- doc_topic and doc_super rows sum to 1.
+- token counts are conserved through the partition-and-merge.
+- settings and save/load carry num_threads.
+
+Recovery *quality* is not asserted here: PAM's super-topic layer is inherently
+high-variance and seed-sensitive (small default alpha + hard single-super
+commitment at init, adaptation only in the final quarter of sweeps — see #497), so
+it is validated serially against a gold corpus in test_pa_gold.py /
+test_pa_doc_super.py, not under threading. Like every AD-LDA model in the roster,
+num_threads>1 is an exact-merge approximation that trades some mixing accuracy for
+speed; the merge correctness (not the model's recovery power) is what these tests
+pin down.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+S = 2            # super-topics
+K = 4            # sub-topics
+Vp = 6           # vocabulary words per sub-topic block
+D = 120
+
+
+def _make_corpus(seed=0):
+    # Two super-topics; each owns two disjoint sub-topic blocks. A document draws
+    # from both blocks of ONE super-topic, so sub-topics co-occur within a super
+    # but never across supers (the structure PAM's super layer should recover).
+    rng = np.random.default_rng(seed)
+    groups = {0: (0, 1), 1: (2, 3)}
+    docs = []
+    for d in range(D):
+        s = d % S
+        b0, b1 = groups[s]
+        doc = []
+        for _ in range(30):
+            b = b0 if rng.random() < 0.5 else b1
+            doc.append(f"b{b}w{rng.integers(Vp)}")
+        docs.append(doc)
+    return docs
+
+
+def _fit(docs, num_threads, seed=42, ctor_threads=None, iters=100):
+    ctor = ctor_threads if ctor_threads is not None else num_threads
+    m = topica.PA(S, K, seed=seed, num_threads=ctor)
+    kw = {} if ctor_threads is None else {"num_threads": num_threads}
+    m.fit(docs, iters=iters, keep_theta_draws=False, **kw)
+    return m
+
+
+def test_serial_is_reproducible():
+    docs = _make_corpus()
+    a = _fit(docs, 1)
+    b = _fit(docs, 1)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_fixed_thread_count_is_deterministic(nt):
+    docs = _make_corpus()
+    a = _fit(docs, nt)
+    b = _fit(docs, nt)
+    assert np.array_equal(a.topic_word, b.topic_word)
+    assert np.array_equal(a.doc_topic, b.doc_topic)
+    assert np.array_equal(a.super_sub, b.super_sub)
+
+
+def test_zero_threads_clamped_to_serial():
+    docs = _make_corpus()
+    serial = _fit(docs, 1)
+    clamped = _fit(docs, 0)
+    assert np.array_equal(serial.topic_word, clamped.topic_word)
+
+
+def test_fit_num_threads_overrides_constructor():
+    docs = _make_corpus()
+    override = _fit(docs, 4, ctor_threads=1)
+    pure4 = _fit(docs, 4)
+    assert np.array_equal(override.topic_word, pure4.topic_word)
+
+
+def test_parallel_preserves_simplex():
+    docs = _make_corpus()
+    m = _fit(docs, 4)
+    np.testing.assert_allclose(m.doc_topic.sum(axis=1), 1.0, rtol=0, atol=1e-6)
+    np.testing.assert_allclose(m.doc_super.sum(axis=1), 1.0, rtol=0, atol=1e-6)
+
+
+@pytest.mark.parametrize("nt", [2, 4, 8])
+def test_token_counts_conserved_under_threading(nt):
+    # The AD-LDA merge must neither lose nor duplicate tokens: the sub-topic->word
+    # matrix, un-normalized back to counts, must sum to the corpus token total. We
+    # check it via doc_lengths (per-doc token counts are preserved) and that every
+    # topic_word row is a proper distribution.
+    docs = _make_corpus()
+    m = _fit(docs, nt)
+    assert sum(m.doc_lengths) == sum(len(d) for d in docs)
+    tw = m.topic_word
+    np.testing.assert_allclose(tw.sum(axis=1), 1.0, rtol=0, atol=1e-9)
+
+
+def test_settings_report_num_threads():
+    m = topica.PA(S, K, num_threads=4)
+    assert m.settings["num_threads"] == 4
+
+
+def test_save_load_round_trips_num_threads(tmp_path):
+    docs = _make_corpus()
+    m = _fit(docs, 4)
+    path = str(tmp_path / "pa_threaded.topica")
+    m.save(path)
+    loaded = topica.PA.load(path)
+    assert loaded.settings["num_threads"] == 4
+    assert np.array_equal(m.topic_word, loaded.topic_word)


### PR DESCRIPTION
Adds a `num_threads` knob to **Pachinko Allocation** — the last count model in the #566 roster — using the same MALLET-style approximate-parallel (AD-LDA) partition-and-merge already shipped for SeededLDA (#573), BTM (#574), LabeledLDA (#571), and DMR/GDMR (#570).

## Why PA is a clean AD-LDA case
PAM's only cross-document shared state is the sub-topic→word counts (`nkw`/`nk`). The per-document two-level tables (`nds` D×S, `ndsk` D×S×K) and per-token super/sub assignments (`zs`/`zk`) are disjoint by document — each worker owns its slice and writes it straight back.

## What changed
- **`src/pa.rs`**: extracted the sampler into a single range-based `run_sweep_pam_range` (the serial `PamModel::sweep` and every AD-LDA worker share it, so there is one copy of the sampling logic and no drift). Added `parallel_sweep_pam`: documents partitioned across workers, each sampling a private `nkw`/`nk` clone, then reconciled — `nkw` additively (`Σ_workers − (W−1)·orig`, i64 accum, clamp ≥0), `nk` **recomputed** from the merged rows so `nk[k] == Σ_w nkw[k][w]` holds exactly (no zero-clamp drift). Only the sub index of the sampled `(super,sub)` pair touches `nkw`, so word-token counts stay conserved per worker and the standard AD-LDA merge applies unchanged. `alpha_sk` is read-only during the sweep (adapted serially by `estimate_alpha_sk` after the merge).
- **`src/python/hierarchical.rs`**: mirror the BTM binding — constructor `num_threads=1` default + `fit(num_threads=)` per-call override, threaded through `settings` (#400) and save/load (`PaState`).
- **`.pyi` stub** + tests.

## Determinism contract (uniform across the arc)
- `num_threads=1` never draws the per-sweep seed → **byte-identical** to the pre-threading serial path (Rust test `num_threads_one_is_bit_identical_to_serial` compares `nkw`/`nk`/`nds`/`ndsk`/`zs`/`zk`).
- A fixed `num_threads>1` + fixed seed is **deterministic** (per-sweep seed from the main RNG; per-worker `Pcg64Mcg`; integer merge is scheduling-independent).

## On recovery quality
Recovery *quality* is deliberately **not** asserted under threading. PAM's super-topic layer is inherently high-variance and seed-sensitive (small default `alpha` + hard single-super commitment at init, adaptation only in the final quarter — see #497); its recovery is validated serially against a gold corpus (`test_pa_gold.py` / `test_pa_doc_super.py`). Like every AD-LDA model in the roster, `num_threads>1` is an exact-merge approximation that trades some mixing accuracy for speed. These tests pin down the *merge correctness*, not the model's recovery power.

## Gates
`cargo test --lib` (257), `pytest tests/` (4001 passed, 32 skipped), `mkdocs build --strict`, `./scripts/preflight.sh` (fmt/clippy/table/stub/settings-doc) all green.

Plan was reviewed by a Gemini agent before implementation (confirmed the merge correctness for PAM's super/sub structure).