### PR TITLE
release: 0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-07-29
+
 ### Added
 
 - **`topica.FactorialLDA` — Factorial LDA (fLDA)** (#606). A port of Paul & Dredze
@@ -22,6 +24,34 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   The reference Java is non-reproducible, so correctness is certified by
   finite-difference gradient and factor-tying tests plus planted topic × sentiment
   recovery rather than by seed parity.
+- **`HLDA` selectable level prior** (#613). The per-level topic prior is now
+  selectable between an asymmetric Dirichlet and a GEM stick-breaking construction,
+  matching the hLDA literature's two standard formulations.
+- **`AnchorLDA` promoted to the validated roster** (#290). The anchor-words spectral
+  estimator (Arora et al. 2013) is now a validated, un-gated model. It is validated
+  against the `anchor-topic` reference implementation: the co-occurrence matrix
+  agrees to numerical precision and, given the same anchors, the RecoverL2 recovery
+  matches the reference on both planted and real text (`parity/anchor_compare.py`).
+  It no longer requires `topica.enable_experimental()`.
+
+### Changed
+
+- **`HDP` estimates the Dirichlet-process concentrations by default** (#617). The
+  top- and document-level concentrations are now inferred rather than fixed, which
+  fixes a degenerate collapse to too few topics on some corpora. Pass explicit
+  concentrations to restore the previous behavior.
+
+### Performance
+
+- **`AnchorLDA` `recover="l2"` is ~140× faster** (#622). The RecoverL2 step was a
+  per-word serial NNLS loop; it is now a vectorized exponentiated-gradient solve of
+  the same squared-error objective (the solver family the reference uses), reaching
+  the same L2 minimum. On 20 Newsgroups at K=50 the recovery drops from ~356s to
+  ~2.6s; the fit is bit-for-bit reproducible.
+- **`HLDA` fits substantially faster** (#611). Per-node marginals are memoized in the
+  nested-CRP path move (#614), the per-node marginal precompute is multi-threaded via
+  `num_threads=` (#616), and the log-gamma terms are tabulated in that precompute for
+  a further ~15× on the marginal step (#619).
 
 ## [0.54.0] - 2026-07-28
 

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.54.0
-date-released: 2026-07-26
+version: 0.55.0
+date-released: 2026-07-29
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than forty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.54.0"
+version = "0.55.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.54.0"
+version = "0.55.0"
 edition = "2021"
 description = "Fast, all-purpose topic modeling for Python, with a Rust core"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.54.0"
+version = "0.55.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.55.0** from main. Version bumped in `Cargo.toml`, `pyproject.toml`, `CITATION.cff`, `Cargo.lock`; CHANGELOG `[0.55.0]` section added.

## Highlights since 0.54.0

**Added**
- `FactorialLDA` — Factorial LDA (Paul & Dredze 2012) (#606)
- `HLDA` selectable level prior — asymmetric Dirichlet + GEM stick-breaking (#613)
- **`AnchorLDA` promoted to the validated roster** with `anchor-topic` reference parity; no longer gated behind `enable_experimental()` (#290)

**Changed**
- **`HDP` estimates the DP concentrations by default** (#617) — fixes degenerate collapse to too few topics; pass explicit concentrations for the old behavior

**Performance**
- **`AnchorLDA` `recover="l2"` ~140×** — vectorized exponentiated-gradient RecoverL2, reference-exact, ~356s → ~2.6s recovery at K=50 (#622)
- **`HLDA` fits substantially faster** — per-node marginal memoization, `num_threads=`, log-gamma tabulation (~15×) (#611)

## Release checklist
- [x] version consistent across Cargo.toml / pyproject.toml / CITATION.cff (`test_version_consistency` passes)
- [x] Cargo.lock updated
- [x] CHANGELOG `[0.55.0]` cut, fresh `[Unreleased]` on top
- [ ] CI green
- [ ] merge, then tag `v0.55.0` (CI publishes to PyPI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)