### PR TITLE
fix(search_k): NaN-safe/parsimony selection, stm coherence, residual dispersion

### DIFF
--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -238,8 +238,15 @@ def find_thoughts(doc_topic: Any, texts: Sequence[str] | None = None, *, topic: 
     ...
 
 
-def search_k(docs: Any, ks: Sequence[int], *, model: str = ..., prevalence: Any | None = ..., content: Any | None = ..., held_out: Any = None, coherence_type: str = ..., **kwargs: Any) -> list[dict]:
-    """Fit an LDA/STM per K; report coherence, exclusivity, and (optional) perplexity."""
+class SearchKResult(list):
+    """List of per-K metric dicts with a direction-aware ``best_k`` selector."""
+    @property
+    def directions(self) -> dict[str, str]: ...
+    def best_k(self, metric: str | None = ...) -> int: ...
+
+
+def search_k(docs: Any, ks: Sequence[int], *, model: str = ..., prevalence: Any | None = ..., content: Any | None = ..., held_out: Any = ..., iters: int = ..., num_samples: int = ..., sample_interval: int = ..., seed: int = ..., coherence_n: int = ..., coherence_type: str = ...) -> SearchKResult:
+    """Fit an LDA/STM per K; report coherence, exclusivity, residual dispersion, and (optional) held-out metric."""
     ...
 
 

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -763,7 +763,20 @@ SEARCH_K_DIRECTIONS = {
     "exclusivity": "maximize",
     "heldout_loglik": "maximize",
     "perplexity": "minimize",
+    "polarization": "maximize",
 }
+
+
+def _argbest_k(rows, score):
+    """The ``k`` at the maximum score, breaking ties toward the *smallest* ``k``.
+
+    Parsimony tie-break: with two K values equally good, prefer the simpler model.
+    This also makes the pick independent of the order ``ks`` was passed in (a plain
+    ``argmax`` returns the first index, so it would depend on grid ordering)."""
+    score = np.asarray(score, dtype=np.float64)
+    best = np.nanmax(score)
+    tied = [i for i, s in enumerate(score) if s == best]
+    return int(min(rows[i]["k"] for i in tied))
 
 
 class SearchKResult(list):
@@ -808,11 +821,15 @@ class SearchKResult(list):
         score = np.zeros(len(self))
         for m in ("coherence", "exclusivity"):
             v = np.array([r[m] for r in self], dtype=np.float64)
-            sd = v.std()
+            sd = np.nanstd(v)
             if sd > 0:
-                z = (v - v.mean()) / sd
+                z = (v - np.nanmean(v)) / sd
+                # A K whose metric is NaN (a degenerate fit) contributes 0 to the
+                # score for that metric -- treated as average, never poisoning the
+                # argmax as raw NaN comparisons would.
+                z = np.nan_to_num(z, nan=0.0)
                 score += z if SEARCH_K_DIRECTIONS[m] == "maximize" else -z
-        return int(self[int(np.argmax(score))]["k"])
+        return _argbest_k(self, score)
 
     def best_k(self, metric: str | None = None) -> int:
         """Return the ``k`` chosen by ``metric``.
@@ -858,16 +875,33 @@ class SearchKResult(list):
                 f"pass held_out= to get a held-out metric"
             )
         if metric == "coherence" and len(self) >= 2:
-            warnings.warn(
-                "best_k(metric='coherence'): mean UMass coherence is roughly "
-                "monotone-decreasing in K, so this tends to return the smallest "
-                "K in the grid. Prefer metric='frontier' (coherence/exclusivity "
-                "knee) or pass held_out= for held-out log-likelihood.",
-                UserWarning,
-                stacklevel=2,
-            )
-        pick = max if SEARCH_K_DIRECTIONS[metric] == "maximize" else min
-        return int(pick(self, key=lambda r: r[metric])["k"])
+            coh_metric = self[0].get("coherence_metric", "u_mass")
+            if coh_metric == "u_mass":
+                warnings.warn(
+                    "best_k(metric='coherence'): mean UMass coherence is roughly "
+                    "monotone-decreasing in K, so this tends to return the smallest "
+                    "K in the grid. Prefer metric='frontier' (coherence/exclusivity "
+                    "knee) or pass held_out= for held-out log-likelihood.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+            else:
+                warnings.warn(
+                    f"best_k(metric='coherence'): selecting on {coh_metric!r} "
+                    "coherence alone ignores exclusivity and parsimony. Prefer "
+                    "metric='frontier' (coherence/exclusivity knee) or pass "
+                    "held_out= for held-out log-likelihood.",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        present = [r for r in self if not np.isnan(r[metric])]
+        if not present:
+            raise ValueError(f"every value for metric {metric!r} is NaN")
+        best = (max if SEARCH_K_DIRECTIONS[metric] == "maximize" else min)(
+            r[metric] for r in present
+        )
+        # Parsimony tie-break: smallest k achieving the best value.
+        return int(min(r["k"] for r in present if r[metric] == best))
 
 
 def search_k(
@@ -893,14 +927,17 @@ def search_k(
     scan K for the model you'll actually report.
 
     Returns a :class:`SearchKResult` (a list of per-K dicts) with ``k``,
-    ``coherence`` (mean of selected coherence type, default ``"u_mass"``),
-    ``exclusivity`` (mean top-word exclusivity), and — when ``held_out`` is
-    supplied — a held-out quality metric. The result also carries
-    ``.directions`` (whether higher or lower is better per metric) and a
-    ``.best_k(metric=...)`` selector. ``best_k`` defaults to the held-out metric
-    when one is supplied, otherwise to a coherence/exclusivity frontier (a knee),
-    because bare UMass coherence is roughly monotone in K and would just return
-    the smallest K scanned.
+    ``coherence`` (mean of the selected coherence type; for ``model="stm"`` with
+    the default ``u_mass`` this is stm's semantic coherence, labelled
+    ``coherence_metric="semcoh"``), ``exclusivity`` (mean top-word exclusivity),
+    ``dispersion`` (residual dispersion, Taddy 2012 — ``>> 1`` means K is too
+    small) with its ``dispersion_pvalue``, and — when ``held_out`` is supplied —
+    a held-out quality metric. The result also carries ``.directions`` (whether
+    higher or lower is better per metric) and a ``.best_k(metric=...)`` selector.
+    ``best_k`` defaults to the held-out metric when one is supplied, otherwise to
+    a coherence/exclusivity frontier (a knee), because bare UMass coherence is
+    roughly monotone in K and would just return the smallest K scanned. Duplicate
+    ``ks`` are dropped; ties in ``best_k`` break toward the smaller (simpler) K.
 
     Two held-out paths are supported, determined by the type of ``held_out``:
 
@@ -959,6 +996,17 @@ def search_k(
             stacklevel=2,
         )
 
+    ks_in = [int(k) for k in ks]
+    ks = list(dict.fromkeys(ks_in))  # de-duplicate, preserving order
+    if len(ks) != len(ks_in):
+        warnings.warn(
+            "search_k: duplicate values in `ks` were dropped so each K is fit "
+            "once (duplicates would also overweight that K in the frontier).",
+            UserWarning,
+            stacklevel=2,
+        )
+
+    ref_docs = _ref_corpus(docs)  # token lists, reused across every K
     rows = []
     for k in ks:
         if model == "stm":
@@ -969,12 +1017,19 @@ def search_k(
             m.fit(docs, iters=iters, num_samples=num_samples,
                   sample_interval=sample_interval)
 
+        coh_label = coherence_type
         if stratified:
             from .content import (stratified_coherence as _strat,
                                   topic_polarization as _pol,
                                   group_exclusivity as _gex)
             coh_val = float(np.mean(_strat(m, docs, content, coherence_type=base_ct,
                                           n=coherence_n)))
+        elif coherence_type == "u_mass" and model == "stm":
+            # stm's searchK reports semantic coherence (semCoh1beta, 0.01
+            # smoothing), not gensim UMass -- use the stm-faithful metric for STM.
+            from .coherence import semantic_coherence
+            coh_val = float(np.mean(semantic_coherence(m, ref_docs, n=coherence_n)))
+            coh_label = "semcoh"
         elif coherence_type == "u_mass" and hasattr(m, "coherence"):
             coh_val = float(np.mean(m.coherence(coherence_n)))
         else:
@@ -982,17 +1037,22 @@ def search_k(
             # m.top_words(coherence_n) returns a list of lists of (word, weight) tuples.
             # Convert to list[list[str]]
             topics = [[w for w, _ in top_list] for top_list in m.top_words(coherence_n)]
-            ref_docs = _ref_corpus(docs)
             scores = external_coherence(topics, ref_docs, coherence_type=base_ct, topn=coherence_n)
             coh_val = float(np.mean(scores))
 
         row = {
             "k": k,
             "coherence": coh_val,
-            "coherence_metric": coherence_type,
+            "coherence_metric": coh_label,
             "exclusivity": (float(np.mean(_gex(m, n=coherence_n))) if stratified
                             else _mean_exclusivity(m.topic_word, coherence_n)),
         }
+        # Residual dispersion (Taddy 2012): dispersion >> 1 is direct evidence K
+        # is too small -- the non-monotone signal stm's searchK reports. Diagnostic
+        # column, not a frontier metric (it keeps falling as K grows).
+        rc = check_residuals(m, ref_docs)
+        row["dispersion"] = float(rc.dispersion)
+        row["dispersion_pvalue"] = float(rc.pvalue)
         if stratified:
             row["polarization"] = float(np.mean(_pol(m)))
         if held_out is not None:

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -819,16 +819,21 @@ class SearchKResult(list):
                 "scan a wider grid or pass a single metric"
             )
         score = np.zeros(len(self))
+        finite = np.ones(len(self), dtype=bool)
         for m in ("coherence", "exclusivity"):
             v = np.array([r[m] for r in self], dtype=np.float64)
+            finite &= np.isfinite(v)
             sd = np.nanstd(v)
             if sd > 0:
-                z = (v - np.nanmean(v)) / sd
-                # A K whose metric is NaN (a degenerate fit) contributes 0 to the
-                # score for that metric -- treated as average, never poisoning the
-                # argmax as raw NaN comparisons would.
-                z = np.nan_to_num(z, nan=0.0)
+                # nan_to_num keeps a NaN in the *other* metric from poisoning this
+                # metric's z-scores; the row itself is excluded below.
+                z = np.nan_to_num((v - np.nanmean(v)) / sd, nan=0.0)
                 score += z if SEARCH_K_DIRECTIONS[m] == "maximize" else -z
+        # A K with a NaN/inf in either frontier metric is a degenerate fit; never
+        # recommend it (unless *every* K is degenerate, then fall back to the
+        # smallest K via the all-zero score).
+        if finite.any():
+            score[~finite] = -np.inf
         return _argbest_k(self, score)
 
     def best_k(self, metric: str | None = None) -> int:

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -301,10 +301,12 @@ class TestSearchKHeldout:
 
     def test_existing_coherence_metric_label_intact(self, small_corpus_held_prevalence):
         docs, held, prevalence = small_corpus_held_prevalence
-        for m_type, prev in (("lda", None), ("stm", prevalence)):
+        # LDA reports gensim UMass; STM reports stm's semantic coherence (semCoh1beta),
+        # the metric stm's searchK actually reports -- each labelled honestly.
+        for m_type, prev, expected in (("lda", None, "u_mass"), ("stm", prevalence, "semcoh")):
             rows = topica.search_k(docs, [2], model=m_type, prevalence=prev,
                                    held_out=held, iters=10, seed=0)
-            assert rows[0]["coherence_metric"] == "u_mass"
+            assert rows[0]["coherence_metric"] == expected
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -185,6 +185,59 @@ def test_frontier_needs_two_k():
         assert one.best_k() == 5
 
 
+def test_best_k_is_nan_safe():
+    # A degenerate fit can yield NaN coherence. Raw max()/z-score would let the
+    # NaN row win (`x > nan` is always False); selection must ignore NaN rows.
+    from topica.validation import SearchKResult
+    rows = SearchKResult([
+        {"k": 2, "coherence": float("nan"), "exclusivity": 0.1, "coherence_metric": "u_mass"},
+        {"k": 5, "coherence": -10.0, "exclusivity": 0.8, "coherence_metric": "u_mass"},
+        {"k": 10, "coherence": -5.0, "exclusivity": 0.9, "coherence_metric": "u_mass"},
+    ])
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        assert rows.best_k("coherence") == 10   # not the NaN row (k=2)
+    assert rows._frontier_k() == 10             # coherence not silently poisoned
+    allnan = SearchKResult([{"k": 2, "coherence": float("nan"), "exclusivity": float("nan")}])
+    with pytest.raises(ValueError, match="NaN"):
+        allnan.best_k("exclusivity")
+
+
+def test_frontier_tie_breaks_toward_smaller_k():
+    # Equal scores must resolve to the smaller (simpler) K regardless of grid order.
+    from topica.validation import SearchKResult
+    for ks in ([50, 10], [10, 50]):
+        rows = SearchKResult([{"k": k, "coherence": -5.0, "exclusivity": 0.5} for k in ks])
+        assert rows._frontier_k() == 10
+
+
+def test_best_k_coherence_warning_matches_coherence_type():
+    # The monotonicity caveat is UMass-specific; for c_v the warning must not claim
+    # UMass monotonicity (c_v is not monotone in K).
+    from topica.validation import SearchKResult
+    cv = SearchKResult([
+        {"k": 2, "coherence": 0.4, "exclusivity": 0.5, "coherence_metric": "c_v"},
+        {"k": 3, "coherence": 0.6, "exclusivity": 0.5, "coherence_metric": "c_v"},
+    ])
+    with pytest.warns(UserWarning, match="'c_v' coherence alone"):
+        cv.best_k("coherence")
+    umass = SearchKResult([
+        {"k": 2, "coherence": -10.0, "exclusivity": 0.5, "coherence_metric": "u_mass"},
+        {"k": 3, "coherence": -12.0, "exclusivity": 0.5, "coherence_metric": "u_mass"},
+    ])
+    with pytest.warns(UserWarning, match="monotone"):
+        umass.best_k("coherence")
+
+
+def test_search_k_reports_residual_dispersion_and_dedupes_ks():
+    docs = [["cat", "dog", "pet"]] * 12 + [["star", "moon", "sky"]] * 12
+    with pytest.warns(UserWarning, match="duplicate"):
+        rows = topica.search_k(docs, [2, 2, 3], iters=60, num_samples=1)
+    assert [r["k"] for r in rows] == [2, 3]                # duplicate K dropped
+    assert all("dispersion" in r and "dispersion_pvalue" in r for r in rows)
+    assert all(np.isfinite(r["dispersion"]) for r in rows)
+
+
 def test_search_k_best_k_defaults_to_heldout_when_present():
     # #153: with a held-out set, best_k defaults to the held-out log-likelihood
     # (maximize) rather than coherence.

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -203,6 +203,32 @@ def test_best_k_is_nan_safe():
         allnan.best_k("exclusivity")
 
 
+def test_frontier_excludes_degenerate_nan_k():
+    # A NaN in either frontier metric marks a degenerate fit. Even if that K has an
+    # extreme value on the *other* metric, the frontier must not recommend it
+    # (nan_to_num would otherwise give it a neutral z and let the extreme win).
+    from topica.validation import SearchKResult
+    rows = SearchKResult([
+        {"k": 2, "coherence": float("nan"), "exclusivity": 1.0},   # degenerate
+        {"k": 5, "coherence": -5.0, "exclusivity": 0.5},
+        {"k": 10, "coherence": -6.0, "exclusivity": 0.5},
+    ])
+    assert rows._frontier_k() in {5, 10}   # never the NaN row
+    assert rows._frontier_k() == 5         # the knee among the valid Ks
+
+
+def test_dispersion_is_a_diagnostic_not_selectable():
+    # dispersion is reported per K but is not a selection metric (it falls
+    # monotonically with K), so best_k must reject it rather than pick a K by it.
+    from topica.validation import SearchKResult
+    rows = SearchKResult([
+        {"k": 2, "coherence": -5.0, "exclusivity": 0.5, "dispersion": 3.0},
+        {"k": 3, "coherence": -6.0, "exclusivity": 0.5, "dispersion": 1.2},
+    ])
+    with pytest.raises(ValueError, match="unknown metric"):
+        rows.best_k("dispersion")
+
+
 def test_frontier_tie_breaks_toward_smaller_k():
     # Equal scores must resolve to the smaller (simpler) K regardless of grid order.
     from topica.validation import SearchKResult


### PR DESCRIPTION
## Summary

Correctness + faithfulness fixes for `search_k` / `SearchKResult`, surfaced by a two-model review (adversarial + faithfulness). Also adds stm's residual-dispersion column.

## Correctness
- **NaN-safe selection.** A degenerate fit can yield NaN coherence. `best_k()` and the z-score frontier used raw `max()`/`std`, and since `x > nan` is always `False` the NaN row *won* (`best_k("coherence")`) or the whole metric was *silently dropped* (frontier). Both now ignore NaN rows (`nanmean`/`nanstd`; drop NaN rows in `best_k`) and raise if a requested metric is entirely NaN. (Verified: previously `best_k("coherence")` returned the NaN row's K.)
- **Parsimony tie-break.** Ties in `best_k`/frontier now resolve to the smallest (simpler) K instead of depending on the order `ks` was passed (`argmax` returned the first index).
- **Coherence-type-aware warning.** `best_k('coherence')` no longer claims *UMass* monotonicity when the scanned metric was `c_v`/`c_npmi`/`c_uci` (which aren't monotone in K).
- **Duplicate `ks` dropped** (they would overweight that K in the frontier); **`polarization`** added to `SEARCH_K_DIRECTIONS` so `best_k('polarization')` works.

## Faithfulness / completeness
- **STM coherence = stm's semantic coherence.** For `model="stm"` with the default `u_mass`, the `coherence` column is now stm's `semCoh1beta` (0.01 smoothing, labelled `coherence_metric="semcoh"`) — the number `stm::searchK` actually reports — via the existing `semantic_coherence`, instead of gensim UMass (+1.0). LDA still reports gensim UMass, labelled honestly.
- **Residual dispersion column.** `search_k` now reports `dispersion` (+ `dispersion_pvalue`) per K via the existing `check_residuals` (Taddy 2012). `dispersion >> 1` is the non-monotone "K too small" signal stm reports. Diagnostic column, not a frontier metric.

## Housekeeping
- Refreshed the `__init__.pyi` stub: real `SearchKResult` return type with `best_k`/`directions`, and the actual keyword params instead of `**kwargs`.
- Hoisted the per-K `_ref_corpus(docs)` conversion out of the loop.

## Tests / docs
- New regression tests: NaN-safety, parsimony tie-break, coherence-type-aware warning, `ks` dedup + dispersion columns. Updated the STM `coherence_metric` label test to expect `semcoh`.
- `test_issue_fixes.py`, `test_heldout.py`, `test_content.py`, `test_stm.py`, `test_plot_search_k.py`, `test_viz.py` green; `mkdocs build --strict` clean.

## Follow-ups (filed separately)
Bigger features intentionally scoped out: parallel per-K fits; multi-seed CIs + a 1-SE parsimony rule; opt-in extra selection criteria + frontier grid-sensitivity docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)