### PR TITLE
feat(frames): sklearn min_df/max_df aliases + accurate module docstring (#647)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Added
+
+- **`from_dataframe` accepts scikit-learn's `min_df` / `max_df` aliases** (#647), so
+  an sklearn/gensim preprocessing habit works unchanged. Following sklearn's
+  convention, an `int` is an absolute document count and a `float` in `[0, 1]` is a
+  proportion: `min_df=5` → `min_doc_freq=5`, `max_df=0.5` → `max_doc_fraction=0.5`.
+  Passing both an alias and its native argument raises.
+
+### Changed
+
+- **The `topica` module docstring is an accurate "start here"** (#647): it now
+  describes the full model roster and a one-glance LDA workflow with the main entry
+  points grouped by task, instead of the stale "fast SparseLDA" one-liner. The
+  dynamic-keyATM `time_prevalence_ci` docstring now points LDA/STM users at
+  `predicted_prevalence` for prevalence over a time covariate.
+
 ### Fixed
 
 - **`topica.coherence` / `coherence_ci` / `semantic_coherence` no longer silently

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -1,8 +1,38 @@
-"""topica: fast SparseLDA topic modeling (MALLET's algorithm) in Rust.
+"""topica: fast, all-purpose topic modeling for Python, with a Rust core.
 
-The heavy lifting lives in the compiled extension ``topica._topica``;
-this module just re-exports its public surface so ``import topica`` works
-and editors/type-checkers see a stable namespace.
+More than a dozen models — LDA, STM, CTM, DMR, keyATM, SAGE, HDP, BERTopic,
+ProdLDA, and more — behind one numpy-native API, each validated against its
+reference implementation. Built for computational social scientists who need a
+defensible, reviewer-ready analysis, not just topics.
+
+Start here (a full LDA workflow is only a few lines)::
+
+    import topica
+
+    corpus = topica.from_dataframe(df, text_col="text")   # build + prune vocab
+    res = topica.search_k(corpus, ks=[10, 20, 30])         # choose K defensibly
+    model = topica.LDA(num_topics=res.best_k()).fit(corpus)
+    topica.topic_table(model)                              # publication-ready labels
+    topica.estimate_effect(model, X=X, corpus=corpus)      # covariate effects + CIs
+
+The main entry points, by task:
+
+- **Corpus**: :func:`from_dataframe`, :class:`Corpus`, :func:`tokenize`.
+- **Models**: :class:`LDA` and the wider family (:class:`STM`, :class:`CTM`,
+  :class:`DMR`, :class:`KeyATM`, :class:`SAGE`, :class:`HDP`, :class:`BERTopic`,
+  …); ``model.fit(corpus)`` then read ``model.topic_word`` / ``model.doc_topic``.
+- **Choosing K**: :func:`search_k` (+ ``.best_k()``), :func:`plot_search_k`.
+- **Interpretation**: :func:`label_topics`, :func:`topic_table`, :func:`frex`,
+  :func:`find_thoughts`, :func:`topics_for_term`.
+- **Validation**: :func:`coherence`, :func:`coherence_ci`, :func:`exclusivity`,
+  :func:`topic_diversity`, :func:`ensemble`, :func:`topic_stability`.
+- **Covariate effects**: :func:`estimate_effect`, :func:`predicted_prevalence`,
+  :func:`one_hot`, :func:`design_matrix`, :func:`spline`.
+- **Provenance**: :func:`record_fit` → :class:`AnalysisManifest`.
+
+The heavy lifting lives in the compiled extension ``topica._topica``; this module
+re-exports its public surface so ``import topica`` works and editors/type-checkers
+see a stable namespace.
 """
 
 from ._topica import (

--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -20,6 +20,51 @@ def _is_polars(obj) -> bool:
     return type(obj).__module__.split(".", 1)[0] == "polars"
 
 
+def _resolve_df_aliases(min_df, max_df, min_doc_freq, max_doc_fraction, n_docs):
+    """Map scikit-learn ``min_df`` / ``max_df`` onto topica's ``min_doc_freq`` /
+    ``max_doc_fraction``, using sklearn's convention (int = absolute document count,
+    float in ``[0, 1]`` = proportion). Raises if an alias collides with its native
+    argument or is out of range."""
+    import math
+
+    def _is_int(v):
+        return isinstance(v, int) and not isinstance(v, bool)
+
+    def _is_float(v):
+        return isinstance(v, float) and not isinstance(v, bool)
+
+    if min_df is not None:
+        if min_doc_freq != 1:
+            raise ValueError("pass either min_df or min_doc_freq, not both")
+        if _is_float(min_df):
+            if not 0.0 <= min_df <= 1.0:
+                raise ValueError(f"float min_df must be in [0, 1], got {min_df!r}")
+            min_doc_freq = max(1, math.ceil(min_df * n_docs))
+        elif _is_int(min_df):
+            if min_df < 1:
+                raise ValueError(f"int min_df must be >= 1, got {min_df!r}")
+            min_doc_freq = min_df
+        else:
+            raise ValueError(f"min_df must be an int or a float, got {min_df!r}")
+
+    if max_df is not None:
+        if max_doc_fraction != 1.0:
+            raise ValueError("pass either max_df or max_doc_fraction, not both")
+        if _is_float(max_df):
+            if not 0.0 <= max_df <= 1.0:
+                raise ValueError(f"float max_df must be in [0, 1], got {max_df!r}")
+            max_doc_fraction = max_df
+        elif _is_int(max_df):
+            if max_df < 1:
+                raise ValueError(f"int max_df must be >= 1, got {max_df!r}")
+            # Absolute doc-count cap -> the fraction the core prunes on.
+            max_doc_fraction = min(1.0, max_df / n_docs)
+        else:
+            raise ValueError(f"max_df must be an int or a float, got {max_df!r}")
+
+    return min_doc_freq, max_doc_fraction
+
+
 def from_dataframe(
     df,
     *,
@@ -34,6 +79,8 @@ def from_dataframe(
     rm_top=0,
     max_features=None,
     vocabulary=None,
+    min_df=None,
+    max_df=None,
 ):
     """Build a :class:`Corpus` from a pandas or Polars DataFrame, keeping
     per-document metadata aligned to the documents that survive pruning.
@@ -77,6 +124,14 @@ def from_dataframe(
         Pin the vocabulary to this fixed, ordered term list (scikit-learn's
         ``vocabulary=``). Mutually exclusive with the frequency-pruning arguments
         and ``max_features``; see :meth:`Corpus.from_documents`.
+    min_df, max_df : scikit-learn ``CountVectorizer`` aliases for the two document-
+        frequency pruning cutoffs, so an sklearn/gensim habit works unchanged.
+        Following sklearn's convention, an ``int`` is an absolute document count and
+        a ``float`` in ``[0, 1]`` is a proportion of documents: ``min_df=5`` keeps
+        terms in at least 5 documents (topica's ``min_doc_freq``); ``max_df=0.5``
+        drops terms in more than half the documents (topica's ``max_doc_fraction``).
+        Pass at most one of each pair — ``min_df`` or ``min_doc_freq``, ``max_df`` or
+        ``max_doc_fraction`` — not both.
     """
     texts = list(df[text_col])  # pandas Series and Polars Series both iterate to values
     if tokenizer is None:
@@ -87,6 +142,11 @@ def from_dataframe(
         ]
     else:
         docs = [tokenizer(t if isinstance(t, str) else "") for t in texts]
+
+    # scikit-learn min_df/max_df aliases -> topica's min_doc_freq/max_doc_fraction.
+    min_doc_freq, max_doc_fraction = _resolve_df_aliases(
+        min_df, max_df, min_doc_freq, max_doc_fraction, len(docs)
+    )
 
     # max_doc_fraction removes the highest document-frequency terms — which on a
     # focused corpus can be the very words it is about (e.g. "immigration" in an

--- a/python/topica/keyatm.py
+++ b/python/topica/keyatm.py
@@ -218,6 +218,13 @@ def visualize_keywords(docs, keywords):
 def time_prevalence_ci(model, timestamps, *, ci=0.95, normalize=True):
     """Per-period topic prevalence with credible intervals from the dynamic keyATM posterior.
 
+    .. note::
+       This is **dynamic-keyATM only** — it reads that model's retained MCMC draws.
+       For prevalence over a time covariate on any other model (LDA, STM, …), use
+       :func:`topica.predicted_prevalence` with a continuous ``year`` (optionally a
+       :func:`topica.spline`), which gives the same over-time curve with intervals
+       via the method of composition.
+
     For a dynamic :class:`~topica.KeyATM` (fit with ``timestamps=`` and
     ``keep_theta_draws=True``), this computes per-period prevalence uncertainty
     directly from the retained MCMC ``theta_draws``. For each posterior draw and

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -80,3 +80,67 @@ def test_metadata_is_settable():
     assert c.metadata is None
     c.metadata = pd.DataFrame({"k": [1, 2, 3]})
     assert list(c.metadata["k"]) == [1, 2, 3]
+
+
+# -- scikit-learn min_df / max_df aliases (issue #647 discoverability) -----------
+
+
+def _alias_frame():
+    # 8 docs; "common" in all 8, "rare" in 1, plus per-doc fillers.
+    rows = [f"common tok{i} tok{(i + 1) % 8} extra{i}" for i in range(8)]
+    rows[0] += " rare"
+    return pd.DataFrame({"text": rows})
+
+
+class TestDfAliases:
+    def test_int_min_df_equals_min_doc_freq(self):
+        df = _alias_frame()
+        a = topica.from_dataframe(df, text_col="text", min_df=2)
+        b = topica.from_dataframe(df, text_col="text", min_doc_freq=2)
+        assert sorted(a.vocabulary) == sorted(b.vocabulary)
+        assert "rare" not in a.vocabulary  # df 1 < 2 -> dropped
+
+    def test_float_max_df_equals_max_doc_fraction(self):
+        df = _alias_frame()
+        with pytest.warns(UserWarning):  # "common" is in all 8 docs
+            a = topica.from_dataframe(df, text_col="text", max_df=0.5)
+        with pytest.warns(UserWarning):
+            b = topica.from_dataframe(df, text_col="text", max_doc_fraction=0.5)
+        assert sorted(a.vocabulary) == sorted(b.vocabulary)
+        assert "common" not in a.vocabulary
+
+    def test_float_min_df_is_a_proportion(self):
+        df = _alias_frame()  # 8 docs; 0.25 -> ceil(2) docs
+        a = topica.from_dataframe(df, text_col="text", min_df=0.25)
+        b = topica.from_dataframe(df, text_col="text", min_doc_freq=2)
+        assert sorted(a.vocabulary) == sorted(b.vocabulary)
+
+    def test_int_max_df_is_an_absolute_count(self):
+        df = _alias_frame()  # 8 docs; max_df=4 -> fraction 0.5
+        with pytest.warns(UserWarning):
+            a = topica.from_dataframe(df, text_col="text", max_df=4)
+        with pytest.warns(UserWarning):
+            b = topica.from_dataframe(df, text_col="text", max_doc_fraction=0.5)
+        assert sorted(a.vocabulary) == sorted(b.vocabulary)
+
+    def test_conflicting_min_aliases_raise(self):
+        df = _alias_frame()
+        with pytest.raises(ValueError, match="min_df or min_doc_freq"):
+            topica.from_dataframe(df, text_col="text", min_df=2, min_doc_freq=2)
+
+    def test_conflicting_max_aliases_raise(self):
+        df = _alias_frame()
+        with pytest.raises(ValueError, match="max_df or max_doc_fraction"):
+            topica.from_dataframe(df, text_col="text", max_df=0.5, max_doc_fraction=0.5)
+
+    @pytest.mark.parametrize("bad", [1.5, -0.1])
+    def test_out_of_range_float_max_df_raises(self, bad):
+        df = _alias_frame()
+        with pytest.raises(ValueError, match=r"in \[0, 1\]"):
+            topica.from_dataframe(df, text_col="text", max_df=bad)
+
+    def test_bool_min_df_is_rejected(self):
+        # bool is an int subclass; True must not be read as min_df=1.
+        df = _alias_frame()
+        with pytest.raises(ValueError, match="min_df must be an int or a float"):
+            topica.from_dataframe(df, text_col="text", min_df=True)


### PR DESCRIPTION
## What

The pure-Python **discoverability & ergonomics** follow-up to the sample-user LDA
audit (#647) — the items that help a first-time user *find* and *correctly call* the
API. No Rust, no rebuild.

## Changes

- **`from_dataframe` accepts scikit-learn's `min_df` / `max_df` aliases** for
  `min_doc_freq` / `max_doc_fraction`. Following sklearn's convention, an `int` is an
  absolute document count and a `float` in `[0, 1]` is a proportion:
  `min_df=5` → `min_doc_freq=5`, `max_df=0.5` → `max_doc_fraction=0.5`,
  `min_df=0.02` → `ceil(0.02·n_docs)`, `max_df=1000` → `min(1, 1000/n_docs)`. Passing
  both an alias and its native argument, or an out-of-range/`bool` value, raises a
  clear error. An sklearn/gensim preprocessing habit now works unchanged.
- **The `topica` module docstring is an accurate "start here"** — the full model
  roster, a one-glance LDA workflow, and the main entry points grouped by task,
  replacing the stale "fast SparseLDA (MALLET's algorithm)" one-liner that
  undersold a 40+-model library and gave no landing pad for the 204-name namespace.
- **`time_prevalence_ci`** (dynamic-keyATM only) now points LDA/STM users at
  `predicted_prevalence` for prevalence over a time covariate — closing the naming
  trap the audit flagged.

## Deferred

The remaining #647 item — PyO3 `help(Model.__init__)` text signatures — is a **Rust**
change touching every model constructor (needs the full build + rust-tests CI), so it
stays a separate PR to propose next. Per-term document frequency and a default
convergence signal likely also need Rust/behavior changes and are left for discussion.

## Validation

- 8 new alias tests (`tests/test_frames.py::TestDfAliases`): int/float semantics for
  both cutoffs, alias-vs-native conflict, out-of-range float, `bool` rejection.
- Every `:func:`/`:class:` reference in the new module docstring resolves.
- `test_frames` / `test_corpus` / `test_corpus_vocab` / `test_keyatm_dynamic` green
  (94 local); `preflight.sh` clean; `mkdocs build --strict` clean.

Part of #647.

🤖 Generated with [Claude Code](https://claude.com/claude-code)