### PR TITLE
fix(manifest): validate record_fit arguments, with topic-reading & K-selection doc fixes

### DIFF
--- a/.claude/skills/topica-analysis/SKILL.md
+++ b/.claude/skills/topica-analysis/SKILL.md
@@ -139,6 +139,13 @@ every topic can be labeled. Count the junk topics. Then let the researcher
 choose, and report sensitivity to that choice. `topica.viz.search_k(rows)` and
 `quality_frontier` make the trade-off legible.
 
+`rows.best_k()` exists, but treat it as one input, not the decision: with a
+`held_out=` set it defaults to the held-out metric, which is roughly monotone in
+K and so tends to return the **largest K you scanned** (it warns when it does).
+Without held-out it defaults to the coherence/exclusivity frontier (a knee). Read
+it as "the K this criterion prefers," report the criterion, and still hand the
+choice to the researcher — never present `best_k()` as the answer.
+
 > **Handoff.** Present the curves and the labeled topics at two or three values
 > of K. The researcher picks K; you report why.
 

--- a/.claude/skills/topica-analysis/SKILL.md
+++ b/.claude/skills/topica-analysis/SKILL.md
@@ -114,6 +114,17 @@ Start minimal and add preprocessing only when topics show artifacts; do not
 pile on cleaning preemptively. Inspect the corpus (document count, length
 distribution, vocabulary size) and report it before modeling.
 
