### PR TITLE
feat(slda,nmf,lsa): num_threads knob for the parallel fits (#567, #568)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1523,6 +1523,7 @@ class SupervisedLDA:
         num_theta_draws: int = 25,
         convergence_tol: float = 0.0,
         check_every: int = 1,
+        num_threads: int | None = None,
     ) -> "SupervisedLDA":
         """Fit the model. `y` is the per-document response (length = number of
         documents). With inference="variational", `iters` is EM iterations and
@@ -4434,6 +4435,7 @@ class NMF:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
+        num_threads: int | None = None,
     ) -> "NMF":
         """Fit on a Corpus or a list of token lists. `iters` is the maximum number
         of multiplicative-update iterations (default 200). convergence_tol
@@ -4507,7 +4509,12 @@ class LSA:
         """weighting is 'tfidf' (default, classic LSI) or 'count'. seed seeds the
         randomized-SVD sketch."""
         ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]]) -> "LSA":
+    def fit(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        num_threads: int | None = None,
+    ) -> "LSA":
         """Fit on a Corpus or a list of token lists. The SVD is a direct solve, so
         there is no iters argument."""
         ...

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -11374,9 +11374,13 @@ impl SupervisedLDA {
     /// early-stop heuristic on the bound trace, not a convergence guarantee.
     /// `check_every` is how often, in EM iterations, the bound is recorded and the
     /// `convergence_tol` test is applied.
+    /// `num_threads` caps the worker pool for the parallel per-document variational
+    /// E-step (`None`/`0` = all cores). Output is deterministic regardless of the
+    /// worker count, so this controls only resource use, not results; it has no
+    /// effect on the serial `inference="gibbs"` backend.
     #[pyo3(signature = (data, y, *, iters=25, var_iters=15,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=1_usize))]
+                        convergence_tol=0.0_f64, check_every=1_usize, num_threads=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -11388,6 +11392,7 @@ impl SupervisedLDA {
         num_theta_draws: usize,
         convergence_tol: f64,
         check_every: usize,
+        num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -11438,33 +11443,36 @@ impl SupervisedLDA {
         let use_gibbs = slf.inference == "gibbs";
 
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
-            let (m, hist, conv) = if use_gibbs {
-                // Gibbs ignores var_iters (no per-document E-step) and never early
-                // stops; convergence_tol is not applicable.
-                slda::fit_slda_gibbs(
-                    &corpus.docs,
-                    &y,
-                    num_types,
-                    k,
-                    alpha,
-                    iters,
-                    check_every,
-                    &mut rng,
-                )
-            } else {
-                slda::fit_slda(
-                    &corpus.docs,
-                    &y,
-                    num_types,
-                    k,
-                    alpha,
-                    iters,
-                    var_iters,
-                    convergence_tol,
-                    check_every,
-                    &mut rng,
-                )
-            };
+            let (m, hist, conv) = run_with_threads(num_threads, || {
+                if use_gibbs {
+                    // Gibbs ignores var_iters (no per-document E-step) and never
+                    // early stops; convergence_tol is not applicable. It is serial,
+                    // so the worker pool is inert here.
+                    slda::fit_slda_gibbs(
+                        &corpus.docs,
+                        &y,
+                        num_types,
+                        k,
+                        alpha,
+                        iters,
+                        check_every,
+                        &mut rng,
+                    )
+                } else {
+                    slda::fit_slda(
+                        &corpus.docs,
+                        &y,
+                        num_types,
+                        k,
+                        alpha,
+                        iters,
+                        var_iters,
+                        convergence_tol,
+                        check_every,
+                        &mut rng,
+                    )
+                }
+            });
             (m, hist, conv, corpus)
         });
 

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -168,14 +168,18 @@ impl NMF {
 
     /// Fit on `data` (a Corpus or list of token lists). `iters` is the maximum
     /// number of multiplicative-update iterations (default 200). `convergence_tol`
-    /// overrides the constructor value for this run (when given).
-    #[pyo3(signature = (data, *, iters=None, convergence_tol=None))]
+    /// overrides the constructor value for this run (when given). `num_threads` caps
+    /// the worker pool for the parallel multiplicative-update matmuls (`None`/`0` =
+    /// all cores); output is deterministic regardless of the worker count, so it
+    /// controls only resource use, not results.
+    #[pyo3(signature = (data, *, iters=None, convergence_tol=None, num_threads=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
+        num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         let tol = convergence_tol.unwrap_or(slf.convergence_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -233,7 +237,9 @@ impl NMF {
             slf.seed,
         );
         let (model, corpus) = py.allow_threads(move || {
-            let m = nmf::fit_nmf(&corpus.docs, k, num_types, bl, ini, tfidf, it, tol, seed);
+            let m = run_with_threads(num_threads, || {
+                nmf::fit_nmf(&corpus.docs, k, num_types, bl, ini, tfidf, it, tol, seed)
+            });
             (m, corpus)
         });
         slf.model = Some(model);
@@ -526,11 +532,16 @@ impl LSA {
     }
 
     /// Fit on `data` (a Corpus or list of token lists). The SVD is a direct solve,
-    /// so there is no `iters` argument.
+    /// so there is no `iters` argument. `num_threads` caps the worker pool for the
+    /// parallel matmuls in the truncated SVD (`None`/`0` = all cores); output is
+    /// deterministic regardless of the worker count, so it controls only resource
+    /// use, not results.
+    #[pyo3(signature = (data, *, num_threads=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
+        num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -565,7 +576,9 @@ impl LSA {
         }
         let (k, tfidf, seed) = (slf.num_topics, slf.weighting_tfidf, slf.seed);
         let (model, corpus) = py.allow_threads(move || {
-            let m = lsa::fit_lsa(&corpus.docs, k, num_types, tfidf, seed);
+            let m = run_with_threads(num_threads, || {
+                lsa::fit_lsa(&corpus.docs, k, num_types, tfidf, seed)
+            });
             (m, corpus)
         });
         slf.model = Some(model);

--- a/tests/test_lsa.py
+++ b/tests/test_lsa.py
@@ -150,3 +150,13 @@ def test_input_validation():
     empty = topica.LSA(3)
     with pytest.raises(Exception):
         empty.fit([])
+
+
+def test_num_threads_is_deterministic_resource_knob():
+    """num_threads bounds the truncated-SVD matmul pool; LSA is a direct solve, so
+    the output must be identical across worker counts. None/0 = all cores."""
+    docs, _vocab = _planted(seed=2)
+    base = topica.LSA(3, seed=1).fit(docs, num_threads=1)
+    for nt in (2, 4, 8, 0, None):
+        m = topica.LSA(3, seed=1).fit(docs, num_threads=nt)
+        assert np.array_equal(base.topic_word, m.topic_word), f"num_threads={nt}"

--- a/tests/test_nmf.py
+++ b/tests/test_nmf.py
@@ -206,3 +206,15 @@ def test_nndsvd_at_exactly_the_rank_is_accepted():
     m = topica.NMF(3, init="nndsvd")
     m.fit(docs, iters=5)  # must not raise/panic
     assert m.topic_word.shape[0] == 3
+
+
+def test_num_threads_is_deterministic_resource_knob():
+    """num_threads bounds the multiplicative-update matmul pool; because NMF is a
+    deterministic solve, the output must be identical across worker counts (the
+    knob controls only resource use). None/0 mean 'all cores' and are accepted."""
+    docs, _vocab, _truth = _planted(seed=2)
+    base = topica.NMF(3, seed=1).fit(docs, iters=40, num_threads=1)
+    for nt in (2, 4, 8, 0, None):
+        m = topica.NMF(3, seed=1).fit(docs, iters=40, num_threads=nt)
+        assert np.array_equal(base.topic_word, m.topic_word), f"num_threads={nt}"
+        assert np.array_equal(base.doc_topic, m.doc_topic), f"num_threads={nt}"

--- a/tests/test_slda.py
+++ b/tests/test_slda.py
@@ -215,3 +215,15 @@ class TestGibbsBackend:
         b = SupervisedLDA(num_topics=2, seed=11, inference="gibbs").fit(docs, y, iters=100)
         assert np.allclose(a.topic_word, b.topic_word)
         assert np.allclose(a.coefficients, b.coefficients)
+
+
+def test_num_threads_is_deterministic_resource_knob():
+    """num_threads caps the parallel per-document variational E-step. sLDA's
+    variational fit is deterministic, so output must be identical across worker
+    counts (the knob controls only resource use). None/0 = all cores."""
+    docs, y = _supervised_corpus(n=80)
+    base = SupervisedLDA(num_topics=2, seed=5).fit(docs, y, iters=10, num_threads=1)
+    for nt in (2, 4, 8, 0, None):
+        m = SupervisedLDA(num_topics=2, seed=5).fit(docs, y, iters=10, num_threads=nt)
+        assert np.array_equal(base.topic_word, m.topic_word), f"num_threads={nt}"
+        assert np.array_equal(base.coefficients, m.coefficients), f"num_threads={nt}"


### PR DESCRIPTION
Closes #567. Closes #568. The two "already threaded, just needs a knob" quick-wins from the #569 roadmap.

## What
- **SupervisedLDA** (#567): its variational per-document E-step already runs `par_iter` (`slda.rs`). Add a fit-only `num_threads` that bounds the worker pool.
- **NMF + LSA** (#568): the multiplicative-update matmuls (`nmf.rs`) and the truncated-SVD (`lsa.rs`, reusing NMF's path) are already rayon-parallel. Same fit-only `num_threads`.

All three pin the pool via the existing `run_with_threads` helper (`mod.rs:113`) — the exact knob CTM/STM already use. `None`/`0` = all cores.

## Fit-only, not a setting — because these are deterministic-output models
Unlike the AD-LDA count models (LDA/DMR/BTM/PA/PT), where `num_threads` changes the *approximate* sampling and is therefore a persisted constructor/settings/save field, these models produce **identical output regardless of worker count**. So `num_threads` is pure resource control and lives only on `fit()` — matching the CTM/STM precedent. The added tests assert byte-identical `topic_word` (and `doc_topic`/`coefficients`) across `num_threads ∈ {1,2,4,8,0,None}`.

For SupervisedLDA the pool is inert on the serial `inference="gibbs"` backend; that backend's AD-LDA threading remains separate work (part of #566).

## Gates
`pytest tests/` (4027 passed, 32 skipped), `mkdocs build --strict`, `./scripts/preflight.sh` (fmt + clippy + stub sync) all green. `.pyi` stub updated for the three `fit` signatures.