### PR TITLE
feat(llm): drop the llm CLI dep; dispatch llm_backend/llm_embed to lightweight provider SDKs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   unchanged **except**: `llm_embed` drops the old `batch=` keyword (the SDKs batch
   natively), it no longer reaches in-process `sentence-transformers` models (compute
   those embeddings directly and pass the array, as every embedding model already
-  accepts), and Anthropic has no embedding API (`llm_embed` raises for it).
+  accepts), and Anthropic has no embedding API (`llm_embed` raises for it). Provider
+  routing is now by model family, not by the old `llm`-CLI plugin slug: a prefixed
+  name like `"ollama/qwen3"` or `"openrouter/…"` resolves by its last path segment
+  (so it defaults to OpenAI) — point at a local/alternate endpoint with `base_url=`
+  instead.
 - **ProdLDA-family VAE decoder now uses a BLAS-free GEMM (2.7–6.8× faster on the
   decoder)** (#378). The hand-coded dense-decoder VAE backbone shared by `ProdLDA`,
   `CombinedTM`, `ZeroShotTM`, `InfoCTM`, and `Scholar` spent most of a fit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,18 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Changed
 
+- **LLM helpers now use lightweight per-provider SDKs instead of the `llm` CLI**
+  (#597). `llm_backend` / `llm_embed` dispatch by model name to the `openai`,
+  `anthropic`, or `google-genai` SDKs (`gpt*`→OpenAI, `claude*`→Anthropic,
+  `gemini*`→Gemini; `provider=` overrides; `base_url=` forces an OpenAI-compatible
+  endpoint for ollama / openrouter / vLLM / LM Studio / groq). This drops the single
+  heavyweight `llm` dependency (which pulled ~42 packages and a pre-release
+  `sqlite-migrate` that `uv` blocks). Extras are now `topica[openai]` /
+  `[anthropic]` / `[gemini]`; `topica[llm]` installs all three. The public API is
+  unchanged **except**: `llm_embed` drops the old `batch=` keyword (the SDKs batch
+  natively), it no longer reaches in-process `sentence-transformers` models (compute
+  those embeddings directly and pass the array, as every embedding model already
+  accepts), and Anthropic has no embedding API (`llm_embed` raises for it).
 - **ProdLDA-family VAE decoder now uses a BLAS-free GEMM (2.7–6.8× faster on the
   decoder)** (#378). The hand-coded dense-decoder VAE backbone shared by `ProdLDA`,
   `CombinedTM`, `ZeroShotTM`, `InfoCTM`, and `Scholar` spent most of a fit

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Your own data is one line away: pass `pandas.read_csv("yours.csv")` to `from_dat
 
 Fits are reproducible and validated: the variational models are identical to the bit, the samplers reproduce from a fixed seed and thread count, and every model is checked against its reference implementation (R `stm`, MALLET, keyATM, and more).
 
-The core needs only NumPy and pandas. Optional extras add features without weighing it down: `topica[viz]` (matplotlib plots), `topica[formula]` (R-style formulas), `topica[polars]` (Polars frames), and `topica[llm]` (LLM labels and embeddings, OpenAI or local via ollama).
+The core needs only NumPy and pandas. Optional extras add features without weighing it down: `topica[viz]` (matplotlib plots), `topica[formula]` (R-style formulas), `topica[polars]` (Polars frames), and, for LLM labels and embeddings, one lightweight provider SDK per backend, dispatched by model name: `topica[openai]` (`gpt-*`, and any OpenAI-compatible endpoint including local ollama via `base_url=`), `topica[anthropic]` (`claude-*`), `topica[gemini]` (`gemini-*`), or `topica[llm]` for all three.
 
 ## Models
 

--- a/docs/examples/llm-topics.md
+++ b/docs/examples/llm-topics.md
@@ -1,9 +1,9 @@
 # LLM embeddings and labels: Du Bois's *Crisis* essays
 
-This worked example runs the **embedding-native** path end to end with the
-[`llm`](https://llm.datasette.io/) library doing the two jobs that touch a model:
-generating the document embeddings and naming the topics. Everything between is
-pure topica. The corpus is the 704 essays W. E. B. Du Bois wrote for *The Crisis*
+This worked example runs the **embedding-native** path end to end. Two steps
+touch a model: generating the document embeddings (a local `sentence-transformers`
+model here) and naming the topics (`llm_backend`). Everything between is pure
+topica. The corpus is the 704 essays W. E. B. Du Bois wrote for *The Crisis*
 between 1910 and 1934 (the same corpus as the [Du Bois example](dubois.md), here
 modeled from sentence embeddings rather than word counts).
 
@@ -12,10 +12,10 @@ modeled from sentence embeddings rather than word counts).
     `plot_report`. For the count-based workflow on this corpus see
     [Du Bois](dubois.md).
 
-    `pip install "topica[llm,viz]"` covers `llm` (OpenAI built in) and the ollama
-    plugin. The local `sentence-transformers` embedder below additionally needs
-    `pip install llm-sentence-transformers`; for a fully local, torch-free run use
-    ollama embeddings (`all-minilm`) instead. Reproducible with
+    `pip install "topica[openai,viz]" sentence-transformers` covers the label
+    model (OpenAI, via `OPENAI_API_KEY`) and the local embedder below. To label
+    with Claude or Gemini instead, install `topica[anthropic]` / `topica[gemini]`
+    and pass that model name. Reproducible with
     [`examples/llm_topics.py`](https://github.com/nealcaren/topica/blob/main/examples/llm_topics.py).
 
 ## 1. Corpus
@@ -32,15 +32,21 @@ docs = [topica.tokenize(t, stopwords=stop, min_length=4) for t in texts]   # tok
 
 ## 2. Embed — once, cached
 
-`llm_embed` produces the document-vector matrix the embedding models need. Naming
-a local `sentence-transformers` model keeps it offline and free; `cache=` writes
-the matrix to disk so re-running the script reloads it instead of re-embedding
-(embeddings are the costly step).
+Any `(num_docs, E)` matrix works as the document vectors. A local
+`sentence-transformers` model keeps this step offline and free; we cache the
+matrix to disk with `save_embeddings` so re-running the script reloads it instead
+of re-embedding (embeddings are the costly step). For a hosted embedder instead,
+`topica.llm_embed(texts, model="text-embedding-3-small")` returns the same shape.
 
 ```python
-doc_emb = topica.llm_embed(
-    texts, model="sentence-transformers/all-MiniLM-L6-v2", cache="crisis_emb.npz"
-)
+import os
+from sentence_transformers import SentenceTransformer
+
+if os.path.exists("crisis_emb.npz"):
+    doc_emb = topica.load_embeddings("crisis_emb.npz")
+else:
+    doc_emb = SentenceTransformer("all-MiniLM-L6-v2").encode(texts)
+    topica.save_embeddings("crisis_emb.npz", doc_emb, texts=texts, model="all-MiniLM-L6-v2")
 doc_emb.shape          # (704, 384)
 ```
 
@@ -100,10 +106,11 @@ topica.topic_label_prompts(model, texts)[1]   # inspect exactly what the model s
 9 voter segregation and rights
 ```
 
-The key is resolved by `llm`: by default the `OPENAI_API_KEY` environment variable
-(or a stored `llm keys` value), or pass `llm_backend(..., key=...)` to hand one in.
-A local model works the same way — `llm_backend("llama3.2", ...)` with the
-`llm-ollama` plugin needs no key at all. The deterministic descriptors
+The key is resolved from the provider's environment variable (here
+`OPENAI_API_KEY`), or pass `llm_backend(..., key=...)` to hand one in. A local
+model works the same way and needs no key —
+`llm_backend("llama3.2", base_url="http://localhost:11434/v1")` routes to an
+ollama server. The deterministic descriptors
 (`label_topics`: FREX / probability / lift) remain the defensible naming for
 publication; the LLM labels are the readable shorthand. With `set_labels=True` they
 replace the default labels everywhere, including the report below.

--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -21,12 +21,16 @@ is an optional extra, so the core stays light. Install the ones you need:
 | `pip install "topica[viz]"` | matplotlib figures: [`plot_report`](../api/diagnostics.md), `quality_frontier(plot=True)`, the search-K and discovery plots |
 | `pip install "topica[formula]"` | The R-style formula interface ([`design_matrix`](../api/keywords.md), `estimate_effect(formula=...)`); pulls in `formulaic` and `pandas` |
 | `pip install "topica[polars]"` | Pass Polars DataFrames/Series to [`from_dataframe`](../api/keywords.md), `align`, and `design_matrix` |
-| `pip install "topica[llm]"` | LLM topic labels and embeddings ([`llm_topic_labels`](../api/diagnostics.md), [`llm_embed`](../api/keywords.md)); installs `llm` plus the ollama plugin, so OpenAI works with `OPENAI_API_KEY` and a fully local path runs through ollama |
+| `pip install "topica[openai]"` | LLM topic labels and embeddings ([`llm_topic_labels`](../api/diagnostics.md), [`llm_embed`](../api/keywords.md)) with OpenAI (`gpt-*`, `text-embedding-*`); also reaches any OpenAI-compatible endpoint (ollama, openrouter, ...) via `base_url=`. Set `OPENAI_API_KEY` or pass `key=` |
+| `pip install "topica[anthropic]"` | Label topics with Claude (`claude-*`); set `ANTHROPIC_API_KEY` or pass `key=` |
+| `pip install "topica[gemini]"` | Label and embed with Gemini (`gemini-*`); set `GEMINI_API_KEY` or pass `key=` |
+| `pip install "topica[llm]"` | All three provider SDKs above, in one install |
 
-Combine extras in one install, e.g. `pip install "topica[llm,viz,formula]"`. For
-local *sentence-transformer* embeddings add `llm-sentence-transformers` (which
-pulls in PyTorch); ollama's own embedding models need nothing extra. Two more
-packages also light up if already present: `pyLDAvis` (interactive
+`llm_backend` / `llm_embed` dispatch to the right SDK by the model name, so you
+install only what you use. Combine extras in one install, e.g.
+`pip install "topica[llm,viz,formula]"`. For fully offline, in-process embeddings
+without a server, use `sentence-transformers` directly and pass the array. Two
+more packages also light up if already present: `pyLDAvis` (interactive
 intertopic-distance charts) and `pandas` (tabular handling of effect/diagnostic
 tables).
 

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -52,15 +52,15 @@ topica.find_thoughts_html(model, texts, n_docs=3)               # highlighted cl
 For readable labels, `llm_topic_labels` asks an LLM to name each topic from its
 top words and representative documents. topica is the plumbing: it assembles the
 prompt and you bring the model. Pass any callable (your own client, a local
-`ollama` endpoint) as `call`, or name a model through the optional
-[`llm`](https://llm.datasette.io/) adapter, which reaches every provider and
-local models via plugins.
+`ollama` endpoint) as `call`, or name a model through the optional `llm_backend`
+adapter, which dispatches by the model name to a lightweight OpenAI / Anthropic /
+Gemini SDK (and reaches any OpenAI-compatible endpoint via `base_url=`).
 
 ```python
 # Bring your own callable (no extra dependency):
 labels = topica.llm_topic_labels(model, texts, backend=my_model_fn, set_labels=True)
 
-# Or name a model via the `llm` adapter (pip install "topica[llm]"):
+# Or name a model via llm_backend (pip install "topica[openai]"):
 backend = topica.llm_backend("gpt-4o-mini", temperature=0)   # pin for stability
 labels = topica.llm_topic_labels(model, texts, backend=backend, set_labels=True)
 
@@ -85,11 +85,12 @@ et al. (2023) show that an LLM, prompted with the *same* instructions the crowd-
 received, tracks human ratings more closely — especially the rating task. topica
 exposes these diagnostics under the **`topica.llm`** namespace — an `llm-bounded`
 family kept distinct from the bit-exact diagnostics above. All reuse the
-provider-agnostic `topica[llm]` backend.
+provider-dispatched `llm_backend`.
 
 ```python
-# A capable open-source model, via OpenRouter or a local endpoint:
-backend = topica.llm.backend("openrouter/meta-llama/llama-3.3-70b-instruct", temperature=0)
+# A capable open-source model via OpenRouter (base_url), or name a hosted model:
+backend = topica.llm.backend("meta-llama/llama-3.3-70b-instruct",
+                             base_url="https://openrouter.ai/api/v1", temperature=0)
 
 topica.llm.coherence(model, backend=backend, n_words=10)        # per-topic 1-3 rating (the headline)
 topica.llm.intrusion(model, backend=backend, n_words=5)         # LLM picks the intruder -> accuracy

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -14,14 +14,21 @@ wherever you like, a sentence-transformer, an API, or a local model such as
 ollama. Everything downstream is in the wheel.
 
 If you would rather not wire up an embedder yourself, `topica.llm_embed` produces
-the matrix through Simon Willison's [`llm`](https://llm.datasette.io/) library
-(the optional `topica[llm]` extra), which reaches OpenAI embeddings and local
-sentence-transformers via plugins:
+the matrix from a hosted embedding model, dispatched by the model name to a
+lightweight provider SDK: OpenAI (`topica[openai]`) or Gemini (`topica[gemini]`).
+It also reaches any OpenAI-compatible `/v1/embeddings` endpoint via `base_url=`
+(e.g. ollama):
 
 ```python
-doc_emb = topica.llm_embed(texts, model="text-embedding-3-small")          # API
-doc_emb = topica.llm_embed(texts, model="sentence-transformers/all-MiniLM-L6-v2")  # local
+doc_emb = topica.llm_embed(texts, model="text-embedding-3-small")   # OpenAI
+doc_emb = topica.llm_embed(texts, model="gemini-embedding-001")     # Gemini
+doc_emb = topica.llm_embed(texts, model="nomic-embed-text",
+                           base_url="http://localhost:11434/v1")    # local ollama
 ```
+
+For fully offline, in-process embeddings without any server, use
+`sentence-transformers` directly and pass the array to any model that accepts
+`embeddings=` (see the end-to-end example below).
 
 Embeddings are costly, so cache them. Pass `cache=path` to embed a corpus once and
 reuse it on later runs (it reloads when the file matches the same `texts`, and
@@ -34,11 +41,12 @@ topica.save_embeddings("emb.npz", doc_emb, texts=texts, model="all-MiniLM-L6-v2"
 doc_emb = topica.load_embeddings("emb.npz")
 ```
 
-End to end, from raw text to a fitted model, with `llm_embed` doing the
-text-to-vectors step offline (no API key, runs in the wheel):
+End to end, from raw text to a fitted model, with `sentence-transformers` doing
+the text-to-vectors step fully offline (no API key, in-process):
 
 ```python
 import topica
+from sentence_transformers import SentenceTransformer
 
 texts = [
     "The economy added jobs as the unemployment rate fell again.",
@@ -49,8 +57,8 @@ texts = [
     "The rookie hit two home runs and drove in five for the win.",
 ]
 
-# text -> (num_docs, E) vectors; the topica[llm] extra, sentence-transformers backend
-doc_emb = topica.llm_embed(texts, model="sentence-transformers/all-MiniLM-L6-v2")
+# text -> (num_docs, E) vectors, computed locally and passed straight in.
+doc_emb = SentenceTransformer("all-MiniLM-L6-v2").encode(texts)
 
 docs = [topica.tokenize(t, stopwords=topica.ENGLISH_STOPWORDS) for t in texts]
 model = topica.BERTopic(min_cluster_size=2, seed=1)

--- a/docs/guides/llm.md
+++ b/docs/guides/llm.md
@@ -17,8 +17,9 @@ without topica taking an API dependency.
 ```python
 import topica
 
-# Bring a model: a callable, or model="ollama/qwen3" via the topica[llm] adapter.
-# topica showcases open-source models; any callable str -> str backend works.
+# Bring a model: a callable, or a model name via llm_backend, e.g.
+# model="gpt-4o-mini" / "claude-3-5-haiku-latest" / "gemini-2.5-flash", or a local
+# model with base_url="http://localhost:11434/v1" (ollama). Any callable works.
 model = topica.TopicGPT(backend=my_callable, assignment="hard")
 model.fit(docs)                       # docs: a Corpus, raw strings, or token lists
 

--- a/examples/bertopic_best_practices.py
+++ b/examples/bertopic_best_practices.py
@@ -53,8 +53,9 @@ def main():
     titles = dataset["title"]  # noqa: F841  (used for hover labels in the original)
 
     # --- Pre-calculate embeddings (the tutorial's all-MiniLM-L6-v2) -------
-    # topica is bring-your-own-vectors. (topica.llm_embed(abstracts,
-    # model="sentence-transformers/all-MiniLM-L6-v2") is the in-package route.)
+    # topica is bring-your-own-vectors: compute the matrix however you like and
+    # pass it in. (For a hosted embedder, topica.llm_embed(abstracts,
+    # model="text-embedding-3-small") returns the same shape.)
     embedding_model = SentenceTransformer("all-MiniLM-L6-v2")
     embeddings = embedding_model.encode(abstracts, show_progress_bar=True)
 

--- a/examples/llm_topics.py
+++ b/examples/llm_topics.py
@@ -1,16 +1,17 @@
-"""End-to-end embedding topics with the `llm` library: embed, model, label, report.
+"""End-to-end embedding topics: embed, model, label, report.
 
-Uses topica.llm_embed to produce document embeddings (cached so the corpus is
-embedded once), fits FASTopic, labels the topics with an LLM, and writes a
-plot_report figure.
+Embeds the corpus once (local sentence-transformers, cached to disk), fits
+FASTopic, labels the topics with an LLM, and writes a plot_report figure.
 
-    pip install "topica[llm,viz]" llm-sentence-transformers
+    pip install "topica[openai,viz]" sentence-transformers
     python examples/llm_topics.py
 
 The embedder is a local sentence-transformers model (offline, no key). The labeler
 defaults to OpenAI gpt-4o-mini, whose key is read from OPENAI_API_KEY (or pass
-key=... to llm_backend). For a fully local, key-free run, install llm-ollama and
-set LABEL_MODEL to a pulled model such as "llama3.2".
+key=... to llm_backend). To label with Claude or Gemini, pip install
+topica[anthropic]/topica[gemini] and set LABEL_MODEL to "claude-3-5-haiku-latest"
+or "gemini-2.5-flash"; for a local run set LABEL_MODEL to a pulled ollama model
+and LABEL_BASE_URL to "http://localhost:11434/v1".
 """
 
 import csv
@@ -23,8 +24,9 @@ ROOT = os.path.dirname(HERE)
 CRISIS = os.path.join(ROOT, "examples", "dubois_crisis.csv")
 STOP = os.path.join(ROOT, "examples", "english-stoplist.txt")
 
-EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"  # local, offline
-LABEL_MODEL = "gpt-4o-mini"                             # OpenAI; key from OPENAI_API_KEY
+EMBED_MODEL = "all-MiniLM-L6-v2"       # local sentence-transformers, offline
+LABEL_MODEL = "gpt-4o-mini"            # OpenAI; key from OPENAI_API_KEY
+LABEL_BASE_URL = None                  # set to an OpenAI-compatible URL for local models
 
 
 def main():
@@ -35,7 +37,14 @@ def main():
     docs = [topica.tokenize(t, stopwords=stop, min_length=4) for t in texts]
 
     # 1. Embed once, cached. Re-runs reload from disk instead of re-embedding.
-    doc_emb = topica.llm_embed(texts, model=EMBED_MODEL, cache=os.path.join(HERE, "crisis_emb.npz"))
+    cache = os.path.join(HERE, "crisis_emb.npz")
+    if os.path.exists(cache):
+        doc_emb = topica.load_embeddings(cache)
+    else:
+        from sentence_transformers import SentenceTransformer
+
+        doc_emb = SentenceTransformer(EMBED_MODEL).encode(texts)
+        topica.save_embeddings(cache, doc_emb, texts=texts, model=EMBED_MODEL)
 
     # 2. Fit an embedding-native, mixed-membership model.
     model = topica.FASTopic(num_topics=10, seed=1)
@@ -45,7 +54,7 @@ def main():
     # the one step that needs a labeling model; skip it gracefully if none is set
     # up, in which case the report keeps topica's default top-word labels.
     try:
-        backend = topica.llm_backend(LABEL_MODEL, temperature=0)
+        backend = topica.llm_backend(LABEL_MODEL, base_url=LABEL_BASE_URL, temperature=0)
         labels = topica.llm_topic_labels(model, texts, backend=backend, set_labels=True)
         for t, label in enumerate(labels):
             print(f"{t:2d}  {label}")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,20 +36,28 @@ formula = ["formulaic>=0.6", "pandas>=1.3"]
 # design_matrix). The DataFrame is not the cost center, so this is a convenience,
 # not a speedup.
 polars = ["polars>=0.20"]
-# Optional adapter for LLM labeling and embeddings (topica.llm_backend /
-# llm_embed). The core (llm_topic_labels with call=..., or your own embeddings)
-# takes any callable/array and needs nothing. This extra adds `llm` plus the
-# ollama plugin, so OpenAI works out of the box (set OPENAI_API_KEY) and a fully
-# local, torch-free path runs through ollama (both chat and embedding models).
-# Local sentence-transformer embeddings additionally need `llm-sentence-transformers`.
-llm = ["llm>=0.13", "llm-ollama"]
+# LLM labeling and embeddings (topica.llm_backend / llm_embed) are optional and
+# provider-dispatched: the model name picks the backend, and you install only the
+# SDK(s) you use. The core (llm_topic_labels with backend=..., or your own
+# embeddings) takes any callable/array and needs none of these. Each SDK is
+# lightweight and wheel-only, unlike the former `llm` CLI, which pulled a large
+# tree including a pre-release of `sqlite-migrate` that breaks `uv pip install`.
+# OpenAI also reaches any OpenAI-compatible endpoint via base_url= (ollama,
+# openrouter, vLLM, LM Studio, groq). Anthropic has no embedding API.
+openai = ["openai>=1.0"]        # gpt-*, and OpenAI-compatible servers via base_url=
+anthropic = ["anthropic>=0.40"]  # claude-*
+gemini = ["google-genai>=1.0"]   # gemini-*
+# The convenience bundle: all three provider SDKs (chat for OpenAI/Anthropic/
+# Gemini, embeddings for OpenAI/Gemini).
+llm = ["openai>=1.0", "anthropic>=0.40", "google-genai>=1.0"]
 # The visualization toolkit (topica.viz), static and interactive in one extra:
 # matplotlib for .to_png(), pandas for every panel's .to_frame(), scipy to seriate
 # the similarity heatmap (degrades gracefully if absent), and plotly (WebGL) as the
 # single interactive .to_html() backend.
 viz = ["matplotlib>=3.4", "pandas>=1.3", "scipy>=1.7", "plotly>=5"]
 # Everything, for a one-shot install.
-all = ["formulaic>=0.6", "pandas>=1.3", "polars>=0.20", "llm>=0.13", "llm-ollama",
+all = ["formulaic>=0.6", "pandas>=1.3", "polars>=0.20",
+       "openai>=1.0", "anthropic>=0.40", "google-genai>=1.0",
        "matplotlib>=3.4", "scipy>=1.7", "plotly>=5"]
 test = ["pytest>=7", "pandas>=1.3", "formulaic>=0.6", "matplotlib>=3.4", "scipy>=1.7", "plotly>=5"]
 

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -812,8 +812,7 @@ def _resolve_llm_call(backend):
         return llm_backend(backend)
     raise TypeError(
         "backend must be a callable (str -> str) or a model-name string; pass e.g. "
-        'backend=topica.llm.backend("openrouter/meta-llama/llama-3.3-70b-instruct") '
-        'or backend="<your model>".'
+        'backend=topica.llm.backend("gpt-4o-mini") or backend="<your model>".'
     )
 
 

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -194,10 +194,16 @@ def load_embeddings(path, *, with_meta=False):
 def _detect_embed_provider(model: str, base_url) -> str:
     """Pick an embedding provider from the model name. ``base_url`` forces an
     OpenAI-compatible endpoint. OpenAI is the default (``text-embedding-3-*``,
-    ``text-embedding-ada-002``); Gemini for ``gemini-embedding-*``."""
+    ``text-embedding-ada-002``); Gemini for ``gemini-embedding-*``. A ``claude-*``
+    model resolves to ``anthropic`` so ``llm_embed`` raises the clear "no
+    embedding API" error rather than mis-routing to OpenAI (mirrors
+    :func:`topica.labeling._detect_provider`)."""
     if base_url is not None:
         return "openai"
-    if model.lower().split("/")[-1].startswith("gemini"):
+    m = model.lower().split("/")[-1]  # tolerate "anthropic/claude-...", "models/gemini-..."
+    if m.startswith("claude"):
+        return "anthropic"
+    if m.startswith("gemini"):
         return "gemini"
     return "openai"
 
@@ -236,6 +242,11 @@ def _gemini_embed(items, model, *, key):
     # Some google-genai versions expose a single-item embed as `.embedding`
     # (singular) with `.embeddings` left None; fall back so a 1-text call works.
     embs = resp.embeddings if resp.embeddings is not None else [resp.embedding]
+    if len(embs) != len(items):  # never silently drop/duplicate rows
+        raise RuntimeError(
+            f"Gemini embed_content returned {len(embs)} embeddings for "
+            f"{len(items)} inputs."
+        )
     return np.asarray([e.values for e in embs], dtype=float)
 
 

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -233,7 +233,10 @@ def _gemini_embed(items, model, *, key):
         ) from e
     client = genai.Client(api_key=key) if key is not None else genai.Client()
     resp = client.models.embed_content(model=model, contents=items)
-    return np.asarray([e.values for e in resp.embeddings], dtype=float)
+    # Some google-genai versions expose a single-item embed as `.embedding`
+    # (singular) with `.embeddings` left None; fall back so a 1-text call works.
+    embs = resp.embeddings if resp.embeddings is not None else [resp.embedding]
+    return np.asarray([e.values for e in embs], dtype=float)
 
 
 def llm_embed(texts, model="text-embedding-3-small", *, provider=None,
@@ -274,6 +277,17 @@ def llm_embed(texts, model="text-embedding-3-small", *, provider=None,
                 return arr
 
     prov = provider or _detect_embed_provider(model, base_url)
+    if prov == "anthropic":
+        raise ValueError(
+            "Anthropic has no embedding API; use an OpenAI or Gemini embedding "
+            "model, or compute embeddings with sentence-transformers and pass the "
+            "array directly."
+        )
+    if prov not in ("openai", "gemini"):
+        raise ValueError(
+            f"unknown embedding provider {prov!r}; expected 'openai' or 'gemini' "
+            "(or pass base_url= for an OpenAI-compatible endpoint)."
+        )
     if prov == "gemini":
         arr = _gemini_embed(items, model, key=key)
     else:

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -191,31 +191,79 @@ def load_embeddings(path, *, with_meta=False):
         return emb, meta
 
 
-def llm_embed(texts, model="text-embedding-3-small", *, key=None, batch=True, cache=None):
-    """Embed ``texts`` with the `llm` library's embedding models, as a dense
-    ``(n, dim)`` float array.
+def _detect_embed_provider(model: str, base_url) -> str:
+    """Pick an embedding provider from the model name. ``base_url`` forces an
+    OpenAI-compatible endpoint. OpenAI is the default (``text-embedding-3-*``,
+    ``text-embedding-ada-002``); Gemini for ``gemini-embedding-*``."""
+    if base_url is not None:
+        return "openai"
+    if model.lower().split("/")[-1].startswith("gemini"):
+        return "gemini"
+    return "openai"
+
+
+def _openai_embed(items, model, *, base_url, key):
+    import importlib
+
+    try:
+        openai = importlib.import_module("openai")
+    except ImportError as e:  # pragma: no cover - exercised via message
+        raise ImportError(
+            "llm_embed with an OpenAI model needs the optional `openai` package "
+            '(pip install openai, or pip install "topica[openai]" / "topica[llm]").'
+        ) from e
+    api_key = key or os.environ.get("OPENAI_API_KEY")
+    if api_key is None and base_url is not None:
+        api_key = "not-needed"  # local compatible servers ignore auth
+    client = openai.OpenAI(base_url=base_url, api_key=api_key)
+    resp = client.embeddings.create(model=model, input=items)
+    return np.asarray([d.embedding for d in resp.data], dtype=float)
+
+
+def _gemini_embed(items, model, *, key):
+    import importlib
+
+    try:
+        genai = importlib.import_module("google.genai")
+    except ImportError as e:  # pragma: no cover - exercised via message
+        raise ImportError(
+            "llm_embed with a Gemini model needs the optional `google-genai` "
+            'package (pip install google-genai, or pip install "topica[gemini]" '
+            '/ "topica[llm]").'
+        ) from e
+    client = genai.Client(api_key=key) if key is not None else genai.Client()
+    resp = client.models.embed_content(model=model, contents=items)
+    return np.asarray([e.values for e in resp.embeddings], dtype=float)
+
+
+def llm_embed(texts, model="text-embedding-3-small", *, provider=None,
+              base_url=None, key=None, cache=None):
+    """Embed ``texts`` as a dense ``(n, dim)`` float array, via a lightweight
+    provider SDK dispatched by the model name.
 
     The embedding models in topica (``BERTopic``, ``Top2Vec``, ``ETM``,
     ``FASTopic``) and :func:`embedding_seeds` all take embeddings you supply; this
-    is one way to produce them. ``model`` names any embedding model
-    `llm <https://llm.datasette.io/>`_ can reach — OpenAI's
-    ``"text-embedding-3-small"`` / ``"3-large"`` (needs an API key), or a local
-    model such as ``"sentence-transformers/all-MiniLM-L6-v2"`` via the
-    ``llm-sentence-transformers`` plugin (no API, runs offline). Pass document
-    texts for document embeddings, or the vocabulary for word embeddings.
+    is one way to produce them. Pass document texts for document embeddings, or
+    the vocabulary for word embeddings.
 
-    By default the API key (for hosted embedders) is resolved by ``llm`` itself: a
-    stored ``llm keys`` value, else the provider's environment variable
-    (``OPENAI_API_KEY`` for OpenAI). Pass ``key`` to override it explicitly.
+    - ``text-embedding-3-*`` / anything else -> OpenAI (the ``openai`` client)
+    - ``gemini-embedding-*``                 -> Gemini (the ``google-genai`` client)
+
+    Pass ``base_url`` to force an OpenAI-compatible ``/v1/embeddings`` endpoint
+    (e.g. ``ollama`` at ``"http://localhost:11434/v1"``); ``provider`` overrides
+    auto-detection. ``key`` sets the API key, else the provider's environment
+    variable is used (``OPENAI_API_KEY`` / ``GEMINI_API_KEY``). Anthropic has no
+    embedding API; for offline in-process embeddings without a server, use
+    ``sentence-transformers`` directly and pass the array to the model.
 
     Embeddings are costly, so pass ``cache=path`` to embed once and reuse: if the
     file exists and was saved for the same ``texts``, it is loaded and no model is
     called; otherwise the embeddings are computed and written there (see
     :func:`save_embeddings`).
 
-    Requires the optional ``llm`` package (``pip install "topica[llm]"``). The
-    embeddings are the only thing topica needs from a model; everything downstream
-    runs in the wheel.
+    Needs the matching optional SDK: ``pip install "topica[openai]"``,
+    ``"topica[gemini]"``, or ``"topica[llm]"``. The embeddings are the only thing
+    topica needs from a model; everything downstream runs in the wheel.
     """
     items = [str(t) for t in texts]
     if cache is not None:
@@ -225,26 +273,12 @@ def llm_embed(texts, model="text-embedding-3-small", *, key=None, batch=True, ca
             if arr.shape[0] == len(items) and meta.get("texts_hash") == _texts_hash(items):
                 return arr
 
-    try:
-        import llm as _llm
-    except ImportError as e:  # pragma: no cover - exercised via message
-        raise ImportError(
-            "llm_embed needs the optional `llm` package "
-            '(pip install llm, or pip install "topica[llm]").'
-        ) from e
-    try:
-        em = _llm.get_embedding_model(model)
-    except Exception as e:
-        from .labeling import _unknown_model_message
+    prov = provider or _detect_embed_provider(model, base_url)
+    if prov == "gemini":
+        arr = _gemini_embed(items, model, key=key)
+    else:
+        arr = _openai_embed(items, model, base_url=base_url, key=key)
 
-        unknown = getattr(_llm, "UnknownModelError", None)
-        if unknown is not None and not isinstance(e, unknown):
-            raise
-        raise ValueError(_unknown_model_message(_llm, model, kind="embedding")) from e
-    if key is not None:
-        em.key = key
-    vecs = list(em.embed_multi(items)) if batch else [em.embed(t) for t in items]
-    arr = np.asarray(vecs, dtype=float)
     if cache is not None:
         save_embeddings(cache, arr, texts=items, model=model)
     return arr

--- a/python/topica/labeling.py
+++ b/python/topica/labeling.py
@@ -4,10 +4,11 @@ topica assembles the labeling prompt from each topic's top words and
 representative documents; you bring the model. The core is dependency-free and
 takes any callable ``str -> str`` (:func:`llm_topic_labels` with ``backend=``), so
 your own client, an ``ollama`` endpoint, or an API wrapper all work without
-topica taking a dependency. :func:`llm_backend` is an optional adapter for Simon
-Willison's `llm <https://llm.datasette.io/>`_ library, so you can name a model
-instead of writing the call yourself — one optional dependency that reaches every
-provider and local models via plugins.
+topica taking a dependency. :func:`llm_backend` is an optional adapter that lets
+you name a model instead of writing the call yourself: it dispatches by the model
+name to a lightweight provider SDK (``gpt-*`` -> OpenAI, ``claude-*`` ->
+Anthropic, ``gemini-*`` -> Gemini), and reaches any OpenAI-compatible endpoint
+(ollama, openrouter, vLLM, ...) via ``base_url=``.
 
 LLM labels are a readable convenience, not a reproducible measurement. Pin the
 model and set temperature to 0 for stability, and keep FREX / probability / lift
@@ -19,23 +20,6 @@ from __future__ import annotations
 import numpy as np
 
 from .analysis import _top_words, representative_docs, set_topic_labels
-
-def _unknown_model_message(_llm, model, kind="chat") -> str:
-    """An actionable error for a model `llm` does not know — the failure a user
-    hits when the needed plugin, server, or pulled model is missing."""
-    try:
-        getter = _llm.get_models if kind == "chat" else _llm.get_embedding_models
-        known = ", ".join(m.model_id for m in list(getter())[:6])
-    except Exception:  # pragma: no cover - defensive
-        known = "(could not list installed models)"
-    plugin = "llm-ollama" if kind == "chat" else "llm-sentence-transformers"
-    return (
-        f"llm has no {kind} model named {model!r}. OpenAI models work once "
-        f"OPENAI_API_KEY is set; for a local model install a plugin and make the "
-        f"model available — e.g. `pip install {plugin}`, and for ollama run the "
-        f"server and `ollama pull {model}`. Known {kind} models include: {known}."
-    )
-
 
 _DEFAULT_INSTRUCTIONS = (
     "You are labeling topics from a topic model fit on a document collection. "
@@ -77,40 +61,140 @@ def topic_label_prompts(model, texts=None, *, n_words=12, n_docs=3, max_chars=30
     return prompts
 
 
-def llm_backend(model="gpt-4o-mini", *, key=None, system=None, **options):
-    """A ``str -> str`` callable backed by the `llm` library, for the ``backend=``
-    argument of :func:`llm_topic_labels`.
+# --- Provider backends: one lightweight SDK per provider, dispatched by model --
+# The distribution to `pip install` and the module to import, per provider.
+_PROVIDER_DIST = {
+    "openai": ("openai", "openai"),
+    "anthropic": ("anthropic", "anthropic"),
+    "gemini": ("google-genai", "google.genai"),
+}
 
-    ``model`` names any model ``llm`` can reach — OpenAI, Anthropic, or local
-    models through plugins such as ``llm-ollama``. By default the API key is
-    resolved by ``llm`` itself: a stored ``llm keys`` value, else the provider's
-    environment variable (``OPENAI_API_KEY`` for OpenAI). Pass ``key`` to override
-    that with an explicit key. ``options`` pass through to ``llm`` (e.g.
-    ``temperature=0`` for reproducible labels where the provider supports it).
-    Requires the optional ``llm`` package (``pip install llm`` or
-    ``pip install "topica[llm]"``).
-    """
+
+def _detect_provider(model: str, base_url) -> str:
+    """Pick a provider from the model name. An explicit ``base_url`` always means
+    an OpenAI-compatible endpoint (ollama, openrouter, vLLM, ...), so OpenAI."""
+    if base_url is not None:
+        return "openai"
+    m = model.lower().split("/")[-1]  # tolerate "models/gemini-..." and "anthropic/claude-..."
+    if m.startswith("claude"):
+        return "anthropic"
+    if m.startswith("gemini"):
+        return "gemini"
+    # OpenAI is the default: gpt-*, o1/o3/o4-*, chatgpt-*, ft:*, and anything a
+    # compatible server exposes.
+    return "openai"
+
+
+def _import_provider(provider: str, func: str):
+    import importlib
+
+    dist, mod = _PROVIDER_DIST[provider]
     try:
-        import llm as _llm
+        return importlib.import_module(mod)
     except ImportError as e:  # pragma: no cover - exercised via message
         raise ImportError(
-            "llm_backend needs the optional `llm` package "
-            '(pip install llm, or pip install "topica[llm]").'
+            f"{func} with a {provider} model needs the optional `{dist}` package "
+            f'(pip install {dist}, or pip install "topica[{provider}]" '
+            f'/ "topica[llm]").'
         ) from e
-    try:
-        obj = _llm.get_model(model)
-    except Exception as e:
-        unknown = getattr(_llm, "UnknownModelError", None)
-        if unknown is not None and not isinstance(e, unknown):
-            raise
-        raise ValueError(_unknown_model_message(_llm, model, kind="chat")) from e
-    if key is not None:
-        obj.key = key
+
+
+def _openai_chat_call(model, *, base_url, key, system, options):
+    import os
+
+    openai = _import_provider("openai", "llm_backend")
+    api_key = key or os.environ.get("OPENAI_API_KEY")
+    if api_key is None and base_url is not None:
+        # Local OpenAI-compatible servers ignore auth, but the client refuses to
+        # construct without a key.
+        api_key = "not-needed"
+    client = openai.OpenAI(base_url=base_url, api_key=api_key)
 
     def call(prompt: str) -> str:
-        return obj.prompt(prompt, system=system, **options).text().strip()
+        messages = []
+        if system is not None:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+        resp = client.chat.completions.create(model=model, messages=messages, **options)
+        return (resp.choices[0].message.content or "").strip()
 
     return call
+
+
+def _anthropic_chat_call(model, *, key, system, options):
+    anthropic = _import_provider("anthropic", "llm_backend")
+    client = anthropic.Anthropic(api_key=key) if key is not None else anthropic.Anthropic()
+    opts = dict(options)
+    max_tokens = opts.pop("max_tokens", 1024)  # required by the Messages API
+
+    def call(prompt: str) -> str:
+        kw = dict(
+            model=model,
+            max_tokens=max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+            **opts,
+        )
+        if system is not None:
+            kw["system"] = system
+        resp = client.messages.create(**kw)
+        parts = [b.text for b in resp.content if getattr(b, "type", None) == "text"]
+        return "".join(parts).strip()
+
+    return call
+
+
+def _gemini_chat_call(model, *, key, system, options):
+    genai = _import_provider("gemini", "llm_backend")
+    from google.genai import types
+
+    client = genai.Client(api_key=key) if key is not None else genai.Client()
+    cfg = None
+    if system is not None or options:
+        cfg = types.GenerateContentConfig(system_instruction=system, **options)
+
+    def call(prompt: str) -> str:
+        resp = client.models.generate_content(model=model, contents=prompt, config=cfg)
+        return (resp.text or "").strip()
+
+    return call
+
+
+def llm_backend(model="gpt-4o-mini", *, provider=None, base_url=None, key=None,
+                system=None, **options):
+    """A ``str -> str`` callable for the ``backend=`` argument of
+    :func:`llm_topic_labels`, dispatched to the right lightweight provider SDK by
+    the model name:
+
+    - ``gpt-*`` / ``o1-*`` / anything else -> OpenAI (the ``openai`` client)
+    - ``claude-*``                         -> Anthropic (the ``anthropic`` client)
+    - ``gemini-*``                         -> Gemini (the ``google-genai`` client)
+
+    Each provider is one lightweight, wheel-only dependency — unlike the former
+    ``llm`` CLI, which pulled a large tree including a pre-release of
+    ``sqlite-migrate`` that breaks ``uv pip install``.
+
+    Pass ``base_url`` to force an OpenAI-compatible endpoint regardless of the
+    model name — local models via ``ollama``
+    (``base_url="http://localhost:11434/v1"``), plus openrouter, vLLM, LM Studio,
+    and groq. ``provider`` overrides auto-detection when a model name is
+    ambiguous. ``key`` sets the API key, else the provider's environment variable
+    is used (``OPENAI_API_KEY`` / ``ANTHROPIC_API_KEY`` / ``GEMINI_API_KEY``); a
+    local server that ignores auth gets a placeholder automatically. ``system`` is
+    an optional system prompt, and ``options`` pass through to the provider's call
+    (``temperature=0`` is honored by all three for stable labels).
+
+    Needs the matching optional SDK: ``pip install "topica[openai]"``,
+    ``"topica[anthropic]"``, ``"topica[gemini]"``, or ``"topica[llm]"`` for all
+    three.
+    """
+    prov = provider or _detect_provider(model, base_url)
+    if prov == "anthropic":
+        return _anthropic_chat_call(model, key=key, system=system, options=options)
+    if prov == "gemini":
+        return _gemini_chat_call(model, key=key, system=system, options=options)
+    return _openai_chat_call(
+        model, base_url=base_url, key=key, system=system, options=options
+    )
 
 
 def llm_topic_labels(model, texts=None, *, backend=None, llm_model="gpt-4o-mini",

--- a/python/topica/labeling.py
+++ b/python/topica/labeling.py
@@ -188,6 +188,11 @@ def llm_backend(model="gpt-4o-mini", *, provider=None, base_url=None, key=None,
     three.
     """
     prov = provider or _detect_provider(model, base_url)
+    if prov not in ("openai", "anthropic", "gemini"):
+        raise ValueError(
+            f"unknown provider {prov!r}; expected 'openai', 'anthropic', or "
+            "'gemini' (or pass base_url= for an OpenAI-compatible endpoint)."
+        )
     if prov == "anthropic":
         return _anthropic_chat_call(model, key=key, system=system, options=options)
     if prov == "gemini":

--- a/python/topica/llm.py
+++ b/python/topica/llm.py
@@ -9,7 +9,7 @@ model — small models are fine for rating but fail the harder intrusion/labelin
 The namespace collects the suite so it reads as a family and signals the shared
 ``llm-bounded`` contract at the call site::
 
-    backend = topica.llm.backend("openrouter/meta-llama/llama-3.3-70b-instruct", temperature=0)
+    backend = topica.llm.backend("gpt-4o-mini", temperature=0)  # or "claude-3-5-haiku-latest", "gemini-2.5-flash"
     topica.llm.coherence(model, backend=backend)        # per-topic 1-3 rating (Stammbach et al. 2023)
     topica.llm.intrusion(model, backend=backend)        # LLM picks the planted intruder -> accuracy
     topica.llm.select_k(models, docs, backend=backend)  # number of topics by doc-label purity

--- a/python/topica/topicgpt.py
+++ b/python/topica/topicgpt.py
@@ -11,8 +11,9 @@ topics with a supporting quote. The headline output is the set of topic
 topica follows the same division of labor here as in :mod:`topica.labeling`:
 topica assembles the prompts; you bring the model. The backend is any callable
 ``str -> str`` (your own client, an ``ollama`` endpoint, a fake for testing, or
-the :func:`topica.llm_backend` adapter for Simon Willison's ``llm`` library), so
-the core takes no API dependency. The prompt templates live in :data:`PROMPTS`
+the :func:`topica.llm_backend` adapter, which dispatches by model name to a
+lightweight OpenAI / Anthropic / Gemini SDK), so the core takes no API
+dependency. The prompt templates live in :data:`PROMPTS`
 and are overridable, because the prompts are part of the method and a researcher
 must be able to audit and adapt them.
 
@@ -435,12 +436,14 @@ class TopicGPT:
     not produce.
 
     The backend is any callable ``str -> str``. Bring your own client, an
-    ``ollama`` endpoint, or pass :func:`topica.llm_backend` ``model`` for the
-    ``topica[llm]`` adapter; a fake callable makes the whole pipeline testable
-    without a network. Pass either ``backend=`` or ``model=`` (the latter routes
-    through :func:`topica.llm_backend`); supplying both raises. topica showcases
-    open-source models (e.g. ``model="ollama/qwen3"`` or an openrouter qwen id),
-    but any backend works.
+    ``ollama`` endpoint, or pass a ``model`` name routed through
+    :func:`topica.llm_backend` (dispatched to a lightweight OpenAI / Anthropic /
+    Gemini SDK by the model name); a fake callable makes the whole pipeline
+    testable without a network. Pass either ``backend=`` or ``model=`` (the latter
+    routes through :func:`topica.llm_backend`); supplying both raises. topica
+    showcases open-source models (e.g. a local ``model="qwen3"`` with
+    ``base_url="http://localhost:11434/v1"``, or an openrouter qwen id), but any
+    backend works.
 
     Determinism is ``llm-bounded``: ``temperature=0`` and a backend ``seed`` give
     *stable*, not bit-reproducible, results. Responses are cached within a fit
@@ -458,7 +461,16 @@ class TopicGPT:
     backend : callable ``str -> str``, optional
         The model. Mutually exclusive with ``model``.
     model : str, optional
-        A model name routed through :func:`topica.llm_backend` (``topica[llm]``).
+        A model name routed through :func:`topica.llm_backend`, which dispatches
+        by name to a lightweight provider SDK (``gpt-*`` -> ``topica[openai]``,
+        ``claude-*`` -> ``topica[anthropic]``, ``gemini-*`` -> ``topica[gemini]``,
+        or all three via ``topica[llm]``). Mutually exclusive with ``backend``.
+    base_url : str, optional
+        Forwarded to :func:`topica.llm_backend`: an OpenAI-compatible endpoint
+        (ollama at ``"http://localhost:11434/v1"``, openrouter, vLLM, ...).
+    key : str, optional
+        Forwarded to :func:`topica.llm_backend` as the API key (else the
+        provider's environment variable is used).
     hierarchical : bool, default False
         When True, ``fit`` also induces a two-level (super/sub) grouping of the
         discovered topics. ``num_topics`` always counts the leaf topics.
@@ -509,6 +521,8 @@ class TopicGPT:
         *,
         backend: Optional[Callable[[str], str]] = None,
         model: Optional[str] = None,
+        base_url: Optional[str] = None,
+        key: Optional[str] = None,
         hierarchical: bool = False,
         assignment: str = "hard",
         sample: Optional[int] = None,
@@ -526,6 +540,8 @@ class TopicGPT:
             raise ValueError("min_topic_count must be >= 1")
         self._backend_arg = backend
         self._model_name = model
+        self._base_url = base_url
+        self._key = key
         self.hierarchical = bool(hierarchical)
         self.assignment = assignment
         self.sample = sample
@@ -579,7 +595,7 @@ class TopicGPT:
         A convenience over ``TopicGPT(prompts={stage: template})`` for swapping a
         single stage, e.g. to adapt the few-shot examples to your domain::
 
-            model = TopicGPT(model="ollama/qwen3").with_prompt(
+            model = TopicGPT(model="gpt-4o-mini").with_prompt(
                 "generation", my_generation_template)
 
         ``stage`` is one of ``"generation"``, ``"refinement"``, ``"assignment"``;
@@ -601,14 +617,23 @@ class TopicGPT:
         if self._model_name is not None:
             from .labeling import llm_backend
 
-            return llm_backend(self._model_name, temperature=self.temperature)
+            return llm_backend(
+                self._model_name,
+                base_url=self._base_url,
+                key=self._key,
+                temperature=self.temperature,
+            )
         raise ImportError(
             "TopicGPT needs a model. Pass a backend callable "
             "(backend=lambda prompt: my_client(prompt)) or a model name "
-            "(model='ollama/qwen3'), which routes through topica.llm_backend and "
-            'needs the optional `llm` package (pip install "topica[llm]"). '
-            "topica showcases open-source models (e.g. an ollama or openrouter "
-            "qwen); any callable str -> str backend works."
+            "(model='gpt-4o-mini', model='claude-3-5-haiku-latest', "
+            "model='gemini-2.5-flash', or a local model with "
+            "base_url='http://localhost:11434/v1'), which routes through "
+            "topica.llm_backend and needs the matching optional SDK "
+            '(pip install "topica[openai]" / "topica[anthropic]" / '
+            '"topica[gemini]" / "topica[llm]"). topica showcases open-source '
+            "models (e.g. an ollama or openrouter qwen); any callable "
+            "str -> str backend works."
         )
 
     def _cache_key(self, prompt: str) -> str:

--- a/python/topica/topicgpt.py
+++ b/python/topica/topicgpt.py
@@ -574,9 +574,13 @@ class TopicGPT:
     def settings(self) -> dict:
         """The constructor configuration as a JSON-serialisable dict, keyword-named
         to match ``__init__`` (issue #400). The ``backend`` callable is data, not a
-        hyperparameter, so it is not reported; ``model`` records the named backend."""
+        hyperparameter, so it is not reported; ``model`` records the named backend.
+        ``key`` is a secret and is deliberately omitted so it never lands in a
+        provenance record or save; ``base_url`` is reported (it is reproducibility-
+        relevant config, e.g. which endpoint served the run)."""
         return {
             "model": self._model_name,
+            "base_url": self._base_url,
             "hierarchical": self.hierarchical,
             "assignment": self.assignment,
             "sample": self.sample,
@@ -595,7 +599,7 @@ class TopicGPT:
         A convenience over ``TopicGPT(prompts={stage: template})`` for swapping a
         single stage, e.g. to adapt the few-shot examples to your domain::
 
-            model = TopicGPT(model="gpt-4o-mini").with_prompt(
+            model = TopicGPT(model="ollama/qwen3").with_prompt(
                 "generation", my_generation_template)
 
         ``stage`` is one of ``"generation"``, ``"refinement"``, ``"assignment"``;

--- a/tests/test_labeling.py
+++ b/tests/test_labeling.py
@@ -1,8 +1,7 @@
-"""LLM topic labeling as plumbing: prompt assembly, the BYO-callable path, and
-the optional `llm` backend. No network or real model is used; the model is a
+"""LLM topic labeling as plumbing: prompt assembly and the bring-your-own
+callable path. The provider-dispatched `llm_backend` / `llm_embed` are covered in
+test_llm_backend.py. No network or real model is used here; the model is a
 deterministic stub callable."""
-
-import importlib.util
 
 import numpy as np
 import pytest
@@ -74,52 +73,7 @@ def test_instructions_override(model_and_texts):
     assert all(p.startswith("LABEL THIS THING") for p in prompts)
 
 
-def test_llm_backend_requires_llm():
-    # When the optional `llm` package is absent, llm_backend raises a clear error;
-    # when present we cannot call a real model in tests, so just check it builds.
-    if importlib.util.find_spec("llm") is None:
-        with pytest.raises(ImportError, match="llm"):
-            topica.llm_backend("gpt-4o-mini")
-    else:
-        assert callable(topica.llm_backend("gpt-4o-mini"))
-
-
-# --- llm_embed: embeddings via the llm library --------------------------------
-
-
-def test_llm_embed_with_a_fake_llm(monkeypatch):
-    import sys
-    import types
-
-    class _FakeEmbModel:
-        def embed_multi(self, items):
-            return ([float(len(t)), 1.0, 2.0] for t in items)
-
-        def embed(self, t):
-            return [float(len(t)), 1.0, 2.0]
-
-    fake = types.ModuleType("llm")
-    fake.get_embedding_model = lambda name: _FakeEmbModel()
-    monkeypatch.setitem(sys.modules, "llm", fake)
-
-    texts = ["aa", "bbbb", "c"]
-    arr = topica.llm_embed(texts, model="whatever")
-    assert arr.shape == (3, 3)
-    assert list(arr[:, 0]) == [2.0, 4.0, 1.0]  # encodes len(text) in our fake
-    # batch=False path takes the same shape.
-    arr2 = topica.llm_embed(texts, model="whatever", batch=False)
-    assert arr2.shape == (3, 3)
-
-
-def test_llm_embed_requires_llm():
-    if importlib.util.find_spec("llm") is None:
-        with pytest.raises(ImportError, match="llm"):
-            topica.llm_embed(["a", "b"])
-    else:
-        pytest.skip("llm is installed; cannot exercise the missing-package path")
-
-
-# --- save/load embeddings and the llm_embed cache -----------------------------
+# --- save/load embeddings roundtrip -------------------------------------------
 
 
 def test_save_load_embeddings_roundtrip(tmp_path):
@@ -132,109 +86,3 @@ def test_save_load_embeddings_roundtrip(tmp_path):
     assert np.array_equal(arr, emb)
     assert meta["model"] == "m1"
     assert "texts_hash" in meta
-
-
-def _counting_fake_llm(monkeypatch):
-    import sys
-    import types
-
-    calls = {"n": 0}
-
-    class _Emb:
-        def embed_multi(self, items):
-            return ([float(len(t)), 0.5] for t in items)
-
-    fake = types.ModuleType("llm")
-
-    def get_embedding_model(name):
-        calls["n"] += 1
-        return _Emb()
-
-    fake.get_embedding_model = get_embedding_model
-    monkeypatch.setitem(sys.modules, "llm", fake)
-    return calls
-
-
-def test_llm_embed_cache_embeds_once(tmp_path, monkeypatch):
-    calls = _counting_fake_llm(monkeypatch)
-    texts = ["alpha", "beta", "gamma"]
-    cache = tmp_path / "cache"
-
-    a = topica.llm_embed(texts, model="x", cache=cache)
-    assert calls["n"] == 1
-    assert (tmp_path / "cache.npz").exists()
-
-    # Second call with the same texts loads from cache; no model is called.
-    b = topica.llm_embed(texts, model="x", cache=cache)
-    assert calls["n"] == 1
-    assert np.array_equal(a, b)
-
-    # Different texts miss the cache and recompute.
-    topica.llm_embed(["alpha", "beta", "delta"], model="x", cache=cache)
-    assert calls["n"] == 2
-
-
-def test_llm_backend_passes_explicit_key(monkeypatch):
-    import sys
-    import types
-
-    seen = {}
-
-    class _Resp:
-        def text(self):
-            return "LABEL"
-
-    class _Model:
-        def __init__(self):
-            self.key = None
-
-        def prompt(self, prompt, **kw):
-            seen["key_at_call"] = self.key
-            return _Resp()
-
-    obj = _Model()
-    fake = types.ModuleType("llm")
-    fake.get_model = lambda name: obj
-    monkeypatch.setitem(sys.modules, "llm", fake)
-
-    # Explicit key is set on the model; default (None) leaves llm to resolve it.
-    call = topica.llm_backend("gpt-4o-mini", key="sk-test-123")
-    assert obj.key == "sk-test-123"
-    assert call("hi") == "LABEL"
-    assert seen["key_at_call"] == "sk-test-123"
-
-    obj.key = None
-    topica.llm_backend("gpt-4o-mini")  # no key -> untouched, llm resolves from env
-    assert obj.key is None
-
-
-def test_unknown_model_gives_actionable_error(monkeypatch):
-    import sys
-    import types
-
-    class UnknownModelError(Exception):
-        pass
-
-    class _M:
-        model_id = "gpt-4o-mini"
-
-    fake = types.ModuleType("llm")
-    fake.UnknownModelError = UnknownModelError
-
-    def get_model(name):
-        raise UnknownModelError(f"Unknown model: {name}")
-
-    fake.get_model = get_model
-    fake.get_models = lambda: [_M()]
-    fake.get_embedding_models = lambda: [_M()]
-    fake.get_embedding_model = lambda name: (_ for _ in ()).throw(UnknownModelError(name))
-    monkeypatch.setitem(sys.modules, "llm", fake)
-
-    with pytest.raises(ValueError) as exc:
-        topica.llm_backend("gemma4:e2b")
-    msg = str(exc.value)
-    assert "gemma4:e2b" in msg and "ollama" in msg and "OPENAI_API_KEY" in msg
-
-    with pytest.raises(ValueError) as exc2:
-        topica.llm_embed(["a"], model="mystery-embedder")
-    assert "mystery-embedder" in str(exc2.value) and "sentence-transformers" in str(exc2.value)

--- a/tests/test_llm_backend.py
+++ b/tests/test_llm_backend.py
@@ -11,7 +11,7 @@ import numpy as np
 import pytest
 
 import topica
-from topica import labeling
+from topica import embedding, labeling
 
 
 # --- fake SDK modules ---------------------------------------------------------
@@ -233,6 +233,52 @@ def test_gemini_embed(monkeypatch):
     arr = topica.llm_embed(["aa", "bbbb"], model="gemini-embedding-001")
     assert arr.shape == (2, 3)
     assert cap["gemini_embed"]["model"] == "gemini-embedding-001"
+
+
+@pytest.mark.parametrize("model,base_url,expected", [
+    ("text-embedding-3-small", None, "openai"),
+    ("gemini-embedding-001", None, "gemini"),
+    ("models/gemini-embedding-001", None, "gemini"),
+    ("claude-3-5-haiku-latest", None, "anthropic"),
+    ("anthropic/claude-3-5-sonnet", None, "anthropic"),
+    ("text-embedding-3-small", "http://localhost:11434/v1", "openai"),
+])
+def test_detect_embed_provider(model, base_url, expected):
+    assert embedding._detect_embed_provider(model, base_url) == expected
+
+
+def test_embed_claude_raises_no_api(monkeypatch):
+    # A claude model auto-detects to anthropic, so the clear "no embedding API"
+    # error fires instead of mis-routing to OpenAI.
+    cap = {}
+    _install(monkeypatch, cap)
+    with pytest.raises(ValueError, match="no embedding API"):
+        topica.llm_embed(["a", "b"], model="claude-3-5-haiku-latest")
+    assert "openai_embed" not in cap  # never dispatched to OpenAI
+
+
+def test_embed_unknown_provider_raises(monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    with pytest.raises(ValueError, match="unknown embedding provider"):
+        topica.llm_embed(["a", "b"], model="whatever", provider="cohere")
+
+
+def test_gemini_embed_length_mismatch_raises(monkeypatch):
+    # A response whose embedding count disagrees with the input count must error,
+    # never silently return the wrong number of rows.
+    cap = {}
+    _install(monkeypatch, cap)
+    genai = sys.modules["google.genai"]
+    short = types.SimpleNamespace(
+        embeddings=[types.SimpleNamespace(values=[1.0, 2.0, 3.0])]
+    )
+    monkeypatch.setattr(
+        genai.Client, "__init__", lambda self, *, api_key=None: setattr(
+            self, "models", types.SimpleNamespace(
+                embed_content=lambda *, model, contents: short)))
+    with pytest.raises(RuntimeError, match="returned 1 embeddings for 2 inputs"):
+        topica.llm_embed(["aa", "bbbb"], model="gemini-embedding-001")
 
 
 def test_embed_cache_embeds_once(tmp_path, monkeypatch):

--- a/tests/test_llm_backend.py
+++ b/tests/test_llm_backend.py
@@ -1,0 +1,278 @@
+"""The provider-dispatched LLM backends: topica.llm_backend (chat) and
+topica.llm_embed (embeddings) pick a lightweight SDK from the model name. No
+network is used; fake `openai`, `anthropic`, and `google.genai` modules stand in
+for the clients so we exercise dispatch, message/config assembly, key handling,
+the base_url OpenAI-compatible path, and the embedding cache."""
+
+import sys
+import types
+
+import numpy as np
+import pytest
+
+import topica
+from topica import labeling
+
+
+# --- fake SDK modules ---------------------------------------------------------
+
+
+def _fake_openai(cap):
+    class _Msg:
+        def __init__(self, content):
+            self.message = types.SimpleNamespace(content=content)
+
+    class _Chat:
+        def create(self, *, model, messages, **opts):
+            cap["openai"] = {"model": model, "messages": messages, "opts": opts}
+            user = [m for m in messages if m["role"] == "user"][-1]["content"]
+            return types.SimpleNamespace(choices=[_Msg(user.splitlines()[0])])
+
+    class _Emb:
+        def create(self, *, model, input):
+            cap["openai_embed"] = {"model": model, "input": list(input)}
+            data = [types.SimpleNamespace(embedding=[float(len(t)), 1.0]) for t in input]
+            return types.SimpleNamespace(data=data)
+
+    class _Client:
+        def __init__(self, *, base_url=None, api_key=None):
+            cap["openai_init"] = {"base_url": base_url, "api_key": api_key}
+            self.chat = types.SimpleNamespace(completions=_Chat())
+            self.embeddings = _Emb()
+
+    mod = types.ModuleType("openai")
+    mod.OpenAI = _Client
+    return mod
+
+
+def _fake_anthropic(cap):
+    class _Block:
+        def __init__(self, text):
+            self.type = "text"
+            self.text = text
+
+    class _Messages:
+        def create(self, *, model, max_tokens, messages, system=None, **opts):
+            cap["anthropic"] = {
+                "model": model, "max_tokens": max_tokens, "system": system,
+                "messages": messages, "opts": opts,
+            }
+            user = messages[-1]["content"]
+            return types.SimpleNamespace(content=[_Block(user.splitlines()[0])])
+
+    class _Client:
+        def __init__(self, *, api_key=None):
+            cap["anthropic_init"] = {"api_key": api_key}
+            self.messages = _Messages()
+
+    mod = types.ModuleType("anthropic")
+    mod.Anthropic = _Client
+    return mod
+
+
+def _fake_genai(cap):
+    # google.genai plus its .types submodule.
+    genai = types.ModuleType("google.genai")
+    gtypes = types.ModuleType("google.genai.types")
+
+    class _Config:
+        def __init__(self, *, system_instruction=None, **kw):
+            self.system_instruction = system_instruction
+            self.kw = kw
+
+    class _Models:
+        def generate_content(self, *, model, contents, config=None):
+            cap["gemini"] = {
+                "model": model, "contents": contents,
+                "system": getattr(config, "system_instruction", None),
+                "opts": getattr(config, "kw", {}),
+            }
+            return types.SimpleNamespace(text=str(contents).splitlines()[0])
+
+        def embed_content(self, *, model, contents):
+            cap["gemini_embed"] = {"model": model, "contents": list(contents)}
+            embs = [types.SimpleNamespace(values=[float(len(t)), 2.0, 3.0]) for t in contents]
+            return types.SimpleNamespace(embeddings=embs)
+
+    class _Client:
+        def __init__(self, *, api_key=None):
+            cap["gemini_init"] = {"api_key": api_key}
+            self.models = _Models()
+
+    genai.Client = _Client
+    gtypes.GenerateContentConfig = _Config
+    google_pkg = sys.modules.get("google") or types.ModuleType("google")
+    return {"google": google_pkg, "google.genai": genai, "google.genai.types": gtypes}
+
+
+def _install(monkeypatch, cap):
+    monkeypatch.setitem(sys.modules, "openai", _fake_openai(cap))
+    monkeypatch.setitem(sys.modules, "anthropic", _fake_anthropic(cap))
+    for name, mod in _fake_genai(cap).items():
+        monkeypatch.setitem(sys.modules, name, mod)
+
+
+# --- provider detection -------------------------------------------------------
+
+
+@pytest.mark.parametrize("model,expected", [
+    ("gpt-4o-mini", "openai"),
+    ("o3-mini", "openai"),
+    ("ft:gpt-4o:acme", "openai"),
+    ("claude-3-5-haiku-latest", "anthropic"),
+    ("anthropic/claude-3-5-sonnet", "anthropic"),
+    ("gemini-2.5-flash", "gemini"),
+    ("models/gemini-2.5-pro", "gemini"),
+])
+def test_detect_provider(model, expected):
+    assert labeling._detect_provider(model, None) == expected
+
+
+def test_base_url_forces_openai():
+    assert labeling._detect_provider("claude-3-5-haiku-latest", "http://x/v1") == "openai"
+
+
+# --- chat dispatch ------------------------------------------------------------
+
+
+def test_openai_chat(monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    call = topica.llm_backend("gpt-4o-mini", key="sk-1", temperature=0)
+    assert call("Label me:\nx") == "Label me:"
+    assert cap["openai"]["opts"] == {"temperature": 0}
+    assert cap["openai_init"]["api_key"] == "sk-1"
+    assert [m["role"] for m in cap["openai"]["messages"]] == ["user"]
+
+
+def test_openai_system_and_env_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+    cap = {}
+    _install(monkeypatch, cap)
+    topica.llm_backend("gpt-4o-mini", system="Be terse.")("hi")
+    assert cap["openai_init"]["api_key"] == "sk-env"
+    assert cap["openai"]["messages"][0] == {"role": "system", "content": "Be terse."}
+
+
+def test_base_url_local_placeholder_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    cap = {}
+    _install(monkeypatch, cap)
+    topica.llm_backend("llama3", base_url="http://localhost:11434/v1")("hi")
+    assert cap["openai_init"]["base_url"] == "http://localhost:11434/v1"
+    assert cap["openai_init"]["api_key"] == "not-needed"
+
+
+def test_anthropic_chat(monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    call = topica.llm_backend("claude-3-5-haiku-latest", key="sk-a",
+                              system="Be terse.", max_tokens=64, temperature=0)
+    assert call("Topic:\nmore") == "Topic:"
+    a = cap["anthropic"]
+    assert a["model"] == "claude-3-5-haiku-latest"
+    assert a["max_tokens"] == 64          # pulled out of options
+    assert a["system"] == "Be terse."
+    assert a["opts"] == {"temperature": 0}
+    assert cap["anthropic_init"]["api_key"] == "sk-a"
+
+
+def test_anthropic_default_max_tokens(monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    topica.llm_backend("claude-3-5-haiku-latest")("hi")
+    assert cap["anthropic"]["max_tokens"] == 1024
+
+
+def test_gemini_chat(monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    call = topica.llm_backend("gemini-2.5-flash", key="sk-g",
+                              system="Be terse.", temperature=0)
+    assert call("Theme:\nrest") == "Theme:"
+    g = cap["gemini"]
+    assert g["model"] == "gemini-2.5-flash"
+    assert g["system"] == "Be terse."
+    assert g["opts"] == {"temperature": 0}
+    assert cap["gemini_init"]["api_key"] == "sk-g"
+
+
+def test_provider_override(monkeypatch):
+    # A base_url-less custom name forced onto anthropic.
+    cap = {}
+    _install(monkeypatch, cap)
+    topica.llm_backend("my-tuned-claude", provider="anthropic")("hi")
+    assert "anthropic" in cap
+
+
+def test_backend_drives_llm_topic_labels(monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    docs = [d.split() for d in (["cat dog pet"] * 20 + ["star moon sky"] * 20)]
+    m = topica.LDA(num_topics=2, seed=1)
+    m.fit(docs, iters=200)
+    labels = topica.llm_topic_labels(m, backend=topica.llm_backend("claude-3-5-haiku-latest"))
+    assert len(labels) == 2 and all(isinstance(x, str) and x for x in labels)
+
+
+# --- embeddings dispatch ------------------------------------------------------
+
+
+def test_openai_embed(monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    arr = topica.llm_embed(["aa", "bbbb", "c"], model="text-embedding-3-small")
+    assert arr.shape == (3, 2)
+    assert list(arr[:, 0]) == [2.0, 4.0, 1.0]
+    assert cap["openai_embed"]["model"] == "text-embedding-3-small"
+
+
+def test_gemini_embed(monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    arr = topica.llm_embed(["aa", "bbbb"], model="gemini-embedding-001")
+    assert arr.shape == (2, 3)
+    assert cap["gemini_embed"]["model"] == "gemini-embedding-001"
+
+
+def test_embed_cache_embeds_once(tmp_path, monkeypatch):
+    cap = {}
+    _install(monkeypatch, cap)
+    calls = {"n": 0}
+    fake = sys.modules["openai"]
+    orig = fake.OpenAI
+
+    class _Counting(orig):
+        def __init__(self, **kw):
+            super().__init__(**kw)
+            inner = self.embeddings.create
+
+            def create(**kwargs):
+                calls["n"] += 1
+                return inner(**kwargs)
+
+            self.embeddings.create = create
+
+    monkeypatch.setattr(fake, "OpenAI", _Counting)
+    cache = tmp_path / "cache"
+    a = topica.llm_embed(["alpha", "beta"], model="text-embedding-3-small", cache=cache)
+    assert calls["n"] == 1 and (tmp_path / "cache.npz").exists()
+    b = topica.llm_embed(["alpha", "beta"], model="text-embedding-3-small", cache=cache)
+    assert calls["n"] == 1  # served from cache
+    assert np.array_equal(a, b)
+
+
+# --- missing-package errors ---------------------------------------------------
+
+
+def test_chat_missing_sdk_message(monkeypatch):
+    # None in sys.modules makes import raise ImportError, simulating absence.
+    monkeypatch.setitem(sys.modules, "anthropic", None)
+    with pytest.raises(ImportError, match="anthropic"):
+        topica.llm_backend("claude-3-5-haiku-latest")
+
+
+def test_embed_missing_sdk_message(monkeypatch):
+    monkeypatch.setitem(sys.modules, "openai", None)
+    with pytest.raises(ImportError, match="openai"):
+        topica.llm_embed(["a", "b"], model="text-embedding-3-small")

--- a/tests/test_model_settings.py
+++ b/tests/test_model_settings.py
@@ -30,7 +30,9 @@ _DATA_ARGS: dict[str, set[str]] = {
     "SeededLDA": {"seed_words"},
     "Scholar": {"covariates", "content"},
     "EmbeddingLDA": {"embeddings", "vocabulary"},
-    "TopicGPT": {"backend"},
+    # `key` is a secret, deliberately kept out of settings (so it never lands in a
+    # provenance record or save); `backend` is a callable, i.e. data not a config.
+    "TopicGPT": {"backend", "key"},
 }
 
 # Zero/low-arg factories for every Rust-backed public model. Guidance/label args


### PR DESCRIPTION
Replaces the single heavyweight `llm` (Simon Willison CLI) dependency with per-provider **lightweight SDKs**, dispatched by the model name. The public API (`llm_backend` / `llm_embed`) is unchanged.

## Why
`uv pip install "topica[llm]"` silently backtracks to an ancient topica, because `llm` core requires a **pre-release** `sqlite-migrate` that uv blocks by default. `llm` also pulls **~42 packages** for the handful of functions topica used.

## Design (unified dispatcher)
```python
topica.llm_backend("gpt-4o-mini")               # -> OpenAI     topica[openai]
topica.llm_backend("claude-3-5-haiku-latest")   # -> Anthropic  topica[anthropic]
topica.llm_backend("gemini-2.5-flash")          # -> Gemini     topica[gemini]
topica.llm_backend("llama3", base_url="http://localhost:11434/v1")  # any OpenAI-compatible endpoint
topica.llm_embed(texts, model="text-embedding-3-small")            # OpenAI / Gemini embeddings
```
- `provider=` overrides auto-detection; `base_url=` forces the OpenAI-compatible client (ollama, openrouter, vLLM, LM Studio, groq).
- `key=` passes a key directly when no env var is set; local servers get a placeholder automatically.
- `topica[llm]` now means **all three** SDKs; `all` follows suit. `llm` + `llm-ollama` dropped.

## SDK footprint (all wheel-only, no pre-releases, uv-clean)
| extra | SDK | ~real deps |
|---|---|---|
| `topica[openai]` | openai | ~8 |
| `topica[anthropic]` | anthropic | ~18 |
| `topica[gemini]` | google-genai | ~25 |
| old `topica[llm]` | llm CLI | ~42 + pre-release `sqlite-migrate` |

## Embeddings / local
`llm_embed` dispatches OpenAI vs Gemini. Anthropic has no embedding API. For fully offline, in-process embeddings without a server, use `sentence-transformers` directly and pass the array (docs/examples updated).

## Live verification (real keys)
- OpenAI `gpt-4o-mini`, Gemini `gemini-2.5-flash` (native), and Claude via OpenRouter `base_url` all labeled a planted 3-topic corpus correctly; embeddings return proper matrices.
- Explicit `key=` works with no env var; no-key-anywhere raises the SDK's clear "pass an api_key / set OPENAI_API_KEY" error.

## Changes
- `labeling.py`: dispatcher + `_openai`/`_anthropic`/`_gemini` chat helpers.
- `embedding.py`: `llm_embed` OpenAI/Gemini dispatch.
- `topicgpt.py`: `TopicGPT(base_url=, key=)` forwarded to `llm_backend`.
- `pyproject.toml`: `openai` / `anthropic` / `gemini` extras; `llm` = all three.
- `tests/test_llm_backend.py`: dispatch + assembly with fake SDK modules.
- Docs + examples migrated off the old `llm`-CLI strings/plugins.

Checks: 4086 tests collect with no import errors; targeted LLM/labeling/eval/topicgpt suites pass; `mkdocs build --strict` clean; pre-push preflight (fmt/clippy/stub) green. No Rust touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)