### PR TITLE
fix(effects): flag naive SEs on no-posterior models; clean posterior_theta_samples refusal (#651)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 - **`posterior_theta_samples` refuses non-logistic-normal models cleanly** (#651):
   a guiding `ValueError` per family (Dirichlet → use `composition_theta`; no posterior
   → use bootstrap) instead of an `AttributeError` on the missing `eta_mean`.
+- **`model_family` no longer misclassifies DETM or EmbeddingLDA** (#651). DETM's
+  `alpha` is a topic-embedding trajectory (not a Dirichlet concentration), so it was
+  wrongly treated as Dirichlet — fabricating composition intervals with no warning;
+  it is now `"none"` (warns / uses bootstrap). EmbeddingLDA delegates a real Dirichlet
+  posterior to an inner SeededLDA, which the class-level check missed, so it was
+  wrongly `"none"` and over-warned; it is now `"dirichlet"` and composes correctly.
 
 ### Changed
 
@@ -49,18 +55,6 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
     `(doc_index, proportion, text)` triple; `plot_search_k` documents the
     `ax.figure.savefig(...)` save path; the `load_dubois` docstring corrects its
     date range to 1910–1934 and notes the 3 exact-duplicate articles.
-=======
-- **`estimate_effect` now flags naive standard errors on models with no θ posterior**
-  (#651). Passing a cluster/embedding model (e.g. BERTopic) fell back to ordinary
-  least squares on its point θ and returned confident-looking CIs with no warning,
-  while `standard_errors`/`effect_plot` correctly refuse for the same models. It now
-  emits a warning (method-of-composition is unavailable; use `method="bootstrap"`),
-  keyed on `model_family` like the other effect tools. A raw point-θ *array* (the
-  documented OLS baseline) and a posterior model used at its point θ are unchanged.
-- **`posterior_theta_samples` refuses non-logistic-normal models cleanly** (#651):
-  a guiding `ValueError` per family (Dirichlet → use `composition_theta`; no posterior
-  → use bootstrap) instead of an `AttributeError` on the missing `eta_mean`.
->>>>>>> f6daf1a (fix(effects): flag naive SEs on no-posterior models; clean posterior_theta_samples refusal (#651))
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   documents all work), so string input is tokenized rather than shredded. A fitted
   model accidentally passed as the reference corpus (arguments swapped) is now
   rejected with a directive error (#647).
+- **`estimate_effect` now flags naive standard errors on models with no θ posterior**
+  (#651). Passing a cluster/embedding model (e.g. BERTopic) fell back to ordinary
+  least squares on its point θ and returned confident-looking CIs with no warning,
+  while `standard_errors`/`effect_plot` correctly refuse for the same models. It now
+  emits a warning (method-of-composition is unavailable; use `method="bootstrap"`),
+  keyed on `model_family` like the other effect tools. A raw point-θ *array* (the
+  documented OLS baseline) and a posterior model used at its point θ are unchanged.
+- **`posterior_theta_samples` refuses non-logistic-normal models cleanly** (#651):
+  a guiding `ValueError` per family (Dirichlet → use `composition_theta`; no posterior
+  → use bootstrap) instead of an `AttributeError` on the missing `eta_mean`.
 
 ### Changed
 
@@ -39,6 +49,18 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
     `(doc_index, proportion, text)` triple; `plot_search_k` documents the
     `ax.figure.savefig(...)` save path; the `load_dubois` docstring corrects its
     date range to 1910–1934 and notes the 3 exact-duplicate articles.
+=======
+- **`estimate_effect` now flags naive standard errors on models with no θ posterior**
+  (#651). Passing a cluster/embedding model (e.g. BERTopic) fell back to ordinary
+  least squares on its point θ and returned confident-looking CIs with no warning,
+  while `standard_errors`/`effect_plot` correctly refuse for the same models. It now
+  emits a warning (method-of-composition is unavailable; use `method="bootstrap"`),
+  keyed on `model_family` like the other effect tools. A raw point-θ *array* (the
+  documented OLS baseline) and a posterior model used at its point θ are unchanged.
+- **`posterior_theta_samples` refuses non-logistic-normal models cleanly** (#651):
+  a guiding `ValueError` per family (Dirichlet → use `composition_theta`; no posterior
+  → use bootstrap) instead of an `AttributeError` on the missing `eta_mean`.
+>>>>>>> f6daf1a (fix(effects): flag naive SEs on no-posterior models; clean posterior_theta_samples refusal (#651))
 
 ### Added
 

--- a/python/topica/effects.py
+++ b/python/topica/effects.py
@@ -123,14 +123,29 @@ def _is_model(obj):
     return hasattr(obj, "doc_topic") and not isinstance(obj, np.ndarray)
 
 
+# Two models whose attribute *shape* fools the structural check below and so must
+# be pinned by name:
+#   - DETM exposes an ``alpha``, but it is a (time, topic, embedding-dim) topic
+#     trajectory, not a Dirichlet concentration — it has no Dirichlet-composition
+#     posterior over theta, so it must be ``"none"`` (Dirichlet composition on it
+#     would fabricate intervals).
+#   - EmbeddingLDA is a Python-layer wrapper that delegates a real Dirichlet
+#     posterior (``theta_draws`` / ``doc_topic``, from an inner SeededLDA) through
+#     ``__getattr__``, which a *class*-level attribute check cannot see.
+_FAMILY_OVERRIDES = {"DETM": "none", "EmbeddingLDA": "dirichlet"}
+
+
 def model_family(model):
     """Which method-of-composition theta sampler suits ``model``.
 
     ``"logistic_normal"`` for STM/CTM (a variational ``eta`` posterior),
     ``"dirichlet"`` for the collapsed-Gibbs models (LDA, keyATM, SeededLDA, ...),
-    or ``"none"`` for models with no posterior over theta (the embedding models),
-    which need ``method="bootstrap"``.
+    or ``"none"`` for models with no posterior over theta (the embedding/cluster
+    models), which need ``method="bootstrap"``.
     """
+    override = _FAMILY_OVERRIDES.get(type(model).__name__)
+    if override is not None:
+        return override
     # Check the class, not the instance: a PyO3 getter on an unfitted model raises
     # "not fitted" rather than being absent, so ``hasattr(model, ...)`` would lie.
     cls = type(model)

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -599,6 +599,13 @@ def estimate_effect(
     standard errors include the topic-estimation uncertainty, not just OLS
     sampling error. Get draws with :func:`posterior_theta_samples`.
 
+    A **point** θ gives OLS standard errors that treat the topic proportions as
+    fixed and so *understate* uncertainty. For a model with a θ posterior, prefer
+    draws (or pass the model with ``nsims=``). For a cluster/embedding model with no
+    posterior (e.g. BERTopic), method-of-composition is unavailable; pass the model
+    (not just its ``doc_topic`` array) so this is flagged, and use
+    ``standard_errors(..., method="bootstrap")`` to quantify uncertainty.
+
     For paper-grade inference two extras matter:
 
     - ``cluster`` — a length-``num_docs`` array of group labels (e.g. speaker,
@@ -714,12 +721,30 @@ def estimate_effect(
     # standard errors (no hand-wiring a sampler); without it, the point theta is
     # used for plain OLS.
     if hasattr(doc_topic, "doc_topic") and not isinstance(doc_topic, np.ndarray):
-        from .effects import composition_theta
+        from .effects import composition_theta, model_family
 
         _model = doc_topic
         if nsims:
             doc_topic = composition_theta(_model, corpus, nsims=nsims, seed=seed)
         else:
+            # A model with no posterior over theta (a cluster/embedding model such as
+            # BERTopic) has no method-of-composition path, so this is plain OLS on a
+            # point estimate: the topic proportions are treated as fixed and the SEs
+            # understate uncertainty. standard_errors()/effect_plot refuse in this
+            # case; warn here too rather than returning confident-looking CIs. (A
+            # posterior model used at its point theta is the documented OLS baseline
+            # and can upgrade via nsims=, so it is not warned.)
+            if model_family(_model) == "none":
+                warnings.warn(
+                    f"{type(_model).__name__} has no posterior over topic "
+                    "proportions, so these standard errors are ordinary least "
+                    "squares on a point estimate: they treat the proportions as "
+                    "fixed and understate uncertainty. Method-of-composition "
+                    "intervals are unavailable for this model; use "
+                    "standard_errors(model, corpus, of='effect', method='bootstrap') "
+                    "to quantify uncertainty.",
+                    stacklevel=2,
+                )
             doc_topic = np.asarray(_model.doc_topic, dtype=np.float64)
 
     theta = np.asarray(doc_topic, dtype=np.float64)
@@ -1546,6 +1571,24 @@ def posterior_theta_samples(model, nsims=25, seed=0):
 
     Returns an array of shape ``(nsims, num_docs, num_topics)``.
     """
+    # This is the logistic-normal (STM/CTM) sampler. Refuse other families cleanly
+    # rather than failing with an AttributeError on the missing ``eta_mean`` getter
+    # (issue #651): point at the right path for each family.
+    from .effects import model_family
+
+    fam = model_family(model)
+    if fam != "logistic_normal":
+        if fam == "dirichlet":
+            raise ValueError(
+                f"{type(model).__name__} has a Dirichlet (not logistic-normal) "
+                "posterior; use topica.composition_theta(model, corpus) to draw "
+                "theta for method-of-composition, not posterior_theta_samples."
+            )
+        raise ValueError(
+            f"{type(model).__name__} has no posterior over topic proportions, so "
+            "theta cannot be sampled. Use standard_errors(model, corpus, "
+            "of='effect', method='bootstrap') for uncertainty on this model."
+        )
     lam = np.asarray(model.eta_mean, dtype=np.float64)  # (D, K-1)
     try:
         cov = np.asarray(model.eta_cov, dtype=np.float64)   # (D, K-1, K-1)

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -247,6 +247,56 @@ def test_posterior_theta_samples_refuses_non_logistic_normal_cleanly():
         topica.stm.posterior_theta_samples(_fitted_bertopic())
 
 
+def _detm_and_embeddinglda():
+    """A tiny DETM and EmbeddingLDA on synthetic word embeddings (no download).
+
+    Both fool the structural ``model_family`` check: DETM exposes a non-Dirichlet
+    ``alpha`` (a topic-embedding trajectory), EmbeddingLDA delegates a real
+    Dirichlet posterior through ``__getattr__``.
+    """
+    topica.enable_experimental()
+    rng = np.random.default_rng(0)
+    vocab = [f"w{i}" for i in range(8)]
+    wemb = rng.normal(size=(8, 5))
+    docs = [[vocab[rng.integers(8)] for _ in range(10)] for _ in range(40)]
+    detm = topica.DETM(num_topics=2, seed=0)
+    detm.fit(docs, wemb, vocab, timestamps=[int(i >= 20) for i in range(40)], iters=15)
+    elda = topica.EmbeddingLDA(num_topics=2, embeddings=wemb, vocabulary=vocab, seed=0)
+    elda.fit(docs, iters=30)
+    return detm, elda
+
+
+def test_detm_is_not_dirichlet_and_is_guarded():
+    # DETM's `alpha` is a topic-embedding trajectory, not a Dirichlet concentration.
+    # It must classify as "none" so estimate_effect warns (not fabricates composition
+    # intervals) and posterior_theta_samples refuses cleanly — the review blocker.
+    detm, _ = _detm_and_embeddinglda()
+    assert topica.model_family(detm) == "none"
+    X = np.random.default_rng(1).random((np.asarray(detm.doc_topic).shape[0], 1))
+    with pytest.warns(UserWarning, match="no posterior"):
+        topica.estimate_effect(detm, X, feature_names=["x"])
+    with pytest.raises(ValueError, match="no posterior"):
+        topica.stm.posterior_theta_samples(detm)
+
+
+def test_embeddinglda_is_dirichlet_via_delegated_posterior():
+    # EmbeddingLDA wraps a SeededLDA (Dirichlet) and delegates theta_draws/doc_topic.
+    # It must classify as "dirichlet": no false no-posterior warning, and composition
+    # actually works through the delegate.
+    _, elda = _detm_and_embeddinglda()
+    assert topica.model_family(elda) == "dirichlet"
+    n, k = np.asarray(elda.doc_topic).shape
+    X = np.random.default_rng(2).random((n, 1))
+    import warnings as _w
+    with _w.catch_warnings():
+        _w.simplefilter("error")  # must NOT emit the no-posterior warning
+        topica.estimate_effect(elda, X, feature_names=["x"])
+    draws = topica.effects.composition_theta(elda, nsims=3)
+    assert draws.shape == (3, n, k)
+    with pytest.raises(ValueError, match="Dirichlet"):
+        topica.stm.posterior_theta_samples(elda)
+
+
 def test_topic_correlation_ci_well_shaped_and_coherent():
     # CTM/STM topic-correlation credible interval from the logistic-normal posterior:
     # K x K, symmetric, unit diagonal, ci_low <= estimate <= ci_high in every cell,

--- a/tests/test_standard_errors.py
+++ b/tests/test_standard_errors.py
@@ -204,6 +204,49 @@ def test_composition_top_words_is_rejected():
         topica.standard_errors(m, corpus, of="top_words", method="composition")
 
 
+def _fitted_bertopic():
+    """A tiny BERTopic on synthetic, well-separated embeddings (no download)."""
+    rng = np.random.default_rng(0)
+    emb = np.vstack([rng.normal(c, 0.1, size=(20, 8)) for c in (-3.0, 0.0, 3.0)])
+    toks = [[f"w{rng.integers(10)}" for _ in range(8)] for _ in range(60)]
+    m = topica.BERTopic(num_clusters=3, clusterer="kmeans", seed=0).fit(toks, emb)
+    return m
+
+
+def test_estimate_effect_warns_on_no_posterior_model_point_theta():
+    # estimate_effect(model) on a cluster/embedding model falls to point-theta OLS
+    # (no method-of-composition possible). It must warn, consistent with
+    # standard_errors/effect_plot refusing — not return confident-looking CIs.
+    m = _fitted_bertopic()
+    n = np.asarray(m.doc_topic).shape[0]
+    X = np.random.default_rng(1).random((n, 1))
+    with pytest.warns(UserWarning, match="no posterior"):
+        topica.estimate_effect(m, X, feature_names=["x"])
+
+
+def test_estimate_effect_point_theta_paths_do_not_falsely_warn():
+    import warnings as _w
+
+    # A raw point-theta ARRAY is the documented OLS baseline (no provenance to judge)
+    # and a posterior model used at its point theta can upgrade via nsims=; neither
+    # should emit the no-posterior warning.
+    m, corpus, x = _planted()
+    X = x[:, None]
+    with _w.catch_warnings():
+        _w.simplefilter("error")
+        topica.estimate_effect(m.doc_topic, X, feature_names=["x"])  # raw array
+        topica.estimate_effect(m, X, feature_names=["x"])            # LDA has a posterior
+
+
+def test_posterior_theta_samples_refuses_non_logistic_normal_cleanly():
+    # A clean, guiding ValueError per family — never an AttributeError on eta_mean.
+    m, corpus, _ = _planted()  # LDA -> dirichlet
+    with pytest.raises(ValueError, match="Dirichlet"):
+        topica.stm.posterior_theta_samples(m)
+    with pytest.raises(ValueError, match="no posterior"):
+        topica.stm.posterior_theta_samples(_fitted_bertopic())
+
+
 def test_topic_correlation_ci_well_shaped_and_coherent():
     # CTM/STM topic-correlation credible interval from the logistic-normal posterior:
     # K x K, symmetric, unit diagonal, ci_low <= estimate <= ci_high in every cell,


### PR DESCRIPTION
## What

topica's covariate-effect guardrails were inconsistent for models with no posterior
over θ (cluster/embedding models such as `BERTopic`). `standard_errors(of="effect",
method="composition")` and `viz.effect_plot` correctly **refuse** to fabricate
uncertainty for them — but `estimate_effect(model, X)` fell back to ordinary least
squares on the point θ and returned confident-looking CIs (z-scores in the 30s) with
**no warning**. A relatedly rough edge: `posterior_theta_samples` on such a model
raised an internal `AttributeError` instead of a clean refusal.

Closes #651

## How

- **`estimate_effect`**: when a *fitted model* with `model_family == "none"` is passed
  without draws (so it uses point θ), emit a warning that the SEs are OLS on a point
  estimate — they treat the topic proportions as fixed and understate uncertainty,
  method-of-composition is unavailable, use `method="bootstrap"`. Keyed on
  `model_family`, exactly like `standard_errors`/`effect_plot`.
  - Deliberately **not** warned (to avoid noise on documented, valid paths): a raw
    point-θ **array** (the documented OLS baseline, used throughout the codebase and
    carrying no provenance to judge), and a *posterior* model used at its point θ
    (which can upgrade to method-of-composition via `nsims=`).
- **`posterior_theta_samples`**: refuse non-logistic-normal models with a guiding
  `ValueError` per family (Dirichlet → use `composition_theta`; none → use bootstrap)
  instead of an `AttributeError` on the missing `eta_mean` getter.
- Docstring clarified that a point θ gives understated OLS SEs, and how to do better
  per family.

## Validation

New tests in `tests/test_standard_errors.py`:

- `estimate_effect(bertopic_model, X)` warns (`match="no posterior"`);
- a raw point-θ array and a posterior model at point θ do **not** warn (`simplefilter("error")`);
- `posterior_theta_samples` raises a clean per-family `ValueError` (Dirichlet / no posterior), never `AttributeError`.

- [ ] `cargo test --lib` passes — n/a, no Rust changes in this PR
- [x] `python -m pytest tests/ -q` passes — `test_standard_errors` (36), plus `test_stm_model`/`test_formulas`/`test_design_coercion`/`test_predicted_prevalence`/`test_estimate_effect_random`/`test_stm_content`/`test_stm_helper_r_parity` (207) and `test_css_extras`/`test_vignette`/`test_theta_draws` (47) all green
- [ ] `./scripts/preflight.sh` clean — not run in this environment
- [ ] docs build clean (`mkdocs build --strict`) — not run in this environment (docstring changed)
- [x] the `.pyi` stub is in sync — no signature change (behavior/docstring only)

## Notes

Found via a BERTopic/ng20 sample-user publication-workflow review. The issue also
noted `topica.ENGLISH_STOPWORDS` is thin; that is a subjective, separate change and is
intentionally left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011LSRmXE8QX4znuxX5DCEYv)_