### PR TITLE
docs: Code of Conduct + community/testing guidance (JOSS readiness)

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+neal.caren@unc.edu. All complaints will be reviewed and investigated promptly
+and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/README.md
+++ b/README.md
@@ -244,6 +244,32 @@ The embedding-native models build on two pure-Rust crates: [**petal-clustering**
 
 Full citations for every model and reference implementation, and how to cite topica, are on the [Citing](https://nealcaren.github.io/topica/citing/) page.
 
+## Contributing, tests, and support
+
+Contributions are welcome. See [CONTRIBUTING](.github/CONTRIBUTING.md) for the
+development setup and workflow, [CONTRIBUTING-MODELS](.github/CONTRIBUTING-MODELS.md)
+for adding a new topic model, and the [conventions guide](docs/contributing/conventions.md)
+for the cross-model naming and API contract. All participants are expected to
+follow our [Code of Conduct](CODE_OF_CONDUCT.md).
+
+To run the test suite after a source build:
+
+```bash
+cargo test --lib                                   # Rust unit tests
+python -m pytest tests/ -q                         # Python tests
+mkdocs build --strict                              # docs build clean
+```
+
+Every push runs these on CI (see the badge above). The `parity/` checks
+validate models against their reference implementations (R `stm`, keyATM,
+MALLET); they skip cleanly when those toolchains are not installed.
+
+- **Report a bug or request a feature:** open an [issue](https://github.com/nealcaren/topica/issues).
+- **Ask a question or share how you are using topica:** start a [discussion](https://github.com/nealcaren/topica/discussions).
+
+topica is maintained by Neal Caren. Issues and pull requests are triaged on a
+best-effort basis.
+
 ## License
 
 Apache-2.0 — see [LICENSE](LICENSE).


### PR DESCRIPTION
Closes two community-guidelines gaps that JOSS-style reviews check for (informed by the Turftopic review, openjournals/joss-reviews#8183). Not a submission — just best practices that make the package better run.

## Changes
- **`CODE_OF_CONDUCT.md`** — Contributor Covenant 2.1, contact `neal.caren@unc.edu`. We had none; reviewers look for it under "community guidelines."
- **README "Contributing, tests, and support" section** — how to run the test suite (`cargo test --lib`, `pytest`, `mkdocs build --strict`), what `parity/` validates, where to report issues, and where to get support. Reviewers score visible tests/CI, so this signposts what already exists.
- **Enabled GitHub Discussions** (repo setting) as the support channel the README now links to.

The CI badge was already present, so item 3's badge was already done — this adds the missing "how to run the tests" guidance.

## Not included
- Verifying clean-env `pip install topica` (a verification task, not a code change) — running separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)