### PR TITLE
perf(vae): GEMM the ProdLDA-family encoder (~1.8–2× single-thread) (#378)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,22 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   not affected — it has its own sparse per-document decoder, not the dense
   `theta·beta`. Encoder GEMMs and the elementwise `O(N·V)` work are untouched
   (candidate follow-ups).
+- **ProdLDA-family VAE encoder now uses a BLAS-free GEMM (1.76× faster
+  single-threaded)** (#378, sequel to the decoder GEMM above). The encoder's dense
+  layer-2 and head projections were per-document scalar loops; they now batch into
+  the same deterministic `matrixmultiply` GEMMs — forward `PRE2 = H1·W2ᵀ`,
+  `MU_RAW/LV_RAW = HD·W_mu/lsᵀ`; backward the `g.w2`/`g.w_mu`/`g.w_ls` cross-document
+  reductions (`dpre2ᵀ·H1`, `dmu/dlvᵀ·HD`) and `dH1`/`dHD`. Layer 1 is sparse and
+  mode-dependent (bag-of-words / embedding / CombinedTM `adapt_bert`), so it stays a
+  per-document accumulation in fixed document order (its forward matvec is now a
+  rayon-parallel, order-preserving map). A full ProdLDA fit is **bit-for-bit
+  identical across `RAYON_NUM_THREADS` and `MATMUL_NUM_THREADS` = 1/2/4**; output
+  differs from the old scalar path only at ~1e-15, so FD-gradient and
+  reference-parity tests are unchanged. Measured 47.7s → 27.1s single-threaded at
+  D3000/V2000/K20/H200 (on top of the decoder GEMM). Multi-core gain is modest
+  (~1.10× on 4 cores): with the encoder and decoder both GEMM'd, the remaining serial
+  `O(N·V)` reconstruction-softmax/batch-norm and the sparse layer-1 now dominate
+  (rayon-ing those is a candidate follow-up).
 
 ## [0.53.0] - 2026-07-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,7 +48,7 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   not affected — it has its own sparse per-document decoder, not the dense
   `theta·beta`. Encoder GEMMs and the elementwise `O(N·V)` work are untouched
   (candidate follow-ups).
-- **ProdLDA-family VAE encoder now uses a BLAS-free GEMM (1.76× faster
+- **ProdLDA-family VAE encoder now uses a BLAS-free GEMM (~1.8–2× faster
   single-threaded)** (#378, sequel to the decoder GEMM above). The encoder's dense
   layer-2 and head projections were per-document scalar loops; they now batch into
   the same deterministic `matrixmultiply` GEMMs — forward `PRE2 = H1·W2ᵀ`,
@@ -60,7 +60,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   identical across `RAYON_NUM_THREADS` and `MATMUL_NUM_THREADS` = 1/2/4**; output
   differs from the old scalar path only at ~1e-15, so FD-gradient and
   reference-parity tests are unchanged. Measured 47.7s → 27.1s single-threaded at
-  D3000/V2000/K20/H200 (on top of the decoder GEMM). Multi-core gain is modest
+  D3000/V2000/K20/H200 (~1.76×; an independent clean baseline-vs-HEAD before/after
+  measured ~2.0×), on top of the decoder GEMM. Multi-core gain is modest
   (~1.10× on 4 cores): with the encoder and decoder both GEMM'd, the remaining serial
   `O(N·V)` reconstruction-softmax/batch-norm and the sparse layer-1 now dominate
   (rayon-ing those is a candidate follow-up).

--- a/benchmarks/notes_issue_378_vae_gemm.md
+++ b/benchmarks/notes_issue_378_vae_gemm.md
@@ -124,7 +124,8 @@ and half `O(N·V)` elementwise (batchnorm apply, vocab softmax, reconstruction).
    `matrixmultiply` to a direct dependency (one line; BLAS-free, no new transitive
    weight). Re-baseline the golden fixtures once and re-run the FD + parity sweeps.
    Prove `np.array_equal` for `topic_word`/`doc_topic` across two thread counts and
-   two runs. Ship — this alone is a real single-threaded win for all six models.
+   two runs. Ship — this alone is a real single-threaded win for all five
+   dense-decoder models (ProdLDA, CombinedTM, ZeroShotTM, InfoCTM, Scholar).
 2. **B — GEMM the encoder** layer-2 + head projections; keep layer-1 sparse.
 3. **C — turn on `matrixmultiply` threading** for free multi-core scaling that stays
    bit-identical across thread counts (verified here).

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -31,6 +31,7 @@
 //! every gradient is checked against finite differences in the unit tests.
 
 use rand::Rng;
+use rayon::prelude::*;
 
 /// Kaiming-uniform initialization matching PyTorch's `nn.Linear` default:
 /// entries uniform on `[-1/sqrt(fan_in), 1/sqrt(fan_in)]`.
@@ -999,7 +1000,14 @@ pub(crate) fn batch_forward(
     // Encoder up to the pre-BN heads. CombinedTM (`BowEmbAdapt`) feeds the *raw*
     // BoW counts (`batch.counts`), matching the reference's `CountVectorizer` input;
     // every other mode keeps the length-normalized BoW (`batch.xns`).
+    // Encoder forward is a pure per-document map (each doc reads shared weights and
+    // writes its own DocCache), so rayon-parallelize it (issue #378 follow-up).
+    // `into_par_iter().map().collect()` on a range preserves index order, so `doc`
+    // is bit-identical to the sequential build regardless of thread count — no
+    // reduction is reordered. This is the reduction-free half the g.beta/g.w*
+    // reductions are not.
     let doc: Vec<DocCache> = (0..n)
+        .into_par_iter()
         .map(|i| {
             let enc_bow = if w.mode == InputMode::BowEmbAdapt {
                 batch.counts[i]

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -343,8 +343,14 @@ impl Weights {
     /// normalized bag of words; `emb` is the dense document embedding (length `E`,
     /// empty for bow-only). Layer 1's input depends on the mode: bow-only uses the
     /// BoW columns of `w1`, emb-only the embedding columns, bow+emb both.
-    fn encode_raw(&self, xn: &[(usize, f64)], emb: &[f64], mask2: &[f64]) -> DocCache {
-        let (h, k) = (self.hidden, self.k);
+    /// Encoder layer 1 for one document: the sparse BoW ⊕ dense second-block matvec
+    /// through `w1`, plus its softplus. Returns `(pre1, h1, adapted)` where `adapted`
+    /// is the CombinedTM `adapt_bert` projection (empty for other modes). This is the
+    /// mode-dependent, sparse part of the encoder; layers 2 and the heads are dense
+    /// and are batched into GEMMs by `batch_forward` (issue #378). `encode_raw` keeps
+    /// them per-document for single-document inference (`transform`).
+    fn encode_layer1(&self, xn: &[(usize, f64)], emb: &[f64]) -> (Vec<f64>, Vec<f64>, Vec<f64>) {
+        let h = self.hidden;
         let cols = self.w1_cols();
         // CombinedTM: project the embedding into vocab space before concatenation.
         let adapted = if self.mode == InputMode::BowEmbAdapt {
@@ -382,6 +388,15 @@ impl Weights {
             pre1[i] = s;
         }
         let h1: Vec<f64> = pre1.iter().map(|&p| softplus(p)).collect();
+        (pre1, h1, adapted)
+    }
+
+    /// Full per-document encoder (layer 1 + layer 2 + heads). Kept for single-document
+    /// inference (`transform`) and tests; `batch_forward` batches layers 2 and the
+    /// heads into GEMMs instead (issue #378), but produces the same `DocCache`.
+    fn encode_raw(&self, xn: &[(usize, f64)], emb: &[f64], mask2: &[f64]) -> DocCache {
+        let (h, k) = (self.hidden, self.k);
+        let (pre1, h1, adapted) = self.encode_layer1(xn, emb);
         // Layer 2 dense.
         let mut pre2 = self.b2.clone();
         for i in 0..h {
@@ -997,16 +1012,16 @@ pub(crate) fn batch_forward(
     let (k, v) = (w.k, w.v);
     let n = batch.xns.len();
 
-    // Encoder up to the pre-BN heads. CombinedTM (`BowEmbAdapt`) feeds the *raw*
-    // BoW counts (`batch.counts`), matching the reference's `CountVectorizer` input;
-    // every other mode keeps the length-normalized BoW (`batch.xns`).
-    // Encoder forward is a pure per-document map (each doc reads shared weights and
-    // writes its own DocCache), so rayon-parallelize it (issue #378 follow-up).
-    // `into_par_iter().map().collect()` on a range preserves index order, so `doc`
-    // is bit-identical to the sequential build regardless of thread count — no
-    // reduction is reordered. This is the reduction-free half the g.beta/g.w*
-    // reductions are not.
-    let doc: Vec<DocCache> = (0..n)
+    // Encoder up to the pre-BN heads (issue #378 follow-up). Layer 1 is sparse and
+    // mode-dependent, so it stays a per-document map — pure (each doc reads shared
+    // weights, writes its own row), so rayon-parallelized and order-preserving.
+    // CombinedTM (`BowEmbAdapt`) feeds the *raw* BoW counts (`batch.counts`), matching
+    // the reference's `CountVectorizer` input; every other mode keeps the
+    // length-normalized BoW (`batch.xns`). Layers 2 and the heads are DENSE, so they
+    // batch into deterministic GEMMs (fixed reduction order → bit-identical regardless
+    // of thread count, like the decoder in #586) instead of per-document scalar loops.
+    let h = w.hidden;
+    let l1: Vec<(Vec<f64>, Vec<f64>, Vec<f64>)> = (0..n)
         .into_par_iter()
         .map(|i| {
             let enc_bow = if w.mode == InputMode::BowEmbAdapt {
@@ -1014,7 +1029,51 @@ pub(crate) fn batch_forward(
             } else {
                 batch.xns[i]
             };
-            w.encode_raw(enc_bow, batch.embs[i], &batch.masks2[i])
+            w.encode_layer1(enc_bow, batch.embs[i])
+        })
+        .collect();
+    // Flatten h1 into a contiguous N×H buffer for the GEMMs.
+    let mut h1_flat = vec![0.0; n * h];
+    for (i, (_, h1, _)) in l1.iter().enumerate() {
+        h1_flat[i * h..(i + 1) * h].copy_from_slice(h1);
+    }
+    // Layer 2: PRE2 (N×H) = H1 (N×H) · W2ᵀ (w2 is H×H row-major), then + b2.
+    let mut pre2_flat = vec![0.0; n * h];
+    crate::gemm::matmul_nt(n, h, h, &h1_flat, &w.w2, &mut pre2_flat);
+    // Dropout on softplus(pre2): HD (N×H). Also fold the b2 bias in here.
+    let mut hd_flat = vec![0.0; n * h];
+    for i in 0..n {
+        let m2 = &batch.masks2[i];
+        for a in 0..h {
+            let p = pre2_flat[i * h + a] + w.b2[a];
+            pre2_flat[i * h + a] = p;
+            hd_flat[i * h + a] = softplus(p) * m2[a];
+        }
+    }
+    // Heads: MU_RAW (N×K) = HD · W_muᵀ + b_mu; LV_RAW = HD · W_lsᵀ + b_ls.
+    let mut mu_raw_flat = vec![0.0; n * k];
+    let mut lv_raw_flat = vec![0.0; n * k];
+    crate::gemm::matmul_nt(n, h, k, &hd_flat, &w.w_mu, &mut mu_raw_flat);
+    crate::gemm::matmul_nt(n, h, k, &hd_flat, &w.w_ls, &mut lv_raw_flat);
+    for i in 0..n {
+        for t in 0..k {
+            mu_raw_flat[i * k + t] += w.b_mu[t];
+            lv_raw_flat[i * k + t] += w.b_ls[t];
+        }
+    }
+    // Assemble per-document DocCache (unchanged downstream/backward contract).
+    let doc: Vec<DocCache> = (0..n)
+        .map(|i| {
+            let (pre1, h1, adapted) = &l1[i];
+            DocCache {
+                pre1: pre1.clone(),
+                h1: h1.clone(),
+                pre2: pre2_flat[i * h..(i + 1) * h].to_vec(),
+                hd: hd_flat[i * h..(i + 1) * h].to_vec(),
+                mu_raw: mu_raw_flat[i * k..(i + 1) * k].to_vec(),
+                lv_raw: lv_raw_flat[i * k..(i + 1) * k].to_vec(),
+                adapted: adapted.clone(),
+            }
         })
         .collect();
     let mu_raw: Vec<Vec<f64>> = doc.iter().map(|d| d.mu_raw.clone()).collect();
@@ -1541,50 +1600,93 @@ pub(crate) fn batch_backward(
     let dmu_raw = BatchNorm::backward(&dmu, &c.bn_mu);
     let dlv_raw = BatchNorm::backward(&dlv, &c.bn_lv);
 
-    // --- Encoder per document. ---
+    // --- Encoder backward (issue #378). ---
+    // The dense layer-2 + head projections are batched into deterministic GEMMs
+    // (fixed reduction order → bit-identical regardless of thread count, like the
+    // decoder in #586); the mode-dependent sparse layer 1 stays a per-document
+    // accumulation in fixed doc order; the activation derivatives are elementwise.
+    //
+    // Flatten the batched intermediates the GEMMs consume (rows are not contiguous in
+    // the per-doc cache); O(N·H)+O(N·K), negligible next to the O(N·H²) products.
+    let mut hd_flat = vec![0.0; n * h];
+    let mut h1_flat = vec![0.0; n * h];
+    let mut dmu_flat = vec![0.0; n * k];
+    let mut dlv_flat = vec![0.0; n * k];
     for i in 0..n {
-        let dc = &c.doc[i];
-        // Heads: mu_raw = W_mu hd + b_mu, lv_raw = W_ls hd + b_ls.
-        let mut dhd = vec![0.0; h];
+        hd_flat[i * h..(i + 1) * h].copy_from_slice(&c.doc[i].hd);
+        h1_flat[i * h..(i + 1) * h].copy_from_slice(&c.doc[i].h1);
+        dmu_flat[i * k..(i + 1) * k].copy_from_slice(&dmu_raw[i]);
+        dlv_flat[i * k..(i + 1) * k].copy_from_slice(&dlv_raw[i]);
+    }
+    // Head weight gradients (K×H reductions): g.w_mu += dmu_rawᵀ·HD, g.w_ls += dlv_rawᵀ·HD.
+    {
+        let mut gwmu = vec![0.0; k * h];
+        let mut gwls = vec![0.0; k * h];
+        crate::gemm::matmul_tn(k, n, h, &dmu_flat, &hd_flat, &mut gwmu);
+        crate::gemm::matmul_tn(k, n, h, &dlv_flat, &hd_flat, &mut gwls);
+        for (g0, a) in g.w_mu.iter_mut().zip(&gwmu) {
+            *g0 += *a;
+        }
+        for (g0, a) in g.w_ls.iter_mut().zip(&gwls) {
+            *g0 += *a;
+        }
+    }
+    // Head bias gradients (column sums over documents, fixed order).
+    for i in 0..n {
         for t in 0..k {
-            let row = t * h;
             g.b_mu[t] += dmu_raw[i][t];
             g.b_ls[t] += dlv_raw[i][t];
-            for j in 0..h {
-                g.w_mu[row + j] += dmu_raw[i][t] * dc.hd[j];
-                g.w_ls[row + j] += dlv_raw[i][t] * dc.hd[j];
-                dhd[j] += dmu_raw[i][t] * w.w_mu[row + j] + dlv_raw[i][t] * w.w_ls[row + j];
-            }
         }
-        // Dropout on h2.
-        let mut dh2 = vec![0.0; h];
-        for j in 0..h {
-            dh2[j] = dhd[j] * batch.masks2[i][j];
+    }
+    // dHD (N×H) = dmu_raw·W_mu + dlv_raw·W_ls (W_mu, W_ls are K×H row-major).
+    let mut dhd_flat = vec![0.0; n * h];
+    {
+        let mut tmp = vec![0.0; n * h];
+        crate::gemm::matmul_nn(n, k, h, &dmu_flat, &w.w_mu, &mut dhd_flat);
+        crate::gemm::matmul_nn(n, k, h, &dlv_flat, &w.w_ls, &mut tmp);
+        for (d, t) in dhd_flat.iter_mut().zip(&tmp) {
+            *d += *t;
         }
-        // softplus on layer 2.
-        let mut dpre2 = vec![0.0; h];
-        for j in 0..h {
-            dpre2[j] = dh2[j] * sigmoid(dc.pre2[j]);
-        }
-        // Layer 2: pre2 = W2 h1 + b2.
-        let mut dh1 = vec![0.0; h];
+    }
+    // dpre2 (N×H) = dHD * mask2 * softplus'(pre2), with softplus'(x) = sigmoid(x).
+    let mut dpre2_flat = vec![0.0; n * h];
+    for i in 0..n {
+        let m2 = &batch.masks2[i];
+        let pre2 = &c.doc[i].pre2;
         for a in 0..h {
-            let row = a * h;
-            g.b2[a] += dpre2[a];
-            for b in 0..h {
-                g.w2[row + b] += dpre2[a] * dc.h1[b];
-                dh1[b] += dpre2[a] * w.w2[row + b];
-            }
+            dpre2_flat[i * h + a] = dhd_flat[i * h + a] * m2[a] * sigmoid(pre2[a]);
         }
-        // softplus on layer 1.
-        let mut dpre1 = vec![0.0; h];
-        for j in 0..h {
-            dpre1[j] = dh1[j] * sigmoid(dc.pre1[j]);
+    }
+    // Layer-2 weight gradient (H×H reduction): g.w2 += dpre2ᵀ·H1. Bias: column sum.
+    {
+        let mut gw2 = vec![0.0; h * h];
+        crate::gemm::matmul_tn(h, n, h, &dpre2_flat, &h1_flat, &mut gw2);
+        for (g0, a) in g.w2.iter_mut().zip(&gw2) {
+            *g0 += *a;
         }
-        // Layer 1: pre1 = W1 [bow ; second] + b1. The BoW columns are sparse in the
-        // vocabulary; the second block (offset by V) is dense. The mode selects which
-        // blocks contribute, mirroring `encode_raw`.
-        let cols = w.w1_cols();
+    }
+    for i in 0..n {
+        for a in 0..h {
+            g.b2[a] += dpre2_flat[i * h + a];
+        }
+    }
+    // dH1 (N×H) = dpre2·W2 (W2 is H×H row-major).
+    let mut dh1_flat = vec![0.0; n * h];
+    crate::gemm::matmul_nn(n, h, h, &dpre2_flat, &w.w2, &mut dh1_flat);
+    // dpre1 (N×H) = dH1 * softplus'(pre1).
+    let mut dpre1_flat = vec![0.0; n * h];
+    for i in 0..n {
+        let pre1 = &c.doc[i].pre1;
+        for a in 0..h {
+            dpre1_flat[i * h + a] = dh1_flat[i * h + a] * sigmoid(pre1[a]);
+        }
+    }
+    // Layer 1 (sparse BoW ⊕ dense second block, mode-dependent): accumulate into
+    // g.w1/g.b1 (+ the CombinedTM adapt_bert weights) per document in fixed doc order
+    // — a sparse cross-document reduction kept serial to preserve bit-identity.
+    let cols = w.w1_cols();
+    for i in 0..n {
+        let dpre1 = &dpre1_flat[i * h..(i + 1) * h];
         if w.mode == InputMode::BowEmbAdapt {
             // CombinedTM: raw BoW ⊕ adapt_bert(emb). Accumulate the gradient into the
             // dense adapted block, back-propagate it into the `adapt_bert` weights.
@@ -1597,7 +1699,7 @@ pub(crate) fn batch_backward(
                 }
                 let base = row + v;
                 for j in 0..v {
-                    g.w1[base + j] += dpre1[a] * dc.adapted[j];
+                    g.w1[base + j] += dpre1[a] * c.doc[i].adapted[j];
                     dadapted[j] += dpre1[a] * w.w1[base + j];
                 }
             }


### PR DESCRIPTION
Sequel to #586 (which GEMM'd the ProdLDA-family **decoder**). This GEMMs the **encoder** — the other half of the fit — for another single-thread speedup. Part of #378.

## What

The encoder's dense **layer-2** and **head projections** were per-document scalar loops. They now batch into the same deterministic, BLAS-free `matrixmultiply` helpers (`src/gemm.rs`) that #586 introduced:

```
forward : PRE2 (N×H) = H1·W2ᵀ ;  MU_RAW/LV_RAW (N×K) = HD·W_mu/lsᵀ
backward: g.w2 += dpre2ᵀ·H1 ;  g.w_mu/ls += dmu/dlvᵀ·HD   (cross-document reductions)
          dH1 = dpre2·W2 ;  dHD = dmu·W_mu + dlv·W_ls
```

- **Layer 1 stays sparse.** It's a sparse, mode-dependent matvec (bag-of-words / embedding / CombinedTM `adapt_bert`), so densifying would lose the sparsity win. Its backward accumulation into `g.w1` stays a per-document sum **in fixed document order** (a sparse cross-document reduction kept serial for bit-identity); its forward matvec is now a **rayon-parallel, order-preserving** map.
- `encode_raw` is refactored to share a new `encode_layer1` helper and is kept intact for single-document inference (`transform`) and tests.
- `g.w2`/`g.w_mu`/`g.w_ls` are GEMM'd into a scratch buffer then `+=` into the gradient — never clobbered, so a coupled/pre-seeded caller (SCHOLAR/InfoCTM) is safe, same pattern as `g.beta` in #586.

## Determinism (the hard constraint)

There are now **two** thread knobs — `RAYON_NUM_THREADS` (the layer-1 map) and `MATMUL_NUM_THREADS` (the GEMMs) — and a full `ProdLDA` fit is **bit-for-bit identical across the whole cross product 1/2/4 × 1/2/4**. The GEMMs have a fixed reduction order; the rayon map is an indexed, order-preserving collect; every remaining reduction (biases, sparse layer-1, loss, batch-norm stats) stays in fixed document order. Output differs from the old scalar path only at ~1e-15 (float rounding), so FD-gradient and reference-parity tests are unchanged.

## Result

| | before (decoder GEMM only) | after (+ encoder GEMM) | speedup |
|---|---|---|---|
| single-thread, D3000/V2000/K20/H200/40 iters | ~40–48s | ~20–27s | **~1.8–2×** |

(My in-repo run: 47.7s → 27.1s = 1.76×. The independent reviewer's clean baseline-vs-HEAD before/after against the exact merge-base measured **~2.0×**.) Combined with #586, the VAE family is ~2.3× faster single-threaded than before either change.

**Multi-core is only modest (~1.10× on 4 cores), by design/discovery:** once the encoder *and* decoder are both GEMM'd, the remaining serial `O(N·V)` reconstruction-softmax / batch-norm and the sparse layer-1 dominate. The prize here turned out to be single-thread, not multi-core — reframed honestly. Rayon-ing the `O(N·V)` elementwise remainder is a candidate follow-up.

## Scope

`ETM(inference="vae")` is unaffected (its own sparse per-document decoder). The dense-decoder family — ProdLDA, CombinedTM, ZeroShotTM, InfoCTM, Scholar — all benefit.

## Testing

- `cargo test --lib` — prodlda 26, etm_vae 9, infoctm 4, scholar 9, `etm::` 12, gemm 5 (all the finite-difference gradient + planted-recovery checks across every input mode and prior).
- `cargo clippy --workspace --all-targets --all-features -D warnings` — clean; `cargo fmt --check` — clean.
- Python: the VAE-family gold + model + determinism suites pass unchanged.

### Independent verification

An independent agent (which did **not** write this) re-derived every `matmul_*` call against the old scalar loops, ran the full FD suite (65/65), confirmed **bit-identical hashes across `RAYON`×`MATMUL` ∈ {1,4}²** (4/4 identical + run-to-run stable), ran the gold + model suites (**124 passed, 0 failed**), checked the numeric delta vs the exact baseline (`topic_word` max-rel **1.6e-15**), and produced the ~2.0× before/after against the correct merge-base. Verdict: *"a faithful, deterministic, and faster implementation — safe to PR."* Its one note (the CHANGELOG under-claimed at 1.76× vs the measured ~2.0×) is reconciled in the latest commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011LSRmXE8QX4znuxX5DCEYv

---
_Generated by [Claude Code](https://claude.ai/code/session_011LSRmXE8QX4znuxX5DCEYv)_