+**This preprocessing advice is for bag-of-words models (LDA, STM, NMF, …).**
+For embedding + cluster models (`BERTopic`, `Top2Vec`), the topics are driven by
+the document *embeddings*, so token cleaning does **not** change the model — the
+same clusters emerge with or without stopword removal. There it only affects the
+c-TF-IDF *labels* on already-formed clusters. So preprocess to get readable
+labels, but do not present stopword/frequency choices as shaping the topics, and
+note that the K-selection tools below (`search_k`) are LDA/STM-only. See the
+[embedding-models guide](https://nealcaren.github.io/topica/guides/embedding/)
+for the embedding-model workflow, including how to sweep K and avoid the `-1`
+noise bucket.
+
 > **Handoff.** Stopword lists and frequency cutoffs change what topics can
 > exist. Surface them; do not bury them in a default.
 
@@ -145,6 +156,14 @@ K and so tends to return the **largest K you scanned** (it warns when it does).
 Without held-out it defaults to the coherence/exclusivity frontier (a knee). Read
 it as "the K this criterion prefers," report the criterion, and still hand the
 choice to the researcher — never present `best_k()` as the answer.
+
+`search_k` covers LDA and STM only (`model="lda"`/`"stm"`); it raises for
+embedding + cluster models. For `BERTopic` / `Top2Vec` there is no held-out
+likelihood — sweep the K knob yourself (`num_clusters` for a fixed-K clusterer,
+or `min_cluster_size` for HDBSCAN) and score each fit by coherence and topic
+diversity, picking the same way (a knee, not a maximum). The
+[embedding-models guide](https://nealcaren.github.io/topica/guides/embedding/)
+works this through.
 
 > **Handoff.** Present the curves and the labeled topics at two or three values
 > of K. The researcher picks K; you report why.

--- a/.claude/skills/topica-analysis/SKILL.md
+++ b/.claude/skills/topica-analysis/SKILL.md
@@ -157,9 +157,21 @@ model.fit(docs, prevalence=X, prevalence_names=names)   # content=... for SAGE
 A plain LDA fit is `topica.LDA(num_topics=20, seed=42).fit(docs, iters=1000)`.
 Check that the fit converged (the EM models expose a bound / `converged` flag;
 the Gibbs models expose log-likelihood history). A model that did not converge is
-not a result. Read topics off `top_words`, `label_topics` (prob / FREX / lift /
-score), and `find_thoughts` (the highest-θ documents for a topic) together: top
-words alone underdetermine what a topic is.
+not a result. Read topics off several surfaces together — top words alone
+underdetermine what a topic is:
+
+- `model.top_words(n)` returns per-topic `(word, weight)` tuples, not bare
+  strings; take just the words with `[w for w, _ in row]`.
+- `label_topics`, `frex`, `relevance`, `find_thoughts`, `topic_table` and
+  `summary` are **module-level functions, not model methods**, and take the
+  model's matrices as the first argument — e.g.
+  `topica.label_topics(model.topic_word, model.vocabulary)` and
+  `topica.find_thoughts(model.doc_topic, texts, topic=t)` (the highest-θ
+  documents for a topic).
+- `label_topics` has no `method=` selector: it reports probability and FREX
+  side by side. For FREX- or relevance-ranked words specifically, call the
+  separate `topica.frex(model.topic_word, model.vocabulary)` or
+  `topica.relevance(model.topic_word, model.vocabulary)`.
 
 ### Phase 4: validate (not optional)
 
@@ -260,8 +272,10 @@ with the diagnostics to defend each one.
   and the README table; consult it rather than relying on any hardcoded list here.
   Common starting points: `LDA`, `STM`, `CTM`, `STS` (sentiment), `DMR`, `HDP`,
   `KeyATM`, `SeededLDA`, `BERTopic`, `GSDMM` (short text)
-- **Read topics:** `top_words`, `label_topics`, `frex`, `relevance`,
-  `find_thoughts`, `topic_table`, `summary`
+- **Read topics:** `model.top_words(n)` (method → `(word, weight)` tuples) plus
+  the module functions `topica.label_topics`, `frex`, `relevance`,
+  `find_thoughts`, `topic_table`, `summary` (first arg is the model's
+  `topic_word` / `doc_topic` matrix, or the model)
 - **Choose K:** `search_k`, `quality_frontier`, `topica.viz.search_k`
 - **Validate:** `coherence`, `exclusivity`, `topic_diversity`,
   `bootstrap_stability`, `word_intrusion`, `document_intrusion`, `diagnostics`

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,6 +113,17 @@ Start minimal and add preprocessing only when topics show artifacts; do not
 pile on cleaning preemptively. Inspect the corpus (document count, length
 distribution, vocabulary size) and report it before modeling.
 
+**This preprocessing advice is for bag-of-words models (LDA, STM, NMF, …).**
+For embedding + cluster models (`BERTopic`, `Top2Vec`), the topics are driven by
+the document *embeddings*, so token cleaning does **not** change the model — the
+same clusters emerge with or without stopword removal. There it only affects the
+c-TF-IDF *labels* on already-formed clusters. So preprocess to get readable
+labels, but do not present stopword/frequency choices as shaping the topics, and
+note that the K-selection tools below (`search_k`) are LDA/STM-only. See the
+[embedding-models guide](https://nealcaren.github.io/topica/guides/embedding/)
+for the embedding-model workflow, including how to sweep K and avoid the `-1`
+noise bucket.
+
 > **Handoff.** Stopword lists and frequency cutoffs change what topics can
 > exist. Surface them; do not bury them in a default.
 
@@ -138,6 +149,21 @@ every topic can be labeled. Count the junk topics. Then let the researcher
 choose, and report sensitivity to that choice. `topica.viz.search_k(rows)` and
 `quality_frontier` make the trade-off legible.
 
+`rows.best_k()` exists, but treat it as one input, not the decision: with a
+`held_out=` set it defaults to the held-out metric, which is roughly monotone in
+K and so tends to return the **largest K you scanned** (it warns when it does).
+Without held-out it defaults to the coherence/exclusivity frontier (a knee). Read
+it as "the K this criterion prefers," report the criterion, and still hand the
+choice to the researcher — never present `best_k()` as the answer.
+
+`search_k` covers LDA and STM only (`model="lda"`/`"stm"`); it raises for
+embedding + cluster models. For `BERTopic` / `Top2Vec` there is no held-out
+likelihood — sweep the K knob yourself (`num_clusters` for a fixed-K clusterer,
+or `min_cluster_size` for HDBSCAN) and score each fit by coherence and topic
+diversity, picking the same way (a knee, not a maximum). The
+[embedding-models guide](https://nealcaren.github.io/topica/guides/embedding/)
+works this through.
+
 > **Handoff.** Present the curves and the labeled topics at two or three values
 > of K. The researcher picks K; you report why.
 
@@ -156,9 +182,21 @@ model.fit(docs, prevalence=X, prevalence_names=names)   # content=... for SAGE
 A plain LDA fit is `topica.LDA(num_topics=20, seed=42).fit(docs, iters=1000)`.
 Check that the fit converged (the EM models expose a bound / `converged` flag;
 the Gibbs models expose log-likelihood history). A model that did not converge is
-not a result. Read topics off `top_words`, `label_topics` (prob / FREX / lift /
-score), and `find_thoughts` (the highest-θ documents for a topic) together: top
-words alone underdetermine what a topic is.
+not a result. Read topics off several surfaces together — top words alone
+underdetermine what a topic is:
+
+- `model.top_words(n)` returns per-topic `(word, weight)` tuples, not bare
+  strings; take just the words with `[w for w, _ in row]`.
+- `label_topics`, `frex`, `relevance`, `find_thoughts`, `topic_table` and
+  `summary` are **module-level functions, not model methods**, and take the
+  model's matrices as the first argument — e.g.
+  `topica.label_topics(model.topic_word, model.vocabulary)` and
+  `topica.find_thoughts(model.doc_topic, texts, topic=t)` (the highest-θ
+  documents for a topic).
+- `label_topics` has no `method=` selector: it reports probability and FREX
+  side by side. For FREX- or relevance-ranked words specifically, call the
+  separate `topica.frex(model.topic_word, model.vocabulary)` or
+  `topica.relevance(model.topic_word, model.vocabulary)`.
 
 ### Phase 4: validate (not optional)
 
@@ -259,8 +297,10 @@ with the diagnostics to defend each one.
   and the README table; consult it rather than relying on any hardcoded list here.
   Common starting points: `LDA`, `STM`, `CTM`, `STS` (sentiment), `DMR`, `HDP`,
   `KeyATM`, `SeededLDA`, `BERTopic`, `GSDMM` (short text)
-- **Read topics:** `top_words`, `label_topics`, `frex`, `relevance`,
-  `find_thoughts`, `topic_table`, `summary`
+- **Read topics:** `model.top_words(n)` (method → `(word, weight)` tuples) plus
+  the module functions `topica.label_topics`, `frex`, `relevance`,
+  `find_thoughts`, `topic_table`, `summary` (first arg is the model's
+  `topic_word` / `doc_topic` matrix, or the model)
 - **Choose K:** `search_k`, `quality_frontier`, `topica.viz.search_k`
 - **Validate:** `coherence`, `exclusivity`, `topic_diversity`,
   `bootstrap_stability`, `word_intrusion`, `document_intrusion`, `diagnostics`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   `doc_embeddings`/`embeddings` parameter), so word-embedding models (ETM, DETM) and
   count-only fits are not mislabeled, and a custom/unregistered subclass is handled
   the same way.
+- **`record_fit` validates its arguments up front with clear messages** (#646).
+  `diagnostics=True` (a natural mistake, since `diagnostics=` wants a list of names)
+  raised an opaque `'bool' object is not iterable`; it now names the valid options.
+  The sibling top-N arguments are hardened the same way: `diagnostics_n` /
+  `topic_words_n` reject a non-integer (a bare `"5"` crashed at the `> 0` gate) and a
+  `bool` (silently treated as `1`), and out-of-range values; numpy integers are still
+  accepted. `prevalence_names` passed without `prevalence` — which silently dropped
+  the names — now raises instead of losing that provenance.
 
 ### Changed
 
@@ -132,6 +140,29 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   left unmatched by the 1-to-1 assignment though its best similarity is at or above
   the threshold) as a "near-miss just under the threshold": the `near_miss` flag now
   requires the best similarity to sit strictly below the match cut.
+
+### Documentation
+
+- **`topica-analysis` guide: topic-reading API corrected** (#643). The guide implied
+  `top_words(n)` returns strings and that `label_topics`/`frex`/`find_thoughts`/
+  `topic_table`/`summary` are model methods with a `label_topics(method=...)` selector.
+  It now shows `top_words(n)` returning `(word, weight)` tuples, presents the others as
+  module functions taking the model's `topic_word`/`doc_topic` matrix, and points to
+  the separate `frex`/`relevance` functions instead of a non-existent selector.
+- **`best_k()` default behavior documented consistently** (#645). `best_k()` defaults
+  to the held-out metric when a `held_out=` set is present, which is roughly monotone
+  in K and tends to land on the largest K scanned (it already warns when it does).
+  `docs/guides/diagnostics.md` wrongly stated the default is always the frontier;
+  corrected, with a caution added to the analysis guide that `best_k()` is one input,
+  not the research decision. No behavior change.
+- **BERTopic K-selection is documented** (#650). `search_k`/`best_k` are LDA/STM-only
+  and the analysis guidance was bag-of-words-centric, leaving embedding + cluster
+  models (BERTopic, Top2Vec) without a path. The choosing-K guide gains an
+  embedding-models section (preprocessing changes only labels not clusters; K is a
+  clusterer setting; a worked coherence/diversity sweep), the analysis skill branches
+  for these models, and the `datasets.md` BERTopic example switches from the HDBSCAN
+  default (which collapses `load_ng20_minilm` to ~2 topics) to a
+  `kmeans`/`num_clusters=5`/`reduce_frequent=True` fit that recovers the newsgroups.
 
 ## [0.55.0] - 2026-07-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -161,7 +161,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   embedding-models section (preprocessing changes only labels not clusters; K is a
   clusterer setting; a worked coherence/diversity sweep), the analysis skill branches
   for these models, and the `datasets.md` BERTopic example switches from the HDBSCAN
-  default (which collapses `load_ng20_minilm` to ~2 topics) to a
+  default (which collapses `load_ng20_minilm` to a degenerate handful of topics,
+  most documents in one bucket) to a
   `kmeans`/`num_clusters=5`/`reduce_frequent=True` fit that recovers the newsgroups.
 
 ## [0.55.0] - 2026-07-29

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -26,10 +26,10 @@ access), not a DataFrame.
 ```python
 b = topica.datasets.load_ng20_minilm()
 docs = [t.split() for t in b.texts]
-# The default HDBSCAN clusterer over UMAP collapses this subset to ~2 topics
-# (it fires a UserWarning when it does). A fixed-K clusterer with reduce_frequent
-# recovers the newsgroups cleanly. See docs/guides/embedding.md, "Avoiding the
-# `-1` noise bucket", for why.
+# The default HDBSCAN clusterer over UMAP collapses this subset to a degenerate
+# handful of topics — ~80% of the documents land in a single bucket. A fixed-K
+# clusterer with reduce_frequent recovers the newsgroups cleanly. See
+# docs/guides/embedding.md, "Avoiding the `-1` noise bucket", for why.
 bt = topica.BERTopic(
     clusterer="kmeans", num_clusters=5, reduce_frequent=True, seed=1,
 ).fit(docs, b.doc_embeddings)

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -26,7 +26,13 @@ access), not a DataFrame.
 ```python
 b = topica.datasets.load_ng20_minilm()
 docs = [t.split() for t in b.texts]
-bt = topica.BERTopic(reducer="umap", n_components=5).fit(docs, b.doc_embeddings)
+# The default HDBSCAN clusterer over UMAP collapses this subset to ~2 topics
+# (it fires a UserWarning when it does). A fixed-K clusterer with reduce_frequent
+# recovers the newsgroups cleanly. See docs/guides/embedding.md, "Avoiding the
+# `-1` noise bucket", for why.
+bt = topica.BERTopic(
+    clusterer="kmeans", num_clusters=5, reduce_frequent=True, seed=1,
+).fit(docs, b.doc_embeddings)
 ```
 
 ::: topica.datasets.load_gadarian

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -176,8 +176,12 @@ optional `criteria=("deveaud", "cao_juan")` columns. Fit several seeds per K wit
 with `n_jobs=-1`). Then let `result.best_k(metric=..., rule=...)` name a K:
 `rule="best"` (the optimum), `"1se"` (the simplest K within one standard error, so
 you don't over-read noise), or `"elbow"` (the diminishing-returns knee of a
-held-out curve). The default `best_k()` picks the coherence/exclusivity *frontier*
-rather than a single monotone metric. The [Choose and justify K](../publishing/choosing-k.md)
+held-out curve). Bare `best_k()` defaults to the held-out metric when a
+`held_out=` set is present and to the coherence/exclusivity *frontier* otherwise —
+and because held-out log-likelihood is roughly monotone in K, the held-out default
+tends to land on the largest K you scanned (it warns when it does). Treat that as
+one input, not the answer: `best_k` names the K a criterion prefers, it does not
+make the research decision for you. The [Choose and justify K](../publishing/choosing-k.md)
 guide works a full example on `poliblog`.
 
 ### Topic alignment

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -279,7 +279,7 @@ Pick the knee of the coherence/diversity trade-off, not the maximum of either.
 With HDBSCAN, sweep `min_cluster_size` instead and watch how much of the corpus
 falls into the `-1` noise bucket; a fixed-K clusterer with `reduce_frequent=True`
 avoids that bucket and, on this dataset, recovers the newsgroups where the
-HDBSCAN default collapses to ~2 topics. The
+HDBSCAN default collapses to a degenerate handful (most documents in one topic). The
 [embedding-models guide](../guides/embedding.md) covers the clusterer choices and
 the noise-bucket problem in depth.
 

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -243,6 +243,46 @@ toward K≈100, at the cost of more topics to label. We would state the goal, na
 the K, and (per the section below) show the headline result survives a few nearby
 values.
 
+## Embedding + cluster models (BERTopic, Top2Vec)
+
+Everything above fits LDA or STM. `search_k` does too — it **raises for
+embedding + cluster models** (`search_k(..., model="bertopic")` →
+`ValueError: model must be 'lda' or 'stm'`). Two things differ for these models:
+
+- **Preprocessing does not change the topics.** Clusters are formed from the
+  document *embeddings*, so stopword and frequency choices only affect the
+  c-TF-IDF *labels* on already-formed clusters, not which documents cluster
+  together. Removing stopwords leaves the topics identical. Preprocess for
+  readable labels, but do not report token cleaning as shaping the model.
+- **K is a clusterer setting, not a scan.** Use `num_clusters` for a fixed-K
+  clusterer (`kmeans`, `gmm`, `agglomerative`) or `min_cluster_size` for HDBSCAN.
+  There is no held-out likelihood.
+
+There is no built-in sweep, so score the K knob yourself with the same
+coherence-vs-diversity judgment used for the frontier above:
+
+```python
+import numpy as np, topica
+
+b = topica.datasets.load_ng20_minilm()
+docs = [t.split() for t in b.texts]
+
+for k in [4, 5, 6, 8, 10]:
+    m = topica.BERTopic(clusterer="kmeans", num_clusters=k,
+                        reduce_frequent=True, seed=1).fit(docs, b.doc_embeddings)
+    cv  = float(np.mean(topica.coherence(m, docs, coherence_type="c_v")))
+    div = topica.topic_diversity(m, topn=25)
+    print(f"K={k:>2}  c_v={cv:.3f}  diversity={div:.2f}  topics={m.num_topics}")
+```
+
+Pick the knee of the coherence/diversity trade-off, not the maximum of either.
+With HDBSCAN, sweep `min_cluster_size` instead and watch how much of the corpus
+falls into the `-1` noise bucket; a fixed-K clusterer with `reduce_frequent=True`
+avoids that bucket and, on this dataset, recovers the newsgroups where the
+HDBSCAN default collapses to ~2 topics. The
+[embedding-models guide](../guides/embedding.md) covers the clusterer choices and
+the noise-bucket problem in depth.
+
 ## Report sensitivity
 
 Pick the `K` that balances metrics, interpretability, and theory, then **show

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -51,6 +51,7 @@ from __future__ import annotations
 import hashlib
 import inspect
 import json
+import numbers
 import platform
 import struct
 from dataclasses import dataclass, field
@@ -688,6 +689,21 @@ def _fit_uses_doc_embeddings(model) -> bool:
     return any(name in ("doc_embeddings", "embeddings") for name in params)
 
 
+def _require_count(value, name: str, *, minimum: int) -> None:
+    """Validate a top-N count argument up front with a clear message.
+
+    ``bool`` is a subclass of ``int``, so ``name=True`` would otherwise pass
+    silently as ``1`` (the same class of mistake as ``diagnostics=True``); a
+    non-int (e.g. ``"5"``) would crash opaquely at the ``> 0`` / slicing site.
+    """
+    # numbers.Integral so numpy integers (np.int64, …) are accepted like plain
+    # ints; bool is Integral too, so it is excluded explicitly.
+    if isinstance(value, bool) or not isinstance(value, numbers.Integral):
+        raise TypeError(f"{name} must be an int (got {value!r})")
+    if value < minimum:
+        raise ValueError(f"{name} must be >= {minimum} (got {value})")
+
+
 def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
                embeddings=None,
                privacy: str = "minimal", content_fingerprint: bool = False,
@@ -755,6 +771,13 @@ def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
         if name not in BUILTIN_DIAGNOSTICS:
             raise ValueError(
                 f"unknown diagnostic {name!r}; choose from {sorted(BUILTIN_DIAGNOSTICS)}")
+    _require_count(diagnostics_n, "diagnostics_n", minimum=1)
+    _require_count(topic_words_n, "topic_words_n", minimum=0)
+    if prevalence is None and prevalence_names is not None:
+        raise ValueError(
+            "prevalence_names given without prevalence; pass the design matrix as "
+            "prevalence= (prevalence_names only labels its columns), or drop "
+            "prevalence_names")
 
     import topica
 

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -746,6 +746,11 @@ def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
         raise ValueError(
             f"privacy must be 'minimal' or 'aggregate' (got {privacy!r}); "
             f"'full' (raw values) is intentionally not available in V1")
+    if diagnostics is not None and not isinstance(diagnostics, (list, tuple)):
+        choices = "{" + ", ".join(repr(d) for d in sorted(BUILTIN_DIAGNOSTICS)) + "}"
+        raise TypeError(
+            f"diagnostics must be a list of diagnostic names (any of {choices}); "
+            f"got {diagnostics!r}")
     for name in diagnostics or ():
         if name not in BUILTIN_DIAGNOSTICS:
             raise ValueError(

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -599,6 +599,19 @@ def test_unknown_diagnostic_rejected(fitted):
         record_fit(model, corpus, diagnostics=["not_a_diagnostic"])
 
 
+def test_diagnostics_true_rejected_with_helpful_message(fitted):
+    corpus, model = fitted
+    # diagnostics=True is a natural mistake; it should raise a clear message
+    # naming the valid options rather than a raw "bool is not iterable".
+    with pytest.raises(TypeError, match=r"diagnostics must be a list of diagnostic names"):
+        record_fit(model, corpus, diagnostics=True)
+    with pytest.raises(TypeError, match=r"'coherence', 'exclusivity'"):
+        record_fit(model, corpus, diagnostics=True)
+    # A bare string is likewise not a valid list of names.
+    with pytest.raises(TypeError, match="diagnostics must be a list"):
+        record_fit(model, corpus, diagnostics="coherence")
+
+
 def test_builtin_diagnostics_is_stable():
     assert BUILTIN_DIAGNOSTICS == ("coherence", "exclusivity")
 

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -612,6 +612,30 @@ def test_diagnostics_true_rejected_with_helpful_message(fitted):
         record_fit(model, corpus, diagnostics="coherence")
 
 
+def test_count_arguments_reject_natural_mistakes(fitted):
+    corpus, model = fitted
+    # bool is an int subclass, so diagnostics_n=True / topic_words_n=True would
+    # otherwise pass silently as 1; a string crashes opaquely at the > / slice.
+    for bad in (True, "5", 1.5):
+        with pytest.raises(TypeError, match="diagnostics_n must be an int"):
+            record_fit(model, corpus, diagnostics=["coherence"], diagnostics_n=bad)
+        with pytest.raises(TypeError, match="topic_words_n must be an int"):
+            record_fit(model, corpus, topic_words_n=bad)
+    # Right type, out-of-range value -> ValueError naming the bound.
+    with pytest.raises(ValueError, match="diagnostics_n must be >= 1"):
+        record_fit(model, corpus, diagnostics=["coherence"], diagnostics_n=0)
+    with pytest.raises(ValueError, match="topic_words_n must be >= 0"):
+        record_fit(model, corpus, topic_words_n=-1)
+
+
+def test_prevalence_names_without_prevalence_rejected(fitted):
+    corpus, model = fitted
+    # Passing names but no design matrix silently dropped the names before;
+    # that lost provenance, so it must raise instead.
+    with pytest.raises(ValueError, match="prevalence_names given without prevalence"):
+        record_fit(model, corpus, prevalence_names=["a", "b"])
+
+
 def test_builtin_diagnostics_is_stable():
     assert BUILTIN_DIAGNOSTICS == ("coherence", "exclusivity")
 


### PR DESCRIPTION
## What

A small batch of paper-cut fixes surfaced by publication-workflow user reviews — one code fix and three documentation corrections.

Closes #646
Closes #643
Closes #645
Closes #650

- **#646 (fix)** — `record_fit` argument validation. `record_fit(m, corpus, diagnostics=True)` raised an opaque `'bool' object is not iterable`; it now raises a clear message naming the valid options. The sibling top-N arguments are hardened the same way, and `prevalence_names` without `prevalence` no longer silently drops the names.
- **#643 (docs)** — the `topica-analysis` guide described a drifted topic-reading API.
- **#645 (docs)** — `best_k()`'s default behavior was documented inconsistently across guides.
- **#650 (docs)** — no documented K-selection path for BERTopic, plus a degenerate flagship example.

> Note: the template asks for one fix per PR. These are bundled deliberately (per the author's request) to share a single CI cycle; they touch disjoint surfaces (`manifest.py` + docs) and each is a self-contained commit.

## How

**#646** — validate up front in `record_fit`, consistent with the existing `privacy=` / unknown-diagnostic checks:
- `diagnostics` must be a `list`/`tuple` of names (a bare string is rejected too), else a `TypeError` naming `{'coherence', 'exclusivity'}`.
- `diagnostics_n` / `topic_words_n` go through a `_require_count` helper: wrong type → `TypeError` (a bare `"5"` used to crash at the `> 0` gate; `True`/`False` used to pass silently as `1`), out-of-range int → `ValueError`. Uses `numbers.Integral` so **numpy integers still work**; `bool` is excluded explicitly.
- `prevalence_names` without `prevalence` → `ValueError` (previously the names were silently discarded, losing provenance).

**#643** — corrected the guide's "Read topics" section and quick reference: `top_words(n)` returns `(word, weight)` tuples (with `[w for w, _ in row]` for just the words); `label_topics`/`frex`/`relevance`/`find_thoughts`/`topic_table`/`summary` are module functions taking the model's `topic_word`/`doc_topic` matrix, not model methods; and there is no `label_topics(method=...)` selector — FREX/relevance are separate functions. The example/publishing docs already used the correct API. `AGENTS.md` regenerated from the skill (`scripts/gen_agents_md.py`).

**#645** — **no behavior change** (chosen over the behavior-change options, since the held-out default is deliberate and covered by existing tests, and the boundary-guard warning already fires). `docs/guides/diagnostics.md` incorrectly claimed the default is always the frontier; corrected to "held-out when present, else frontier, and it tends to land on the grid-max K." Added a caution to the analysis guide that `best_k()` is one input, not the research decision. `choosing-k.md` was already consistent.

**#650** — added an "Embedding + cluster models" section to `choosing-k.md` (`search_k` is LDA/STM-only; preprocessing changes only c-TF-IDF labels, not the clusters; K is a clusterer setting; a worked coherence/diversity sweep), branched the analysis skill for these models, and switched the `datasets.md` BERTopic example from the HDBSCAN default (which collapses `load_ng20_minilm` to ~2 topics) to `kmeans, num_clusters=5, reduce_frequent=True` (recovers the newsgroups). The depth already lives in `docs/guides/embedding.md`; this closes the discoverability gap.

## Validation

I could not build the Rust extension or run the toolchain in my working environment, so **CI is the first full run** of pytest / mkdocs / cargo. What I verified locally:

- **#646** validation logic exercised directly (bool rejection, numpy-int acceptance via `numbers.Integral`, range checks); `python -m py_compile` clean on the changed module and tests. New tests added in `tests/test_manifest.py`.
- **Doc examples** cross-checked against the `.pyi` stubs (BERTopic constructor params, `coherence`/`topic_diversity`, dataset accessors) and existing correct usages.
- **Doc links** resolve (`../guides/embedding.md` is a real page — relevant since CI runs `mkdocs build --strict`).
- **`AGENTS.md` in sync** (`scripts/gen_agents_md.py --check` clean) — `tests/test_agents_md_sync.py` enforces this and the SKILL.md edits would otherwise fail it.

- [ ] `cargo test --lib` passes *(no Rust changes; not run locally)*
- [ ] `python -m pytest tests/ -q` passes *(not runnable locally — no built extension; CI is first run)*
- [ ] `./scripts/preflight.sh` clean *(not runnable locally; AGENTS.md sync verified)*
- [ ] docs build clean (`mkdocs build --strict`) *(links checked by hand; CI is first run)*
- [x] no binding signatures changed, so the `.pyi` stub is unaffected

## Notes

#642 (the `align_topics`/`compare` correlated-topic mis-classification fix) was deliberately **not** included here — it's a substantial algorithmic change that belongs in its own PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CKmkmz4phatg4JH2Dij8SX

---
_Generated by [Claude Code](https://claude.ai/code/session_01CKmkmz4phatg4JH2Dij8SX)_