### PR TITLE
fix(compare): stop mis-classifying correlated-topic models as splits/merges (#642)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,11 +123,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   extra partner is flagged only when it sits close to a topic's own best match
   *relative to the fit's own cross-topic similarity floor*, not against a fixed
   constant. As a result `align_topics(tw, tw)` and `compare(tw, tw)` return K matches /
-  0 splits / 0 merges for any model (verified on a real STM/poliblog fit across the
-  cosine, JS, RBO and EMD metrics), while genuine one-to-many relationships — including
-  a B-topic that is a real blend of two A-topics, at equal or unequal K — are still
-  detected. The Hungarian list interface (used by `ensemble`, `topic_stability`, and
-  `viz/health`) was already correct and is unchanged.
+  0 splits / 0 merges for any model with distinct topics (verified on a real
+  STM/poliblog fit across the cosine, JS, RBO and EMD metrics), while genuine
+  one-to-many relationships — including a B-topic that is a real blend of two A-topics,
+  at equal or unequal K — are still detected. The Hungarian list interface (used by
+  `ensemble`, `topic_stability`, and `viz/health`) was already correct and is unchanged.
+  A `compare` card no longer mislabels a high-similarity split/merge child (a topic
+  left unmatched by the 1-to-1 assignment though its best similarity is at or above
+  the threshold) as a "near-miss just under the threshold": the `near_miss` flag now
+  requires the best similarity to sit strictly below the match cut.
 
 ## [0.55.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -109,6 +109,26 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   flag is robust to a NumPy-scalar `threshold`; and a manifest whose recorded
   `num_topics` disagrees with its retained rows is rejected.
 
+### Fixed
+
+- **`align_topics` / `compare` no longer mis-classify correlated-topic models as
+  unstable** (#642). The split/merge classifier used a fixed absolute cosine threshold
+  (default `0.3`): for correlated-topic families (STM, CTM, …) a large fraction of
+  *off-diagonal* topic pairs clear `0.3`, so almost every topic was labelled a
+  split/merge — `align_topics(tw, tw)` on identical STM topics reported 1 match / 19
+  splits / 19 merges instead of 20 / 0 / 0, and `compare` inherited the same error,
+  reporting a bit-identical fit as near-totally unstable. Matches are now the Hungarian
+  1-to-1 assignment restricted to pairs above `threshold` (already correct underneath,
+  and correlation-insensitive), and splits/merges are a background-relative overlay: an
+  extra partner is flagged only when it sits close to a topic's own best match
+  *relative to the fit's own cross-topic similarity floor*, not against a fixed
+  constant. As a result `align_topics(tw, tw)` and `compare(tw, tw)` return K matches /
+  0 splits / 0 merges for any model (verified on a real STM/poliblog fit across the
+  cosine, JS, RBO and EMD metrics), while genuine one-to-many relationships — including
+  a B-topic that is a real blend of two A-topics, at equal or unequal K — are still
+  detected. The Hungarian list interface (used by `ensemble`, `topic_stability`, and
+  `viz/health`) was already correct and is unchanged.
+
 ## [0.55.0] - 2026-07-29
 
 ### Added

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -192,16 +192,24 @@ It supports several distance metrics:
 
 If the models have different vocabularies, `align_topics` automatically intersects them, projects the distributions, and re-normalizes them.
 
-You can inspect relationship classifications (e.g. splits, merges, and unaligned topics) based on a similarity threshold:
+You can inspect relationship classifications (matches, splits, merges, and unaligned topics):
 ```python
 result = topica.align_topics(model_a, model_b, metric="cosine", threshold=0.3)
 
-result.matches     # clean 1-to-1 matches
-result.splits      # topic in A splitting to multiple in B
-result.merges      # topic in B merging from multiple in A
+result.matches     # Hungarian 1-to-1 pairs whose similarity clears `threshold`
+result.splits      # topic in A splitting to multiple in B (overlay on the matches)
+result.merges      # topic in B merging from multiple in A (overlay on the matches)
 result.unaligned_a # topics in A with no match above threshold
 result.unaligned_b # topics in B with no match above threshold
 ```
+
+`threshold` sets the one-to-one match cut. Splits and merges are an *overlay*: an extra
+partner is flagged only when it is close to a topic's own best match *relative to this
+fit's cross-topic similarity floor*, so a matched topic that also has a close extra
+partner shows up in both `matches` and `splits`/`merges`. Because the overlay calibrates
+to each fit, correlated-topic families (STM/CTM) — whose off-diagonal cosines are high —
+are no longer mislabelled as near-total splits/merges, and `align_topics(tw, tw)` returns
+K matches with zero splits/merges for any model (issue #642).
 
 ## Topic structure and document outliers
 

--- a/docs/guides/model-comparison.md
+++ b/docs/guides/model-comparison.md
@@ -290,22 +290,25 @@ that question as a first-class operation rather than a manual diff.
 ```python
 cmp = topica.compare(fit_a, fit_b)
 
-cmp.aligned            # mutual-best matched topic pairs (each the other's unique above-threshold match)
+cmp.aligned            # Hungarian 1-to-1 matched topic pairs above `threshold`
 cmp.unmatched_a        # topics that vanished (only in A) — never force-paired
 cmp.unmatched_b        # topics that appeared (only in B)
-cmp.splits, cmp.merges # one-to-many outcomes, named honestly (esp. across different K)
+cmp.splits, cmp.merges # one-to-many outcomes (overlay), named honestly (esp. across different K)
 cmp.drift              # per-pair distance + whether it exceeds the reseed range
 cmp.prevalence_shift   # change in topic prevalence, with a posterior-spread uncertainty
 print(cmp.render())    # HTML card (same house as the manifest render()); to_markdown() too
 ```
 
-Alignment reuses `align_topics`, which pairs two topics only when each is the
-other's *unique* above-`threshold` match, so a topic with no honest counterpart is
-reported as *appeared* / *vanished*, not paired to its least-bad neighbor — and a
-split (one topic in A → two in B) is a named outcome, not a silent mismatch. This
-matters most when the two fits have different K. (The reseed null below reads the
-Hungarian self-assignment `align_topics` also exposes, so every A-topic has a
-self-match to measure wander against.)
+Alignment reuses `align_topics`, which pairs two topics by the Hungarian 1-to-1
+assignment and keeps a pair when its similarity clears `threshold`, so a topic with no
+honest counterpart is reported as *appeared* / *vanished*, not paired to its least-bad
+neighbor. Splits and merges (one topic in A → two in B, or vice versa) are an overlay,
+flagged only when an extra partner is close to a topic's own best match *relative to the
+fit's cross-topic similarity floor* — so a correlated-topic fit (STM/CTM) compared with
+itself reports full stability instead of near-total splits/merges, and genuine
+one-to-many outcomes across different K are still named (issue #642). (The reseed null
+below reads the Hungarian self-assignment `align_topics` also exposes, so every A-topic
+has a self-match to measure wander against.)
 
 **Drift needs a null.** Give `compare` a reseed baseline and each matched pair is
 flagged when it moves *beyond the range of self-agreement A shows across the

--- a/python/topica/compare.py
+++ b/python/topica/compare.py
@@ -189,10 +189,13 @@ class UnmatchedTopic:
     status: str  # "vanished" (a-only) or "appeared" (b-only)
     top_words: list[str]
     prevalence: float
-    #: This topic's best similarity to *any* topic on the other side (necessarily
-    #: below ``threshold`` — that is why it is unmatched). When it sits just under
-    #: the threshold the "disappearance" may be top-word churn rather than a real
-    #: vanish/appear (see :attr:`near_miss`); ``None`` if the other side is empty.
+    #: This topic's best similarity to *any* topic on the other side. Usually below
+    #: ``threshold`` (which is why the topic is unmatched), but not always: the
+    #: Hungarian-anchored classifier can leave a topic unmatched with a best
+    #: similarity at or above ``threshold`` — a split/merge child that lost the
+    #: one-to-one assignment (named in ``splits``/``merges``). When it sits *just
+    #: under* the threshold the "disappearance" may be top-word churn rather than a
+    #: real vanish/appear (see :attr:`near_miss`); ``None`` if the other side is empty.
     best_similarity: float | None = None
 
     @property
@@ -369,7 +372,15 @@ def _unmatched(
     row = sim[idx, :] if axis == 0 else sim[:, idx]
     best = float(row.max()) if row.size else None
     u = UnmatchedTopic(int(idx), side, status, words, float(prev), best_similarity=best)
-    u._near_miss = best is not None and best >= _NEAR_MISS_FRACTION * threshold
+    # A near-miss is a topic that *almost* matched: its best cross-similarity sits
+    # just under the match threshold. The upper bound matters since the (#642)
+    # Hungarian-anchored classifier can leave a topic unmatched with a best
+    # similarity at or ABOVE threshold — a split/merge child that lost the 1-to-1
+    # assignment. That is a strong partner, not a churn near-miss, and the
+    # splits/merges overlay already names it, so it must not be flagged here.
+    u._near_miss = (
+        best is not None and _NEAR_MISS_FRACTION * threshold <= best < threshold
+    )
     return u
 
 

--- a/python/topica/compare.py
+++ b/python/topica/compare.py
@@ -18,11 +18,13 @@ Three uses, one tool:
 Design commitments:
 
 - **Alignment is reused, not reinvented.** Matching runs through
-  :func:`topica.align_topics`, which pairs two topics only when each is the other's
-  *unique* above-``threshold`` partner (a mutual-best rule that never force-pairs),
-  and reports splits, merges, and unaligned topics. (The reseed null below instead
-  reads the Hungarian self-assignment :func:`align_topics` also exposes, so a topic
-  always has a self-match to measure wander against.)
+  :func:`topica.align_topics`, which pairs two topics by the Hungarian 1-to-1
+  assignment and keeps a pair when its similarity clears ``threshold``, then reports
+  splits, merges, and unaligned topics. Splits/merges are a background-relative overlay
+  (an extra partner close to a topic's own best match relative to the fit's cross-topic
+  floor), so correlated-topic models are not mislabelled as unstable (issue #642). (The
+  reseed null below reads the same Hungarian self-assignment, so a topic always has a
+  self-match to measure wander against.)
 - **The "unmatched" bucket is honest.** A topic with no good counterpart is reported
   as *appeared* / *vanished*, never paired to its least-bad neighbor; a split (one
   topic in A → two in B) is a named outcome. This matters most across different K.
@@ -58,7 +60,7 @@ from typing import Any, Callable, Sequence
 
 import numpy as np
 
-from .validation import align_topics
+from .validation import _classify_alignment, _hungarian, align_topics
 
 __all__ = ["compare", "CompareResult", "MatchedPair", "UnmatchedTopic"]
 
@@ -438,45 +440,16 @@ class _Alignment:
 
 
 def _classify_similarity(sim: np.ndarray, threshold: float) -> _Alignment:
-    """Mutual-best classification from a similarity matrix, identical in semantics to
-    :func:`align_topics` step 5 (``validation.py``): a pair matches only when each
-    topic is the other's *unique* above-``threshold`` partner; one-to-many is a
-    split/merge; no partner is *unaligned*."""
-    na, nb = sim.shape
-    adj_a: dict[int, list[tuple[int, float]]] = {i: [] for i in range(na)}
-    adj_b: dict[int, list[tuple[int, float]]] = {j: [] for j in range(nb)}
-    for i in range(na):
-        for j in range(nb):
-            s = float(sim[i, j])
-            if s >= threshold:
-                adj_a[i].append((j, s))
-                adj_b[j].append((i, s))
-    for i in adj_a:
-        adj_a[i].sort(key=lambda x: x[1], reverse=True)
-    for j in adj_b:
-        adj_b[j].sort(key=lambda x: x[1], reverse=True)
-
-    matches: list[tuple[int, int, float]] = []
-    splits: dict[int, list[tuple[int, float]]] = {}
-    merges: dict[int, list[tuple[int, float]]] = {}
-    unaligned_a: list[int] = []
-    unaligned_b: list[int] = []
-    for i in range(na):
-        targets = adj_a[i]
-        if len(targets) == 0:
-            unaligned_a.append(i)
-        elif len(targets) == 1:
-            j, s = targets[0]
-            if len(adj_b[j]) == 1:
-                matches.append((i, j, s))
-        else:
-            splits[i] = targets
-    for j in range(nb):
-        sources = adj_b[j]
-        if len(sources) == 0:
-            unaligned_b.append(j)
-        elif len(sources) > 1:
-            merges[j] = sources
+    """Hungarian-anchored classification from a precomputed similarity matrix, using the
+    same shared classifier as :func:`align_topics` (``validation._classify_alignment``,
+    issue #642): matches are the Hungarian 1-to-1 pairs above ``threshold``, and
+    splits/merges are a background-relative overlay that stays empty on a correlated
+    self-alignment. Used by the manifest path, which has only a Jaccard matrix (no live
+    ``align_topics`` call) to classify."""
+    pairs = _hungarian(1.0 - sim)
+    matches, splits, merges, unaligned_a, unaligned_b = _classify_alignment(
+        sim, pairs, threshold
+    )
     return _Alignment(matches, splits, merges, unaligned_a, unaligned_b)
 
 
@@ -613,15 +586,19 @@ def compare(
     :class:`~topica.AnalysisManifest` records recorded with ``topic_words_n>0`` — in
     which case topics are aligned by Jaccard overlap of the retained top-word sets
     without refitting (see the module docstring; mixing a model with a manifest is
-    refused). Topics are matched one-to-one when each is the other's *unique*
-    above-``threshold`` partner (:func:`align_topics`, a mutual-best rule — never
-    force-paired); topics with no honest counterpart are reported as *vanished* (only
-    in ``a``) or *appeared* (only in ``b``), and one-to-many relationships as
-    *splits* / *merges*.
+    refused). Topics are matched one-to-one by the Hungarian assignment
+    (:func:`align_topics`), keeping a pair when its similarity clears ``threshold``;
+    topics with no honest counterpart are reported as *vanished* (only in ``a``) or
+    *appeared* (only in ``b``). One-to-many relationships (*splits* / *merges*) are an
+    overlay on top of that matching, flagged only when an extra partner is close to a
+    topic's own best match *relative to this fit's cross-topic similarity floor* — so
+    correlated-topic families (STM/CTM), whose off-diagonal cosines are high, are no
+    longer reported as near-total splits/merges, and comparing a fit with itself yields
+    K matched / 0 split / 0 merged regardless of correlation (issue #642).
 
     ``metric``/``threshold`` default per path: live fits use ``metric="cosine"`` with
-    ``threshold=0.3`` (permissive on real corpora, where shared common words push
-    cross-topic cosine up — raise it if you see spurious splits/merges); manifests use
+    ``threshold=0.3`` (the minimum similarity for a one-to-one match; splits/merges
+    self-calibrate to the fit and do not depend on it); manifests use
     ``metric="jaccard"`` with a lower default (~0.12) matched to the Jaccard scale of
     top-word sets. Pass ``threshold=`` to override either.
 

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -2191,12 +2191,19 @@ class AlignmentResult(list):
 
     Behaves as a list of ``(topic_a, topic_b, distance)`` tuples for backward
     compatibility, but exposes additional attributes for advanced analysis:
-    - ``matches``: List of 1-to-1 matched pairs ``(topic_a, topic_b, similarity)``
+    - ``matches``: List of 1-to-1 matched pairs ``(topic_a, topic_b, similarity)`` — the
+      Hungarian assignment restricted to pairs that clear ``threshold``.
     - ``splits``: Dictionary mapping ``topic_a -> list of (topic_b, similarity)``
     - ``merges``: Dictionary mapping ``topic_b -> list of (topic_a, similarity)``
     - ``unaligned_a``: List of unmatched topics in Model A
     - ``unaligned_b``: List of unmatched topics in Model B
     - ``similarity_matrix``: Raw pairwise similarity matrix of shape ``(K_A, K_B)``
+
+    ``splits``/``merges`` are a background-relative overlay on the match/unaligned
+    partition (issue #642), so a matched topic that also has an extra close partner
+    appears in both ``matches`` and ``splits``/``merges``. Comparing a fit with itself
+    yields K matches and no splits/merges for any model, including correlated-topic
+    families (STM/CTM) whose off-diagonal similarities are high.
     """
     def __init__(
         self,
@@ -2331,6 +2338,123 @@ def _emd_similarity(p_a, p_b, top_idx_a, top_idx_b, word_embeddings, depth):
     return float(similarity)
 
 
+# Split/merge overlay calibration (issue #642). ``_SPLIT_GAP`` is the fraction of the
+# gap between a topic's own best match and the model's cross-topic background that a
+# second partner must close to count as a genuine split/merge; ``_SPLIT_BG_QUANTILE``
+# is the quantile of off-target similarities used as that background. Both ride the
+# model's own similarity scale, so a fixed pair works across metrics (cosine/js/rbo/
+# emd/jaccard) — see the module tests' per-metric self-alignment invariant.
+_SPLIT_GAP = 0.25
+_SPLIT_BG_QUANTILE = 0.9
+
+
+def _split_background(M, argmax, split_gap, bg_quantile):
+    """Robust background level of *off-target* similarities for one direction.
+
+    ``M`` is ``(lines × candidates)`` and ``argmax`` each line's best candidate. Pools
+    every non-argmax similarity (the model's own cross-topic floor, matched signal
+    removed) and takes its ``bg_quantile`` quantile, then recomputes once after dropping
+    provisional outliers so a genuine co-partner cannot inflate the very floor that would
+    then reject it (this matters at small K, where the pool is tiny)."""
+    n_lines, n_cand = M.shape
+    if n_cand < 2:
+        return 0.0
+    rows = np.arange(n_lines)
+    off = np.ones(M.shape, dtype=bool)
+    off[rows, argmax] = False
+    pool = M[off]
+    if pool.size == 0:
+        return 0.0
+    q = float(np.quantile(pool, bg_quantile))
+    best = M[rows, argmax]
+    cut = best - split_gap * (best - q)
+    kept = off & (M < cut[:, None])
+    pool2 = M[kept]
+    if pool2.size >= max(4, n_cand):
+        q = float(np.quantile(pool2, bg_quantile))
+    return q
+
+
+def _co_partners(M, threshold, split_gap, bg_quantile):
+    """One-to-many partners per line, calibrated to the model's own similarity scale.
+
+    Returns ``{line: [(candidate, sim), ...]}`` (best first) for every line that keeps at
+    least one *extra* candidate beyond its own best match. A candidate ``k`` qualifies
+    when ``M[i, k] >= best_i - split_gap * (best_i - q)``, where ``q`` is the off-target
+    background quantile: the bar is a gap measured against *this model's* cross-topic
+    floor, never a fixed absolute threshold, so correlated-topic families do not
+    manufacture partners. A line whose own best match is a diffuse near-background value
+    (``best_i <= q``) gets a bar at or above ``best_i`` and so never splits; a line whose
+    best match is itself below ``threshold`` (no real primary) is skipped entirely."""
+    n_lines, n_cand = M.shape
+    result: dict[int, list] = {}
+    if n_cand < 2:
+        return result
+    rows = np.arange(n_lines)
+    argmax = np.argmax(M, axis=1)
+    best = M[rows, argmax]
+    q = _split_background(M, argmax, split_gap, bg_quantile)
+    cut = best - split_gap * (best - q)
+    for i in range(n_lines):
+        if best[i] < threshold:
+            continue
+        ci = cut[i]
+        extra = [
+            (int(k), float(M[i, k]))
+            for k in range(n_cand)
+            if k != argmax[i] and M[i, k] >= ci
+        ]
+        if extra:
+            targets = [(int(argmax[i]), float(best[i]))] + extra
+            targets.sort(key=lambda t: t[1], reverse=True)
+            result[int(i)] = targets
+    return result
+
+
+def _classify_alignment(
+    similarity_matrix,
+    hungarian_pairs,
+    threshold,
+    *,
+    split_gap=_SPLIT_GAP,
+    bg_quantile=_SPLIT_BG_QUANTILE,
+):
+    """Hungarian-anchored match / split / merge classification (issue #642).
+
+    ``matches`` are the Hungarian 1-to-1 pairs that clear ``threshold`` — the correct,
+    correlation-insensitive headline: a self-alignment recovers the diagonal at
+    similarity 1.0, so ``align_topics(tw, tw)`` returns K matches for *any* model,
+    including correlated-topic families (STM/CTM) whose off-diagonal cosines are high.
+    ``splits``/``merges`` are a background-relative *overlay* (see :func:`_co_partners`)
+    that stays empty on such a self-alignment instead of the old fixed-``threshold``
+    adjacency, which reported near-total instability for identical inputs.
+
+    Returns ``(matches, splits, merges, unaligned_a, unaligned_b)`` in the historical
+    shapes — ``matches`` a list of ``(i, j, sim)``, ``splits`` ``{i: [(j, sim), ...]}``,
+    ``merges`` ``{j: [(i, sim), ...]}``. ``matches`` and ``splits``/``merges`` may
+    overlap: a cleanly matched topic that *also* has an extra partner appears in both,
+    the match giving its 1-to-1 counterpart and the split/merge naming the extra."""
+    S = np.asarray(similarity_matrix, dtype=np.float64)
+    na, nb = S.shape
+
+    matches = []
+    matched_a: set[int] = set()
+    matched_b: set[int] = set()
+    for i, j in hungarian_pairs:
+        s = float(S[i, j])
+        if s >= threshold:
+            matches.append((int(i), int(j), s))
+            matched_a.add(int(i))
+            matched_b.add(int(j))
+    unaligned_a = [i for i in range(na) if i not in matched_a]
+    unaligned_b = [j for j in range(nb) if j not in matched_b]
+
+    splits = _co_partners(S, threshold, split_gap, bg_quantile)
+    merges = _co_partners(S.T, threshold, split_gap, bg_quantile)
+
+    return matches, splits, merges, unaligned_a, unaligned_b
+
+
 def align_topics(
     a,
     b,
@@ -2352,6 +2476,13 @@ def align_topics(
     Returns an `AlignmentResult` object which behaves as a list of ``(topic_a, topic_b, distance)``
     tuples sorted by ``topic_a``, but exposes additional attributes: ``matches``, ``splits``,
     ``merges``, ``unaligned_a``, ``unaligned_b``, and ``similarity_matrix``.
+
+    ``matches`` is the Hungarian assignment restricted to pairs above ``threshold``;
+    ``splits``/``merges`` are a background-relative overlay calibrated to the fit's own
+    cross-topic similarity, so ``align_topics(tw, tw)`` returns K matches and no
+    splits/merges for any model — including correlated-topic families (STM/CTM) whose
+    off-diagonal cosines are high (issue #642). ``threshold`` sets the one-to-one match
+    cut; the split/merge overlay self-calibrates and does not depend on it.
     """
     A = _as_topic_word(a)
     B = _as_topic_word(b)
@@ -2456,45 +2587,14 @@ def align_topics(
             legacy_dist = float(1.0 - similarity_matrix[i, j])
         legacy_pairs.append((i, j, legacy_dist))
 
-    # 5. Threshold-based classification (splits, merges, matches, unaligned)
-    matches = []
-    splits = {}
-    merges = {}
-    unaligned_a = []
-    unaligned_b = []
-    
-    adj_a = {i: [] for i in range(A.shape[0])}
-    adj_b = {j: [] for j in range(B.shape[0])}
-    
-    for i in range(A.shape[0]):
-        for j in range(B.shape[0]):
-            sim = float(similarity_matrix[i, j])
-            if sim >= threshold:
-                adj_a[i].append((j, sim))
-                adj_b[j].append((i, sim))
-                
-    for i in adj_a:
-        adj_a[i].sort(key=lambda x: x[1], reverse=True)
-    for j in adj_b:
-        adj_b[j].sort(key=lambda x: x[1], reverse=True)
-        
-    for i in range(A.shape[0]):
-        targets = adj_a[i]
-        if len(targets) == 0:
-            unaligned_a.append(i)
-        elif len(targets) == 1:
-            j, sim = targets[0]
-            if len(adj_b[j]) == 1:
-                matches.append((i, j, sim))
-        else:
-            splits[i] = targets
-            
-    for j in range(B.shape[0]):
-        sources = adj_b[j]
-        if len(sources) == 0:
-            unaligned_b.append(j)
-        elif len(sources) > 1:
-            merges[j] = sources
+    # 5. Hungarian-anchored classification (issue #642). Matches are the Hungarian
+    #    1-to-1 pairs above threshold; splits/merges are a background-relative overlay
+    #    that stays empty on a correlated-topic self-alignment. The old fixed-threshold
+    #    adjacency mislabelled correlated models (STM/CTM) as near-total splits/merges.
+    hungarian_pairs = [(i, j) for (i, j, _d) in legacy_pairs]
+    matches, splits, merges, unaligned_a, unaligned_b = _classify_alignment(
+        similarity_matrix, hungarian_pairs, threshold
+    )
 
     return AlignmentResult(
         legacy_pairs,

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -2200,10 +2200,13 @@ class AlignmentResult(list):
     - ``similarity_matrix``: Raw pairwise similarity matrix of shape ``(K_A, K_B)``
 
     ``splits``/``merges`` are a background-relative overlay on the match/unaligned
-    partition (issue #642), so a matched topic that also has an extra close partner
-    appears in both ``matches`` and ``splits``/``merges``. Comparing a fit with itself
-    yields K matches and no splits/merges for any model, including correlated-topic
-    families (STM/CTM) whose off-diagonal similarities are high.
+    partition (issue #642), so a topic that has an extra close partner appears in both
+    ``matches`` (or ``unaligned``) and ``splits``/``merges``. Comparing a fit with
+    itself yields K matches and no splits/merges for any model whose topics are
+    distinct — including correlated-topic families (STM/CTM) whose off-diagonal
+    similarities are high. (Two *identical* topics are genuinely interchangeable, so a
+    self-alignment of a model that contains exact-duplicate topics reports them as a
+    split/merge — an honest signal that the topics cannot be told apart.)
     """
     def __init__(
         self,
@@ -2385,7 +2388,20 @@ def _co_partners(M, threshold, split_gap, bg_quantile):
     floor, never a fixed absolute threshold, so correlated-topic families do not
     manufacture partners. A line whose own best match is a diffuse near-background value
     (``best_i <= q``) gets a bar at or above ``best_i`` and so never splits; a line whose
-    best match is itself below ``threshold`` (no real primary) is skipped entirely."""
+    best match is itself below ``threshold`` (no real primary) is skipped entirely.
+
+    A line need not have taken a one-to-one match to be a split/merge key: a genuine
+    merge target (one topic that absorbs two, whose two sources each matched a cleaner
+    counterpart elsewhere) is itself *unaligned*, so this overlay is intentionally not
+    gated to matched lines — it can name a topic that also appears in
+    ``unaligned_a``/``unaligned_b`` (a genuine many-to-one that is also "appeared").
+
+    ``split_gap`` deliberately favors precision: a second partner must close a solid
+    fraction of the gap from the background floor up to the best match, so a merely
+    correlated neighbour is usually not called a split. This is a heuristic — a well-
+    separated but weaker second partner can be missed, and on a heavily correlated draw
+    an unrelated topic can occasionally be named; use the raw ``similarity_matrix`` when
+    you need the exact one-to-many picture."""
     n_lines, n_cand = M.shape
     result: dict[int, list] = {}
     if n_cand < 2:
@@ -2480,9 +2496,11 @@ def align_topics(
     ``matches`` is the Hungarian assignment restricted to pairs above ``threshold``;
     ``splits``/``merges`` are a background-relative overlay calibrated to the fit's own
     cross-topic similarity, so ``align_topics(tw, tw)`` returns K matches and no
-    splits/merges for any model — including correlated-topic families (STM/CTM) whose
-    off-diagonal cosines are high (issue #642). ``threshold`` sets the one-to-one match
-    cut; the split/merge overlay self-calibrates and does not depend on it.
+    splits/merges for any model with distinct topics — including correlated-topic
+    families (STM/CTM) whose off-diagonal cosines are high (issue #642); exact-duplicate
+    topics are the honest exception (they report as a split/merge, being interchangeable).
+    ``threshold`` sets the one-to-one match cut; the split/merge overlay self-calibrates
+    and does not depend on it.
     """
     A = _as_topic_word(a)
     B = _as_topic_word(b)

--- a/tests/test_align_topics.py
+++ b/tests/test_align_topics.py
@@ -157,6 +157,64 @@ def test_align_topics_vocab_intersection():
     assert res[1][0] == 1 and res[1][1] == 1
 
 
+def _correlated_tw(k, v=60, seed=0):
+    """Topic-word rows that all share common vocabulary mass, so their off-diagonal
+    cosine is high — the STM/CTM regime that broke the old fixed-threshold classifier
+    (issue #642)."""
+    return np.random.default_rng(seed).random((k, v)) + 0.5
+
+
+def test_align_topics_self_alignment_invariant_correlated():
+    # The regression invariant from issue #642: align_topics(tw, tw) must yield
+    # K matches / 0 splits / 0 merges for ANY valid tw, including correlated-topic
+    # models where a large fraction of off-diagonal cosines clear the old 0.3 threshold.
+    tw = _correlated_tw(10, seed=42)
+    an = tw / np.linalg.norm(tw, axis=1, keepdims=True)
+    off = (an @ an.T)[~np.eye(10, dtype=bool)]
+    assert np.median(off) > 0.5  # genuinely correlated — the regime that used to break
+    for metric in ("cosine", "js", "rbo", "emd"):
+        al = align_topics(tw, tw, metric=metric)
+        assert len(al.matches) == 10, metric
+        assert len(al.splits) == 0, metric
+        assert len(al.merges) == 0, metric
+        assert not al.unaligned_a and not al.unaligned_b, metric
+        # The Hungarian pairing underneath still recovers the diagonal exactly.
+        assert max(d for _, _, d in al) < 1e-9, metric
+
+
+def test_align_topics_correlated_extra_topic_not_spurious_split():
+    # Unequal K in the correlated regime: an extra B-topic that is broadly similar to
+    # every A-topic must NOT turn every A-topic into a spurious split/merge (a naive
+    # leftover-threshold rule would re-introduce the #642 bug). The extra is surfaced
+    # as an unaligned/appeared topic instead.
+    a = _correlated_tw(8, seed=1)
+    b = np.vstack([a, _correlated_tw(1, seed=2)])
+    al = align_topics(a, b)
+    assert len(al.matches) == 8
+    assert len(al.splits) == 0
+    assert len(al.merges) == 0
+    assert al.unaligned_b == [8]
+
+
+def test_align_topics_genuine_merge_still_detected():
+    # The calibration must not "pass" by never splitting/merging: a B-topic that is a
+    # genuine blend of two well-separated A-topics is still reported as a merge.
+    phi_a = np.array([
+        [10.0, 10.0, 0.0, 0.0, 0.0, 0.0],   # A0 on w0,w1
+        [0.0, 0.0, 0.0, 0.0, 10.0, 10.0],   # A1 on w4,w5
+    ])
+    phi_b = np.array([
+        [10.0, 1.0, 0.0, 0.0, 0.0, 0.0],    # B0 ~ A0
+        [1.0, 1.0, 0.0, 0.0, 1.0, 1.0],     # B1 blends A0 and A1  -> genuine merge
+        [0.0, 0.0, 0.0, 0.0, 10.0, 1.0],    # B2 ~ A1
+    ])
+    al = align_topics(phi_a, phi_b, threshold=0.3)
+    # B1 (index 1) merges sources A0 and A1.
+    assert 1 in al.merges
+    sources = {i for i, _ in al.merges[1]}
+    assert {0, 1} <= sources
+
+
 def test_align_topics_splits_merges_unaligned():
     # We construct a scenario with splits, merges, and unaligned topics
     # Model A has 3 topics, Model B has 3 topics

--- a/tests/test_align_topics.py
+++ b/tests/test_align_topics.py
@@ -182,6 +182,36 @@ def test_align_topics_self_alignment_invariant_correlated():
         assert max(d for _, _, d in al) < 1e-9, metric
 
 
+def test_align_topics_self_alignment_invariant_small_k():
+    # The K/0/0 self-alignment invariant must hold at small K too (K=1,2,3), not just
+    # the K=10 case — small pools are where the background quantile is most fragile.
+    for k in (1, 2, 3):
+        tw = _correlated_tw(k, seed=7 + k)
+        for metric in ("cosine", "js", "rbo", "emd"):
+            al = align_topics(tw, tw, metric=metric)
+            assert len(al.matches) == k, (k, metric)
+            assert len(al.splits) == 0 and len(al.merges) == 0, (k, metric)
+            assert not al.unaligned_a and not al.unaligned_b, (k, metric)
+
+
+def test_align_topics_genuine_split_still_detected():
+    # Symmetric counterpart to the merge test: an A-topic that is split into two
+    # well-separated B-topics is still reported as a split (the overlay is not so
+    # precision-biased that it never fires).
+    phi_a = np.array([
+        [10.0, 10.0, 0.0, 0.0, 0.0, 0.0],   # A0 on w0,w1 (will split)
+        [0.0, 0.0, 0.0, 0.0, 10.0, 10.0],   # A1 on w4,w5
+    ])
+    phi_b = np.array([
+        [10.0, 1.0, 0.0, 0.0, 0.0, 0.0],    # B0 ~ A0
+        [1.0, 10.0, 0.0, 0.0, 0.0, 0.0],    # B1 ~ A0 (the split partner)
+        [0.0, 0.0, 0.0, 0.0, 10.0, 10.0],   # B2 ~ A1
+    ])
+    al = align_topics(phi_a, phi_b, threshold=0.3)
+    assert 0 in al.splits
+    assert {j for j, _ in al.splits[0]} >= {0, 1}
+
+
 def test_align_topics_correlated_extra_topic_not_spurious_split():
     # Unequal K in the correlated regime: an extra B-topic that is broadly similar to
     # every A-topic must NOT turn every A-topic into a spurious split/merge (a naive

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -38,6 +38,22 @@ def _onehot_topics(k, v, seed=0, noise=0.0):
 
 # --- alignment basics ---------------------------------------------------------
 
+def test_compare_self_alignment_invariant_correlated():
+    # Issue #642: comparing a correlated-topic fit (STM/CTM, where off-diagonal cosine
+    # is high) with itself must report full stability — K matched, nothing split, merged,
+    # vanished, or appeared — not near-total instability.
+    tw = np.random.default_rng(7).random((10, 60)) + 0.5  # high off-diagonal cosine
+    a, b = DummyModel(tw), DummyModel(tw)
+    cmp = topica.compare(a, b)
+    assert len(cmp.aligned) == 10
+    assert len(cmp.splits) == 0
+    assert len(cmp.merges) == 0
+    assert not cmp.unmatched_a and not cmp.unmatched_b
+    # matched pairs are the identity, at distance ~0
+    assert {p.topic_a: p.topic_b for p in cmp.aligned} == {i: i for i in range(10)}
+    assert max(p.distance for p in cmp.aligned) < 1e-9
+
+
 def test_compare_matches_permuted_topics():
     phi = _onehot_topics(4, 16, seed=1)
     a = DummyModel(phi)

--- a/tests/test_compare.py
+++ b/tests/test_compare.py
@@ -411,6 +411,34 @@ def test_near_miss_survives_a_numpy_scalar_threshold():
     assert u_np.as_dict()["near_miss"] is True
 
 
+def test_near_miss_not_flagged_when_best_at_or_above_threshold():
+    # The #642 Hungarian-anchored classifier can leave a topic unmatched with a best
+    # similarity AT or ABOVE threshold (a split/merge child that lost the 1-to-1
+    # assignment). That is a strong partner, not a churn near-miss — it must not be
+    # flagged (the old rule `best >= 0.8*threshold` had no upper bound and produced a
+    # self-contradictory "near-miss: best sim 1.000, just under 0.30" card).
+    sim = np.array([[0.999]])  # best ~1.0, well above threshold 0.3
+    u = _unmatched(0, "b", "appeared", ["w"], 0.5, sim, 0.3, axis=0)
+    assert u.best_similarity > 0.3
+    assert u.near_miss is False
+
+
+def test_compare_split_child_is_not_a_near_miss():
+    # End to end: a genuine split (A0 -> {B0, B1}) leaves one split-child unmatched
+    # with best sim ~1.0. Its card must not read as a "near-miss just under threshold".
+    def _norm(x):
+        x = np.atleast_2d(x)
+        return x / x.sum(1, keepdims=True)
+    V = 40
+    A = _norm(np.array([np.eye(V)[k * 10:(k + 1) * 10].sum(0) for k in range(4)]))
+    B = _norm(np.vstack([A[0], A[0] + np.eye(V)[0] * 0.01, A[1], A[2], A[3]]))
+    cmp = topica.compare(A, B)
+    hi = [u for u in cmp.unmatched_b if (u.best_similarity or 0) >= cmp.threshold]
+    assert hi, "expected an unmatched split-child with best sim above threshold"
+    assert all(not u.near_miss for u in hi)
+    assert "just under" not in cmp.to_markdown()
+
+
 @pytest.mark.slow
 def test_compare_manifests_agrees_with_live_on_real_lda():
     rng = np.random.default_rng(0)


### PR DESCRIPTION
## What

`align_topics` and `topica.compare` mis-reported correlated-topic models (STM, CTM) as wildly unstable. The split/merge classifier used a fixed absolute cosine threshold (default `0.3`); for these families a large fraction of *off-diagonal* topic-pair cosines exceed `0.3`, so almost every topic had multiple above-threshold neighbours and was labelled a split/merge — even for **identical** inputs. `align_topics(tw, tw)` on identical STM topics returned 1 match / 19 splits / 19 merges instead of 20 / 0 / 0, and `compare` inherited the same error, reporting a bit-identical fit as near-totally unstable. The Hungarian 1-to-1 pairing underneath was already correct.

Closes #642

## How

A single Hungarian-anchored classifier (`validation._classify_alignment`) is now shared by `align_topics` and `compare` (the manifest path feeds it Hungarian pairs from the Jaccard matrix; the live path routes through `align_topics`, so the duplicated classifier in `compare.py` is gone):

- **`matches`** = the Hungarian 1-to-1 assignment restricted to pairs above `threshold`. This is correlation-insensitive: a self-alignment recovers the diagonal at similarity 1.0, so it yields K matches for any model.
- **`splits` / `merges`** are now a background-relative **overlay** rather than absolute-threshold adjacency. An extra partner is flagged only when it is close to a topic's *own* best match relative to the fit's own cross-topic similarity floor — a quantile of off-target similarities, recomputed once to de-contaminate small-K pools — never against a fixed constant. Because the bar rides each fit's own similarity scale, one calibration (`_SPLIT_GAP=0.25`, `_SPLIT_BG_QUANTILE=0.9`) works across metrics without per-metric tuning.

Tradeoffs / scope notes:
- `matches` and `splits`/`merges` may now **overlap**: a cleanly matched topic that also has a close extra partner appears in both (the match gives its 1-to-1 counterpart, the split/merge names the extra). Documented in the `AlignmentResult` docstring and the guides.
- `threshold` now governs the one-to-one match cut only; the split/merge overlay self-calibrates and no longer depends on it (the old "raise `threshold` if you see spurious splits" workaround is removed from the docs).
- The Hungarian **list** interface (used by `ensemble`, `topic_stability`, `viz/health`) was already correct and is untouched.

## Validation

The regression invariant from the issue — `align_topics(tw, tw)` and `compare(tw, tw)` must give K / 0 / 0 for any `tw` — is now enforced by tests, verified on a **real STM/poliblog fit** (reproducing the issue's off-diag cosine median 0.219, frac>0.3 = 0.24):

- `align_topics(tw, tw)` → **20 matches / 0 splits / 0 merges** across **cosine, JS, RBO, and EMD**; `compare(tw, tw)` likewise. Also holds at an extreme off-diagonal cosine median of 0.924.
- **Genuine detection preserved:** a B-topic that is a real blend of two A-topics is still reported as a merge (`merges={20:[3,7]}`), and an A→{B0,B1} split is detected — at equal *and* unequal K. A correlated *extra* topic at unequal K produces **0 spurious splits/merges** and is surfaced as appeared/unaligned.
- New regression tests: per-metric self-alignment invariant, correlated-extra-not-split, genuine-merge-still-detected (`test_align_topics.py`), and `compare` self-alignment (`test_compare.py`).

Checklist:

- [ ] `cargo test --lib` — not run; no Rust changed (Python + docs only).
- [x] `python -m pytest tests/ -q` — ran every module touching these paths: `test_align_topics`, `test_compare`, `test_ensemble`, `test_diagnostics`, `test_validation`, `test_cross_ensemble`, `test_topic_diagnostics`, `test_pipeline_diagnostics`, `test_diagnostics_table` → **362 passed, 15 skipped**. Full-suite run left for CI.
- [ ] `./scripts/preflight.sh` — not run (fmt/clippy/generated-file sync target the Rust core, unchanged here).
- [ ] `mkdocs build --strict` — not run; this environment lacks the mkdocstrings handler plugins. Docs changes are prose-only (no new cross-references or structure), in `diagnostics.md` and `model-comparison.md`.
- [x] `.pyi` stub in sync — verified; no binding signature changed, and the `AlignmentResult` field shapes (`splits`/`merges` dicts) are unchanged.

## Notes

The approach was hardened through two adversarial design reviews before implementation. The first replaced the naive "subtract the Hungarian backbone, re-run absolute-threshold on the leftovers" idea (which re-created the bug at unequal K and dropped genuine equal-K splits). The second caught that a fixed relative margin over-flags for JS (which has a hard similarity floor of `1 − ln2 ≈ 0.307`) and degenerates for Jaccard — which is why the final rule anchors on a distribution quantile that self-calibrates per metric, with a per-metric self-alignment test as the acceptance gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKmkmz4phatg4JH2Dij8SX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKmkmz4phatg4JH2Dij8SX)_