### PR TITLE
fix(workflow): reviewer-safety fixes from the sample-user LDA audit (#647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,31 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   matched the vocabulary and the score degenerated silently — e.g. `c_v == 1.0` for
   every topic. These functions now normalize their reference corpus the same way
   `diagnostics` does (a `Corpus`, raw strings split on whitespace, or already-tokenized
-  documents all work), so string input is tokenized rather than shredded.
+  documents all work), so string input is tokenized rather than shredded. A fitted
+  model accidentally passed as the reference corpus (arguments swapped) is now
+  rejected with a directive error (#647).
+
+### Changed
+
+- **Reviewer-safety fixes from a sample-user LDA-workflow audit (#647).** A batch
+  of usability/correctness improvements to the analysis path a first-time user
+  walks:
+  - `estimate_effect` results gain a `.pvalue` (two-sided, from the Wald `z`) and
+    name-keyed accessors `.effect_of(name)` / `.by_feature`, plus a `pvalue` column
+    in `.to_frame()`. With the default `add_intercept=True`, `coef[0]` is the
+    intercept, so reading effects by name avoids silently reporting the baseline
+    constant instead of a covariate.
+  - `best_k()` now warns when a monotone metric (`heldout_loglik`/`perplexity`)
+    selects the largest K scanned — the optimum is at the grid boundary, so the real
+    best K may lie beyond it (symmetric to the existing coherence warning).
+  - `from_dataframe(..., max_doc_fraction<1.0)` warns when it drops very high
+    document-frequency terms — on a focused corpus these can be the words it is
+    about.
+  - Docs: a "Covariate effects on a plain LDA model (not only STM)" section in the
+    covariates guide; `find_thoughts`' stub return type tightened to the real
+    `(doc_index, proportion, text)` triple; `plot_search_k` documents the
+    `ax.figure.savefig(...)` save path; the `load_dubois` docstring corrects its
+    date range to 1910–1934 and notes the 3 exact-duplicate articles.
 
 ### Added
 

--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -127,6 +127,39 @@ Build non-linear and interaction terms with `topica.spline` and
 `topica.interaction`. Full detail and the journal-grade treatment are in the
 [Publishing](../publishing/effects.md) track.
 
+### On a plain LDA model (not only STM)
+
+You do **not** have to switch to `STM` to get covariate effects with honest
+uncertainty. `estimate_effect` takes any fitted model (or its `doc_topic`) — a plain
+`LDA` works — and propagates topic-estimation uncertainty via the method of
+composition. STM additionally embeds the prevalence covariates in the prior *during*
+estimation (so the topics themselves are informed by the covariates); reach for it
+when that is the goal, but for "how does topic prevalence differ by group, with a
+CI?" on an already-fitted LDA, `estimate_effect(model, X=..., corpus=corpus)` is the
+direct path.
+
+```python
+model = topica.LDA(num_topics=20, seed=1)
+model.fit(corpus, iters=1000)
+
+X, names = topica.one_hot(corpus.metadata["rating"], prefix="rating_")
+effects = topica.estimate_effect(model, X=X, feature_names=names, corpus=corpus, nsims=50)
+```
+
+**Read effects by name, not by position.** `add_intercept=True` is the default, so
+each result's `feature_names` is `["intercept", "rating_Liberal", ...]` and `coef[0]`
+is the baseline **intercept**, not your covariate. Reading `coef[0]` as "the effect"
+is a common way to publish the wrong number. Use the name-keyed accessors:
+
+```python
+e = effects[topic]
+e.effect_of("rating_Liberal")   # {'coef':..., 'se':..., 'z':..., 'pvalue':..., 'ci_low':..., 'ci_high':...}
+e.by_feature                    # every covariate keyed by name
+e.to_frame()                    # tidy rows with a named `feature` column and a pvalue
+```
+
+`e.pvalue` (two-sided, from the Wald `z`) is available for significance reporting.
+
 ### Random intercepts for nested data
 
 When documents are nested in units — states, outlets, authors — whose baseline

--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -248,8 +248,8 @@ def topic_correlation(doc_topic: Any, *, threshold: float = 0.05) -> Any:
     ...
 
 
-def find_thoughts(doc_topic: Any, texts: Sequence[str] | None = None, *, topic: int, n: int = 3) -> list:
-    """The n documents most associated with a topic."""
+def find_thoughts(doc_topic: Any, texts: Sequence[Any] | None = None, *, topic: int, n: int = 3) -> list[tuple[int, float, Any]]:
+    """The n documents most associated with a topic, as (doc_index, proportion, text) triples."""
     ...
 
 

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -318,10 +318,25 @@ def _as_reference(texts):
     character, so every top word misses the vocabulary and the score silently
     degenerates — e.g. ``c_v == 1.0`` for every topic (issue #648). Mirrors
     ``validation._ref_corpus`` so ``coherence`` and ``diagnostics`` agree on input.
+
+    A fitted model passed as the reference (the usual ``topics``/``texts`` argument
+    slip) is rejected with a directive error rather than a cryptic failure.
     """
     if hasattr(texts, "documents"):
         return texts.documents()
-    texts = list(texts)
+    if hasattr(texts, "topic_word") or hasattr(texts, "doc_topic"):
+        raise TypeError(
+            "texts looks like a fitted model, not a reference corpus. Pass the model "
+            "as the first argument (topics/model) and the corpus — a topica.Corpus, "
+            "raw-string documents, or list[list[str]] — as texts."
+        )
+    try:
+        texts = list(texts)
+    except TypeError as e:
+        raise TypeError(
+            "texts must be a topica.Corpus, raw-string documents, or a list of "
+            f"tokenized documents (list[list[str]]); got {type(texts).__name__}"
+        ) from e
     if texts and isinstance(texts[0], str):
         return [t.split() for t in texts]
     return [list(t) for t in texts]
@@ -425,7 +440,9 @@ def coherence_ci(
     topics : a fitted model, or a list of topics (each a list of words / ``(word,
         prob)`` pairs). The top words are extracted once and held fixed.
     texts : the reference corpus to resample — a :class:`Corpus`, raw-string
-        documents, or tokenized documents (as in :func:`coherence`).
+        documents, or tokenized documents (as in :func:`coherence`). A fitted model
+        passed here (the ``topics``/``texts`` arguments swapped) is rejected with a
+        clear error.
     coherence_type, topn, window_size, epsilon : as in :func:`coherence`.
     n_boot : number of bootstrap resamples (each recomputes co-occurrence, so this
         is O(n_boot x corpus size); the windowed measures (``c_v`` etc.) are the

--- a/python/topica/datasets/__init__.py
+++ b/python/topica/datasets/__init__.py
@@ -270,7 +270,7 @@ def load_poliblog(*, return_path: bool = False):
 
 
 def load_dubois(*, return_path: bool = False):
-    """Load Du Bois-era articles from The Crisis, 1910-1922 (704 documents).
+    """Load Du Bois-era articles from The Crisis, 1910-1934 (704 documents).
 
     Raw text in the ``text`` column; covariates ``year``, ``decade``,
     ``volume``, ``issue``, ``author``, ``subjects``. Build a corpus with
@@ -281,7 +281,9 @@ def load_dubois(*, return_path: bool = False):
             df, text_col="text", stopwords=topica.ENGLISH_STOPWORDS
         )
 
-    Downloaded once and cached. Pass ``return_path=True`` for the CSV path.
+    The corpus holds a few (3) exact-duplicate articles reprinted across issues;
+    drop them with ``df.drop_duplicates("text")`` if a fit should not double-count
+    them. Downloaded once and cached. Pass ``return_path=True`` for the CSV path.
     """
     return _load("dubois", return_path)
 

--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -8,6 +8,7 @@ prevalence regression. These helpers keep text and metadata bound together.
 
 from __future__ import annotations
 
+import warnings
 from typing import Sequence
 
 from . import Corpus, tokenize
@@ -86,6 +87,35 @@ def from_dataframe(
         ]
     else:
         docs = [tokenizer(t if isinstance(t, str) else "") for t in texts]
+
+    # max_doc_fraction removes the highest document-frequency terms — which on a
+    # focused corpus can be the very words it is about (e.g. "immigration" in an
+    # immigration corpus). The pruning happens in the Rust core with no feedback, so
+    # surface the dropped high-frequency terms here before they vanish silently.
+    if max_doc_fraction < 1.0 and docs and vocabulary is None:
+        from collections import Counter
+
+        n_docs = len(docs)
+        doc_freq: Counter = Counter()
+        for d in docs:
+            doc_freq.update(set(d))
+        thresh = max_doc_fraction * n_docs
+        dropped = sorted(
+            (w for w, c in doc_freq.items() if c > thresh),
+            key=lambda w: doc_freq[w],
+            reverse=True,
+        )
+        if dropped:
+            shown = ", ".join(f"{w!r} ({doc_freq[w] / n_docs:.0%})" for w in dropped[:8])
+            more = "" if len(dropped) <= 8 else f", +{len(dropped) - 8} more"
+            warnings.warn(
+                f"max_doc_fraction={max_doc_fraction} drops {len(dropped)} very "
+                f"common term(s) from the vocabulary: {shown}{more}. On a focused "
+                "corpus these can be the words it is about; raise max_doc_fraction "
+                "(or leave it at 1.0) to keep them.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     corpus = Corpus.from_documents(
         docs,

--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -93,17 +93,22 @@ def from_dataframe(
     # immigration corpus). The pruning happens in the Rust core with no feedback, so
     # surface the dropped high-frequency terms here before they vanish silently.
     if max_doc_fraction < 1.0 and docs and vocabulary is None:
+        import math
         from collections import Counter
 
         n_docs = len(docs)
         doc_freq: Counter = Counter()
         for d in docs:
-            doc_freq.update(set(d))
-        thresh = max_doc_fraction * n_docs
+            doc_freq.update(w for w in set(d) if w)  # ignore empty tokens, as the core does
+        # Match the Rust core's cutoff exactly: a term is dropped iff its document
+        # frequency exceeds ceil(n_docs * max_doc_fraction) (mod.rs `max_df`). Using
+        # the un-rounded product would over-report on a non-integral threshold.
+        max_df = math.ceil(n_docs * max_doc_fraction)
+        # Frequency-descending, then alphabetical, so the sampled list is
+        # deterministic under any hash seed.
         dropped = sorted(
-            (w for w, c in doc_freq.items() if c > thresh),
-            key=lambda w: doc_freq[w],
-            reverse=True,
+            (w for w, c in doc_freq.items() if c > max_df),
+            key=lambda w: (-doc_freq[w], w),
         )
         if dropped:
             shown = ", ".join(f"{w!r} ({doc_freq[w] / n_docs:.0%})" for w in dropped[:8])

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -41,7 +41,16 @@ import numpy as np
 
 @dataclass
 class TopicEffect:
-    """OLS of one topic's proportion on the covariates."""
+    """OLS of one topic's proportion on the covariates.
+
+    ``coef``/``se``/``z``/``ci_low``/``ci_high``/``pvalue`` are aligned to
+    ``feature_names`` **positionally**. With ``add_intercept=True`` (the
+    :func:`~topica.estimate_effect` default) ``feature_names[0]`` is ``"intercept"``,
+    so ``coef[0]`` is the baseline constant, *not* your covariate — a common way to
+    accidentally report the wrong number. Prefer name-keyed access
+    (:meth:`effect_of`, :attr:`by_feature`, :meth:`to_frame`) over positional
+    indexing.
+    """
 
     topic: int
     feature_names: list[str]
@@ -54,7 +63,48 @@ class TopicEffect:
     vcov: np.ndarray = None  # full (p, p) coefficient covariance (Rubin-pooled)
     varcomp: dict = None  # random-effect variance components (sd), when random= is set
 
+    @property
+    def pvalue(self) -> np.ndarray:
+        """Two-sided normal p-value per feature, from the Wald statistic ``z``.
+
+        ``P(|Z| > |z|) = erfc(|z| / sqrt(2))``; ``nan`` where ``z`` is ``nan`` (e.g.
+        an unreliable bootstrap SE). Aligned to :attr:`feature_names`."""
+        import math
+
+        z = np.asarray(self.z, dtype=float)
+        out = np.full(z.shape, np.nan)
+        finite = np.isfinite(z)
+        out[finite] = [math.erfc(abs(v) / math.sqrt(2.0)) for v in z[finite]]
+        return out
+
+    def effect_of(self, feature: str) -> dict:
+        """Named-feature accessor: the row for ``feature`` as a dict of ``coef``,
+        ``se``, ``z``, ``ci_low``, ``ci_high``, ``pvalue``. Raises ``KeyError`` with
+        the available names if ``feature`` is not a covariate — the safe alternative
+        to guessing a positional index (see the class note on the intercept)."""
+        names = list(self.feature_names)
+        if feature not in names:
+            raise KeyError(
+                f"{feature!r} is not a covariate of this effect; available: {names}"
+            )
+        j = names.index(feature)
+        return {
+            "coef": float(self.coef[j]),
+            "se": float(self.se[j]),
+            "z": float(self.z[j]),
+            "ci_low": float(self.ci_low[j]),
+            "ci_high": float(self.ci_high[j]),
+            "pvalue": float(self.pvalue[j]),
+        }
+
+    @property
+    def by_feature(self) -> dict:
+        """``{feature_name: effect_of(name)}`` — every covariate keyed by name, so a
+        result reads without positional indexing."""
+        return {name: self.effect_of(name) for name in self.feature_names}
+
     def as_dict(self) -> dict:
+        pval = self.pvalue
         return {
             "topic": self.topic,
             **{
@@ -62,6 +112,7 @@ class TopicEffect:
                     "coef": float(self.coef[j]),
                     "se": float(self.se[j]),
                     "z": float(self.z[j]),
+                    "pvalue": float(pval[j]),
                     "ci": (float(self.ci_low[j]), float(self.ci_high[j])),
                 }
                 for j, name in enumerate(self.feature_names)
@@ -72,9 +123,11 @@ class TopicEffect:
     def to_frame(self):
         """Return a tidy pandas DataFrame, one row per feature.
 
-        Columns are ``topic``, ``feature``, ``coef``, ``se``, ``z``, ``ci_low``,
-        ``ci_high``, and ``r_squared`` (the topic's value, repeated). Because the
-        ``topic`` column is included, concatenating the frames from a whole
+        Columns are ``topic``, ``feature``, ``coef``, ``se``, ``z``, ``pvalue``,
+        ``ci_low``, ``ci_high``, and ``r_squared`` (the topic's value, repeated).
+        The named ``feature`` column is the safe way to read a specific covariate's
+        effect — an ``intercept`` row is present when ``add_intercept=True``. Because
+        the ``topic`` column is included, concatenating the frames from a whole
         :func:`estimate_effect` call gives one row per (topic, feature)::
 
             import pandas as pd
@@ -90,6 +143,7 @@ class TopicEffect:
                 "coef": np.asarray(self.coef, dtype=float),
                 "se": np.asarray(self.se, dtype=float),
                 "z": np.asarray(self.z, dtype=float),
+                "pvalue": np.asarray(self.pvalue, dtype=float),
                 "ci_low": np.asarray(self.ci_low, dtype=float),
                 "ci_high": np.asarray(self.ci_high, dtype=float),
                 "r_squared": self.r_squared,

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -67,34 +67,48 @@ class TopicEffect:
     def pvalue(self) -> np.ndarray:
         """Two-sided normal p-value per feature, from the Wald statistic ``z``.
 
-        ``P(|Z| > |z|) = erfc(|z| / sqrt(2))``; ``nan`` where ``z`` is ``nan`` (e.g.
-        an unreliable bootstrap SE). Aligned to :attr:`feature_names`."""
+        ``P(|Z| > |z|) = erfc(|z| / sqrt(2))``; ``nan`` only where ``z`` is ``nan``
+        (e.g. an unreliable bootstrap SE). An infinite ``z`` (a nonzero coefficient
+        with a zero SE) gives ``0.0``, consistent with the formula. Aligned to
+        :attr:`feature_names`."""
         import math
 
-        z = np.asarray(self.z, dtype=float)
+        z = np.atleast_1d(np.asarray(self.z, dtype=float))
         out = np.full(z.shape, np.nan)
-        finite = np.isfinite(z)
-        out[finite] = [math.erfc(abs(v) / math.sqrt(2.0)) for v in z[finite]]
-        return out
+        valid = ~np.isnan(z)  # inf is valid -> erfc(inf)=0.0; only nan stays nan
+        out[valid] = [math.erfc(abs(v) / math.sqrt(2.0)) for v in z[valid]]
+        return out.reshape(np.shape(self.z))
 
     def effect_of(self, feature: str) -> dict:
         """Named-feature accessor: the row for ``feature`` as a dict of ``coef``,
         ``se``, ``z``, ``ci_low``, ``ci_high``, ``pvalue``. Raises ``KeyError`` with
-        the available names if ``feature`` is not a covariate — the safe alternative
-        to guessing a positional index (see the class note on the intercept)."""
+        the available names if ``feature`` is not a covariate, or ``ValueError`` if
+        the name is not unique (ambiguous) — the safe alternative to guessing a
+        positional index (see the class note on the intercept)."""
         names = list(self.feature_names)
         if feature not in names:
             raise KeyError(
                 f"{feature!r} is not a covariate of this effect; available: {names}"
             )
+        if names.count(feature) > 1:
+            raise ValueError(
+                f"{feature!r} appears {names.count(feature)} times in feature_names, "
+                "so named access is ambiguous; read the row positionally via "
+                ".coef/.se/... or .to_frame() instead."
+            )
         j = names.index(feature)
+        coef = np.atleast_1d(self.coef)
+        se = np.atleast_1d(self.se)
+        ci_low = np.atleast_1d(self.ci_low)
+        ci_high = np.atleast_1d(self.ci_high)
+        pval = np.atleast_1d(self.pvalue)
         return {
-            "coef": float(self.coef[j]),
-            "se": float(self.se[j]),
-            "z": float(self.z[j]),
-            "ci_low": float(self.ci_low[j]),
-            "ci_high": float(self.ci_high[j]),
-            "pvalue": float(self.pvalue[j]),
+            "coef": float(coef[j]),
+            "se": float(se[j]),
+            "z": float(np.atleast_1d(self.z)[j]),
+            "ci_low": float(ci_low[j]),
+            "ci_high": float(ci_high[j]),
+            "pvalue": float(pval[j]),
         }
 
     @property

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1155,7 +1155,24 @@ class SearchKResult(list):
             return self._elbow_k(present, metric, maximize)
         best = (max if maximize else min)(r[metric] for r in present)
         # Parsimony tie-break: smallest k achieving the best value.
-        return int(min(r["k"] for r in present if r[metric] == best))
+        pick = int(min(r["k"] for r in present if r[metric] == best))
+        # Boundary guard: held-out log-likelihood and perplexity usually improve
+        # with K on real corpora, so rule='best' tends to return the largest K
+        # scanned — a grid artifact, not a real optimum. Warn (symmetric to the
+        # coherence path) so a user doesn't publish the grid endpoint unexamined.
+        if metric in ("heldout_loglik", "perplexity") and len(present) >= 2:
+            k_max = max(r["k"] for r in present)
+            if pick == k_max:
+                warnings.warn(
+                    f"best_k(metric={metric!r}) selected K={pick}, the largest K "
+                    "scanned: this metric tends to keep improving with K, so the "
+                    "optimum is at the grid boundary and the real best K may lie "
+                    "beyond it. Widen ks=, or use rule='elbow' (diminishing-returns "
+                    "knee) or metric='frontier' (coherence/exclusivity knee).",
+                    UserWarning,
+                    stacklevel=2,
+                )
+        return pick
 
     def _one_se_k(self, present, metric, maximize):
         """One-standard-error rule on a scalar ``metric``: the smallest K whose
@@ -1770,7 +1787,14 @@ def plot_search_k(rows, *, metrics=("coherence", "exclusivity"), ax=None):
     :func:`search_k`; ``metrics`` selects which of its keys to draw (any of
     ``"coherence"``, ``"exclusivity"``, ``"perplexity"``, ``"heldout_loglik"``).
     Only metrics present in the rows are drawn; absent keys are silently skipped.
-    Returns the primary matplotlib ``Axes``. Requires matplotlib.
+
+    Returns the primary matplotlib ``Axes`` (consistent with topica's other
+    ``plot_*`` helpers). To save the figure, go through the axes' figure::
+
+        ax = topica.plot_search_k(rows)
+        ax.figure.savefig("search_k.png", dpi=150, bbox_inches="tight")
+
+    Requires matplotlib.
     """
     try:
         import matplotlib.pyplot as plt

--- a/tests/test_sample_user_647.py
+++ b/tests/test_sample_user_647.py
@@ -55,6 +55,37 @@ def test_effect_pvalue_is_nan_where_z_is_nan():
     assert np.isnan(e.pvalue[1])
 
 
+def test_effect_pvalue_infinite_z_is_zero():
+    # A nonzero coef with a zero SE gives z=+/-inf; under erfc(|z|/sqrt2) that is p=0,
+    # not nan (only nan z stays nan).
+    from topica.stm import TopicEffect
+
+    e = TopicEffect(
+        topic=0, feature_names=["a", "b", "c"],
+        coef=np.ones(3), se=np.ones(3),
+        z=np.array([np.inf, -np.inf, np.nan]),
+        ci_low=np.zeros(3), ci_high=np.ones(3), r_squared=0.0,
+    )
+    assert e.pvalue[0] == 0.0 and e.pvalue[1] == 0.0
+    assert np.isnan(e.pvalue[2])
+
+
+def test_effect_named_access_rejects_duplicate_feature_names():
+    # Named access must not silently return only the first of two identically named
+    # covariates (it is advertised as the *safe* path).
+    from topica.stm import TopicEffect
+
+    e = TopicEffect(
+        topic=0, feature_names=["x", "x"],
+        coef=np.array([1.0, 2.0]), se=np.ones(2), z=np.ones(2),
+        ci_low=np.zeros(2), ci_high=np.ones(2), r_squared=0.0,
+    )
+    with pytest.raises(ValueError, match="appears 2 times"):
+        e.effect_of("x")
+    with pytest.raises(ValueError, match="appears 2 times"):
+        _ = e.by_feature
+
+
 # --- best_k: boundary warning on a monotone metric ------------------------------
 
 def test_best_k_warns_at_grid_boundary_for_heldout():
@@ -120,3 +151,34 @@ def test_from_dataframe_no_warning_without_upper_pruning():
     with warnings.catch_warnings():
         warnings.simplefilter("error")
         topica.from_dataframe(_frame(), text_col="text", min_doc_freq=1)
+
+
+def test_from_dataframe_warning_matches_rust_ceil_cutoff():
+    # The core keeps terms with doc_freq <= ceil(n_docs * max_doc_fraction). On a
+    # non-integral threshold the warning must use the SAME ceil cutoff, or it warns
+    # about terms the core actually kept. 3 docs, "common" in 2, fraction 0.5:
+    # ceil(1.5)=2, so "common" (df 2) is KEPT and must NOT be warned.
+    df = pd.DataFrame({"text": ["common a", "common b", "c d"]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # any warning fails the test
+        corpus = topica.from_dataframe(df, text_col="text", max_doc_fraction=0.5)
+    assert "common" in corpus.vocabulary  # the core kept it; the warning agreed by staying silent
+
+
+def test_from_dataframe_warned_terms_are_actually_dropped():
+    # Every term the warning names must be absent from the resulting vocabulary
+    # (no false alarms). 6 docs, "shared" in all (df 6 > ceil(0.5*6)=3 -> dropped);
+    # "a"/"b" in 3 each (df 3 == cutoff -> kept); unique fillers keep docs non-empty.
+    df = pd.DataFrame({"text": [
+        "shared alpha filla", "shared alpha fillb", "shared alpha fillc",
+        "shared beta filld", "shared beta fille", "shared beta fillf",
+    ]})
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        corpus = topica.from_dataframe(df, text_col="text", max_doc_fraction=0.5)
+    msgs = [str(x.message) for x in w if "max_doc_fraction" in str(x.message)]
+    assert msgs and "shared" in msgs[0]
+    vocab = set(corpus.vocabulary)
+    assert "shared" not in vocab                 # warned -> genuinely dropped
+    assert {"alpha", "beta"} <= vocab            # at-cutoff terms (df 3) kept, not warned
+    assert "alpha" not in msgs[0] and "beta" not in msgs[0]

--- a/tests/test_sample_user_647.py
+++ b/tests/test_sample_user_647.py
@@ -1,0 +1,122 @@
+"""Reviewer-safety fixes from the sample-user LDA-workflow audit (issue #647).
+
+Each test pins one finding: a footgun that could put a wrong number in a paper,
+an opaque failure, or a silent drop — the things two first-time-user agents hit
+running the full LDA workflow end to end.
+"""
+
+import warnings
+
+import numpy as np
+import pandas as pd
+import pytest
+
+import topica
+from topica.validation import SearchKResult
+
+
+# --- estimate_effect: intercept footgun + missing p-value -----------------------
+
+def _effects():
+    # A tiny (D, K) theta and a one-covariate design; add_intercept=True by default
+    # so feature_names becomes ['intercept', 'x'].
+    rng = np.random.default_rng(0)
+    theta = rng.dirichlet(np.ones(3), size=40)
+    x = (np.arange(40) < 20).astype(float)  # binary covariate
+    return topica.estimate_effect(theta, X=x, feature_names=["x"])
+
+
+def test_effect_has_pvalue_aligned_to_features():
+    e = _effects()[0]
+    assert e.feature_names == ["intercept", "x"]
+    p = e.pvalue
+    assert p.shape == (2,)
+    assert np.all((p >= 0) & (p <= 1))
+    # pvalue reaches the tidy frame and the dict summary.
+    assert "pvalue" in e.to_frame().columns
+    assert "pvalue" in e.as_dict()["x"]
+
+
+def test_effect_named_access_avoids_intercept_footgun():
+    # coef[0] is the INTERCEPT, not the covariate — the silent-wrong-number trap.
+    # effect_of / by_feature read the covariate by name instead of by position.
+    e = _effects()[0]
+    assert e.effect_of("x")["coef"] == pytest.approx(float(e.coef[1]))
+    assert e.effect_of("x")["coef"] != pytest.approx(float(e.coef[0]))  # not the intercept
+    assert set(e.by_feature) == {"intercept", "x"}
+    assert e.by_feature["x"]["pvalue"] == pytest.approx(float(e.pvalue[1]))
+    with pytest.raises(KeyError, match="not a covariate"):
+        e.effect_of("nope")
+
+
+def test_effect_pvalue_is_nan_where_z_is_nan():
+    e = _effects()[0]
+    e.z[1] = np.nan
+    assert np.isnan(e.pvalue[1])
+
+
+# --- best_k: boundary warning on a monotone metric ------------------------------
+
+def test_best_k_warns_at_grid_boundary_for_heldout():
+    rows = SearchKResult([
+        {"k": 5, "heldout_loglik": -100.0},
+        {"k": 10, "heldout_loglik": -90.0},
+        {"k": 15, "heldout_loglik": -80.0},  # optimum at the largest K -> boundary
+    ])
+    with pytest.warns(UserWarning, match="largest K scanned"):
+        assert rows.best_k() == 15  # default metric resolves to heldout_loglik
+
+
+def test_best_k_no_warning_for_interior_optimum():
+    rows = SearchKResult([
+        {"k": 5, "heldout_loglik": -100.0},
+        {"k": 10, "heldout_loglik": -80.0},  # interior optimum
+        {"k": 15, "heldout_loglik": -90.0},
+    ])
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        assert rows.best_k() == 10
+
+
+# --- coherence_ci: accept (model, corpus); reject swapped args ------------------
+
+def _corpus_and_model():
+    docs = [["a", "b", "c"], ["a", "b", "d"], ["c", "d", "e"], ["a", "c", "e"]] * 8
+    corpus = topica.Corpus.from_documents(docs)
+    m = topica.LDA(num_topics=2, seed=1)
+    m.fit(corpus, iters=40)
+    return corpus, m
+
+
+def test_coherence_ci_accepts_model_and_corpus():
+    corpus, m = _corpus_and_model()
+    ci = topica.coherence_ci(m, corpus, n_boot=20, seed=0)
+    assert ci.estimate.shape == (2,)
+
+
+def test_coherence_ci_rejects_model_as_texts_clearly():
+    _, m = _corpus_and_model()
+    with pytest.raises(TypeError, match="looks like a fitted model"):
+        topica.coherence_ci([["a", "b"]], m, n_boot=5)
+
+
+# --- from_dataframe: warn when max_doc_fraction drops corpus-defining terms ------
+
+def _frame():
+    # "core" appears in every doc (100% > 0.5); the rest vary.
+    docs = [
+        "core alpha beta", "core alpha gamma", "core beta delta",
+        "core gamma delta", "core alpha beta", "core delta gamma",
+    ]
+    return pd.DataFrame({"text": docs, "grp": list("aabbab")})
+
+
+def test_from_dataframe_warns_on_high_df_pruning():
+    with pytest.warns(UserWarning, match="max_doc_fraction=0.5 drops"):
+        topica.from_dataframe(_frame(), text_col="text", max_doc_fraction=0.5)
+
+
+def test_from_dataframe_no_warning_without_upper_pruning():
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        topica.from_dataframe(_frame(), text_col="text", min_doc_freq=1)

--- a/tests/test_stm.py
+++ b/tests/test_stm.py
@@ -192,7 +192,8 @@ class TestEstimateEffect:
         )
         df = effects[0].to_frame()
         assert list(df.columns) == [
-            "topic", "feature", "coef", "se", "z", "ci_low", "ci_high", "r_squared"
+            "topic", "feature", "coef", "se", "z", "pvalue", "ci_low", "ci_high",
+            "r_squared"
         ]
         assert len(df) == len(effects[0].feature_names)  # intercept + x
         assert set(df["feature"]) == {"intercept", "x"}


### PR DESCRIPTION
## What

The **reviewer-safety bundle** from the two-agent sample-user audit (#647): a
coherent, pure-Python batch on the theme *don't let a first-time user publish a
wrong number*. Addresses the Tier-1 correctness traps and the cheap Tier-2/3/4
API-truth + docs items; the one item needing Rust (PyO3 `help(Model.__init__)`
`__text_signature__`) is deferred to a follow-up.

## Changes

**Tier 1 — correctness traps**
- **`estimate_effect` intercept footgun + missing p-value.** Results gain `.pvalue`
  (two-sided, from the Wald `z`), name-keyed `.effect_of(name)` / `.by_feature`, and
  a `pvalue` column in `.to_frame()`. With the default `add_intercept=True`,
  `coef[0]` is the *intercept*, so reading effects by name (not position) avoids
  silently reporting the baseline constant as a covariate effect.
- **`best_k()` grid-boundary warning.** Warns when `heldout_loglik`/`perplexity`
  select the largest K scanned (optimum at the grid edge → real best K may lie
  beyond it), symmetric to the existing coherence warning.
- **`from_dataframe` silent high-DF pruning.** `max_doc_fraction<1.0` now warns
  which very-common terms it drops — on a focused corpus these can be the words it
  is about (e.g. `negro`/`white`/`colored` on `dubois`).

**Tier 2 — broken/opaque**
- **`coherence_ci(model, corpus)`** now accepts a fitted model + a `topica.Corpus`
  (like `coherence`); a model passed as `texts` raises a directive error instead of
  `object of type 'Corpus' has no len()`.

**Tier 3/4 — API-truth + docs**
- `find_thoughts` stub return type tightened to the real `(doc_index, proportion,
  text)` triple; `plot_search_k` documents the `ax.figure.savefig(...)` save path.
- New **"Covariate effects on a plain LDA model (not only STM)"** section in the
  covariates guide, with the read-by-name guidance.
- `load_dubois` docstring: corrected range to **1910–1934** and noted the 3
  exact-duplicate articles.

## Validation

- New `tests/test_sample_user_647.py` (9 tests) pins each finding.
- `test_stm` `to_frame` column set updated for the added `pvalue` column.
- Affected suites green (effects, coherence, frames, stm, search_k, manifest, viz,
  heldout, predicted_prevalence — 214 passed locally).
- `preflight.sh` clean (fmt + clippy, no Rust changed); `mkdocs build --strict` clean.
- Note: 4 warnings now emitted by existing endpoint-selection tests in
  `test_issue_fixes` are **expected** — the new `best_k` boundary warning firing on
  tests that deliberately select the grid edge.

Closes #647 (partial — reviewer-safety bundle; remaining items tracked in the issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)