### PR TITLE
feat(ensemble): bootstrap CIs for agreement / stability

### DIFF
--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -415,6 +415,9 @@ class EnsembleResult:
     reference: int | None
     n_runs: int
     runs: list
+    agreement_ci: tuple[float, float] | None
+    agreement_se: float | None
+    stability_ci: Any
     def __init__(
         self,
         *,
@@ -430,6 +433,9 @@ class EnsembleResult:
         reference: int | None,
         n_runs: int,
         runs: list,
+        agreement_ci: tuple[float, float] | None = ...,
+        agreement_se: float | None = ...,
+        stability_ci: Any = ...,
     ) -> None: ...
 
 
@@ -449,6 +455,8 @@ def ensemble(
     min_cores: int | None = None,
     masking: str = "mass",
     masking_threshold: float | None = None,
+    n_boot: int = 0,
+    boot_seed: int = 0,
 ) -> EnsembleResult:
     """Combine several topic-model fits into one consensus model."""
     ...

--- a/python/topica/ensemble.py
+++ b/python/topica/ensemble.py
@@ -105,6 +105,16 @@ class EnsembleResult:
         ``"cluster"``).
     n_runs : number of fits combined.
     runs : the input fits, in the order given.
+    agreement_ci : ``(lo, hi)`` bootstrap percentile CI for ``agreement``, or
+        ``None`` unless ``ensemble(..., n_boot>0)`` was requested. Resamples the
+        runs with replacement and recomputes the consensus, so it says whether a
+        difference in ``agreement`` across K (or model families) is real or just
+        noise from which runs were combined.
+    agreement_se : bootstrap standard error of ``agreement`` (``None`` unless
+        bootstrapped).
+    stability_ci : ``(K, 2)`` per-topic bootstrap CI for ``stability`` (matched
+        back to the base topics), or ``None``. Only produced for ``"cluster"`` and
+        ``"align"`` (fixed K); ``"stable"`` gives the scalar ``agreement_ci`` only.
     """
 
     topic_word: np.ndarray
@@ -119,12 +129,18 @@ class EnsembleResult:
     reference: int | None
     n_runs: int
     runs: list = field(repr=False)
+    agreement_ci: tuple | None = None
+    agreement_se: float | None = None
+    stability_ci: np.ndarray | None = field(default=None, repr=False)
 
     def __repr__(self):  # noqa: D105
         K = self.topic_word.shape[0]
+        ci = ""
+        if self.agreement_ci is not None:
+            ci = f" [{self.agreement_ci[0]:.3f}, {self.agreement_ci[1]:.3f}]"
         return (
             f"EnsembleResult(method={self.method!r}, n_runs={self.n_runs}, K={K}, "
-            f"agreement={self.agreement:.3f}, reliable={int(np.sum(self.reliable))}/{K})"
+            f"agreement={self.agreement:.3f}{ci}, reliable={int(np.sum(self.reliable))}/{K})"
         )
 
     def top_words(self, n=10):
@@ -771,10 +787,65 @@ def _ensemble_stable(runs, betas, thetas, vocab, K, V, *,
 # Public entry point
 # ---------------------------------------------------------------------------
 
+def _attach_bootstrap_ci(base, runs, betas, thetas, weights, run_fn, n_boot, boot_seed):
+    """Resample the runs with replacement ``n_boot`` times, recompute the
+    consensus each time, and attach percentile CIs for ``agreement`` (and, for the
+    fixed-K methods, per-topic ``stability``). Deterministic given ``boot_seed``."""
+    from .validation import align_topics
+
+    if n_boot < 0:
+        raise ValueError(f"n_boot must be >= 0, got {n_boot}")
+    rng = np.random.default_rng(boot_seed)
+    n = len(runs)
+    K = base.topic_word.shape[0]
+    per_topic = base.method in ("cluster", "align")  # fixed K -> topics are matchable
+    w = None if weights is None else np.asarray(weights, dtype=np.float64)
+    agrees = []
+    stab_samples = [[] for _ in range(K)] if per_topic else None
+    for _ in range(n_boot):
+        idx = rng.integers(0, n, size=n)
+        rs = [runs[i] for i in idx]
+        bs = [betas[i] for i in idx]
+        ts = [thetas[i] for i in idx] if thetas is not None else None
+        ws = None if w is None else w[idx]
+        try:
+            res = run_fn(rs, bs, ts, ws)
+            if np.isfinite(res.agreement):
+                agrees.append(res.agreement)
+            if per_topic and res.topic_word.shape[0] == K:
+                # match each resample topic back to a base topic (Hungarian)
+                for base_i, boot_j, _d in align_topics(
+                        base.topic_word, res.topic_word, metric="cosine"):
+                    stab_samples[base_i].append(float(res.stability[boot_j]))
+        except Exception:
+            continue  # a degenerate resample contributes nothing, not a crash
+
+    # Center each CI on the observed estimate and take its half-width from the
+    # bootstrap standard error (the 95% normal interval). Resampling runs with
+    # replacement duplicates runs, which self-corroborate and bias the resampling
+    # *distribution* of a clustering agreement upward; the bootstrap SE (its
+    # spread) is the trustworthy part, so we use that rather than raw percentiles.
+    z = 1.959963984540054  # normal 97.5th percentile
+    if agrees:
+        a = np.asarray(agrees, dtype=np.float64)
+        se = float(np.std(a, ddof=1)) if len(a) > 1 else 0.0
+        base.agreement_se = se
+        base.agreement_ci = (max(0.0, base.agreement - z * se),
+                             min(1.0, base.agreement + z * se))
+    if per_topic:
+        ci = np.full((K, 2), np.nan)
+        for i, s in enumerate(stab_samples):
+            if len(s) > 1:
+                se_i = float(np.std(s, ddof=1))
+                ci[i] = (max(0.0, base.stability[i] - z * se_i),
+                         min(1.0, base.stability[i] + z * se_i))
+        base.stability_ci = ci
+
+
 def ensemble(runs, *, method="cluster", num_topics=None, lambda_=0.5,
              distance="rbo", topn=10, reference="medoid", metric="cosine",
              weights=None, eps=0.1, min_samples=None, min_cores=None,
-             masking="mass", masking_threshold=None):
+             masking="mass", masking_threshold=None, n_boot=0, boot_seed=0):
     """Combine several topic-model fits into one consensus model.
 
     The consensus is more reliable than any single run — it beats the median run
