### PR TITLE
fix(ctm): clarify word-vs-document embeddings for CombinedTM/ZeroShotTM (#663)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,14 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Fixed
 
+- **`CombinedTM` / `ZeroShotTM` flag the word-vs-document embedding mistake** (#663).
+  These models take *document* (sentence) embeddings, one row per document, unlike
+  `ETM`/`EmbeddingLDA` which take *word* embeddings. Passing word embeddings by
+  mistake was previously caught only as a bare row-count mismatch. When the row
+  count equals the vocabulary size (and not the document count), the error now names
+  the likely cause. The class docstrings and the embedding guide state the
+  document-embedding requirement explicitly, and the guide's CombinedTM/ZeroShotTM
+  examples now run offline on `load_ng20_minilm`.
 - **`record_fit(model, docs)` accepts token lists** (#661). `fit` takes a sequence
   of token lists, so passing the same value to `record_fit` is a natural first call;
   it previously crashed with `'list' object has no attribute 'num_docs'`. The corpus

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -419,19 +419,43 @@ unchanged from ProdLDA. Mixing the contextual signal into the encoder yields mor
 coherent topics than the bag of words alone. You bring the per-document
 embeddings at `fit`, one row per document, in corpus order.
 
+!!! note "Document embeddings, not word embeddings"
+    CombinedTM and ZeroShotTM (like BERTopic and FASTopic) take **document
+    (sentence) embeddings**, one row per *document*. This is the opposite of
+    [`EmbeddingLDA`](#embeddinglda), `ETM`, and `Top2Vec`, which take **word
+    embeddings** (one row per *vocabulary word*). The bundled `load_ng20_minilm`
+    carries both (`doc_embeddings` and `word_embeddings`); pass `doc_embeddings`
+    here. Passing word embeddings is caught only when the vocabulary and document
+    counts differ, so mind the argument.
+
+**When to reach for it.** CombinedTM is the pick when you want a **mixed-membership**
+topic model (a full θ per document) that also leans hard on a document embedding:
+it pairs BERTopic's semantic signal with LDA's soft assignments. Prefer it over
+[`EmbeddingLDA`](#embeddinglda) when the embedding should *drive* inference rather
+than lightly seed it, and over `BERTopic` when you need per-document mixtures
+instead of one hard cluster per document. `doc_topic` rows are proper distributions
+(they sum to 1), unlike BERTopic's hard labels.
+
+Everything below runs offline on the bundled dataset (no encoder needed):
+
 ```python
 import topica
 
-doc_emb = embed(docs)                    # (num_docs, E), your encoder of choice
+ng = topica.datasets.load_ng20_minilm()
+docs = [t.split() for t in ng["texts"]]
 
 model = topica.CombinedTM(num_topics=20, seed=1)
-model.fit(docs, doc_emb, iters=150)
+model.fit(docs, ng["doc_embeddings"], iters=150)   # document embeddings, one row/doc
 
 model.topic_word                         # (num_topics, vocab) softmax(beta_k)
-model.doc_topic                          # (num_docs, num_topics) theta
+model.doc_topic                          # (num_docs, num_topics) theta, rows sum to 1
 model.top_words(8, topic=0)
 model.bound, model.converged             # the ELBO at the final epoch
 ```
+
+CombinedTM's encoder first layer is `Linear(2V, hidden)`, so it is markedly slower
+than ZeroShotTM (whose encoder reads only the embedding); budget accordingly at the
+default `iters=200`.
 
 `transform` maps new documents the same way, so it needs both the tokens and
 their embeddings:
@@ -456,15 +480,25 @@ ZeroShotTM (Bianchi, Nozza & Hovy 2021) takes the same idea one step further: th
 encoder reads *only* the contextual document embedding, with no bag of words at
 all. The decoder still reconstructs the bag of words, so topics remain proper
 word distributions, but topic proportions are inferred from the embedding alone.
-The constructor and surface match CombinedTM.
+The constructor and surface match CombinedTM (and it likewise takes **document**
+embeddings, not word embeddings). Because the encoder reads only the embedding, it
+is faster than CombinedTM.
+
+**When to reach for it.** ZeroShotTM's niche is **cross-lingual / zero-shot** work
+(below) and cases where you want the topics inferred purely from a strong document
+embedder. When lexical co-occurrence carries real signal, CombinedTM (which also
+reads the bag of words) is usually the safer choice.
 
 ```python
 import topica
 
+ng = topica.datasets.load_ng20_minilm()
+docs = [t.split() for t in ng["texts"]]
+
 model = topica.ZeroShotTM(num_topics=20, seed=1)
-model.fit(docs, embed(docs), iters=150)
+model.fit(docs, ng["doc_embeddings"], iters=150)   # document embeddings only
 model.topic_word
-model.doc_topic
+model.doc_topic                                    # theta, rows sum to 1
 ```
 
 Dropping the bag of words from the encoder is what enables **cross-lingual

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -4443,7 +4443,9 @@ class CombinedTM:
     adapt_bert linear projection into vocabulary space before being concatenated
     with the raw bag-of-words counts (first layer Linear(2V, hidden)). The
     product-of-experts decoder still reconstructs the bag of words. Bring the
-    embeddings at fit() as a (num_docs, E) array, aligned to the documents.
+    embeddings at fit() as a (num_docs, E) array, aligned to the documents: these
+    are document (sentence) embeddings, one row per document, NOT the word
+    embeddings that ETM/EmbeddingLDA take.
     Reference implementation: contextualized-topic-models (Bianchi et al., MIT)."""
     @property
     def settings(self) -> dict:
@@ -4550,7 +4552,9 @@ class ZeroShotTM:
     a multilingual encoder maps to the trained topics without any bag of words,
     enabling cross-lingual transfer: fit on one language, transform documents in
     another. Bring the embeddings at fit() as a (num_docs, E) array, aligned to the
-    documents. Reference implementation: contextualized-topic-models (Bianchi et
+    documents: these are document (sentence) embeddings, one row per document, NOT
+    the word embeddings that ETM/EmbeddingLDA take.
+    Reference implementation: contextualized-topic-models (Bianchi et
     al., MIT)."""
     @property
     def settings(self) -> dict:

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -1974,7 +1974,7 @@ pub fn fit_prodlda<R: Rng>(
 /// `emb_dim`; pass empty rows and `emb_dim == 0` for the bow-only path). The
 /// decoder, prior, KL, reparameterization, batchnorm, Adam, and BoW reconstruction
 /// loss are identical across modes; only the layer-1 input differs. CombinedTM is
-/// [`InputMode::BowEmb`], ZeroShotTM is [`InputMode::EmbOnly`].
+/// [`InputMode::BowEmbAdapt`], ZeroShotTM is [`InputMode::EmbOnly`].
 #[allow(clippy::too_many_arguments)]
 pub fn fit_avitm<R: Rng>(
     docs: &[Vec<u32>],

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -2624,14 +2624,31 @@ fn u8_to_mode(m: u8) -> prodlda::InputMode {
 }
 
 /// Parse `doc_embeddings` into dense rows and check the row count matches the
-/// document count.
-fn parse_doc_embeddings(data: &Bound<'_, PyAny>, num_docs: usize) -> PyResult<Vec<Vec<f64>>> {
+/// document count. `vocab_size` is used only to detect the common mistake of
+/// passing WORD embeddings (one row per vocabulary word) to these
+/// document-embedding models, and add a targeted hint to the error.
+fn parse_doc_embeddings(
+    data: &Bound<'_, PyAny>,
+    num_docs: usize,
+    vocab_size: usize,
+) -> PyResult<Vec<Vec<f64>>> {
     let embs = parse_features(data)?;
     if embs.len() != num_docs {
+        // A matrix with one row per vocabulary word is almost certainly word
+        // embeddings passed by mistake: CombinedTM/ZeroShotTM take document
+        // (sentence) embeddings, one row per document, unlike ETM/EmbeddingLDA.
+        let hint = if embs.len() == vocab_size {
+            " (this equals the vocabulary size -- did you pass WORD embeddings? \
+             CombinedTM and ZeroShotTM take document/sentence embeddings, one row \
+             per document, not the word embeddings ETM/EmbeddingLDA use)"
+        } else {
+            ""
+        };
         return Err(PyValueError::new_err(format!(
-            "doc_embeddings has {} rows but corpus has {} documents",
+            "doc_embeddings has {} rows but corpus has {} documents{}",
             embs.len(),
-            num_docs
+            num_docs,
+            hint
         )));
     }
     check_all_finite_2d("doc_embeddings", &embs)?;
@@ -2702,10 +2719,12 @@ macro_rules! ctm_embedding_model {
             /// Create an unfitted model. `alpha` is the symmetric Dirichlet prior
             /// concentration (reference 1.0); `hidden_size` is the encoder width
             /// (reference 100); `dropout` is the dropout rate on the hidden layer
-            /// and on `theta`; `batch_size`/`lr` drive Adam (reference 200/0.002,
-            /// with `beta1 = 0.99`); `convergence_tol > 0` stops early on the
-            /// relative change in the epoch ELBO (0 runs all epochs). Pass `iters`
-            /// to :meth:`fit` to set the number of epochs.
+            /// and on `theta`; `batch_size`/`lr` drive Adam (`lr` reference 0.002,
+            /// `beta1 = 0.99`; the `batch_size` default 200 is the ProdLDA/AVITM
+            /// figure, larger than the CTM package's 64); `convergence_tol > 0`
+            /// stops early on the relative change in the epoch ELBO (0 runs all
+            /// epochs). Pass `iters` to :meth:`fit` to set the number of epochs
+            /// (default 200; the CTM package uses 100).
             ///
             /// `num_topics` is the number of topics K; `seed` seeds the RNG. `contrastive`
             /// adds an InfoNCE contrastive term on the topic vectors, scaled by
@@ -2814,7 +2833,8 @@ macro_rules! ctm_embedding_model {
                         "vocabulary must have at least num_topics words",
                     ));
                 }
-                let embs = parse_doc_embeddings(doc_embeddings, corpus.num_docs())?;
+                let embs =
+                    parse_doc_embeddings(doc_embeddings, corpus.num_docs(), num_types)?;
                 let emb_dim = embs.first().map(|r| r.len()).unwrap_or(0);
                 if emb_dim == 0 {
                     return Err(PyValueError::new_err(
@@ -2987,8 +3007,10 @@ macro_rules! ctm_embedding_model {
                 doc_embeddings: &Bound<'py, PyAny>,
             ) -> PyResult<Bound<'py, PyArray2<f64>>> {
                 let m = self.fitted_model()?;
-                let docs = docs_to_ids(data, &self.corpus.as_ref().unwrap().id_to_word)?;
-                let embs = parse_doc_embeddings(doc_embeddings, docs.len())?;
+                let corpus = self.corpus.as_ref().unwrap();
+                let docs = docs_to_ids(data, &corpus.id_to_word)?;
+                let embs =
+                    parse_doc_embeddings(doc_embeddings, docs.len(), corpus.id_to_word.len())?;
                 Ok(vecs_to_arr2(&m.transform_with_emb(&docs, &embs)).to_pyarray_bound(py))
             }
 
@@ -3170,8 +3192,10 @@ through a learned `adapt_bert` linear projection into vocabulary space before it
 is concatenated with the raw bag-of-words counts, so the encoder's first layer is \
 `Linear(2V, hidden)`. Mixing contextual embeddings into the encoder yields more \
 coherent topics than bag-of-words ProdLDA. Bring the embeddings at :meth:`fit` as \
-a `(num_docs, E)` array, aligned to the documents. The reference implementation is \
-`contextualized-topic-models` (Bianchi et al., MIT)."
+a `(num_docs, E)` array, aligned to the documents. These are *document* (sentence) \
+embeddings, one row per document, NOT the word embeddings that ETM/EmbeddingLDA \
+take. The reference implementation is `contextualized-topic-models` (Bianchi et \
+al., MIT)."
 );
 
 ctm_embedding_model!(
@@ -3186,6 +3210,8 @@ the bag of words. Because topics are inferred from the embedding alone, a \
 document embedded with a multilingual encoder maps to the trained topics without \
 any bag of words at all, which enables cross-lingual transfer: fit on one \
 language, :meth:`transform` documents in another. Bring the embeddings at \
-:meth:`fit` as a `(num_docs, E)` array, aligned to the documents. The reference \
-implementation is `contextualized-topic-models` (Bianchi et al., MIT)."
+:meth:`fit` as a `(num_docs, E)` array, aligned to the documents. These are \
+*document* (sentence) embeddings, one row per document, NOT the word embeddings \
+that ETM/EmbeddingLDA take. The reference implementation is \
+`contextualized-topic-models` (Bianchi et al., MIT)."
 );

--- a/tests/test_combinedtm.py
+++ b/tests/test_combinedtm.py
@@ -138,6 +138,20 @@ def test_rejects_wrong_embedding_rows(cls):
 
 
 @pytest.mark.parametrize("cls", MODELS, ids=MODEL_IDS)
+def test_word_embedding_mistake_gives_targeted_hint(cls):
+    # #663 review: passing WORD embeddings (one row per vocab word) to these
+    # document-embedding models is the classic mistake. When the row count equals
+    # the vocabulary size (and not the document count), the error must name the
+    # likely cause instead of just reporting a row mismatch.
+    docs, embs, vocab = _planted(n=60)
+    assert len(vocab) != len(docs)  # so the vocab-sized matrix hits the mismatch path
+    wrong = np.zeros((len(vocab), embs.shape[1]))  # one row per vocabulary word
+    m = _model(cls, seed=1)
+    with pytest.raises(ValueError, match="WORD embeddings"):
+        m.fit(docs, wrong, iters=10)
+
+
+@pytest.mark.parametrize("cls", MODELS, ids=MODEL_IDS)
 def test_rejects_k_below_two(cls):
     with pytest.raises(ValueError):
         cls(1)


### PR DESCRIPTION
Implements the fixes from the CombinedTM/ZeroShotTM review (a CTM-author faithfulness pass + a first-time-user usability pass). The author review found the models **faithful** to the reference ([contextualized-topic-models](https://github.com/MilaNLProc/contextualized-topic-models), Bianchi et al.); every gap was about the **word-vs-document embedding** distinction and doc runnability.

## Changes
- **Targeted error guard.** `CombinedTM`/`ZeroShotTM` take *document* embeddings (one row per document). Passing *word* embeddings by mistake was caught only as a bare row-count mismatch. When the row count equals the vocabulary size (and not the document count), the error now names the likely cause:
  > `doc_embeddings has 3521 rows but corpus has 2594 documents (this equals the vocabulary size -- did you pass WORD embeddings? CombinedTM and ZeroShotTM take document/sentence embeddings, one row per document, not the word embeddings ETM/EmbeddingLDA use)`

  Applies to both `fit` and `transform`.
- **Docstrings (Rust + `.pyi`) and the guide** now state explicitly these take document (sentence) embeddings, NOT word embeddings.
- **Guide runnability + guidance:** the CombinedTM/ZeroShotTM examples run offline on `load_ng20_minilm` (were undefined `embed(docs)` placeholders); added a "which embedding does each model want" callout, a "when to reach for it" note (incl. CombinedTM vs EmbeddingLDA, both mixed-membership + embedding), the mixed-membership θ note, and CombinedTM's cost vs ZeroShotTM.
- **Doc accuracy:** corrected the constructor docstring's `batch_size` claim (CTM reference default is 64, not 200 — 200 is the ProdLDA/AVITM figure topica keeps), and a stale internal comment (`CombinedTM is BowEmbAdapt`, not `BowEmb`).

No behavior change beyond the improved error message; defaults and fitted output are unchanged (no gold regen needed). Regression test added for the word-embedding hint.

## Gates
`pytest` (CTM suites), `mkdocs build --strict`, `scripts/preflight.sh` (fmt/clippy/stub/table sync) all green.

Related: #663. The faithfulness review confirmed the CTM implementation matches the reference architecture (encoder inputs, ProdLDA decoder, bit-exact KL, zero-shot transform).

🤖 Generated with [Claude Code](https://claude.com/claude-code)