### PR TITLE
fix(usability): EmbeddingLDA record_fit/search_k + guide section (#661)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   it previously crashed with `'list' object has no attribute 'num_docs'`. The corpus
   argument is now coerced via `Corpus.from_documents`, and a value that is neither a
   `Corpus` nor tokenized documents raises a clear error naming the constructor.
+- **`EmbeddingLDA.fit` exposes a convergence signal** (#661). It now forwards
+  `convergence_tol` and `check_every` to the underlying SeededLDA, so `fit_history`
+  holds the `(iteration, log_likelihood)` trace and `converged` becomes a real
+  early-stopping verdict (`convergence_tol=1e-4` stops once the trace flattens).
+  Previously the delegated `converged` was always `False` with no way to enable it.
 - **`search_k`'s unsupported-model error explains the alternative** (#661). Passing
   `model="EmbeddingLDA"` (or any embedding model) raised a bare `model must be 'lda'
   or 'stm'`. The message now says why (`search_k` fits an LDA/STM per K and cannot
@@ -37,12 +42,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 ### Documentation
 
 - **`EmbeddingLDA` has a dedicated guide section** (#661). `docs/guides/embedding.md`
-  gained a full worked example that runs offline on `load_ng20_minilm`, covering the
-  word-seed and `doc_embeddings=` prior modes, `document_topic_prior`, the
-  `.embedding.npz` save sidecar, and two easy-to-miss conventions: `topic_word` is
-  indexed by `model.vocabulary` (same words, different order from the `vocabulary=`
-  you pass, which only aligns the embedding rows), and `coherence(n)` returns a
-  per-topic vector to average. The class docstring documents the vocabulary caveat.
+  gained a full worked example on `load_ng20_minilm` (no embedder needed), covering
+  the word-seed and `doc_embeddings=` prior modes, `document_topic_prior`, the
+  `.embedding.npz` save sidecar, the convergence signal (`fit_history` /
+  `convergence_tol` / `converged`), and two easy-to-miss conventions: `topic_word`
+  is indexed by `model.vocabulary` (generally a subset of the `vocabulary=` you
+  pass, in a different order, since that argument only aligns the embedding rows),
+  and `coherence(n)` returns a per-topic vector to average. `docs/publishing/choosing-k.md`
+  gains a "Fixed-K embedding models" section for the refit-per-K sweep. The class
+  docstring documents the vocabulary caveat.
 
 - **`topica.coherence` / `coherence_ci` / `semantic_coherence` no longer silently
   mis-score raw-string input** (#648). Passing a list of document *strings* (as the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,26 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Fixed
 
+- **`record_fit(model, docs)` accepts token lists** (#661). `fit` takes a sequence
+  of token lists, so passing the same value to `record_fit` is a natural first call;
+  it previously crashed with `'list' object has no attribute 'num_docs'`. The corpus
+  argument is now coerced via `Corpus.from_documents`, and a value that is neither a
+  `Corpus` nor tokenized documents raises a clear error naming the constructor.
+- **`search_k`'s unsupported-model error explains the alternative** (#661). Passing
+  `model="EmbeddingLDA"` (or any embedding model) raised a bare `model must be 'lda'
+  or 'stm'`. The message now says why (`search_k` fits an LDA/STM per K and cannot
+  infer the embeddings) and points at the by-hand K sweep in the choosing-K guide.
+
+### Documentation
+
+- **`EmbeddingLDA` has a dedicated guide section** (#661). `docs/guides/embedding.md`
+  gained a full worked example that runs offline on `load_ng20_minilm`, covering the
+  word-seed and `doc_embeddings=` prior modes, `document_topic_prior`, the
+  `.embedding.npz` save sidecar, and two easy-to-miss conventions: `topic_word` is
+  indexed by `model.vocabulary` (same words, different order from the `vocabulary=`
+  you pass, which only aligns the embedding rows), and `coherence(n)` returns a
+  per-topic vector to average. The class docstring documents the vocabulary caveat.
+
 - **`topica.coherence` / `coherence_ci` / `semantic_coherence` no longer silently
   mis-score raw-string input** (#648). Passing a list of document *strings* (as the
   docs' own examples do) was iterated character-by-character, so no top word ever

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -293,6 +293,78 @@ Sinkhorn (every gradient checked against finite differences) and steps with Adam
 `dt_alpha`/`tw_alpha` are the inverse entropic regularizations for the two
 transport problems (reference defaults 3.0 and 2.0); larger is sharper.
 
+## EmbeddingLDA
+
+`EmbeddingLDA` is a fixed-K, every-document LDA anchored by embeddings on **both
+sides**. The *word* embeddings define the topics: k-means clusters them into
+`num_topics` groups and seeds each topic with the `top_m` words nearest its
+centroid (a prior on the topic-word side, via [`SeededLDA`](models.md#guided-topics)).
+Optionally, *document* embeddings in the same space bias each document's topic
+mixture toward the topics it is closest to (a per-document prior on the
+document-topic side). Both are priors: the Gibbs sampler reconciles them with word
+co-occurrence and can override either. Unlike BERTopic/Top2Vec there is no noise
+bucket (every document is modeled), and unlike them K is set in advance.
+
+Everything here runs offline. The bundled `load_ng20_minilm` dataset carries a
+word-embedding matrix with its aligned vocabulary, so no embedder is needed:
+
+```python
+import topica
+import numpy as np
+
+ng = topica.datasets.load_ng20_minilm()   # documents + labels + MiniLM embeddings
+docs = [t.split() for t in ng["texts"]]
+
+# Word-seed mode: the vocabulary embeddings anchor the topics.
+model = topica.EmbeddingLDA(
+    num_topics=5,
+    embeddings=ng["word_embeddings"],      # (vocab, E), one row per word
+    vocabulary=ng["vocab"],                # aligned to the embedding rows
+    seed=0,
+)
+model.fit(docs, iters=1000)
+for topic in model.top_words(8):
+    print([word for word, _ in topic])
+```
+
+`vocabulary=` aligns the **embedding** rows; it is not the fitted output
+vocabulary. After `fit`, `topic_word` columns are indexed by `model.vocabulary`,
+the vocabulary the underlying SeededLDA rebuilds from the corpus, which holds the
+same words in a **different order**. Index `topic_word` with `model.vocabulary`,
+never with the `vocabulary=` you passed, or use the helpers that already pair them:
+`model.top_words(n)` and `topica.label_topics(model.topic_word, model.vocabulary)`.
+
+**Document-embedding prior.** Pass `doc_embeddings=` (one row per document, same
+space as the words) to `fit` to add the document-topic prior. `doc_anchor` sets its
+strength: `α_{d,k} = alpha + doc_anchor * max(cos(doc_d, centroid_k), 0)`. Inspect
+it before fitting with `document_topic_prior`:
+
+```python
+prior = model.document_topic_prior(ng["doc_embeddings"])   # (num_docs, num_topics)
+model.fit(docs, doc_embeddings=ng["doc_embeddings"], iters=1000)
+```
+
+The fitted surface (`topic_word`, `doc_topic`, `top_words`, `estimate_effect`, …)
+is delegated to the underlying SeededLDA, so the full [effects](../publishing/effects.md)
+and reporting stack applies. Two conventions to keep straight:
+
+- `coherence(n)` returns a **per-topic** vector (UMass here, so more-negative is
+  worse); average it for the single number `topic_table`/`search_k` report:
+  `float(model.coherence(10).mean())`.
+- `search_k` does not accept `EmbeddingLDA` (it fits LDA/STM per K and cannot infer
+  the embeddings). Sweep K by hand: fit each K and compare
+  `model.coherence(10).mean()`; see the "Embedding + cluster models" section of
+  [choosing K](../publishing/choosing-k.md).
+
+**Saving.** `save(path)` writes the SeededLDA core to `path` **and** a companion
+`<path>.embedding.npz` sidecar (centroids, seeds, hyperparameters). Both files are
+needed to reload; ship both when replicating, or `load` raises `FileNotFoundError`.
+
+```python
+model.save("elda.topica")                 # also writes elda.topica.embedding.npz
+reloaded = topica.EmbeddingLDA.load("elda.topica")
+```
+
 ## CombinedTM
 
 CombinedTM (Bianchi, Terragni & Hovy 2021) is [`ProdLDA`](models.md#prodlda) with
@@ -485,10 +557,10 @@ somewhere. Two ways out:
   labels = theta.argmax(1)          # == model.labels
   ```
 
-- **Use a fixed-K, every-document model.** `EmbeddingLDA`, `FASTopic`, and `ETM`
-  are embedding-driven but give every document a full topic distribution `θ` with
-  no noise bucket. In our testing `EmbeddingLDA` gave the best recovery when the
-  `-1` bucket was the problem.
+- **Use a fixed-K, every-document model.** [`EmbeddingLDA`](#embeddinglda),
+  `FASTopic`, and `ETM` are embedding-driven but give every document a full topic
+  distribution `θ` with no noise bucket. In our testing `EmbeddingLDA` gave the
+  best recovery when the `-1` bucket was the problem.
 
 `reduce_outliers()` (below) is the third option: keep HDBSCAN, then reassign the
 `-1` documents after the fact.

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -305,8 +305,9 @@ document-topic side). Both are priors: the Gibbs sampler reconciles them with wo
 co-occurrence and can override either. Unlike BERTopic/Top2Vec there is no noise
 bucket (every document is modeled), and unlike them K is set in advance.
 
-Everything here runs offline. The bundled `load_ng20_minilm` dataset carries a
-word-embedding matrix with its aligned vocabulary, so no embedder is needed:
+No embedder needed here. The `load_ng20_minilm` dataset (downloaded and cached on
+first use, no `sentence-transformers`/`torch` install) carries a word-embedding
+matrix with its aligned vocabulary, so nothing calls an embedding model:
 
 ```python
 import topica
@@ -329,8 +330,11 @@ for topic in model.top_words(8):
 
 `vocabulary=` aligns the **embedding** rows; it is not the fitted output
 vocabulary. After `fit`, `topic_word` columns are indexed by `model.vocabulary`,
-the vocabulary the underlying SeededLDA rebuilds from the corpus, which holds the
-same words in a **different order**. Index `topic_word` with `model.vocabulary`,
+the vocabulary the underlying SeededLDA rebuilds from the corpus. That is generally
+a **subset in a different order**: only corpus words that survived tokenisation and
+pruning (on the fully-covered `load_ng20_minilm` demo it is the same 3521 words,
+just reordered, but a real corpus with externally-sourced embeddings will drop
+words). Index `topic_word` with `model.vocabulary`,
 never with the `vocabulary=` you passed, or use the helpers that already pair them:
 `model.top_words(n)` and `topica.label_topics(model.topic_word, model.vocabulary)`.
 
@@ -349,12 +353,26 @@ is delegated to the underlying SeededLDA, so the full [effects](../publishing/ef
 and reporting stack applies. Two conventions to keep straight:
 
 - `coherence(n)` returns a **per-topic** vector (UMass here, so more-negative is
-  worse); average it for the single number `topic_table`/`search_k` report:
-  `float(model.coherence(10).mean())`.
+  worse); average it for a single model-level score comparable to `search_k`'s
+  coherence column: `float(model.coherence(10).mean())`. (`topic_table` reports
+  prevalence/prob/frex per topic, not coherence.)
 - `search_k` does not accept `EmbeddingLDA` (it fits LDA/STM per K and cannot infer
   the embeddings). Sweep K by hand: fit each K and compare
-  `model.coherence(10).mean()`; see the "Embedding + cluster models" section of
+  `model.coherence(10).mean()`; see the "Fixed-K embedding models" section of
   [choosing K](../publishing/choosing-k.md).
+
+**Convergence.** The fit is a collapsed Gibbs sampler, so `converged` reports
+whether *early stopping* fired, not whether the chain mixed. It stays `False` under
+the default `convergence_tol=0.0` (the fit runs the full `iters`). Every
+`check_every` sweeps the log-likelihood is recorded, so `model.fit_history` holds
+the `(iteration, log_likelihood)` trace to check for a plateau; pass a tolerance to
+stop early once it flattens:
+
+```python
+model.fit(docs, iters=1000, convergence_tol=1e-4, check_every=25)
+model.converged          # True if the trace flattened before iters
+model.fit_history[-1]    # (last iteration run, log_likelihood)
+```
 
 **Saving.** `save(path)` writes the SeededLDA core to `path` **and** a companion
 `<path>.embedding.npz` sidecar (centroids, seeds, hyperparameters). Both files are

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -283,6 +283,33 @@ HDBSCAN default collapses to a degenerate handful (most documents in one topic).
 [embedding-models guide](../guides/embedding.md) covers the clusterer choices and
 the noise-bucket problem in depth.
 
+## Fixed-K embedding models (EmbeddingLDA, ETM, FASTopic)
+
+`EmbeddingLDA`, `ETM`, and `FASTopic` are embedding-driven but are **not**
+clusterers: K is a model setting you fix in advance and every document gets a full
+topic distribution, so unlike BERTopic/Top2Vec you sweep K the ordinary way, by
+**refitting per K**. `search_k` still raises for them (it only fits LDA/STM, and
+`EmbeddingLDA` needs embeddings/vocabulary it cannot infer), so run the same
+coherence-vs-diversity sweep by hand:
+
+```python
+import numpy as np, topica
+
+b = topica.datasets.load_ng20_minilm()
+docs = [t.split() for t in b.texts]
+
+for k in [4, 5, 6, 8, 10]:
+    m = topica.EmbeddingLDA(num_topics=k, embeddings=b.word_embeddings,
+                            vocabulary=b.vocab, seed=1).fit(docs, iters=1000)
+    coh = float(m.coherence(10).mean())     # per-topic UMass vector -> mean
+    div = topica.topic_diversity(m, topn=25)
+    print(f"K={k:>2}  coherence={coh:.1f}  diversity={div:.2f}")
+```
+
+Pick the knee, not the maximum. Note the sign convention differs from the c_v sweep
+above: `EmbeddingLDA.coherence` is per-topic UMass (more-negative is worse), so
+average it and compare on that scale.
+
 ## Report sensitivity
 
 Pick the `K` that balances metrics, interpretability, and theory, then **show

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -268,6 +268,16 @@ class EmbeddingLDA:
     (``topic_word``, ``doc_topic``, ``top_words``, ``coherence``, ...) is
     delegated to the underlying SeededLDA.
 
+    .. note::
+       The ``vocabulary=`` you pass here aligns the **embedding** rows; it is not
+       the fitted output vocabulary. After :meth:`fit`, ``topic_word`` columns are
+       indexed by ``model.vocabulary``, the vocabulary the underlying SeededLDA
+       rebuilds from the corpus you fit on, which is typically a *subset in a
+       different order* (only words that survived tokenisation/pruning). Do not
+       index ``topic_word`` (or build coherence) with the ``vocabulary=`` you
+       passed; use ``model.vocabulary``, or the helpers that already pair them:
+       ``top_words()`` and ``label_topics(model.topic_word, model.vocabulary)``.
+
     No embedder of your own? :func:`~topica.llm_embed` builds the ``embeddings``
     matrix (OpenAI, or offline ``sentence-transformers``).
 

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -375,14 +375,38 @@ class EmbeddingLDA:
         sim = (de / norms) @ self._centroids.T
         return self.alpha + self.doc_anchor * np.maximum(sim, 0.0)
 
-    def fit(self, data, *, doc_embeddings=None, iters: int = 1000) -> "EmbeddingLDA":
+    def fit(
+        self,
+        data,
+        *,
+        doc_embeddings=None,
+        iters: int = 1000,
+        convergence_tol: float = 0.0,
+        check_every: int = 10,
+    ) -> "EmbeddingLDA":
         """Fit on ``data`` (a Corpus or list of token lists). If ``doc_embeddings``
         is given (one row per document, same embedding space as the vocabulary),
         each document's topic mixture is biased toward the topics its embedding is
         nearest, as a prior the sampler can still override. ``iters`` is the number
-        of Gibbs sweeps for the underlying SeededLDA fit."""
+        of Gibbs sweeps for the underlying SeededLDA fit.
+
+        Convergence signal. Every ``check_every`` sweeps the collapsed
+        log-likelihood is recorded, so after fitting :attr:`fit_history` holds the
+        ``(iteration, log_likelihood)`` trace to eyeball (or plot) for a plateau.
+        ``convergence_tol`` (default ``0.0``, off) enables early stopping: once the
+        relative change in that log-likelihood falls below it the sweep loop stops
+        and :attr:`converged` is ``True``. With the default ``0.0`` the fit always
+        runs the full ``iters`` and :attr:`converged` stays ``False`` (it means
+        "early-stopping never triggered", not "did not mix"); set e.g.
+        ``convergence_tol=1e-4`` to get a genuine verdict and a shorter fit."""
         prior = self.document_topic_prior(doc_embeddings) if doc_embeddings is not None else None
-        self._model.fit(data, iters=iters, doc_topic_prior=prior)
+        self._model.fit(
+            data,
+            iters=iters,
+            doc_topic_prior=prior,
+            convergence_tol=convergence_tol,
+            check_every=check_every,
+        )
         return self
 
     @property

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -781,6 +781,8 @@ def record_fit(model, corpus, *, prevalence=None, prevalence_names=None,
 
     import topica
 
+    corpus = _as_corpus(corpus)
+
     cls = type(model).__name__
     settings, settings_coverage = _capture_settings(model)
 
@@ -947,6 +949,31 @@ def _retained_prevalence(model) -> list[float] | None:
         return [float(x) for x in np.asarray(_as_doc_topic(model)).mean(axis=0)]
     except (AttributeError, TypeError, ValueError):
         return None
+
+
+def _as_corpus(corpus):
+    """Coerce ``record_fit``'s ``corpus`` argument to a :class:`Corpus`.
+
+    ``fit`` accepts pre-tokenised documents (a sequence of token lists), so a
+    natural first call is ``record_fit(model, docs)`` with the same value. A
+    ``Corpus`` is passed through untouched; anything without ``num_docs`` is
+    built via :meth:`Corpus.from_documents`, and if that fails we raise a clear
+    error naming the constructor rather than the opaque
+    ``'list' object has no attribute 'num_docs'`` from downstream.
+    """
+    import topica
+
+    if hasattr(corpus, "num_docs"):
+        return corpus
+    try:
+        return topica.Corpus.from_documents(corpus)
+    except Exception as exc:
+        raise TypeError(
+            "record_fit's corpus must be a topica.Corpus or a sequence of "
+            "token lists (the same documents you passed to fit); building a "
+            f"Corpus from the given value failed ({exc}). Construct one "
+            "explicitly with topica.Corpus.from_documents(docs)."
+        ) from exc
 
 
 def _corpus_block(corpus, privacy, content_fingerprint, key) -> dict[str, Any]:

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -965,9 +965,22 @@ def _as_corpus(corpus):
 
     if hasattr(corpus, "num_docs"):
         return corpus
+    # Most likely mistake: raw document strings instead of token lists. Caught
+    # here because from_documents' Rust error ("Can't extract 'str' to 'Vec'") is
+    # opaque, and iterating a str would otherwise tokenise character-by-character.
+    if isinstance(corpus, (list, tuple)) and corpus and isinstance(corpus[0], str):
+        raise TypeError(
+            "record_fit's corpus looks like raw document strings; it needs "
+            "tokenised documents (a list of token lists) or a topica.Corpus. "
+            "Tokenise first, e.g. [topica.tokenize(t) for t in texts], or build "
+            "the corpus with topica.Corpus.from_documents(...).")
     try:
         return topica.Corpus.from_documents(corpus)
-    except Exception as exc:
+    except TypeError as exc:
+        # Wrong element type (e.g. a scalar, or non-token items). A ValueError from
+        # from_documents (empty corpus, all-stopword docs) is a clear semantic error
+        # about the corpus itself, so let it propagate unchanged rather than
+        # relabelling it a type problem.
         raise TypeError(
             "record_fit's corpus must be a topica.Corpus or a sequence of "
             "token lists (the same documents you passed to fit); building a "

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1411,8 +1411,9 @@ def search_k(
             f"models (EmbeddingLDA) need embeddings/vocabulary search_k cannot "
             f"infer, and embedding+cluster models (BERTopic, Top2Vec) set K by the "
             f"clusterer, not by refitting. Sweep K for those by hand: fit each K "
-            f"and compare topica.coherence(...).mean(); see the 'Embedding + cluster "
-            f"models' section of docs/publishing/choosing-k.md.")
+            f"and compare the mean coherence; see the 'Fixed-K embedding models' "
+            f"(EmbeddingLDA) and 'Embedding + cluster models' (BERTopic/Top2Vec) "
+            f"sections of docs/publishing/choosing-k.md.")
     if int(num_seeds) < 1:
         raise ValueError(f"num_seeds must be >= 1, got {num_seeds!r}")
     if content is not None and model != "stm":

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1405,7 +1405,14 @@ def search_k(
     from . import LDA, STM  # local import to avoid a cycle at module load
 
     if model not in ("lda", "stm"):
-        raise ValueError("model must be 'lda' or 'stm'")
+        raise ValueError(
+            f"search_k fits an LDA or STM per K; model must be 'lda' or 'stm' "
+            f"(got {model!r}). Other models are not scanned here: embedding-guided "
+            f"models (EmbeddingLDA) need embeddings/vocabulary search_k cannot "
+            f"infer, and embedding+cluster models (BERTopic, Top2Vec) set K by the "
+            f"clusterer, not by refitting. Sweep K for those by hand: fit each K "
+            f"and compare topica.coherence(...).mean(); see the 'Embedding + cluster "
+            f"models' section of docs/publishing/choosing-k.md.")
     if int(num_seeds) < 1:
         raise ValueError(f"num_seeds must be >= 1, got {num_seeds!r}")
     if content is not None and model != "stm":

--- a/tests/test_embedding_lda.py
+++ b/tests/test_embedding_lda.py
@@ -156,6 +156,25 @@ def test_v1_mode_unchanged_without_doc_embeddings():
     assert np.array_equal(a.topic_word, b.topic_word)
 
 
+def test_convergence_signal_passthrough():
+    # #661: EmbeddingLDA.fit forwards convergence_tol/check_every to SeededLDA, so
+    # fit_history is populated and `converged` becomes a real early-stop verdict.
+    vocab, emb, blocks = _blocks()
+    docs = _corpus(blocks, n_docs=400)
+
+    # Default: full run, no early stop, but the trace is still recorded.
+    m = topica.EmbeddingLDA(num_topics=3, embeddings=emb, vocabulary=vocab, seed=3)
+    m.fit(docs, iters=200, check_every=25)
+    assert m.converged is False
+    assert m.fit_history and m.fit_history[-1][0] == 200
+
+    # A tolerance turns on early stopping: it must converge before iters here.
+    m2 = topica.EmbeddingLDA(num_topics=3, embeddings=emb, vocabulary=vocab, seed=3)
+    m2.fit(docs, iters=2000, convergence_tol=1e-4, check_every=25)
+    assert m2.converged is True
+    assert m2.fit_history[-1][0] < 2000
+
+
 def test_doc_embeddings_dim_validation():
     vocab, emb, blocks = _blocks()
     m = topica.EmbeddingLDA(num_topics=3, embeddings=emb, vocabulary=vocab, seed=1)

--- a/tests/test_heldout.py
+++ b/tests/test_heldout.py
@@ -308,6 +308,14 @@ class TestSearchKHeldout:
                                    held_out=held, iters=10, seed=0)
             assert rows[0]["coherence_metric"] == expected
 
+    def test_unsupported_model_error_names_the_manual_path(self):
+        # #661: search_k only fits LDA/STM. EmbeddingLDA and the embedding+cluster
+        # models are rejected, but the message must say why and point at the
+        # by-hand K sweep, not just "model must be 'lda' or 'stm'".
+        with pytest.raises(ValueError, match="EmbeddingLDA") as exc:
+            topica.search_k([["a", "b"]], [2], model="EmbeddingLDA")
+        assert "choosing-k" in str(exc.value)
+
 
 # ---------------------------------------------------------------------------
 # Issue #55: search_k(held_out=Heldout) used to raise TypeError

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -641,16 +641,24 @@ def test_record_fit_accepts_token_lists(fitted):
     # It must coerce them to a Corpus, not crash with 'list has no num_docs'.
     _, model = fitted
     rec = record_fit(model, DOCS, iters=50)
+    # Assert the concretely-correct counts (not a tautological equality with a
+    # Corpus built the same way): DOCS has no pruning, so tokens are all retained.
     assert rec.corpus["num_docs"] == len(DOCS)
-    # Same documents as an explicit Corpus give the same corpus block.
-    corpus = topica.Corpus.from_documents(DOCS)
-    assert record_fit(model, corpus).corpus == rec.corpus
+    assert rec.corpus["total_tokens"] == sum(len(d) for d in DOCS)
 
 
 def test_record_fit_rejects_non_corpus_with_clear_message(fitted):
     _, model = fitted
     with pytest.raises(TypeError, match="Corpus.from_documents"):
         record_fit(model, 5)
+
+
+def test_record_fit_flags_raw_strings_not_token_lists(fitted):
+    # The likely mistake is passing raw document strings; give a targeted hint
+    # instead of the opaque "Can't extract 'str' to 'Vec'" from downstream.
+    _, model = fitted
+    with pytest.raises(TypeError, match="raw document strings"):
+        record_fit(model, ["a whole document as one string", "another one"])
 
 
 def test_builtin_diagnostics_is_stable():

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -636,6 +636,23 @@ def test_prevalence_names_without_prevalence_rejected(fitted):
         record_fit(model, corpus, prevalence_names=["a", "b"])
 
 
+def test_record_fit_accepts_token_lists(fitted):
+    # #661: fit() takes token lists, so record_fit(model, docs) is a natural call.
+    # It must coerce them to a Corpus, not crash with 'list has no num_docs'.
+    _, model = fitted
+    rec = record_fit(model, DOCS, iters=50)
+    assert rec.corpus["num_docs"] == len(DOCS)
+    # Same documents as an explicit Corpus give the same corpus block.
+    corpus = topica.Corpus.from_documents(DOCS)
+    assert record_fit(model, corpus).corpus == rec.corpus
+
+
+def test_record_fit_rejects_non_corpus_with_clear_message(fitted):
+    _, model = fitted
+    with pytest.raises(TypeError, match="Corpus.from_documents"):
+        record_fit(model, 5)
+
+
 def test_builtin_diagnostics_is_stable():
     assert BUILTIN_DIAGNOSTICS == ("coherence", "exclusivity")
 


### PR DESCRIPTION
Addresses the API and docs friction from the #661 sample-user usability audit (the user gate of the #660 experimental triple check). Scope: everything **except** the model-level convergence signal (no `bound`/`ll_history`), which stays open on #661. Tier 1 (scrambled `labels`) was already fixed in #660.

## Code

- **Tier 2 — `record_fit(model, docs)` crashed on token lists.** `fit` accepts a sequence of token lists, so passing the same value to `record_fit` is a natural first call; it raised `'list' object has no attribute 'num_docs'`, and `Corpus(docs)` also raised (only the undiscoverable `Corpus.from_documents` worked). `record_fit` now coerces via `Corpus.from_documents`, and a value that is neither a `Corpus` nor tokenized documents raises a clear error naming the constructor.
- **Tier 4 — `search_k(model="EmbeddingLDA")` gave a bare error.** The message now explains that `search_k` fits an LDA/STM per K and cannot infer embeddings (and that embedding+cluster models set K by the clusterer), and points at the by-hand K sweep in the choosing-K guide. Wiring EmbeddingLDA into `search_k` proper is left as a separate feature.

## Docs

- **Tier 4 — `EmbeddingLDA` was one bullet in `embedding.md`.** Added a dedicated section: an offline worked example on `load_ng20_minilm` (no uninstallable embedder), the `doc_embeddings=` prior mode and `document_topic_prior`, the `.embedding.npz` save sidecar, and the two conventions the audit stumbled on.
- **Tier 3 — vocab ordering & coherence convention.** The section and the class docstring now document that `topic_word` is indexed by `model.vocabulary` (same words, different order from the `vocabulary=` you pass, which only aligns embedding rows), and that `coherence(n)` returns a per-topic vector to average.

## Tests / gates

- New regression tests: token-list coercion, non-corpus clear error, improved `search_k` message.
- `pytest` (manifest / heldout / embedding-lda suites, 130+ pass), `mkdocs build --strict` clean, `scripts/preflight.sh` green.

Related: #660, #661.

🤖 Generated with [Claude Code](https://claude.com/claude-code)