@@ -815,6 +886,14 @@ def ensemble(runs, *, method="cluster", num_topics=None, lambda_=0.5,
         (default) or ``"rank"`` and ``masking_threshold`` its cutoff (gensim
         defaults 0.95 / 0.11). A larger ``eps`` or smaller ``min_cores`` yields more
         (looser) stable topics.
+    n_boot : if ``> 0``, bootstrap the ``agreement`` (and per-topic ``stability``
+        for ``"cluster"``/``"align"``) by resampling the runs with replacement
+        ``n_boot`` times and recomputing the consensus, filling
+        ``EnsembleResult.agreement_ci`` / ``agreement_se`` / ``stability_ci``. Off
+        by default; a few hundred resamples is typical. Tells you whether a
+        difference in ``agreement`` is real or just noise from the run sample.
+    boot_seed : RNG seed for the bootstrap resampling (default ``0``), so the CI is
+        reproducible.
 
     Returns
     -------
@@ -827,29 +906,31 @@ def ensemble(runs, *, method="cluster", num_topics=None, lambda_=0.5,
     betas, thetas, vocab, K, V = _gather(runs)
     if K == 0:
         raise ValueError("runs contain no topics (K == 0); nothing to ensemble")
-
+    if method not in ("cluster", "align", "stable"):
+        raise ValueError("method must be 'cluster', 'align', or 'stable'")
     if method == "cluster":
         if distance not in ("rbo", "jaccard"):
             raise ValueError("distance must be 'rbo' or 'jaccard'")
         if not 0.0 <= lambda_ <= 1.0:
             raise ValueError(f"lambda_ must be in [0, 1], got {lambda_!r}")
-        return _ensemble_cluster(
-            runs, betas, thetas, vocab, K, V,
-            num_topics=num_topics, lambda_=lambda_, distance=distance,
-            topn=topn, weights=weights,
-        )
-    if method == "align":
-        return _ensemble_align(
-            runs, betas, thetas, vocab, K, V,
-            reference=reference, metric=metric, topn=topn, weights=weights,
-        )
-    if method == "stable":
-        return _ensemble_stable(
-            runs, betas, thetas, vocab, K, V,
-            eps=eps, min_samples=min_samples, min_cores=min_cores,
-            masking=masking, masking_threshold=masking_threshold,
-        )
-    raise ValueError("method must be 'cluster', 'align', or 'stable'")
+
+    def _run(rs, bs, ts, ws):
+        if method == "cluster":
+            return _ensemble_cluster(rs, bs, ts, vocab, K, V, num_topics=num_topics,
+                                     lambda_=lambda_, distance=distance, topn=topn,
+                                     weights=ws)
+        if method == "align":
+            return _ensemble_align(rs, bs, ts, vocab, K, V, reference=reference,
+                                   metric=metric, topn=topn, weights=ws)
+        return _ensemble_stable(rs, bs, ts, vocab, K, V, eps=eps,
+                                min_samples=min_samples, min_cores=min_cores,
+                                masking=masking, masking_threshold=masking_threshold)
+
+    result = _run(runs, betas, thetas, weights)
+    if n_boot:
+        _attach_bootstrap_ci(result, runs, betas, thetas, weights, _run,
+                             int(n_boot), boot_seed)
+    return result
 
 
 def cross_ensemble(

--- a/python/topica/ensemble.py
+++ b/python/topica/ensemble.py
@@ -105,11 +105,13 @@ class EnsembleResult:
         ``"cluster"``).
     n_runs : number of fits combined.
     runs : the input fits, in the order given.
-    agreement_ci : ``(lo, hi)`` bootstrap percentile CI for ``agreement``, or
-        ``None`` unless ``ensemble(..., n_boot>0)`` was requested. Resamples the
-        runs with replacement and recomputes the consensus, so it says whether a
-        difference in ``agreement`` across K (or model families) is real or just
-        noise from which runs were combined.
+    agreement_ci : ``(lo, hi)`` 95% bootstrap CI for ``agreement`` (a normal
+        interval centered on the estimate with a half-width from the bootstrap
+        standard error, clipped to ``[0, 1]``), or ``None`` unless
+        ``ensemble(..., n_boot>0)`` was requested. Resamples the runs with
+        replacement and recomputes the consensus, so it says whether a difference
+        in ``agreement`` across K (or model families) is real or just noise from
+        which runs were combined.
     agreement_se : bootstrap standard error of ``agreement`` (``None`` unless
         bootstrapped).
     stability_ci : ``(K, 2)`` per-topic bootstrap CI for ``stability`` (matched
@@ -789,36 +791,48 @@ def _ensemble_stable(runs, betas, thetas, vocab, K, V, *,
 
 def _attach_bootstrap_ci(base, runs, betas, thetas, weights, run_fn, n_boot, boot_seed):
     """Resample the runs with replacement ``n_boot`` times, recompute the
-    consensus each time, and attach percentile CIs for ``agreement`` (and, for the
-    fixed-K methods, per-topic ``stability``). Deterministic given ``boot_seed``."""
+    consensus each time, and attach normal (bootstrap-SE) CIs for ``agreement``
+    (and, for the fixed-K methods, per-topic ``stability``). Deterministic given
+    ``boot_seed``."""
     from .validation import align_topics
 
     if n_boot < 0:
         raise ValueError(f"n_boot must be >= 0, got {n_boot}")
-    rng = np.random.default_rng(boot_seed)
     n = len(runs)
+    if n < 4:
+        warnings.warn(
+            f"bootstrap CI over only {n} runs is unreliable: a large fraction of "
+            "resamples draw duplicate runs (which trivially agree), inflating the "
+            "interval. Combine more runs for a meaningful CI.",
+            UserWarning, stacklevel=3)
+    rng = np.random.default_rng(boot_seed)
     K = base.topic_word.shape[0]
     per_topic = base.method in ("cluster", "align")  # fixed K -> topics are matchable
     w = None if weights is None else np.asarray(weights, dtype=np.float64)
     agrees = []
     stab_samples = [[] for _ in range(K)] if per_topic else None
-    for _ in range(n_boot):
-        idx = rng.integers(0, n, size=n)
-        rs = [runs[i] for i in idx]
-        bs = [betas[i] for i in idx]
-        ts = [thetas[i] for i in idx] if thetas is not None else None
-        ws = None if w is None else w[idx]
-        try:
-            res = run_fn(rs, bs, ts, ws)
-            if np.isfinite(res.agreement):
-                agrees.append(res.agreement)
-            if per_topic and res.topic_word.shape[0] == K:
-                # match each resample topic back to a base topic (Hungarian)
-                for base_i, boot_j, _d in align_topics(
-                        base.topic_word, res.topic_word, metric="cosine"):
-                    stab_samples[base_i].append(float(res.stability[boot_j]))
-        except Exception:
-            continue  # a degenerate resample contributes nothing, not a crash
+    # Warnings from the internal resamples (e.g. a resample that yields a singleton
+    # cluster) are about throwaway resamples, not the user's ensemble; suppress them
+    # so a few hundred bootstraps do not flood the caller.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        for _ in range(n_boot):
+            idx = rng.integers(0, n, size=n)
+            rs = [runs[i] for i in idx]
+            bs = [betas[i] for i in idx]
+            ts = [thetas[i] for i in idx] if thetas is not None else None
+            ws = None if w is None else w[idx]
+            try:
+                res = run_fn(rs, bs, ts, ws)
+                if np.isfinite(res.agreement):
+                    agrees.append(res.agreement)
+                if per_topic and res.topic_word.shape[0] == K:
+                    # match each resample topic back to a base topic (Hungarian)
+                    for base_i, boot_j, _d in align_topics(
+                            base.topic_word, res.topic_word, metric="cosine"):
+                        stab_samples[base_i].append(float(res.stability[boot_j]))
+            except Exception:
+                continue  # a degenerate resample contributes nothing, not a crash
 
     # Center each CI on the observed estimate and take its half-width from the
     # bootstrap standard error (the 95% normal interval). Resampling runs with
@@ -826,9 +840,9 @@ def _attach_bootstrap_ci(base, runs, betas, thetas, weights, run_fn, n_boot, boo
     # *distribution* of a clustering agreement upward; the bootstrap SE (its
     # spread) is the trustworthy part, so we use that rather than raw percentiles.
     z = 1.959963984540054  # normal 97.5th percentile
-    if agrees:
+    if len(agrees) > 1:  # need >=2 resamples to estimate a standard error
         a = np.asarray(agrees, dtype=np.float64)
-        se = float(np.std(a, ddof=1)) if len(a) > 1 else 0.0
+        se = float(np.std(a, ddof=1))
         base.agreement_se = se
         base.agreement_ci = (max(0.0, base.agreement - z * se),
                              min(1.0, base.agreement + z * se))

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -254,6 +254,61 @@ class TestStableMethod:
             assert results[core].label in stable
 
 
+class TestBootstrapCI:
+    """#627: bootstrap CIs for agreement / stability (SEs-everywhere)."""
+
+    def _noisy_runs(self, m=6, K=4, V=12, noise=0.05, seed=0):
+        rng = np.random.default_rng(seed)
+        protos = np.zeros((K, V))
+        for k in range(K):
+            protos[k, 3 * k:3 * k + 3] = 1.0
+        protos /= protos.sum(1, keepdims=True)
+        runs = []
+        for _ in range(m):
+            b = np.clip(protos + rng.normal(0, noise, protos.shape), 1e-6, None)
+            runs.append(b / b.sum(1, keepdims=True))
+        return runs
+
+    def test_off_by_default(self):
+        res = topica.ensemble(self._noisy_runs())
+        assert res.agreement_ci is None and res.agreement_se is None
+        assert res.stability_ci is None
+
+    @pytest.mark.parametrize("method", ["cluster", "align", "stable"])
+    def test_agreement_ci_is_sane(self, method):
+        runs = self._noisy_runs()
+        res = topica.ensemble(runs, method=method, n_boot=150, boot_seed=1)
+        lo, hi = res.agreement_ci
+        assert 0.0 <= lo <= res.agreement <= hi <= 1.0   # centered, clipped, contains
+        assert res.agreement_se >= 0.0
+
+    def test_per_topic_ci_only_for_fixed_k(self):
+        runs = self._noisy_runs()
+        for method in ("cluster", "align"):
+            res = topica.ensemble(runs, method=method, n_boot=100, boot_seed=2)
+            assert res.stability_ci.shape == (res.topic_word.shape[0], 2)
+            for i in range(len(res.stability)):
+                lo, hi = res.stability_ci[i]
+                if not np.isnan(lo):
+                    assert lo <= res.stability[i] <= hi
+        # stable has a variable topic count, so only the scalar agreement CI
+        assert topica.ensemble(runs, method="stable", n_boot=100).stability_ci is None
+
+    def test_bootstrap_is_deterministic(self):
+        runs = self._noisy_runs()
+        a = topica.ensemble(runs, n_boot=100, boot_seed=7)
+        b = topica.ensemble(runs, n_boot=100, boot_seed=7)
+        assert a.agreement_ci == b.agreement_ci
+        assert np.array_equal(a.stability_ci, b.stability_ci, equal_nan=True)
+        # a different seed generally gives a (slightly) different interval
+        c = topica.ensemble(runs, n_boot=100, boot_seed=8)
+        assert a.agreement_se >= 0 and c.agreement_se >= 0
+
+    def test_negative_n_boot_raises(self):
+        with pytest.raises(ValueError, match="n_boot must be"):
+            topica.ensemble(self._noisy_runs(), n_boot=-1)
+
+
 class TestApiSurface:
     def test_accepts_select_model_result(self):
         runs = [np.eye(3)[[0, 1, 2]] + 0.01, np.eye(3)[[1, 0, 2]] + 0.01]

--- a/tests/test_ensemble.py
+++ b/tests/test_ensemble.py
@@ -8,6 +8,8 @@ alternative. Most tests work on hand-built topic-word arrays so the ground truth
 known exactly; a couple exercise the real fitted-model path end to end.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -307,6 +309,16 @@ class TestBootstrapCI:
     def test_negative_n_boot_raises(self):
         with pytest.raises(ValueError, match="n_boot must be"):
             topica.ensemble(self._noisy_runs(), n_boot=-1)
+
+    def test_few_runs_warn(self):
+        # With <4 runs a large fraction of resamples are all-duplicate, so the CI
+        # is unreliable -- warn rather than report a falsely tight interval.
+        with pytest.warns(UserWarning, match="unreliable"):
+            topica.ensemble(self._noisy_runs(m=3), n_boot=50, lambda_=1.0)
+        # enough runs: no small-n warning (lambda_=1.0 avoids the doc-topic note)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            topica.ensemble(self._noisy_runs(m=6), n_boot=50, lambda_=1.0)
 
 
 class TestApiSurface:


### PR DESCRIPTION
## Summary

`agreement` and per-topic `stability` were point estimates with no error bar, so a user comparing `agreement` across K or model families couldn't tell a real difference from run-sample noise. `ensemble()` gains `n_boot` / `boot_seed`. Closes #627 (SEs-everywhere roadmap).

## What it does
With `n_boot>0`, resample the runs with replacement, recompute the consensus each time (same method + params), and fill three new `EnsembleResult` fields:
- **`agreement_ci`** `(lo, hi)`, **`agreement_se`** — for all methods.
- **`stability_ci`** `(K, 2)` — per-topic, for the fixed-K `cluster`/`align` methods (bootstrapped topics matched back to the base consensus via `align_topics`/Hungarian). `stable` has a variable topic count, so it gets the scalar CI only.

Off by default; deterministic given `boot_seed`.

## Statistics note
The CIs are **centered on the observed estimate** with a half-width from the bootstrap **standard error** (95% normal interval), clipped to `[0, 1]`. Resampling runs with replacement duplicates runs, which self-corroborate and bias the resampling *distribution* of a clustering agreement upward — so a raw percentile interval can exclude the point estimate. The bootstrap SE (its spread) is the trustworthy part, and centering on the estimate keeps the interval honest. Verified: all three methods produce `lo <= agreement <= hi`, clipped to `[0,1]`, and per-topic CIs contain their point estimates.

## Tests / docs
`TestBootstrapCI`: off-by-default, sane/centered/clipped CIs across all three methods, per-topic CIs only for fixed K, determinism, and the `n_boot<0` guard. `.pyi` + docstrings updated. `test_ensemble.py`, `test_cross_ensemble.py`, `test_agreement.py` green (50); `mkdocs build --strict` clean.

`cross_ensemble` bootstrap is a natural follow-up (structurally different vocab handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)