### PR TITLE
fix(coherence): tokenize raw-string reference corpora instead of shredding to chars (#648)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Fixed
+
+- **`topica.coherence` / `coherence_ci` / `semantic_coherence` no longer silently
+  mis-score raw-string input** (#648). Passing a list of document *strings* (as the
+  docs' own examples do) was iterated character-by-character, so no top word ever
+  matched the vocabulary and the score degenerated silently — e.g. `c_v == 1.0` for
+  every topic. These functions now normalize their reference corpus the same way
+  `diagnostics` does (a `Corpus`, raw strings split on whitespace, or already-tokenized
+  documents all work), so string input is tokenized rather than shredded.
+
 ### Added
 
 - **`topica.compare` now compares two `AnalysisManifest`s without refitting** (#415).

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -310,6 +310,23 @@ def _occurrences(texts, vocab, tops, window):
 # Public API
 # ---------------------------------------------------------------------------
 
+def _as_reference(texts):
+    """Normalize a coherence reference corpus to ``list[list[str]]``.
+
+    Accepts a Corpus, raw strings (split on whitespace), or already-tokenized
+    documents. Without this, a list of raw strings would be iterated character by
+    character, so every top word misses the vocabulary and the score silently
+    degenerates — e.g. ``c_v == 1.0`` for every topic (issue #648). Mirrors
+    ``validation._ref_corpus`` so ``coherence`` and ``diagnostics`` agree on input.
+    """
+    if hasattr(texts, "documents"):
+        return texts.documents()
+    texts = list(texts)
+    if texts and isinstance(texts[0], str):
+        return [t.split() for t in texts]
+    return [list(t) for t in texts]
+
+
 def coherence(topics, texts, *, coherence_type="c_v", topn=10, window_size=None, epsilon=1e-12):
     """Per-topic coherence against a reference corpus.
 
@@ -317,8 +334,11 @@ def coherence(topics, texts, *, coherence_type="c_v", topn=10, window_size=None,
     ----------
     topics : a fitted model, or a list of topics (each a list of words, or of
         ``(word, prob)`` pairs).
-    texts : list of tokenized documents (``list[list[str]]``) — the reference
-        corpus. Pass your training documents, or an external corpus.
+    texts : the reference corpus, as a :class:`Corpus`, a list of raw-string
+        documents (split on whitespace), or already-tokenized documents
+        (``list[list[str]]``). Pass your training documents, or an external corpus.
+        (Raw strings are tokenized for you — passing them is not silently scored
+        character-by-character; see issue #648.)
     coherence_type : one of ``"u_mass"``, ``"c_uci"``, ``"c_npmi"``, ``"c_v"``
         (default ``"c_v"``).
     topn : number of top words per topic to score (default 10).
@@ -336,10 +356,10 @@ def coherence(topics, texts, *, coherence_type="c_v", topn=10, window_size=None,
         raise ValueError(f"coherence_type must be one of {_VALID}, got {coherence_type!r}")
     if not isinstance(topn, (int, np.integer)) or topn < 1:
         raise ValueError(f"topn must be a positive integer, got {topn!r}")
+    texts = _as_reference(texts)
     if len(texts) == 0:
         raise ValueError("texts is empty; pass the reference corpus as list[list[str]]")
     tops = _extract_topics(topics, topn)
-    texts = [list(d) for d in texts]
     relevant = sorted({w for t in tops for w in t})
     vocab = {w: i for i, w in enumerate(relevant)}
 
@@ -404,7 +424,8 @@ def coherence_ci(
     ----------
     topics : a fitted model, or a list of topics (each a list of words / ``(word,
         prob)`` pairs). The top words are extracted once and held fixed.
-    texts : list of tokenized documents — the reference corpus to resample.
+    texts : the reference corpus to resample — a :class:`Corpus`, raw-string
+        documents, or tokenized documents (as in :func:`coherence`).
     coherence_type, topn, window_size, epsilon : as in :func:`coherence`.
     n_boot : number of bootstrap resamples (each recomputes co-occurrence, so this
         is O(n_boot x corpus size); the windowed measures (``c_v`` etc.) are the
@@ -417,12 +438,12 @@ def coherence_ci(
     CoherenceCI
         ``(estimate, se, ci_low, ci_high)``, each ``(num_topics,)``.
     """
+    texts = _as_reference(texts)
     if len(texts) == 0:
         raise ValueError("texts is empty; pass the reference corpus as list[list[str]]")
     # Fix the top words once; pass them as the `topics` argument on every resample
     # so the coherence is recomputed for the same words against new corpora.
     tops = _extract_topics(topics, topn)
-    texts = [list(d) for d in texts]
     common = dict(coherence_type=coherence_type, topn=topn, window_size=window_size, epsilon=epsilon)
     estimate = coherence(tops, texts, **common)
 
@@ -592,7 +613,8 @@ def semantic_coherence(model_or_phi, texts, vocabulary=None, *, n=10):
 
     `model_or_phi` is a fitted model (uses its ``topic_word`` / ``vocabulary``) or a
     ``(K, V)`` array (then pass ``vocabulary``). ``texts`` is the reference corpus:
-    a :class:`topica.Corpus`, or a list of token lists (the words per document).
+    a :class:`topica.Corpus`, raw-string documents, or a list of token lists (raw
+    strings are tokenized, not scored character-by-character; see issue #648).
     """
     from ._topica import inspect_semantic_coherence
 
@@ -603,7 +625,7 @@ def semantic_coherence(model_or_phi, texts, vocabulary=None, *, n=10):
         vocabulary = list(texts.vocabulary)
     vocab_list = _vocabulary_of(model_or_phi, vocabulary)
     vocab = {w: i for i, w in enumerate(vocab_list)}
-    docs = texts.documents() if hasattr(texts, "documents") else texts
+    docs = _as_reference(texts)  # Corpus / raw strings / token lists -> token lists (#648)
     docs_ids = [[vocab[w] for w in d if w in vocab] for d in docs]
     return np.asarray(
         inspect_semantic_coherence(phi.tolist(), docs_ids, int(n)), dtype=np.float64

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -46,6 +46,49 @@ class TestCoherenceRanksTopics:
         assert s.shape == (3,)
 
 
+class TestCoherenceAcceptsInputForms:
+    """Raw strings and a Corpus must score identically to token lists — never
+    silently iterated character-by-character to a degenerate constant (issue #648).
+    """
+
+    def test_raw_strings_match_token_lists(self, reference):
+        strings = [" ".join(d) for d in reference]
+        for ct in ALL_TYPES:
+            tok = topica.coherence([COHERENT, INCOHERENT], reference, coherence_type=ct, topn=3)
+            s = topica.coherence([COHERENT, INCOHERENT], strings, coherence_type=ct, topn=3)
+            np.testing.assert_allclose(s, tok, err_msg=ct)
+
+    def test_raw_strings_are_not_a_degenerate_constant(self, reference):
+        # The bug returned 1.0 for every topic (chars never match the vocab).
+        strings = [" ".join(d) for d in reference]
+        s = topica.coherence([COHERENT, INCOHERENT], strings, coherence_type="c_v", topn=3)
+        assert not np.allclose(s, 1.0)
+        assert s[0] > s[1]  # coherent still beats incoherent
+
+    def test_corpus_reference_matches_token_lists(self, reference):
+        corpus = topica.Corpus.from_documents(reference, min_doc_freq=1)
+        tok = topica.coherence([COHERENT, INCOHERENT], reference, coherence_type="c_npmi", topn=3)
+        c = topica.coherence([COHERENT, INCOHERENT], corpus, coherence_type="c_npmi", topn=3)
+        np.testing.assert_allclose(c, tok)
+
+    def test_coherence_ci_accepts_strings(self, reference):
+        strings = [" ".join(d) for d in reference]
+        tok = topica.coherence_ci([COHERENT, INCOHERENT], reference,
+                                  coherence_type="c_npmi", topn=3, n_boot=50, seed=0)
+        s = topica.coherence_ci([COHERENT, INCOHERENT], strings,
+                                coherence_type="c_npmi", topn=3, n_boot=50, seed=0)
+        np.testing.assert_allclose(s.estimate, tok.estimate)
+
+    def test_semantic_coherence_accepts_strings(self, reference):
+        corpus = topica.Corpus.from_documents(reference, min_doc_freq=1)
+        m = topica.LDA(3, seed=0).fit(corpus, iters=30)
+        strings = [" ".join(d) for d in reference]
+        np.testing.assert_allclose(
+            topica.semantic_coherence(m, strings),
+            topica.semantic_coherence(m, [list(d) for d in reference]),
+        )
+
+
 class TestCoherenceCI:
     def test_shape_and_estimate_matches_point(self, reference):
         r = topica.coherence_ci(


### PR DESCRIPTION
## What

`topica.coherence`, `coherence_ci`, and `semantic_coherence` silently returned a
degenerate score when handed a list of **raw document strings** — the exact input the
docs' own examples use (`docs/publishing/validation.md`: `topica.coherence(model, texts, ...)`).
Each string was iterated **character-by-character**, so no top word ever matched the
vocabulary and the metric collapsed (e.g. `c_v == 1.0` for every topic) with no error or
warning. A publishing user copies the documented call and reports near-perfect coherence.

Closes #648

## How

The functions did `texts = [list(d) for d in texts]`, which turns `"obama campaign"` into
`['o','b','a','m','a', ...]`. The sibling `diagnostics()` already tokenized strings correctly
(via `validation._ref_corpus`), so the two disagreed on identical input.

- Added a shared `_as_reference(texts)` helper in `coherence.py` mirroring
  `validation._ref_corpus`: a `Corpus`, raw strings (split on whitespace), or
  already-tokenized documents all normalize to `list[list[str]]`.
- Routed `coherence`, `coherence_ci`, and `semantic_coherence` through it (the last had the
  same latent footgun).
- Updated docstrings to state that raw strings are tokenized, not scored character-by-character.

The documented `coherence(model, texts, ...)` call is now correct; token-list and `Corpus`
input are unchanged.

## Validation

Reproduced the bug and confirmed the fix on `ng20_minilm`:

```python
topica.coherence(m, d['texts'])          # raw strings — before: [1. 1. 1. 1. 1.]
                                         #               after:  [0.692 0.796 0.648 0.506 0.751]
topica.coherence(m, [t.split() for t in d['texts']])   # token lists (reference)
```

After the fix, string input scores **identically** to token lists and to a `Corpus`, and is
never a degenerate constant; empty input still raises.

New regression tests (`tests/test_coherence.py::TestCoherenceAcceptsInputForms`): raw strings
== token lists across all four coherence types; strings are not a degenerate 1.0 constant and
still rank coherent > incoherent; `Corpus` == token lists; `coherence_ci` and
`semantic_coherence` accept strings.

- [ ] `cargo test --lib` passes — n/a, no Rust changes in this PR
- [x] `python -m pytest tests/ -q` passes — `test_coherence` + `test_coherence_fast` (42) and the coherence consumers `test_validation`/`test_content`/`test_ensemble` (65) all pass
- [ ] `./scripts/preflight.sh` clean — not run in this environment
- [ ] docs build clean (`mkdocs build --strict`) — not run in this environment (docstrings changed)
- [x] the `.pyi` stub is in sync — no signature changes (behavior only)

## Notes

Found via a BERTopic/ng20 sample-user publication-workflow review (ranked the most dangerous
finding: a fabricated near-perfect quality metric copied straight from the docs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LSRmXE8QX4znuxX5DCEYv)_