### PR TITLE
perf(hlda): memoize per-node marginals in the nested-CRP path move (#611)

### DIFF
--- a/src/hlda.rs
+++ b/src/hlda.rs
@@ -420,13 +420,29 @@ impl HldaModel {
             })
             .collect();
 
+        // Per-node marginal cache. `level_log_marginal(node, level_words[node.level])`
+        // depends only on the node's counts and the document's (fixed) level-words,
+        // so it is identical for every candidate path passing through that node —
+        // the dominant `log_gamma` cost. Compute it once per node and reuse. A node
+        // in a candidate's existing prefix always sits at its own level, so
+        // `level_words[lev]` is the right multiset. Bit-for-bit identical to scoring
+        // each candidate independently.
+        let mut marg_cache: Vec<Option<f64>> = vec![None; self.nodes.len()];
         let mut log_scores = Vec::with_capacity(cands.len());
         for cand in &cands {
             let mut s = cand.log_prior;
             for lev in 0..l {
                 if lev < cand.new_from {
                     let node = cand.nodes[lev];
-                    s += self.level_log_marginal(node, &level_words[lev]);
+                    let m = match marg_cache[node] {
+                        Some(v) => v,
+                        None => {
+                            let v = self.level_log_marginal(node, &level_words[lev]);
+                            marg_cache[node] = Some(v);
+                            v
+                        }
+                    };
+                    s += m;
                 } else {
                     s += empty_marginal[lev];
                 }


### PR DESCRIPTION
## What & why

Part 2 of #611 (the HLDA scaling problem). Profiling the full 20NG showed HLDA's
runtime is almost entirely the **candidate-path scoring** in `sample_path`: fit
wall time tracks candidate-scorings at a constant **~3.1µs each** across all corpus
sizes, and each scoring calls `level_log_marginal` (a `log_gamma` loop over the
document's words per level). The same tree node is re-scored once per candidate
that passes through it, even though `level_log_marginal(node, level_words[node.level])`
depends only on the node's counts and the document's fixed level-words.

**Fix:** memoize the marginal per node index (`marg_cache: Vec<Option<f64>>`) —
compute it once per path resample, reuse across every candidate through that node.

## Bit-for-bit identical

This removes only redundant `log_gamma` work; it changes no result:
- Same `topic_word` hash as the pre-change build on a fixed corpus+seed.
- The committed planted-gold (`tests/test_hlda_gold.py`) and determinism tests pass
  unchanged.
- A node's `level` is fixed at creation, so a node index only ever maps to one
  `level_words[lev]`; counts are immutable during the scoring loop; the `s += m`
  additions keep the same order and values.

## Measured speedup (real 20NG, depth 3, 30 iters, fit-only wall)

| docs | before | after | speedup |
|------|--------|-------|---------|
| 1000 | 50.1s | 29.6s | 1.69× |
| 2000 | 128.4s | 78.5s | 1.64× |
| 4000 | 203.2s | 123.9s | 1.64× |
| 8000 | 599.6s | 378.1s | 1.59× |

Scaling stays superlinear — every document re-scores the whole tree, which is
inherent to the nested-CRP Gibbs sampler — but the constant drops ~1.6×
(18k×500 iters projects from ~7h to ~4.3h).

## Follow-ups (not in this PR)

- Fuse candidate enumeration with scoring to drop the per-candidate prefix `Vec`
  clone (~15M allocations on the 20NG run).
- Thread the per-document loop (AD-LDA-style), as other Gibbs models do.
- The bookkeeping I first suspected (`swap_remove_node` path-rescan,
  `delete_empty_subtrees` linear scan) is <0.1% of runtime — not worth touching.

## Dual review

Both reviewers verified bit-for-bit correctness with no blockers: **Codex**
(faithful) and **Gemini 3.1-pro** (adversarial, cross-family) each checked the
level-invariance, count-immutability, cache bounds, and float-order independently.

🤖 Generated with [Claude Code](https://claude.com/claude-code)