### PR TITLE
release: 0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-07-28
+
 ### Added
 
 - **`topica.SemanticSignalSeparation` — Semantic Signal Separation (S³)** (#589).
@@ -50,6 +52,20 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Fixed
 
+- **`BERTopic` / `Top2Vec` no longer collapse to ~2 topics on real embeddings**
+  (#602, completing #555). The 0.53.0 fix (`find_ab_params`) addressed only one of
+  three stacked causes. (1) The in-house HDBSCAN used `petal-clustering`, whose
+  cluster selection diverged from the reference `hdbscan` package on real UMAP
+  projections (ARI 0.12–0.16; 2 topics where the reference finds 13) — replaced with
+  a faithful from-scratch HDBSCAN\* (`src/hdbscan.rs`: mutual-reachability MST,
+  condensed tree, excess-of-mass selection) that matches the reference `generic`
+  algorithm at ARI 0.99–1.00. (2) The UMAP layout emitted each undirected edge's two
+  directed halves adjacently, so the sequential SGD over-attracted and collapsed the
+  layout — edges are now sorted canonically and negative sampling is per-vertex,
+  matching `umap-learn`. (3) `BERTopic` defaulted `min_dist=0.1`, where even
+  `umap-learn` collapses on this data; the default is now `0.0` to match upstream
+  BERTopic. (Reference-default `boruvka` MST parity on tie-heavy data is tracked in
+  #603.)
 - **`DMR` / `GDMR` covariate prior now faithfully reproduces `tomotopy`** (#563).
   topica's Dirichlet-multinomial regression diverged from the `tomotopy` reference
   on poliblog (K=10) at an aligned topic-word cosine of ~0.25, far below both

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.53.0
+version: 0.54.0
 date-released: 2026-07-26
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.53.0"
+version = "0.54.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.53.0"
+version = "0.54.0"
 edition = "2021"
 description = "Fast, all-purpose topic modeling for Python, with a Rust core"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.53.0"
+version = "0.54.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.54.0**, shipping the work that has accumulated on `main` since the `v0.53.0` tag.

## Highlights

- **`SemanticSignalSeparation` / S³** (#600) — turftopic's flagship ported: topics as independent axes of semantic space (FastICA over embeddings).
- **BERTopic/Top2Vec reducer-collapse fully fixed** (#602, completing #555) — 0.53.0's `find_ab_params` fix covered only one of three causes. Faithful from-scratch HDBSCAN\* replacing petal-clustering (reference-`generic` parity, ARI 0.99–1.00), canonical UMAP edge ordering + per-vertex negative RNG, and `BERTopic` default `min_dist=0.0` to match upstream.
- **LLM backend reverted to the `llm` library** (#605 reverting #597) — the uv/`sqlite-migrate` pre-release blocker that motivated #597 is gone (stable `0.2` published); `uv pip install "topica[llm]"` resolves cleanly. `topica[llm]` = `llm` + `llm-ollama` again.
- Plus `topica.compare` (#415), `load_ng20_minilm` (#599), the `DMR`/`GDMR` covariate-prior fidelity fix (#563), and ProdLDA BLAS-free GEMM encoder/decoder.

## Version bumps

`Cargo.toml`, `pyproject.toml`, `CITATION.cff`, `Cargo.lock` → `0.54.0`; CHANGELOG `[Unreleased]` rolled into `[0.54.0] - 2026-07-28`.

## After merge

Tag `v0.54.0` to trigger the PyPI publish (the `v*` tag is what CI publishes on). This is what finally gets the `topica[llm]` fix, the reducer/HDBSCAN fixes, and S³ onto PyPI.

Gates: `test_version_consistency` (4 passed), `scripts/preflight.sh`, maturin build reports `topica 0.54.0` — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)