### PR TITLE
feat(search_k): opt-in Deveaud / Cao Juan selection criteria

### DIFF
--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -245,7 +245,7 @@ class SearchKResult(list):
     def best_k(self, metric: str | None = ..., *, rule: str = ...) -> int: ...
 
 
-def search_k(docs: Any, ks: Sequence[int], *, model: str = ..., prevalence: Any | None = ..., content: Any | None = ..., held_out: Any = ..., iters: int = ..., num_samples: int = ..., sample_interval: int = ..., seed: int = ..., coherence_n: int = ..., coherence_type: str = ..., n_jobs: int = ..., num_seeds: int = ...) -> SearchKResult:
+def search_k(docs: Any, ks: Sequence[int], *, model: str = ..., prevalence: Any | None = ..., content: Any | None = ..., held_out: Any = ..., iters: int = ..., num_samples: int = ..., sample_interval: int = ..., seed: int = ..., coherence_n: int = ..., coherence_type: str = ..., n_jobs: int = ..., num_seeds: int = ..., criteria: Sequence[str] = ...) -> SearchKResult:
     """Fit an LDA/STM per K; report coherence, exclusivity, residual dispersion, and (optional) held-out metric."""
     ...
 

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1619,10 +1619,12 @@ def _deveaud(topic_word) -> float:
     k = phi.shape[0]
     if k < 2:
         return float("nan")
-    eps = 1e-12
 
     def _kl(p, q):
-        return float(np.sum(np.where(p > 0, p * np.log((p + eps) / (q + eps)), 0.0)))
+        # The mixture q = (p+q)/2 is strictly positive wherever p > 0, so no
+        # smoothing is needed and the result is an exact Jensen-Shannon term.
+        mask = p > 0
+        return float(np.sum(p[mask] * np.log(p[mask] / q[mask])))
 
     total, pairs = 0.0, 0
     for i in range(k):

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -769,7 +769,14 @@ SEARCH_K_DIRECTIONS = {
     "heldout_loglik": "maximize",
     "perplexity": "minimize",
     "polarization": "maximize",
+    # Opt-in ldatuning-style criteria (search_k(criteria=...)).
+    "deveaud": "maximize",   # mean pairwise JS divergence between topics
+    "cao_juan": "minimize",  # mean pairwise cosine similarity between topics
 }
+
+# Extra K-selection criteria computable from the topic-word matrix, requested via
+# search_k(criteria=...). Off by default and out of the frontier.
+_SEARCH_K_CRITERIA = ("deveaud", "cao_juan")
 
 
 def _argbest_k(rows, score):
@@ -1044,6 +1051,7 @@ def search_k(
     coherence_type="u_mass",
     n_jobs=1,
     num_seeds=_SEARCH_K_DEFAULT_SEEDS,
+    criteria=(),
 ):
     """Fit a model for each K and report quality metrics (stm's ``searchK``).
 
@@ -1103,6 +1111,13 @@ def search_k(
         column, and ``best_k(rule="1se")`` becomes available (the simplest K within
         one SE of the optimum). The per-K work parallelizes over ``(K, seed)`` via
         ``n_jobs``. A single seed carries no standard errors (backward-compatible).
+    criteria : optional extra K-selection criteria to report as columns (default
+        none). ``"deveaud"`` (Deveaud et al. 2014; mean pairwise Jensen-Shannon
+        divergence between topics, higher = more distinct) and ``"cao_juan"``
+        (Cao Juan et al. 2009; mean pairwise topic cosine, lower = less redundant).
+        Opt-in and out of the frontier, but selectable via ``best_k("deveaud")`` /
+        ``best_k("cao_juan")`` and carry standard errors under ``num_seeds>1`` like
+        any other metric.
     """
     from . import LDA, STM  # local import to avoid a cycle at module load
 
@@ -1112,6 +1127,12 @@ def search_k(
         raise ValueError(f"num_seeds must be >= 1, got {num_seeds!r}")
     if content is not None and model != "stm":
         raise ValueError("content covariates are only supported when model='stm'")
+
+    criteria = tuple(criteria)
+    bad = [c for c in criteria if c not in _SEARCH_K_CRITERIA]
+    if bad:
+        raise ValueError(
+            f"unknown criteria {bad}; choose from {list(_SEARCH_K_CRITERIA)}")
 
     valid_coh = ("u_mass", "c_uci", "c_npmi", "c_v")
     coherence_type = coherence_type.lower()
@@ -1194,6 +1215,9 @@ def search_k(
         rc = check_residuals(m, ref_docs)
         row["dispersion"] = float(rc.dispersion)
         row["dispersion_pvalue"] = float(rc.pvalue)
+        # Opt-in ldatuning-style criteria from the topic-word matrix.
+        for c in criteria:
+            row[c] = _extra_criterion(c, m.topic_word)
         if stratified:
             row["polarization"] = float(np.mean(_pol(m)))
         if held_out is not None:
@@ -1570,6 +1594,47 @@ def plot_topic_discovery(model, *, ax=None):
 def _mean_exclusivity(topic_word, n: int) -> float:
     from .coherence import exclusivity
     return float(np.mean(exclusivity(topic_word, n=n)))
+
+
+def _cao_juan(topic_word) -> float:
+    """Mean pairwise cosine similarity between topic-word distributions
+    (Cao Juan et al. 2009). Lower is better -- redundant topics are similar, so
+    the least-redundant K minimizes it. ``nan`` for a single topic."""
+    phi = np.asarray(topic_word, dtype=np.float64)
+    k = phi.shape[0]
+    if k < 2:
+        return float("nan")
+    norm = np.linalg.norm(phi, axis=1)
+    unit = phi / np.where(norm > 0, norm, 1.0)[:, None]
+    sim = unit @ unit.T
+    return float(sim[np.triu_indices(k, 1)].mean())
+
+
+def _deveaud(topic_word) -> float:
+    """Mean pairwise Jensen-Shannon divergence between topic-word distributions
+    (Deveaud et al. 2014). Higher is better -- distinct topics diverge, so the
+    most-distinct K maximizes it. ``nan`` for a single topic."""
+    phi = np.asarray(topic_word, dtype=np.float64)
+    phi = phi / np.clip(phi.sum(axis=1, keepdims=True), 1e-300, None)
+    k = phi.shape[0]
+    if k < 2:
+        return float("nan")
+    eps = 1e-12
+
+    def _kl(p, q):
+        return float(np.sum(np.where(p > 0, p * np.log((p + eps) / (q + eps)), 0.0)))
+
+    total, pairs = 0.0, 0
+    for i in range(k):
+        for j in range(i + 1, k):
+            mix = 0.5 * (phi[i] + phi[j])
+            total += 0.5 * _kl(phi[i], mix) + 0.5 * _kl(phi[j], mix)
+            pairs += 1
+    return total / pairs
+
+
+def _extra_criterion(name, topic_word) -> float:
+    return {"deveaud": _deveaud, "cao_juan": _cao_juan}[name](topic_word)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -281,6 +281,58 @@ def test_search_k_reports_residual_dispersion_and_dedupes_ks():
     assert all(np.isfinite(r["dispersion"]) for r in rows)
 
 
+def test_extra_criteria_detect_redundant_topics():
+    # #633: the discriminating behavior the criteria exist for. Four near-orthogonal
+    # topics vs the same four plus a duplicate fifth: the redundant topic must raise
+    # cao_juan (topics more similar) and lower deveaud (topics less distinct).
+    from topica.validation import _cao_juan, _deveaud
+    V = 8
+    base = np.zeros((4, V))
+    for i in range(4):
+        base[i, 2 * i:2 * i + 2] = 0.5
+    dup = np.vstack([base, base[0]])  # 5th topic duplicates the 1st
+    assert _cao_juan(dup) > _cao_juan(base)
+    assert _deveaud(dup) < _deveaud(base)
+    # exact sentinels: identical topics -> cosine 1 / JSD 0; disjoint -> cosine 0
+    same = np.array([[0.5, 0.5, 0.0, 0.0], [0.5, 0.5, 0.0, 0.0]])
+    orth = np.array([[1.0, 0.0, 0.0, 0.0], [0.0, 1.0, 0.0, 0.0]])
+    assert _cao_juan(same) == pytest.approx(1.0)
+    assert _cao_juan(orth) == pytest.approx(0.0)
+    assert _deveaud(same) == pytest.approx(0.0)
+    assert _deveaud(orth) == pytest.approx(np.log(2))
+    # single topic -> nan (no pairs)
+    assert np.isnan(_cao_juan(np.array([[1.0, 0.0]])))
+    assert np.isnan(_deveaud(np.array([[1.0, 0.0]])))
+
+
+def test_search_k_criteria_are_opt_in_and_selectable():
+    # #633: criteria default off (out of the frontier default) and are added only
+    # when requested; then they are selectable and carry SEs under num_seeds>1.
+    docs = [["cat", "dog", "pet"]] * 12 + [["star", "moon", "sky"]] * 12 + \
+           [["red", "blue", "green"]] * 12
+    plain = topica.search_k(docs, [2, 3], iters=60, num_samples=1, num_seeds=1)
+    assert "deveaud" not in plain[0] and "cao_juan" not in plain[0]
+
+    res = topica.search_k(docs, [2, 3, 4], iters=60, num_samples=1, num_seeds=1,
+                          criteria=["deveaud", "cao_juan"])
+    assert all("deveaud" in r and "cao_juan" in r for r in res)
+    assert res.directions["deveaud"] == "maximize"
+    assert res.directions["cao_juan"] == "minimize"
+    assert res.best_k("deveaud") in {r["k"] for r in res}
+    assert res.best_k("cao_juan") in {r["k"] for r in res}
+    # criteria stay out of the default selection (no held-out -> frontier)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert res.best_k() == res.best_k("frontier")
+
+    with pytest.raises(ValueError, match="unknown criteria"):
+        topica.search_k(docs, [2], criteria=["bogus"])
+
+    multi = topica.search_k(docs, [2, 3], iters=60, num_samples=1, num_seeds=3,
+                            criteria=["deveaud"])
+    assert "deveaud_se" in multi[0]
+
+
 def test_search_k_num_seeds_reports_se_and_is_backward_compatible():
     # #632: num_seeds=1 (default) reports no standard-error columns; num_seeds>1
     # adds <metric>_se for every varying metric and keeps <metric> as the mean.

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -300,6 +300,12 @@ def test_extra_criteria_detect_redundant_topics():
     assert _cao_juan(orth) == pytest.approx(0.0)
     assert _deveaud(same) == pytest.approx(0.0)
     assert _deveaud(orth) == pytest.approx(np.log(2))
+    # Three mutually-disjoint topics: all 3 pairs have JSD ln2, cosine 0. The
+    # criterion is the *mean* over pairs (== ln2 / 0), not the sum (3*ln2 / 0) --
+    # this pins the pair-count normalization for K>2.
+    tri = np.array([[1.0, 0, 0], [0, 1.0, 0], [0, 0, 1.0]])
+    assert _deveaud(tri) == pytest.approx(np.log(2))
+    assert _cao_juan(tri) == pytest.approx(0.0)
     # single topic -> nan (no pairs)
     assert np.isnan(_cao_juan(np.array([[1.0, 0.0]])))
     assert np.isnan(_deveaud(np.array([[1.0, 0.0]])))


### PR DESCRIPTION
## Summary

`search_k` gains a `criteria=` option (default none) for the two most common `ldatuning`-style K-selection criteria, computed from the topic-word matrix. Addresses the criteria portion of #633.

- **`"deveaud"`** (Deveaud et al. 2014): mean pairwise **Jensen-Shannon divergence** between topics; higher = more distinct (maximize).
- **`"cao_juan"`** (Cao Juan et al. 2009): mean pairwise topic **cosine similarity**; lower = less redundant (minimize).

## Design (matches the issue's "keep surface small")
- **Opt-in and out of the frontier default.** Added only when requested; `best_k()` (no held-out → frontier) never selects them.
- **Selectable** via `best_k("deveaud")` / `best_k("cao_juan")` (registered in `SEARCH_K_DIRECTIONS` with correct directions).
- **Compose with multi-seed:** they flow through aggregation, so they carry `<metric>_se` under `num_seeds>1` like any other metric.
- Unknown criteria names raise.

## Validation
The redundancy signal these criteria exist for: a duplicate topic **raises `cao_juan`** and **lowers `deveaud`**. Plus exact sentinels — identical topics → cosine 1 / JSD 0; disjoint → cosine 0 / JSD ln2; single topic → nan.

## Deferred
The issue's **perplexity-elbow** selector and **configurable frontier weighting** are left out (separable, lower value) — tracked for a follow-up.

## Tests / docs
New tests: the criteria math + redundancy detection, opt-in/selectable/SE behavior, and the unknown-name guard. `.pyi` + docstring updated. `test_issue_fixes.py`, `test_heldout.py`, `test_content.py`, `test_plot_search_k.py` green (117); `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)