### PR TITLE
feat: embedding_regression — validated conText replacement (Rodriguez, Spirling & Stewart 2023)

### DIFF
--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -308,11 +308,13 @@ The method regresses à la carte embeddings on your covariates. An à la carte
 embedding of a focal term is the (transformed) count-weighted mean of its context
 words' pretrained vectors, so it captures how *that* mention is used. For a focal
 term the unit of analysis is one row per mention (`aggregate="instance"`, conText's
-default); with `target=None` it embeds whole documents. The effect size for a
-covariate is the squared Euclidean norm of its coefficient, deflated for
-small-sample bias (`statistic="squared_deflated"`, the default and conText's
-headline: a value near zero means no detectable shift), with a permutation p-value
-and a bootstrap confidence interval.
+default; each mention is treated as an independent observation, matching conText's
+default with no within-document clustering correction); with `target=None` it embeds
+whole documents. The effect size for a covariate is the squared Euclidean norm of its
+coefficient, deflated for small-sample bias (`statistic="squared_deflated"`, the
+default and conText's headline: a value near zero means no detectable shift), with a
+permutation p-value and a confidence interval (a leave-one-out jackknife t-interval
+under the default `inference="context"`).
 
 ```python
 # You bring pretrained word embeddings as {word: vector} (GloVe, word2vec, ...).
@@ -333,20 +335,36 @@ fit.nearest_neighbors({"party_R": 1}, n=10)          # what "immigration" means 
 fit.nns_ratio({"party_R": 1}, {"party_R": 0}, n=10)  # R-vs-D contrast
 ```
 
+The `transform` argument controls the à la carte step. The default `"additive"`
+(identity) is the count-weighted average of the context words' pretrained vectors
+with no learned transform: fast, always defined, and the right choice when you are
+comparing groups in a fixed pretrained space. `"estimate"` learns the ALC transform
+`A` from your corpus (Khodak et al. 2018), which sharpens rare-word embeddings but
+needs a corpus with at least `D` distinct words above `min_count`; on a small or
+high-dimensional corpus it is rank-deficient and `embedding_regression` warns and
+may return distorted effect sizes -- prefer `"additive"` there, or pass a
+precomputed matrix (a conText matrix transposed, see below). Both are validated
+against conText; the parity check uses a supplied `A`.
+
 Categorical covariates are dummy-coded (first level dropped as the reference), so a
-`party` column of `"D"`/`"R"` becomes a `party_R` coefficient. The
+`party` column of `"D"`/`"R"` becomes a `party_R` coefficient. `summary()` prints
+which level is the reference. The
 `nearest_neighbors` at a covariate value, and the `nns_ratio` contrast between two
 values, are how you read *what* the shift is: they rank pretrained vocabulary words
 near the predicted embedding, so a partisan split in the meaning of `immigration`
 shows up as different neighbor words for each party.
 
-Inference matches the current conText package by default (`inference="context"`): a
+Inference follows the current conText package by default (`inference="context"`): a
 Freedman-Lane residual-permutation p-value and a leave-one-out jackknife t-interval,
-so a reviewer re-running conText gets the same procedure. The jackknife interval is
-centered on the estimate; the original article's method (`inference="paper"`) uses a
-covariate permutation and a document bootstrap instead, whose interval sits above the
-point estimate because the coefficient norm is biased upward (prefer
-`squared_deflated`, which removes that bias).
+so a reviewer re-running conText gets the same procedure. The estimates and the
+jackknife interval match conText to numerical precision; the permutation p-value uses
+the selected `statistic` with a `(1 + #ge) / (1 + permutations)` smoothing, so it
+will not be bit-identical to conText's unsmoothed count (and floors near
+`1 / permutations` -- raise `permutations` to resolve small p-values). The jackknife
+interval is centered on the estimate; the original article's method
+(`inference="paper"`) uses a covariate permutation and a bootstrap over the resampled
+rows instead, whose interval sits above the point estimate because the coefficient
+norm is biased upward (prefer `squared_deflated`, which removes that bias).
 
 One more note for conText users: its published transform matrices (for example
 `cr_transform`) are the transpose of what :func:`compute_transform` returns, so pass

--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -294,45 +294,61 @@ Neither sees a difference in *meaning* that is not a word swap. When two groups
 use the same words but frame a term differently, or use different words for the
 same idea, the difference lives in a pretrained embedding space, not in counts.
 
-`embedding_regression` is topica's port of the à la carte on text (conText)
-embedding regression of Rodriguez, Spirling and Stewart (2023). It asks the
-native embedding-and-covariate question: *does a covariate shift what a word or
-theme means?* Its canonical use is "do Republicans and Democrats mean different
-things by `immigration`?".
+`embedding_regression` implements the à la carte on text (conText) embedding
+regression of Rodriguez, Spirling and Stewart (2023). It asks the native
+embedding-and-covariate question: *does a covariate shift what a word or theme
+means?* Its canonical use is "do Republicans and Democrats mean different things
+by `immigration`?". It is a **text-as-data analysis tool, not a topic model** (it
+produces no topics and needs no `enable_experimental`), and it is a drop-in for the
+R `conText` package: `parity/embedding_regression_context.py` checks topica against
+conText on conText's own bundled data and reproduces its à la carte embeddings,
+squared coefficient norm, and HC1-deflated norm to numerical precision.
 
-The method regresses per-document à la carte embeddings on your covariates. An à
-la carte embedding of a focal term in a document is the (transformed) average of
-its context words' pretrained vectors, so it captures how *that* instance of the
-term is used. The effect size for a covariate is the Euclidean norm of its
-coefficient (a larger norm means the covariate moves the term's meaning more),
-with a permutation p-value and a bootstrap confidence interval.
+The method regresses à la carte embeddings on your covariates. An à la carte
+embedding of a focal term is the (transformed) count-weighted mean of its context
+words' pretrained vectors, so it captures how *that* mention is used. For a focal
+term the unit of analysis is one row per mention (`aggregate="instance"`, conText's
+default); with `target=None` it embeds whole documents. The effect size for a
+covariate is the squared Euclidean norm of its coefficient, deflated for
+small-sample bias (`statistic="squared_deflated"`, the default and conText's
+headline: a value near zero means no detectable shift), with a permutation p-value
+and a bootstrap confidence interval.
 
 ```python
 # You bring pretrained word embeddings as {word: vector} (GloVe, word2vec, ...).
 fit = topica.embedding_regression(
     docs,                       # tokenized documents (word order matters)
-    covariates=party,           # (N,) or (N, p); no intercept column
+    covariates=party,           # numeric (N,)/(N, p), or category labels (dummy-coded)
     pre_trained=glove,          # {word: vector} or (matrix, vocab)
-    names=["republican"],
+    names=["party"],
     target="immigration",       # focal term; omit to embed whole documents
     window=6,
-    transform="estimate",       # learn the ALC matrix from docs, or pass one, or "additive"
+    transform="estimate",       # learn the ALC matrix, pass one, or "additive" (identity)
     permutations=100,
     bootstrap=100,
 )
 
 print(fit.summary())            # covariate, effect size, CI, permutation p
-fit.nearest_neighbors({"republican": 1}, n=10)   # what "immigration" means to R
-fit.nns_ratio({"republican": 1}, {"republican": 0}, n=10)  # R-vs-D contrast
+fit.nearest_neighbors({"party_R": 1}, n=10)          # what "immigration" means to R
+fit.nns_ratio({"party_R": 1}, {"party_R": 0}, n=10)  # R-vs-D contrast
 ```
 
-The `nearest_neighbors` at a covariate value, and the `nns_ratio` contrast
-between two values, are how you read *what* the shift is: they rank pretrained
-vocabulary words near the predicted embedding, so a partisan split in the meaning
-of `immigration` shows up as different neighbor words for each party.
+Categorical covariates are dummy-coded (first level dropped as the reference), so a
+`party` column of `"D"`/`"R"` becomes a `party_R` coefficient. The
+`nearest_neighbors` at a covariate value, and the `nns_ratio` contrast between two
+values, are how you read *what* the shift is: they rank pretrained vocabulary words
+near the predicted embedding, so a partisan split in the meaning of `immigration`
+shows up as different neighbor words for each party.
 
-Unlike an STM prevalence covariate, this is a description of meaning, not a
-generative topic model, so it does not need `enable_experimental`. It also sidesteps
-the trap of putting a document's own embedding on the covariate side of a topic
-model (see [Embedding topics](embedding.md)): here the embedding *is* the outcome
-being described, and the covariate is external metadata, exactly as in a regression.
+Two notes for conText users. topica follows the method of Rodriguez, Spirling &
+Stewart (2023); its inference differs from the current conText package in form
+(covariate permutation and a document bootstrap here, vs. residual permutation and a
+jackknife there), though the point estimates and deflated norms match. And conText's
+published transform matrices (for example `cr_transform`) are the transpose of what
+:func:`compute_transform` returns, so pass an external conText matrix as
+`transform=cr_transform.T`.
+
+This also sidesteps the trap of putting a document's own embedding on the covariate
+side of a topic model (see [Embedding topics](embedding.md)): here the embedding
+*is* the outcome being described, and the covariate is external metadata, exactly as
+in a regression.

--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -285,3 +285,54 @@ approaches or exceeds the number of documents.
 
 Use `search_k`, the coherence×exclusivity frontier, and an `HDP` sanity check.
 See [Choose and justify K](../publishing/choosing-k.md).
+
+## Covariate effects on meaning: embedding regression
+
+The covariates above act on topic *prevalence* (how much a group discusses a
+theme) and, through content covariates, on the *words* a group uses for a topic.
+Neither sees a difference in *meaning* that is not a word swap. When two groups
+use the same words but frame a term differently, or use different words for the
+same idea, the difference lives in a pretrained embedding space, not in counts.
+
+`embedding_regression` is topica's port of the à la carte on text (conText)
+embedding regression of Rodriguez, Spirling and Stewart (2023). It asks the
+native embedding-and-covariate question: *does a covariate shift what a word or
+theme means?* Its canonical use is "do Republicans and Democrats mean different
+things by `immigration`?".
+
+The method regresses per-document à la carte embeddings on your covariates. An à
+la carte embedding of a focal term in a document is the (transformed) average of
+its context words' pretrained vectors, so it captures how *that* instance of the
+term is used. The effect size for a covariate is the Euclidean norm of its
+coefficient (a larger norm means the covariate moves the term's meaning more),
+with a permutation p-value and a bootstrap confidence interval.
+
+```python
+# You bring pretrained word embeddings as {word: vector} (GloVe, word2vec, ...).
+fit = topica.embedding_regression(
+    docs,                       # tokenized documents (word order matters)
+    covariates=party,           # (N,) or (N, p); no intercept column
+    pre_trained=glove,          # {word: vector} or (matrix, vocab)
+    names=["republican"],
+    target="immigration",       # focal term; omit to embed whole documents
+    window=6,
+    transform="estimate",       # learn the ALC matrix from docs, or pass one, or "additive"
+    permutations=100,
+    bootstrap=100,
+)
+
+print(fit.summary())            # covariate, effect size, CI, permutation p
+fit.nearest_neighbors({"republican": 1}, n=10)   # what "immigration" means to R
+fit.nns_ratio({"republican": 1}, {"republican": 0}, n=10)  # R-vs-D contrast
+```
+
+The `nearest_neighbors` at a covariate value, and the `nns_ratio` contrast
+between two values, are how you read *what* the shift is: they rank pretrained
+vocabulary words near the predicted embedding, so a partisan split in the meaning
+of `immigration` shows up as different neighbor words for each party.
+
+Unlike an STM prevalence covariate, this is a description of meaning, not a
+generative topic model, so it does not need `enable_experimental`. It also sidesteps
+the trap of putting a document's own embedding on the covariate side of a topic
+model (see [Embedding topics](embedding.md)): here the embedding *is* the outcome
+being described, and the covariate is external metadata, exactly as in a regression.

--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -340,13 +340,17 @@ values, are how you read *what* the shift is: they rank pretrained vocabulary wo
 near the predicted embedding, so a partisan split in the meaning of `immigration`
 shows up as different neighbor words for each party.
 
-Two notes for conText users. topica follows the method of Rodriguez, Spirling &
-Stewart (2023); its inference differs from the current conText package in form
-(covariate permutation and a document bootstrap here, vs. residual permutation and a
-jackknife there), though the point estimates and deflated norms match. And conText's
-published transform matrices (for example `cr_transform`) are the transpose of what
-:func:`compute_transform` returns, so pass an external conText matrix as
-`transform=cr_transform.T`.
+Inference matches the current conText package by default (`inference="context"`): a
+Freedman-Lane residual-permutation p-value and a leave-one-out jackknife t-interval,
+so a reviewer re-running conText gets the same procedure. The jackknife interval is
+centered on the estimate; the original article's method (`inference="paper"`) uses a
+covariate permutation and a document bootstrap instead, whose interval sits above the
+point estimate because the coefficient norm is biased upward (prefer
+`squared_deflated`, which removes that bias).
+
+One more note for conText users: its published transform matrices (for example
+`cr_transform`) are the transpose of what :func:`compute_transform` returns, so pass
+an external conText matrix as `transform=cr_transform.T`.
 
 This also sidesteps the trap of putting a document's own embedding on the covariate
 side of a topic model (see [Embedding topics](embedding.md)): here the embedding

--- a/parity/embedding_regression_context.py
+++ b/parity/embedding_regression_context.py
@@ -1,0 +1,146 @@
+"""Parity: topica.embedding_regression vs the R ``conText`` package.
+
+Runs conText's own bundled example data (``cr_sample_corpus``, ``cr_glove_subset``,
+``cr_transform``) through both R ``conText`` and topica and checks that the à la
+carte document embeddings (``dem``), the squared coefficient norm, and the
+HC1-deflated norm agree. This is the reference validation that makes
+``topica.embedding_regression`` a drop-in replacement for conText, not a
+reimplementation.
+
+Skips cleanly when Rscript, ``conText`` or ``quanteda`` are unavailable (CI does not
+install R), exactly like the other ``parity/*_compare.py`` scripts.
+
+Run directly (``python parity/embedding_regression_context.py``) for a verbose
+report, or under pytest.
+"""
+
+import csv
+import os
+import shutil
+import subprocess
+import tempfile
+
+import numpy as np
+import pytest
+
+import topica
+
+# conText's reported values on this fixture (immigration ~ party), for reference
+# when R is unavailable; the live R run below is authoritative when present.
+_CONTEXT_SQUARED = 9.858888
+_CONTEXT_DEFLATED = 8.398819
+_CONTEXT_N_INSTANCES = 924
+
+
+def _run_reference(tmp):
+    """Export conText's bundled fixtures and reference outputs. Returns the tmp dir,
+    or None if Rscript/conText/quanteda are unavailable."""
+    if shutil.which("Rscript") is None:
+        return None
+    rscript = f"""
+    ok <- suppressWarnings(suppressMessages(require(conText))) &&
+          suppressWarnings(suppressMessages(require(quanteda)))
+    if (!ok) quit(status = 42)
+    outdir <- "{tmp}"
+    data("cr_sample_corpus"); data("cr_glove_subset"); data("cr_transform")
+    toks <- tokens(cr_sample_corpus)
+    writeLines(as.character(cr_sample_corpus), file.path(outdir, "texts.txt"))
+    write.csv(docvars(cr_sample_corpus), file.path(outdir, "docvars.csv"), row.names=FALSE)
+    write.csv(cr_glove_subset, file.path(outdir, "glove.csv"))
+    write.csv(cr_transform, file.path(outdir, "transform.csv"), row.names=FALSE)
+    ic <- tokens_context(x = toks, pattern = "immigration", window = 6L, verbose = FALSE)
+    idem <- dem(x = dfm(ic), pre_trained = cr_glove_subset, transform = TRUE,
+                transform_matrix = cr_transform, verbose = FALSE)
+    write.csv(as.matrix(idem), file.path(outdir, "ref_dem.csv"), row.names=FALSE)
+    con <- file(file.path(outdir, "ctx_tokens.txt"), "w")
+    for (ctx in as.list(ic)) writeLines(paste(ctx, collapse=" "), con)
+    close(con)
+    set.seed(2021)
+    m <- conText(formula = immigration ~ party, data = toks, pre_trained = cr_glove_subset,
+                 transform = TRUE, transform_matrix = cr_transform, jackknife = FALSE,
+                 permute = TRUE, num_permutations = 10, window = 6L,
+                 case_insensitive = TRUE, verbose = FALSE)
+    write.csv(m@normed_coefficients, file.path(outdir, "ref_norms.csv"), row.names=FALSE)
+    """
+    res = subprocess.run(["Rscript", "-e", rscript], capture_output=True, text=True)
+    if res.returncode == 42 or not os.path.exists(os.path.join(tmp, "ref_norms.csv")):
+        return None
+    res.check_returncode()
+    return tmp
+
+
+def _load_glove(tmp):
+    words, rows = [], []
+    with open(os.path.join(tmp, "glove.csv")) as f:
+        r = csv.reader(f)
+        next(r)
+        for row in r:
+            words.append(row[0].strip('"'))
+            rows.append([float(x) for x in row[1:]])
+    return words, np.array(rows)
+
+
+def _fixture():
+    tmp = tempfile.mkdtemp(prefix="ctext_parity_")
+    if _run_reference(tmp) is None:
+        pytest.skip("Rscript / conText / quanteda not available for embedding-regression parity")
+    return tmp
+
+
+def test_alc_embeddings_match_context_dem():
+    """topica's ALC embedding equals conText's dem() row-for-row (bit-exact)."""
+    tmp = _fixture()
+    words, G = _load_glove(tmp)
+    A = np.loadtxt(os.path.join(tmp, "transform.csv"), delimiter=",", skiprows=1)
+    ref = np.loadtxt(os.path.join(tmp, "ref_dem.csv"), delimiter=",", skiprows=1)
+    ctx = [line.split() for line in open(os.path.join(tmp, "ctx_tokens.txt")).read().splitlines()]
+    # conText's transform is the transpose of topica's convention.
+    Y, _ = topica.alc_embeddings(ctx, (G, words), transform=A.T, target=None)
+    assert Y.shape == ref.shape
+    assert np.max(np.abs(Y - ref)) < 1e-9
+
+
+def test_regression_norms_match_context():
+    """topica reproduces conText's squared and HC1-deflated coefficient norms."""
+    tmp = _fixture()
+    words, G = _load_glove(tmp)
+    A = np.loadtxt(os.path.join(tmp, "transform.csv"), delimiter=",", skiprows=1)
+    texts = open(os.path.join(tmp, "texts.txt")).read().splitlines()
+    docvars = list(csv.DictReader(open(os.path.join(tmp, "docvars.csv"))))
+    party = np.array([d["party"] for d in docvars])
+    docs = [t.split() for t in texts]
+
+    ref = list(csv.DictReader(open(os.path.join(tmp, "ref_norms.csv"))))[0]
+    ref_sq = float(ref["normed.estimate.orig"])
+    ref_defl = float(ref["normed.estimate.deflated"])
+
+    for stat, ref_val in [("squared", ref_sq), ("squared_deflated", ref_defl)]:
+        r = topica.embedding_regression(
+            docs, party, (G, words), names=["party"], transform=A.T,
+            target="immigration", window=6, aggregate="instance",
+            statistic=stat, permutations=0, bootstrap=0)
+        assert r.n_obs == _CONTEXT_N_INSTANCES
+        assert abs(r.normed_estimate[0] - ref_val) < 1e-4, (stat, r.normed_estimate[0], ref_val)
+
+
+if __name__ == "__main__":
+    tmp = tempfile.mkdtemp(prefix="ctext_parity_")
+    if _run_reference(tmp) is None:
+        print("SKIP: Rscript / conText / quanteda unavailable")
+        raise SystemExit(0)
+    words, G = _load_glove(tmp)
+    A = np.loadtxt(os.path.join(tmp, "transform.csv"), delimiter=",", skiprows=1)
+    ref = np.loadtxt(os.path.join(tmp, "ref_dem.csv"), delimiter=",", skiprows=1)
+    ctx = [line.split() for line in open(os.path.join(tmp, "ctx_tokens.txt")).read().splitlines()]
+    Y, _ = topica.alc_embeddings(ctx, (G, words), transform=A.T, target=None)
+    print(f"ALC dem max|diff| = {np.max(np.abs(Y - ref)):.2e}  (n={len(ctx)})")
+
+    texts = open(os.path.join(tmp, "texts.txt")).read().splitlines()
+    party = np.array([d["party"] for d in csv.DictReader(open(os.path.join(tmp, "docvars.csv")))])
+    docs = [t.split() for t in texts]
+    refn = list(csv.DictReader(open(os.path.join(tmp, "ref_norms.csv"))))[0]
+    for stat, key in [("squared", "normed.estimate.orig"), ("squared_deflated", "normed.estimate.deflated")]:
+        r = topica.embedding_regression(docs, party, (G, words), names=["party"], transform=A.T,
+                                        target="immigration", window=6, aggregate="instance",
+                                        statistic=stat, permutations=0, bootstrap=0)
+        print(f"{stat:16s} topica={r.normed_estimate[0]:.6f}  conText={float(refn[key]):.6f}")

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -191,6 +191,12 @@ from .narrative import NarrativeTM  # noqa: E402  (pure-Python NarrativeTM wrapp
 PLTM = PolylingualLDA  # noqa: E402
 from . import stm  # noqa: E402  (stm imports names defined above)
 from .stm import align_corpus, spline, interaction, topic_correlation_ci, TopicCorrelationCI  # noqa: E402  (general covariate-design helpers)
+from .embedding_regression import (  # noqa: E402  (conText embedding regression: covariate effects on meaning)
+    embedding_regression,
+    EmbeddingRegression,
+    alc_embeddings,
+    compute_transform,
+)
 from . import keyatm  # noqa: E402  (keyATM-specific workflow helpers)
 from . import effects  # noqa: E402  (model-neutral prevalence analysis)
 from . import validation  # noqa: E402  (post-hoc topic diagnostics surface)
@@ -460,6 +466,10 @@ __all__ = [
     "topic_label_prompts",
     "TopicGPT",
     "estimate_effect",
+    "embedding_regression",
+    "EmbeddingRegression",
+    "alc_embeddings",
+    "compute_transform",
     "by_strata",
     "prevalence_ci",
     "top_topics",

--- a/python/topica/embedding_regression.py
+++ b/python/topica/embedding_regression.py
@@ -1,36 +1,44 @@
 """Embedding regression: context-specific description and inference.
 
-A faithful port of the *à la carte on text* (conText) embedding regression of
+A validated port of the *à la carte on text* (conText) embedding regression of
 Rodriguez, Spirling and Stewart (2023, "Embedding Regression: Models for
 Context-Specific Description and Inference", *American Political Science Review*),
-which builds on the à la carte (ALC) embeddings of Khodak et al. (2018).
+which builds on the à la carte (ALC) embeddings of Khodak et al. (2018). It is
+checked bit-for-bit against the R ``conText`` package on its own bundled data
+(``parity/embedding_regression_context.py``): identical ALC embeddings, squared
+coefficient norm, and HC1-deflated norm.
 
-The question this answers is different from the covariate topic models here (STM,
-DMR, Scholar). Those ask how a covariate shifts topic *prevalence* -- how *much* a
-group discusses a theme. Embedding regression asks how a covariate shifts *meaning*
--- *how* a group uses a word or theme, in a pretrained embedding space where
-semantic and framing differences live that word counts cannot see. "Do Republicans
-and Democrats mean different things by 'immigration'?" is its native question.
+This is a **text-as-data analysis tool, not a topic model.** The covariate topic
+models here (STM, DMR, Scholar) ask how a covariate shifts topic *prevalence* --
+how *much* a group discusses a theme. Embedding regression asks how a covariate
+shifts *meaning* -- *how* a group uses a word or theme, in a pretrained embedding
+space where semantic and framing differences live that word counts cannot see.
+"Do Republicans and Democrats mean different things by 'immigration'?" is its
+native question. It is a regression on embeddings, so it needs no
+``enable_experimental`` and produces no topics.
 
 The pipeline is entirely numpy-native and mirrors ``conText``:
 
 1. :func:`compute_transform` learns the ALC transform matrix ``A`` from a corpus and
-   a set of pretrained word embeddings (or you supply a precomputed ``A``).
+   pretrained word embeddings (or you supply a precomputed ``A``).
 2. :func:`alc_embeddings` turns each document -- or each context around a focal term
-   -- into a single ALC embedding: the (count-weighted) mean of its in-vocabulary
-   context words' pretrained vectors, mapped through ``A``.
-3. :func:`embedding_regression` regresses those ``N x D`` embeddings on a covariate
-   design matrix (multivariate OLS), reports the Euclidean norm of each covariate's
-   ``D``-dimensional coefficient as its effect size, and gets a permutation p-value
-   and bootstrap confidence interval for that norm.
-4. :meth:`EmbeddingRegression.nearest_neighbors` and
-   :meth:`EmbeddingRegression.nns_ratio` describe *what* the shift means, by ranking
-   pretrained vocabulary words near the predicted embedding at chosen covariate
-   values.
+   -- into an ALC embedding: the count-weighted mean of its in-vocabulary context
+   words' pretrained vectors, mapped through ``A``.
+3. :func:`embedding_regression` regresses those embeddings on a covariate design
+   (multivariate OLS), reports each covariate coefficient's squared Euclidean norm
+   (with an HC1 small-sample-deflated variant, conText's headline), and gets a
+   permutation p-value and bootstrap confidence interval.
+4. :meth:`EmbeddingRegression.nearest_neighbors` / :meth:`EmbeddingRegression.nns_ratio`
+   describe *what* the shift means by ranking pretrained vocabulary words near the
+   predicted embedding at chosen covariate values.
 
 You bring the pretrained embeddings (GloVe, word2vec, a local model) as a
-``(word -> vector)`` mapping, following topica's convention that the library does
-not call an embedding model for you.
+``{word: vector}`` mapping or ``(matrix, vocab)`` pair, per topica's convention that
+the library does not call an embedding model for you.
+
+Note on transform orientation: ``conText``'s published transform matrices (e.g.
+``cr_transform``) are the transpose of what :func:`compute_transform` returns here.
+Pass a ``conText`` matrix as ``transform=cr_transform.T``.
 """
 
 from __future__ import annotations
@@ -50,9 +58,11 @@ __all__ = [
 # ---------------------------------------------------------------------------
 # Pretrained embedding lookup
 # ---------------------------------------------------------------------------
-def _as_lookup(pre_trained):
+def _as_lookup(pre_trained, case_insensitive):
     """Accept a dict ``{word: vector}`` or a ``(matrix, vocab)`` pair and return
-    ``(words, matrix, index)`` with a float64 ``(V, D)`` matrix."""
+    ``(words, matrix, index)`` with a float64 ``(V, D)`` matrix. When
+    ``case_insensitive`` the lookup index is keyed on lowercased words so cased
+    pretrained vocabularies (e.g. word2vec) still match lowercased tokens."""
     if isinstance(pre_trained, dict):
         words = list(pre_trained.keys())
         matrix = np.asarray([pre_trained[w] for w in words], dtype=np.float64)
@@ -64,13 +74,24 @@ def _as_lookup(pre_trained):
             raise ValueError("pre_trained matrix rows must match the vocabulary length")
     if matrix.ndim != 2:
         raise ValueError("pretrained embeddings must be 2-d (vocab, dim)")
-    index = {w: i for i, w in enumerate(words)}
+    if not np.isfinite(matrix).all():
+        raise ValueError("pretrained embeddings contain non-finite values (NaN or inf)")
+    if case_insensitive:
+        index = {}
+        for i, w in enumerate(words):
+            index.setdefault(w.lower(), i)
+    else:
+        index = {w: i for i, w in enumerate(words)}
     return words, matrix, index
 
 
-def _context_windows(tokens, target, window, case_insensitive):
+def _lookup(index, token, case_insensitive):
+    return index.get(token.lower() if case_insensitive else token)
+
+
+def _contexts_in_doc(tokens, target, window, case_insensitive):
     """Yield the context token lists (focal token excluded) around each occurrence
-    of ``target`` in ``tokens``. ``target`` may be a string or a set of strings."""
+    of ``target`` in one document. ``target`` may be a string or a set of strings."""
     targets = {target} if isinstance(target, str) else set(target)
     if case_insensitive:
         targets = {t.lower() for t in targets}
@@ -88,48 +109,42 @@ def _context_windows(tokens, target, window, case_insensitive):
 def compute_transform(docs, pre_trained, *, window=6, min_count=100, case_insensitive=True):
     """Estimate the à la carte transform matrix ``A`` (``D x D``) from a corpus.
 
-    Following Khodak et al. (2018): for every vocabulary word with at least
-    ``min_count`` occurrences, form ``u_w``, the average of the pretrained vectors
-    of the words appearing in its context windows, and regress the word's own
-    pretrained vector ``v_w`` on ``u_w`` across words. The least-squares solution is
-    ``A = (U'U)^-1 U'V`` where ``U`` stacks the ``u_w`` and ``V`` the ``v_w``. The
-    resulting ``A`` corrects a raw additive context embedding toward the target
-    word's own representation, so the ALC embedding ``u @ A`` lives in the pretrained
-    space.
+    Following Khodak et al. (2018): for every vocabulary word occurring at least
+    ``min_count`` times, form ``u_w``, the average of the pretrained vectors of the
+    words in its context windows, and regress the word's own pretrained vector
+    ``v_w`` on ``u_w`` across words. The least-squares solution ``A = (U'U)^-1 U'V``
+    maps a raw additive context embedding toward the target word's representation, so
+    ``u @ A`` lives in the pretrained space.
+
+    ``conText``'s published transform matrices are the transpose of this ``A``; apply
+    an external ``conText`` matrix as ``transform=matrix.T``.
 
     Parameters
     ----------
     docs : sequence of token lists
-        The corpus, tokenized. Word order matters (context windows are used).
     pre_trained : dict or (matrix, vocab)
-        Pretrained word embeddings.
     window : int, default 6
-        Context window each side of a word. The paper recommends >= 5.
+        Context window each side of a word (paper recommends >= 5).
     min_count : int, default 100
-        Minimum corpus frequency for a word to enter the transform regression.
+        Minimum number of *occurrences* of a word for it to enter the regression.
     case_insensitive : bool, default True
-        Lowercase tokens before matching them to the pretrained vocabulary.
-
-    Returns
-    -------
-    numpy.ndarray
-        The ``(D, D)`` transform matrix ``A``.
     """
-    _, matrix, index = _as_lookup(pre_trained)
-    D = matrix.shape[1]
-    lower = case_insensitive
+    import warnings
 
-    # Accumulate, per word, the sum of context vectors and the context count.
+    _, matrix, index = _as_lookup(pre_trained, case_insensitive)
+    D = matrix.shape[1]
+
     ctx_sum: dict[int, np.ndarray] = {}
-    ctx_cnt: dict[int, int] = {}
+    ctx_cnt: dict[int, int] = {}   # context-token count (denominator of u_w)
+    word_cnt: dict[int, int] = {}  # word occurrence count (for min_count)
     for tokens in docs:
-        ids = [index.get(t.lower() if lower else t) for t in tokens]
+        ids = [_lookup(index, t, case_insensitive) for t in tokens]
         n = len(ids)
         for i, wi in enumerate(ids):
             if wi is None:
                 continue
-            lo = max(0, i - window)
-            hi = min(n, i + window + 1)
+            word_cnt[wi] = word_cnt.get(wi, 0) + 1
+            lo, hi = max(0, i - window), min(n, i + window + 1)
             for j in range(lo, hi):
                 if j == i or ids[j] is None:
                     continue
@@ -140,19 +155,32 @@ def compute_transform(docs, pre_trained, *, window=6, min_count=100, case_insens
                 ctx_cnt[wi] += 1
 
     rows_u, rows_v = [], []
-    for wi, cnt in ctx_cnt.items():
-        if cnt >= min_count:
-            rows_u.append(ctx_sum[wi] / cnt)
+    for wi, wc in word_cnt.items():
+        if wc >= min_count and ctx_cnt.get(wi, 0) > 0:
+            rows_u.append(ctx_sum[wi] / ctx_cnt[wi])
             rows_v.append(matrix[wi])
     if len(rows_u) < D:
         raise ValueError(
-            f"only {len(rows_u)} words meet min_count={min_count}; need at least "
-            f"D={D} to estimate the transform. Lower min_count or use transform='additive'."
+            f"only {len(rows_u)} words occur at least min_count={min_count} times; need "
+            f"at least D={D} to estimate the transform. Lower min_count or use "
+            f"transform='additive'."
         )
     U = np.asarray(rows_u)
     V = np.asarray(rows_v)
-    # A = (U'U)^-1 U'V  (least squares of V on U, no intercept)
-    A, *_ = np.linalg.lstsq(U, V, rcond=None)
+    A, _resid, rank, _sv = np.linalg.lstsq(U, V, rcond=None)
+    if rank < D:
+        warnings.warn(
+            f"transform design is rank-deficient (rank {rank} < {D}); the estimated A "
+            "may be unstable. Use more data or transform='additive'.",
+            stacklevel=2,
+        )
+    fro = float(np.linalg.norm(A))
+    if fro > 20 * np.sqrt(D):
+        warnings.warn(
+            f"estimated transform has large norm (||A||_F={fro:.1f}); results may be "
+            "distorted. Check that the corpus is large enough for min_count.",
+            stacklevel=2,
+        )
     return A
 
 
@@ -160,64 +188,121 @@ def compute_transform(docs, pre_trained, *, window=6, min_count=100, case_insens
 # ALC document / focal-term embeddings (dem)
 # ---------------------------------------------------------------------------
 def alc_embeddings(docs, pre_trained, *, transform=None, target=None, window=6,
-                   case_insensitive=True):
-    """Compute one à la carte embedding per document.
+                   case_insensitive=True, aggregate="document"):
+    """Compute à la carte embeddings.
 
-    Each document's embedding is the count-weighted mean of its in-vocabulary
-    context words' pretrained vectors, mapped through the transform ``A``. With
-    ``target=None`` the context is the whole document; with a focal ``target`` the
-    context is the tokens within ``window`` of each occurrence of the term (the
-    focal token excluded), pooled over the document.
+    Each embedding is the count-weighted mean of its in-vocabulary context words'
+    pretrained vectors, mapped through the transform ``A``. Out-of-vocabulary tokens
+    are dropped and the mean taken over the remaining in-vocabulary occurrences; a
+    context with no in-vocabulary token is dropped.
 
-    Out-of-vocabulary tokens are dropped and the mean taken over the remaining
-    in-vocabulary occurrences. A document with no in-vocabulary context is dropped.
+    With ``target=None`` the context is the whole document (one row per document).
+    With a focal ``target``:
+
+    - ``aggregate="instance"`` (conText's unit of analysis): one row per *occurrence*
+      of the term, the window around that occurrence (focal token excluded).
+    - ``aggregate="document"``: one row per document, pooling all of its occurrences'
+      contexts.
 
     Parameters
     ----------
     docs : sequence of token lists
     pre_trained : dict or (matrix, vocab)
     transform : numpy.ndarray or None
-        The ``(D, D)`` matrix ``A``. ``None`` uses the identity ("additive"
-        embeddings), a valid, simpler baseline.
+        The ``(D, D)`` matrix ``A``; ``None`` uses the identity ("additive"). A
+        ``conText`` matrix must be passed transposed.
     target : str, sequence of str, or None
-        Focal term(s). ``None`` embeds the whole document.
     window : int, default 6
     case_insensitive : bool, default True
+    aggregate : {"document", "instance"}, default "document"
+        Ignored when ``target`` is None (always one row per document).
 
     Returns
     -------
     (numpy.ndarray, numpy.ndarray)
-        ``embeddings`` of shape ``(n_kept, D)`` and ``kept`` -- the integer indices
-        of the documents that produced an embedding (in ``docs`` order).
+        ``embeddings`` of shape ``(n_rows, D)`` and ``doc_ids`` -- the source
+        document index for each row (for clustering). In document mode there is one
+        row per surviving document; in instance mode one row per surviving mention.
     """
-    _, matrix, index = _as_lookup(pre_trained)
+    if aggregate not in ("document", "instance"):
+        raise ValueError("aggregate must be 'document' or 'instance'")
+    if target is not None and window < 1:
+        raise ValueError("window must be >= 1 when a target is given")
+    _, matrix, index = _as_lookup(pre_trained, case_insensitive)
     D = matrix.shape[1]
     A = np.eye(D) if transform is None else np.asarray(transform, dtype=np.float64)
     if A.shape != (D, D):
         raise ValueError(f"transform must be ({D}, {D}) to match the embedding dim")
-    lower = case_insensitive
 
-    embs, kept = [], []
-    for d, tokens in enumerate(docs):
-        if target is None:
-            contexts = [tokens]
-        else:
-            contexts = list(_context_windows(tokens, target, window, case_insensitive))
+    def embed(ctx_tokens):
         vec = np.zeros(D)
         n = 0
-        for ctx in contexts:
-            for t in ctx:
-                wi = index.get(t.lower() if lower else t)
-                if wi is not None:
-                    vec += matrix[wi]
-                    n += 1
-        if n == 0:
-            continue
-        embs.append((vec / n) @ A)
-        kept.append(d)
+        for t in ctx_tokens:
+            wi = _lookup(index, t, case_insensitive)
+            if wi is not None:
+                vec += matrix[wi]
+                n += 1
+        return (vec / n) @ A if n else None
+
+    embs, doc_ids = [], []
+    for d, tokens in enumerate(docs):
+        if target is None:
+            v = embed(tokens)
+            if v is not None:
+                embs.append(v)
+                doc_ids.append(d)
+        else:
+            contexts = list(_contexts_in_doc(tokens, target, window, case_insensitive))
+            if aggregate == "instance":
+                for ctx in contexts:
+                    v = embed(ctx)
+                    if v is not None:
+                        embs.append(v)
+                        doc_ids.append(d)
+            else:  # pool all of the document's contexts into one row
+                v = embed([t for ctx in contexts for t in ctx])
+                if v is not None:
+                    embs.append(v)
+                    doc_ids.append(d)
     if not embs:
-        raise ValueError("no document had any in-vocabulary context tokens")
-    return np.asarray(embs), np.asarray(kept, dtype=int)
+        raise ValueError(
+            "no context produced an embedding (target not in vocabulary, or all "
+            "contexts out-of-vocabulary)"
+        )
+    return np.asarray(embs), np.asarray(doc_ids, dtype=int)
+
+
+# ---------------------------------------------------------------------------
+# Design helpers
+# ---------------------------------------------------------------------------
+def _build_design(covariates, names):
+    """Return ``(Xraw (N,p), names)``. A 1-D non-numeric covariate is dummy-coded
+    (sorted categories, first dropped as reference, columns named ``col_level``)."""
+    arr = np.asarray(covariates, dtype=object) if _is_categorical(covariates) else None
+    if arr is not None:
+        cats = sorted(set(arr.tolist()))
+        ref, levels = cats[0], cats[1:]
+        Xraw = np.array([[1.0 if v == lv else 0.0 for lv in levels] for v in arr])
+        base = names[0] if names else "x"
+        return Xraw, [f"{base}_{lv}" for lv in levels], ref
+    X = np.asarray(covariates, dtype=np.float64)
+    if X.ndim == 1:
+        X = X[:, None]
+    p = X.shape[1]
+    if names is None:
+        names = [f"x{i}" for i in range(p)]
+    names = list(names)
+    if len(names) != p:
+        raise ValueError(f"names has {len(names)} entries but there are {p} covariates")
+    return X, names, None
+
+
+def _is_categorical(covariates):
+    if isinstance(covariates, np.ndarray) and covariates.dtype.kind in "OUS":
+        return covariates.ndim == 1
+    if isinstance(covariates, (list, tuple)) and covariates and isinstance(covariates[0], str):
+        return True
+    return False
 
 
 # ---------------------------------------------------------------------------
@@ -238,14 +323,13 @@ class EmbeddingRegression:
     normed_estimate : numpy.ndarray
         ``(n_covariates,)`` effect size per covariate (see ``statistic``).
     p_value : numpy.ndarray
-        ``(n_covariates,)`` permutation p-values for the effect size.
+        ``(n_covariates,)`` permutation p-values.
     normed_ci : numpy.ndarray
         ``(n_covariates, 2)`` bootstrap percentile CI for the effect size.
     intercept : numpy.ndarray
-        The ``(D,)`` intercept (the reference-level ALC embedding).
+        The ``(D,)`` intercept (reference-level ALC embedding).
     statistic : str
-        Which effect size was reported: ``"norm"``, ``"squared"`` or
-        ``"squared_deflated"``.
+        ``"norm"``, ``"squared"`` or ``"squared_deflated"``.
     """
 
     coefficients: np.ndarray
@@ -256,19 +340,15 @@ class EmbeddingRegression:
     intercept: np.ndarray
     statistic: str
     confidence_level: float
-    _design_names: list = field(default=None, repr=False)
+    n_obs: int
+    reference_level: object = None
     _pretrained_words: list = field(default=None, repr=False)
     _pretrained_matrix: np.ndarray = field(default=None, repr=False)
-    _beta_full: np.ndarray = field(default=None, repr=False)  # (p+1, D) incl intercept
 
     # -- interpretation -----------------------------------------------------
     def predict(self, profile) -> np.ndarray:
-        """The predicted ALC embedding at a covariate profile.
-
-        ``profile`` is a mapping ``{covariate_name: value}`` or a length-``p`` array
-        in ``names`` order; unspecified covariates default to 0 (their reference
-        level). The intercept is added automatically.
-        """
+        """Predicted ALC embedding at a covariate profile (``{name: value}`` or a
+        length-``p`` array in ``names`` order; unset covariates default to 0)."""
         p = len(self.names)
         x = np.zeros(p)
         if isinstance(profile, dict):
@@ -283,45 +363,42 @@ class EmbeddingRegression:
         return self.intercept + x @ self.coefficients
 
     def nearest_neighbors(self, profile, *, n=10, candidates=None):
-        """Pretrained words most similar to the predicted embedding at ``profile``.
-
-        Returns a list of ``(word, cosine)`` pairs, highest first. ``candidates``, if
-        given, restricts the ranking to that set of words (the paper notes this cuts
-        noise from rare/garbage vocabulary).
-        """
+        """Pretrained words most similar to the predicted embedding at ``profile``;
+        list of ``(word, cosine)``, highest first. ``candidates`` restricts the pool."""
         if self._pretrained_matrix is None:
             raise RuntimeError("nearest_neighbors needs the pretrained embeddings kept at fit")
-        yhat = self.predict(profile)
-        return _cosine_topn(yhat, self._pretrained_words, self._pretrained_matrix, n, candidates)
+        return _cosine_topn(self.predict(profile), self._pretrained_words,
+                            self._pretrained_matrix, n, candidates)
 
     def nns_ratio(self, profile_a, profile_b, *, n=10, candidates=None):
-        """Contrast two covariate profiles by cosine ratio.
-
-        For each candidate word ``q`` (the union of the two profiles' top-``n``
-        neighbors, or ``candidates`` if given), returns ``(word, ratio)`` with
-        ``ratio = cos(y_a, q) / cos(y_b, q)``; ``ratio > 1`` means ``q`` sits closer
-        to profile ``a``. Sorted by ratio, descending.
-        """
+        """Contrast two profiles: for each candidate word, ``cos(y_a, q)/cos(y_b, q)``.
+        Only words with a positive cosine to *both* profiles are ranked (the ratio is
+        meaningless when a cosine is <= 0); ``ratio > 1`` means closer to ``a``."""
         if self._pretrained_matrix is None:
             raise RuntimeError("nns_ratio needs the pretrained embeddings kept at fit")
         ya, yb = self.predict(profile_a), self.predict(profile_b)
         words, M = self._pretrained_words, self._pretrained_matrix
         if candidates is None:
-            top_a = {w for w, _ in _cosine_topn(ya, words, M, n, None)}
-            top_b = {w for w, _ in _cosine_topn(yb, words, M, n, None)}
-            candidates = top_a | top_b
+            top = {w for w, _ in _cosine_topn(ya, words, M, n, None)}
+            top |= {w for w, _ in _cosine_topn(yb, words, M, n, None)}
+            candidates = top
         idx = [i for i, w in enumerate(words) if w in candidates]
+        if not idx:
+            return []
         Mn = M[idx] / (np.linalg.norm(M[idx], axis=1, keepdims=True) + 1e-12)
         ca = Mn @ (ya / (np.linalg.norm(ya) + 1e-12))
         cb = Mn @ (yb / (np.linalg.norm(yb) + 1e-12))
-        ratio = ca / np.where(np.abs(cb) < 1e-12, np.nan, cb)
-        order = np.argsort(-ratio)
-        return [(words[idx[i]], float(ratio[i])) for i in order]
+        out = [(words[idx[i]], float(ca[i] / cb[i]))
+               for i in range(len(idx)) if ca[i] > 0 and cb[i] > 0]
+        out.sort(key=lambda t: -t[1])
+        return out
 
     def summary(self):
         """A compact text table of covariate, effect size, CI and p-value."""
         lines = [f"Embedding regression ({self.statistic}, "
-                 f"{int(self.confidence_level * 100)}% CI)"]
+                 f"{int(self.confidence_level * 100)}% CI, n={self.n_obs})"]
+        if self.statistic == "squared_deflated":
+            lines.append("(deflated = squared norm - HC1 bias; can be <=0 under the null)")
         lines.append(f"{'covariate':<20s} {'estimate':>10s} {'ci_low':>9s} "
                      f"{'ci_high':>9s} {'p':>7s}")
         for i, nm in enumerate(self.names):
@@ -333,7 +410,8 @@ class EmbeddingRegression:
 
 def _cosine_topn(vec, words, matrix, n, candidates):
     if candidates is not None:
-        idx = np.array([i for i, w in enumerate(words) if w in set(candidates)])
+        cset = set(candidates)
+        idx = np.array([i for i, w in enumerate(words) if w in cset])
         if idx.size == 0:
             return []
     else:
@@ -345,26 +423,42 @@ def _cosine_topn(vec, words, matrix, n, candidates):
 
 
 def _ols(X, Y):
-    """Multivariate OLS ``B = (X'X)^-1 X'Y``; returns ``B`` and ``(X'X)^-1``."""
-    XtX = X.T @ X
-    XtX_inv = np.linalg.pinv(XtX)
+    """Multivariate OLS ``B = (X'X)^-1 X'Y``; returns ``B`` and ``(X'X)^-1``.
+    Warns if the design is rank-deficient (collinear/constant covariates), which
+    makes the min-norm ``pinv`` solution and the intercept unreliable."""
+    import warnings
+
+    if np.linalg.matrix_rank(X) < X.shape[1]:
+        warnings.warn(
+            "covariate design is rank-deficient (constant or collinear covariate); "
+            "coefficients and the intercept are not uniquely identified.",
+            stacklevel=3,
+        )
+    XtX_inv = np.linalg.pinv(X.T @ X)
     B = XtX_inv @ (X.T @ Y)
     return B, XtX_inv
 
 
 def _effect_size(B, X, Y, XtX_inv, statistic):
-    """Per-covariate effect size from coefficient block ``B[1:]`` (intercept at 0)."""
-    beta = B[1:]  # (p, D)
-    sq = np.sum(beta ** 2, axis=1)  # squared norm per covariate
+    """Per-covariate effect size from the coefficient block ``B[1:]`` (intercept at 0).
+    ``squared_deflated`` subtracts the HC1 robust bias ``sum_d Var_hc1(beta_jd)`` to
+    match conText's ``normed.estimate.deflated``."""
+    beta = B[1:]
+    sq = np.sum(beta ** 2, axis=1)
     if statistic == "norm":
         return np.sqrt(sq)
     if statistic == "squared":
         return sq
     if statistic == "squared_deflated":
+        N, k = X.shape
         resid = Y - X @ B
-        dof = max(X.shape[0] - X.shape[1], 1)
-        sigma2_tr = np.sum(resid ** 2) / dof  # trace(Sigma_eps) estimate
-        bias = np.diag(XtX_inv)[1:] * sigma2_tr
+        XtXi_Xt = XtX_inv @ X.T                      # (k, N)
+        scale = N / max(N - k, 1)                     # HC1 finite-sample correction
+        bias = np.zeros(B.shape[0] - 1)
+        for j in range(1, B.shape[0]):
+            hj = XtXi_Xt[j]                            # (N,)
+            # sum_d Var(beta_jd) = sum_d sum_i hj_i^2 e_id^2  (HC0) then HC1-scaled
+            bias[j - 1] = scale * np.sum((hj ** 2)[:, None] * resid ** 2)
         return sq - bias
     raise ValueError("statistic must be 'norm', 'squared' or 'squared_deflated'")
 
@@ -378,7 +472,8 @@ def embedding_regression(
     transform="additive",
     target=None,
     window=6,
-    statistic="norm",
+    aggregate=None,
+    statistic="squared_deflated",
     permutations=100,
     bootstrap=100,
     confidence_level=0.95,
@@ -386,89 +481,89 @@ def embedding_regression(
     seed=0,
     keep_pretrained=True,
 ):
-    """Regress à la carte document embeddings on covariates (conText).
+    """Regress à la carte embeddings on covariates (conText embedding regression).
 
     Parameters
     ----------
     docs : sequence of token lists
-        The tokenized corpus (word order matters).
-    covariates : array-like (N, p) or (N,)
-        The covariate design, one row per document, **without** an intercept
-        (added internally). Rows must align with ``docs`` before ALC dropping.
+    covariates : array-like
+        ``(N,)`` or ``(N, p)`` numeric design (no intercept), or a ``(N,)`` sequence
+        of category labels (dummy-coded, first level dropped as reference).
     pre_trained : dict or (matrix, vocab)
-        Pretrained word embeddings.
     names : sequence of str, optional
-        Covariate names; defaults to ``x0, x1, ...``.
+        Covariate names (for a categorical covariate, the single source name).
     transform : {"additive", "estimate"}, numpy.ndarray, or None, default "additive"
-        The ALC transform ``A``. ``"additive"``/``None`` uses the identity;
-        ``"estimate"`` calls :func:`compute_transform` on ``docs``; or pass a matrix.
+        ALC transform ``A``. ``"additive"``/``None`` = identity; ``"estimate"`` calls
+        :func:`compute_transform`; or pass a matrix (a ``conText`` matrix must be
+        transposed first).
     target : str, sequence of str, or None
-        Focal term(s) whose context is embedded; ``None`` embeds whole documents.
+        Focal term(s); ``None`` embeds whole documents.
     window : int, default 6
-    statistic : {"norm", "squared", "squared_deflated"}, default "norm"
-        Effect-size functional of each covariate coefficient. ``"norm"`` is the
-        paper's Euclidean norm; ``"squared_deflated"`` applies a small-sample bias
-        correction to the squared norm.
+    aggregate : {"instance", "document"}, optional
+        Unit of analysis for a focal term. Defaults to ``"instance"`` (one row per
+        mention, as conText) when ``target`` is given, else ``"document"``.
+    statistic : {"squared_deflated", "squared", "norm"}, default "squared_deflated"
+        Effect size. ``"squared_deflated"`` is conText's headline (squared norm minus
+        HC1 bias; centered at ~0 under the null). ``"norm"`` is the paper's Euclidean
+        norm (biased upward). ``"squared"`` is the raw squared norm.
     permutations : int, default 100
-        Covariate permutations for the p-value (paper uses 100). 0 skips.
+        Covariate permutations for the p-value; 0 skips. p is smoothed as
+        ``(1 + #{perm >= obs}) / (1 + permutations)``.
     bootstrap : int, default 100
-        Document bootstrap resamples for the CI. 0 skips.
+        Document bootstrap resamples for the CI; 0 skips.
     confidence_level : float, default 0.95
     case_insensitive : bool, default True
     seed : int, default 0
     keep_pretrained : bool, default True
-        Retain the pretrained matrix on the result so ``nearest_neighbors`` works.
 
     Returns
     -------
     EmbeddingRegression
     """
     rng = np.random.default_rng(seed)
-    words, matrix, _ = _as_lookup(pre_trained)
+    words, matrix, _ = _as_lookup(pre_trained, case_insensitive)
 
-    if transform == "estimate":
-        A = compute_transform(docs, (matrix, words), window=window,
-                              case_insensitive=case_insensitive)
-    elif transform == "additive" or transform is None:
+    if isinstance(transform, str):
+        if transform == "estimate":
+            A = compute_transform(docs, (matrix, words), window=window,
+                                  case_insensitive=case_insensitive)
+        elif transform == "additive":
+            A = None
+        else:
+            raise ValueError("transform string must be 'additive' or 'estimate'")
+    elif transform is None:
         A = None
     else:
         A = np.asarray(transform, dtype=np.float64)
 
-    Y, kept = alc_embeddings(docs, (matrix, words), transform=A, target=target,
-                             window=window, case_insensitive=case_insensitive)
+    if aggregate is None:
+        aggregate = "instance" if target is not None else "document"
 
-    Xraw = np.asarray(covariates, dtype=np.float64)
-    if Xraw.ndim == 1:
-        Xraw = Xraw[:, None]
-    if Xraw.shape[0] != len(docs):
+    Y, doc_ids = alc_embeddings(docs, (matrix, words), transform=A, target=target,
+                                window=window, case_insensitive=case_insensitive,
+                                aggregate=aggregate)
+
+    Xraw_full, names, reference = _build_design(covariates, names)
+    if Xraw_full.shape[0] != len(docs):
         raise ValueError("covariates must have one row per document")
-    Xraw = Xraw[kept]  # align to documents that produced an embedding
+    Xraw = Xraw_full[doc_ids]  # expand/align to the surviving rows (instances or docs)
     p = Xraw.shape[1]
-    if names is None:
-        names = [f"x{i}" for i in range(p)]
-    names = list(names)
-    if len(names) != p:
-        raise ValueError(f"names has {len(names)} entries but there are {p} covariates")
-
     N = Xraw.shape[0]
-    X = np.column_stack([np.ones(N), Xraw])  # intercept + covariates
+    X = np.column_stack([np.ones(N), Xraw])
     B, XtX_inv = _ols(X, Y)
     est = _effect_size(B, X, Y, XtX_inv, statistic)
 
-    # permutation p-value: shuffle covariate rows, refit, recompute effect size.
     if permutations and permutations > 0:
         ge = np.zeros(p)
         for _ in range(permutations):
             perm = rng.permutation(N)
             Xp = np.column_stack([np.ones(N), Xraw[perm]])
             Bp, inv_p = _ols(Xp, Y)
-            ep = _effect_size(Bp, Xp, Y, inv_p, statistic)
-            ge += (ep >= est)
-        p_value = ge / permutations
+            ge += (_effect_size(Bp, Xp, Y, inv_p, statistic) >= est)
+        p_value = (1.0 + ge) / (1.0 + permutations)  # Phipson-Smyth smoothing
     else:
         p_value = np.full(p, np.nan)
 
-    # bootstrap CI on the effect size: resample documents with replacement.
     if bootstrap and bootstrap > 0:
         boot = np.empty((bootstrap, p))
         for b in range(bootstrap):
@@ -491,8 +586,8 @@ def embedding_regression(
         intercept=B[0],
         statistic=statistic,
         confidence_level=confidence_level,
-        _design_names=["(intercept)"] + names,
+        n_obs=N,
+        reference_level=reference,
         _pretrained_words=words if keep_pretrained else None,
         _pretrained_matrix=matrix if keep_pretrained else None,
-        _beta_full=B,
     )

--- a/python/topica/embedding_regression.py
+++ b/python/topica/embedding_regression.py
@@ -463,6 +463,42 @@ def _effect_size(B, X, Y, XtX_inv, statistic):
     raise ValueError("statistic must be 'norm', 'squared' or 'squared_deflated'")
 
 
+def _residual_permutation_p(X, Y, B, est, statistic, n_perm, rng):
+    """Freedman-Lane residual permutation p-value (conText's procedure): permute the
+    rows of the fitted residuals, refit, and compare the effect size to ``est``."""
+    resid = Y - X @ B
+    N = X.shape[0]
+    p = B.shape[0] - 1
+    ge = np.zeros(p)
+    for _ in range(n_perm):
+        rp = resid[rng.permutation(N)]
+        Bp, inv_p = _ols(X, rp)
+        ge += (_effect_size(Bp, X, rp, inv_p, statistic) >= est)
+    return (1.0 + ge) / (1.0 + n_perm)
+
+
+def _jackknife_ci(X, Y, statistic, est, confidence_level):
+    """Leave-one-out jackknife SE and t-interval for the effect size (conText's
+    default CI). Returns ``(ci (p,2), se (p,))``."""
+    from scipy.stats import t as _t
+
+    N, k = X.shape
+    p = k - 1
+    thetas = np.empty((N, p))
+    keep = np.ones(N, dtype=bool)
+    for i in range(N):
+        keep[i] = False
+        Xi, Yi = X[keep], Y[keep]
+        Bi, inv_i = _ols(Xi, Yi)
+        thetas[i] = _effect_size(Bi, Xi, Yi, inv_i, statistic)
+        keep[i] = True
+    theta_bar = thetas.mean(axis=0)
+    se = np.sqrt((N - 1) / N * np.sum((thetas - theta_bar) ** 2, axis=0))
+    tcrit = _t.ppf(1 - (1 - confidence_level) / 2, N - 1)
+    ci = np.column_stack([est - tcrit * se, est + tcrit * se])
+    return ci, se
+
+
 def embedding_regression(
     docs,
     covariates,
@@ -474,6 +510,7 @@ def embedding_regression(
     window=6,
     aggregate=None,
     statistic="squared_deflated",
+    inference="context",
     permutations=100,
     bootstrap=100,
     confidence_level=0.95,
@@ -506,11 +543,19 @@ def embedding_regression(
         Effect size. ``"squared_deflated"`` is conText's headline (squared norm minus
         HC1 bias; centered at ~0 under the null). ``"norm"`` is the paper's Euclidean
         norm (biased upward). ``"squared"`` is the raw squared norm.
+    inference : {"context", "paper"}, default "context"
+        How the p-value and confidence interval are computed. ``"context"`` matches
+        the current R ``conText`` package: a Freedman-Lane residual-permutation
+        p-value and a leave-one-out jackknife t-interval (the interval is centered on
+        the estimate). ``"paper"`` is the original article's method: a covariate
+        permutation p-value and a document bootstrap percentile interval (the norm's
+        upward bias makes that interval sit above the point estimate).
     permutations : int, default 100
-        Covariate permutations for the p-value; 0 skips. p is smoothed as
+        Permutations for the p-value; 0 skips. p is smoothed as
         ``(1 + #{perm >= obs}) / (1 + permutations)``.
     bootstrap : int, default 100
-        Document bootstrap resamples for the CI; 0 skips.
+        Bootstrap resamples for the ``"paper"`` CI; 0 skips. Ignored for ``"context"``
+        (which uses the jackknife).
     confidence_level : float, default 0.95
     case_insensitive : bool, default True
     seed : int, default 0
@@ -550,21 +595,29 @@ def embedding_regression(
     p = Xraw.shape[1]
     N = Xraw.shape[0]
     X = np.column_stack([np.ones(N), Xraw])
+    if inference not in ("context", "paper"):
+        raise ValueError("inference must be 'context' or 'paper'")
     B, XtX_inv = _ols(X, Y)
     est = _effect_size(B, X, Y, XtX_inv, statistic)
 
-    if permutations and permutations > 0:
+    # p-value
+    if not permutations or permutations <= 0:
+        p_value = np.full(p, np.nan)
+    elif inference == "context":
+        p_value = _residual_permutation_p(X, Y, B, est, statistic, permutations, rng)
+    else:  # paper: permute the covariate
         ge = np.zeros(p)
         for _ in range(permutations):
             perm = rng.permutation(N)
             Xp = np.column_stack([np.ones(N), Xraw[perm]])
             Bp, inv_p = _ols(Xp, Y)
             ge += (_effect_size(Bp, Xp, Y, inv_p, statistic) >= est)
-        p_value = (1.0 + ge) / (1.0 + permutations)  # Phipson-Smyth smoothing
-    else:
-        p_value = np.full(p, np.nan)
+        p_value = (1.0 + ge) / (1.0 + permutations)
 
-    if bootstrap and bootstrap > 0:
+    # confidence interval
+    if inference == "context":
+        ci, _se = _jackknife_ci(X, Y, statistic, est, confidence_level)
+    elif bootstrap and bootstrap > 0:
         boot = np.empty((bootstrap, p))
         for b in range(bootstrap):
             idx = rng.integers(0, N, size=N)

--- a/python/topica/embedding_regression.py
+++ b/python/topica/embedding_regression.py
@@ -221,13 +221,25 @@ def alc_embeddings(docs, pre_trained, *, transform=None, target=None, window=6,
     -------
     (numpy.ndarray, numpy.ndarray)
         ``embeddings`` of shape ``(n_rows, D)`` and ``doc_ids`` -- the source
-        document index for each row (for clustering). In document mode there is one
-        row per surviving document; in instance mode one row per surviving mention.
+        document index for each row, used to align covariates to the surviving rows.
+        In document mode there is one row per surviving document; in instance mode
+        one row per surviving mention (each mention is an independent observation --
+        within-document clustering is not corrected for, matching conText's default).
     """
     if aggregate not in ("document", "instance"):
         raise ValueError("aggregate must be 'document' or 'instance'")
     if target is not None and window < 1:
         raise ValueError("window must be >= 1 when a target is given")
+    # A raw string is iterable, so a document passed as text (rather than a token
+    # list) would silently be treated as a sequence of single characters -- none in
+    # vocabulary -- and surface later as the opaque "no context" error. Catch it
+    # here with the actual fix.
+    docs = list(docs)
+    if docs and isinstance(docs[0], str):
+        raise ValueError(
+            "docs must be a sequence of token lists, not raw strings; tokenize "
+            "first (e.g. [t.split() for t in docs])"
+        )
     _, matrix, index = _as_lookup(pre_trained, case_insensitive)
     D = matrix.shape[1]
     A = np.eye(D) if transform is None else np.asarray(transform, dtype=np.float64)
@@ -265,9 +277,16 @@ def alc_embeddings(docs, pre_trained, *, transform=None, target=None, window=6,
                     embs.append(v)
                     doc_ids.append(d)
     if not embs:
+        if target is not None:
+            raise ValueError(
+                f"no context produced an embedding for target {target!r}: it does "
+                "not occur in the corpus, or every window around it is entirely "
+                "out-of-vocabulary. Check the term is present and lowercased to "
+                "match the pretrained vocabulary."
+            )
         raise ValueError(
-            "no context produced an embedding (target not in vocabulary, or all "
-            "contexts out-of-vocabulary)"
+            "no document produced an embedding: every document is entirely "
+            "out-of-vocabulary against the pretrained embeddings"
         )
     return np.asarray(embs), np.asarray(doc_ids, dtype=int)
 
@@ -281,6 +300,11 @@ def _build_design(covariates, names):
     arr = np.asarray(covariates, dtype=object) if _is_categorical(covariates) else None
     if arr is not None:
         cats = sorted(set(arr.tolist()))
+        if len(cats) < 2:
+            raise ValueError(
+                f"categorical covariate has a single level ({cats[0]!r}); a "
+                "regression needs at least two groups to contrast"
+            )
         ref, levels = cats[0], cats[1:]
         Xraw = np.array([[1.0 if v == lv else 0.0 for lv in levels] for v in arr])
         base = names[0] if names else "x"
@@ -325,7 +349,9 @@ class EmbeddingRegression:
     p_value : numpy.ndarray
         ``(n_covariates,)`` permutation p-values.
     normed_ci : numpy.ndarray
-        ``(n_covariates, 2)`` bootstrap percentile CI for the effect size.
+        ``(n_covariates, 2)`` confidence interval for the effect size: a
+        leave-one-out jackknife t-interval under ``inference="context"`` (the
+        default), a bootstrap percentile interval under ``inference="paper"``.
     intercept : numpy.ndarray
         The ``(D,)`` intercept (reference-level ALC embedding).
     statistic : str
@@ -397,12 +423,17 @@ class EmbeddingRegression:
         """A compact text table of covariate, effect size, CI and p-value."""
         lines = [f"Embedding regression ({self.statistic}, "
                  f"{int(self.confidence_level * 100)}% CI, n={self.n_obs})"]
+        if self.reference_level is not None:
+            lines.append(f"reference level: {self.reference_level}")
         if self.statistic == "squared_deflated":
             lines.append("(deflated = squared norm - HC1 bias; can be <=0 under the null)")
-        lines.append(f"{'covariate':<20s} {'estimate':>10s} {'ci_low':>9s} "
+        # Widen the covariate column to the longest name so dummy names like
+        # ``party_rec.sport.baseball`` do not push the numeric columns out of line.
+        w = max(20, *(len(n) for n in self.names)) if self.names else 20
+        lines.append(f"{'covariate':<{w}s} {'estimate':>10s} {'ci_low':>9s} "
                      f"{'ci_high':>9s} {'p':>7s}")
         for i, nm in enumerate(self.names):
-            lines.append(f"{nm:<20s} {self.normed_estimate[i]:10.4f} "
+            lines.append(f"{nm:<{w}s} {self.normed_estimate[i]:10.4f} "
                          f"{self.normed_ci[i, 0]:9.4f} {self.normed_ci[i, 1]:9.4f} "
                          f"{self.p_value[i]:7.3f}")
         return "\n".join(lines)
@@ -544,11 +575,16 @@ def embedding_regression(
         HC1 bias; centered at ~0 under the null). ``"norm"`` is the paper's Euclidean
         norm (biased upward). ``"squared"`` is the raw squared norm.
     inference : {"context", "paper"}, default "context"
-        How the p-value and confidence interval are computed. ``"context"`` matches
-        the current R ``conText`` package: a Freedman-Lane residual-permutation
-        p-value and a leave-one-out jackknife t-interval (the interval is centered on
-        the estimate). ``"paper"`` is the original article's method: a covariate
-        permutation p-value and a document bootstrap percentile interval (the norm's
+        How the p-value and confidence interval are computed. ``"context"`` follows
+        the current R ``conText`` package's procedure: a Freedman-Lane
+        residual-permutation p-value and a leave-one-out jackknife t-interval (the
+        interval is centered on the estimate and matches conText's to numerical
+        precision). The permutation p-value uses the selected ``statistic`` and the
+        validity-preserving ``(1 + #ge) / (1 + permutations)`` smoothing, so it will
+        not be bit-identical to conText's unsmoothed count (conText also permutes the
+        uncorrected norm); the effect-size estimates and the jackknife interval are.
+        ``"paper"`` is the original article's method: a covariate permutation p-value
+        and a bootstrap percentile interval over the resampled rows (the norm's
         upward bias makes that interval sit above the point estimate).
     permutations : int, default 100
         Permutations for the p-value; 0 skips. p is smoothed as

--- a/python/topica/embedding_regression.py
+++ b/python/topica/embedding_regression.py
@@ -1,0 +1,498 @@
+"""Embedding regression: context-specific description and inference.
+
+A faithful port of the *à la carte on text* (conText) embedding regression of
+Rodriguez, Spirling and Stewart (2023, "Embedding Regression: Models for
+Context-Specific Description and Inference", *American Political Science Review*),
+which builds on the à la carte (ALC) embeddings of Khodak et al. (2018).
+
+The question this answers is different from the covariate topic models here (STM,
+DMR, Scholar). Those ask how a covariate shifts topic *prevalence* -- how *much* a
+group discusses a theme. Embedding regression asks how a covariate shifts *meaning*
+-- *how* a group uses a word or theme, in a pretrained embedding space where
+semantic and framing differences live that word counts cannot see. "Do Republicans
+and Democrats mean different things by 'immigration'?" is its native question.
+
+The pipeline is entirely numpy-native and mirrors ``conText``:
+
+1. :func:`compute_transform` learns the ALC transform matrix ``A`` from a corpus and
+   a set of pretrained word embeddings (or you supply a precomputed ``A``).
+2. :func:`alc_embeddings` turns each document -- or each context around a focal term
+   -- into a single ALC embedding: the (count-weighted) mean of its in-vocabulary
+   context words' pretrained vectors, mapped through ``A``.
+3. :func:`embedding_regression` regresses those ``N x D`` embeddings on a covariate
+   design matrix (multivariate OLS), reports the Euclidean norm of each covariate's
+   ``D``-dimensional coefficient as its effect size, and gets a permutation p-value
+   and bootstrap confidence interval for that norm.
+4. :meth:`EmbeddingRegression.nearest_neighbors` and
+   :meth:`EmbeddingRegression.nns_ratio` describe *what* the shift means, by ranking
+   pretrained vocabulary words near the predicted embedding at chosen covariate
+   values.
+
+You bring the pretrained embeddings (GloVe, word2vec, a local model) as a
+``(word -> vector)`` mapping, following topica's convention that the library does
+not call an embedding model for you.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+import numpy as np
+
+__all__ = [
+    "compute_transform",
+    "alc_embeddings",
+    "embedding_regression",
+    "EmbeddingRegression",
+]
+
+
+# ---------------------------------------------------------------------------
+# Pretrained embedding lookup
+# ---------------------------------------------------------------------------
+def _as_lookup(pre_trained):
+    """Accept a dict ``{word: vector}`` or a ``(matrix, vocab)`` pair and return
+    ``(words, matrix, index)`` with a float64 ``(V, D)`` matrix."""
+    if isinstance(pre_trained, dict):
+        words = list(pre_trained.keys())
+        matrix = np.asarray([pre_trained[w] for w in words], dtype=np.float64)
+    else:
+        matrix, vocab = pre_trained
+        words = list(vocab)
+        matrix = np.asarray(matrix, dtype=np.float64)
+        if matrix.shape[0] != len(words):
+            raise ValueError("pre_trained matrix rows must match the vocabulary length")
+    if matrix.ndim != 2:
+        raise ValueError("pretrained embeddings must be 2-d (vocab, dim)")
+    index = {w: i for i, w in enumerate(words)}
+    return words, matrix, index
+
+
+def _context_windows(tokens, target, window, case_insensitive):
+    """Yield the context token lists (focal token excluded) around each occurrence
+    of ``target`` in ``tokens``. ``target`` may be a string or a set of strings."""
+    targets = {target} if isinstance(target, str) else set(target)
+    if case_insensitive:
+        targets = {t.lower() for t in targets}
+    for i, tok in enumerate(tokens):
+        hit = tok.lower() if case_insensitive else tok
+        if hit in targets:
+            lo = max(0, i - window)
+            hi = min(len(tokens), i + window + 1)
+            yield [tokens[j] for j in range(lo, hi) if j != i]
+
+
+# ---------------------------------------------------------------------------
+# à la carte transform matrix A
+# ---------------------------------------------------------------------------
+def compute_transform(docs, pre_trained, *, window=6, min_count=100, case_insensitive=True):
+    """Estimate the à la carte transform matrix ``A`` (``D x D``) from a corpus.
+
+    Following Khodak et al. (2018): for every vocabulary word with at least
+    ``min_count`` occurrences, form ``u_w``, the average of the pretrained vectors
+    of the words appearing in its context windows, and regress the word's own
+    pretrained vector ``v_w`` on ``u_w`` across words. The least-squares solution is
+    ``A = (U'U)^-1 U'V`` where ``U`` stacks the ``u_w`` and ``V`` the ``v_w``. The
+    resulting ``A`` corrects a raw additive context embedding toward the target
+    word's own representation, so the ALC embedding ``u @ A`` lives in the pretrained
+    space.
+
+    Parameters
+    ----------
+    docs : sequence of token lists
+        The corpus, tokenized. Word order matters (context windows are used).
+    pre_trained : dict or (matrix, vocab)
+        Pretrained word embeddings.
+    window : int, default 6
+        Context window each side of a word. The paper recommends >= 5.
+    min_count : int, default 100
+        Minimum corpus frequency for a word to enter the transform regression.
+    case_insensitive : bool, default True
+        Lowercase tokens before matching them to the pretrained vocabulary.
+
+    Returns
+    -------
+    numpy.ndarray
+        The ``(D, D)`` transform matrix ``A``.
+    """
+    _, matrix, index = _as_lookup(pre_trained)
+    D = matrix.shape[1]
+    lower = case_insensitive
+
+    # Accumulate, per word, the sum of context vectors and the context count.
+    ctx_sum: dict[int, np.ndarray] = {}
+    ctx_cnt: dict[int, int] = {}
+    for tokens in docs:
+        ids = [index.get(t.lower() if lower else t) for t in tokens]
+        n = len(ids)
+        for i, wi in enumerate(ids):
+            if wi is None:
+                continue
+            lo = max(0, i - window)
+            hi = min(n, i + window + 1)
+            for j in range(lo, hi):
+                if j == i or ids[j] is None:
+                    continue
+                if wi not in ctx_sum:
+                    ctx_sum[wi] = np.zeros(D)
+                    ctx_cnt[wi] = 0
+                ctx_sum[wi] += matrix[ids[j]]
+                ctx_cnt[wi] += 1
+
+    rows_u, rows_v = [], []
+    for wi, cnt in ctx_cnt.items():
+        if cnt >= min_count:
+            rows_u.append(ctx_sum[wi] / cnt)
+            rows_v.append(matrix[wi])
+    if len(rows_u) < D:
+        raise ValueError(
+            f"only {len(rows_u)} words meet min_count={min_count}; need at least "
+            f"D={D} to estimate the transform. Lower min_count or use transform='additive'."
+        )
+    U = np.asarray(rows_u)
+    V = np.asarray(rows_v)
+    # A = (U'U)^-1 U'V  (least squares of V on U, no intercept)
+    A, *_ = np.linalg.lstsq(U, V, rcond=None)
+    return A
+
+
+# ---------------------------------------------------------------------------
+# ALC document / focal-term embeddings (dem)
+# ---------------------------------------------------------------------------
+def alc_embeddings(docs, pre_trained, *, transform=None, target=None, window=6,
+                   case_insensitive=True):
+    """Compute one à la carte embedding per document.
+
+    Each document's embedding is the count-weighted mean of its in-vocabulary
+    context words' pretrained vectors, mapped through the transform ``A``. With
+    ``target=None`` the context is the whole document; with a focal ``target`` the
+    context is the tokens within ``window`` of each occurrence of the term (the
+    focal token excluded), pooled over the document.
+
+    Out-of-vocabulary tokens are dropped and the mean taken over the remaining
+    in-vocabulary occurrences. A document with no in-vocabulary context is dropped.
+
+    Parameters
+    ----------
+    docs : sequence of token lists
+    pre_trained : dict or (matrix, vocab)
+    transform : numpy.ndarray or None
+        The ``(D, D)`` matrix ``A``. ``None`` uses the identity ("additive"
+        embeddings), a valid, simpler baseline.
+    target : str, sequence of str, or None
+        Focal term(s). ``None`` embeds the whole document.
+    window : int, default 6
+    case_insensitive : bool, default True
+
+    Returns
+    -------
+    (numpy.ndarray, numpy.ndarray)
+        ``embeddings`` of shape ``(n_kept, D)`` and ``kept`` -- the integer indices
+        of the documents that produced an embedding (in ``docs`` order).
+    """
+    _, matrix, index = _as_lookup(pre_trained)
+    D = matrix.shape[1]
+    A = np.eye(D) if transform is None else np.asarray(transform, dtype=np.float64)
+    if A.shape != (D, D):
+        raise ValueError(f"transform must be ({D}, {D}) to match the embedding dim")
+    lower = case_insensitive
+
+    embs, kept = [], []
+    for d, tokens in enumerate(docs):
+        if target is None:
+            contexts = [tokens]
+        else:
+            contexts = list(_context_windows(tokens, target, window, case_insensitive))
+        vec = np.zeros(D)
+        n = 0
+        for ctx in contexts:
+            for t in ctx:
+                wi = index.get(t.lower() if lower else t)
+                if wi is not None:
+                    vec += matrix[wi]
+                    n += 1
+        if n == 0:
+            continue
+        embs.append((vec / n) @ A)
+        kept.append(d)
+    if not embs:
+        raise ValueError("no document had any in-vocabulary context tokens")
+    return np.asarray(embs), np.asarray(kept, dtype=int)
+
+
+# ---------------------------------------------------------------------------
+# Embedding regression
+# ---------------------------------------------------------------------------
+@dataclass
+class EmbeddingRegression:
+    """Result of :func:`embedding_regression`.
+
+    Attributes
+    ----------
+    coefficients : numpy.ndarray
+        ``(n_covariates, D)`` -- each covariate's D-dimensional coefficient
+        (intercept excluded). Individual dimensions are not interpretable; use the
+        norm and the nearest-neighbor methods.
+    names : list of str
+        Covariate names, aligned with ``coefficients`` rows.
+    normed_estimate : numpy.ndarray
+        ``(n_covariates,)`` effect size per covariate (see ``statistic``).
+    p_value : numpy.ndarray
+        ``(n_covariates,)`` permutation p-values for the effect size.
+    normed_ci : numpy.ndarray
+        ``(n_covariates, 2)`` bootstrap percentile CI for the effect size.
+    intercept : numpy.ndarray
+        The ``(D,)`` intercept (the reference-level ALC embedding).
+    statistic : str
+        Which effect size was reported: ``"norm"``, ``"squared"`` or
+        ``"squared_deflated"``.
+    """
+
+    coefficients: np.ndarray
+    names: list
+    normed_estimate: np.ndarray
+    p_value: np.ndarray
+    normed_ci: np.ndarray
+    intercept: np.ndarray
+    statistic: str
+    confidence_level: float
+    _design_names: list = field(default=None, repr=False)
+    _pretrained_words: list = field(default=None, repr=False)
+    _pretrained_matrix: np.ndarray = field(default=None, repr=False)
+    _beta_full: np.ndarray = field(default=None, repr=False)  # (p+1, D) incl intercept
+
+    # -- interpretation -----------------------------------------------------
+    def predict(self, profile) -> np.ndarray:
+        """The predicted ALC embedding at a covariate profile.
+
+        ``profile`` is a mapping ``{covariate_name: value}`` or a length-``p`` array
+        in ``names`` order; unspecified covariates default to 0 (their reference
+        level). The intercept is added automatically.
+        """
+        p = len(self.names)
+        x = np.zeros(p)
+        if isinstance(profile, dict):
+            for k, v in profile.items():
+                if k not in self.names:
+                    raise KeyError(f"unknown covariate {k!r}; have {self.names}")
+                x[self.names.index(k)] = v
+        else:
+            x = np.asarray(profile, dtype=np.float64).ravel()
+            if x.size != p:
+                raise ValueError(f"profile must have {p} entries (one per covariate)")
+        return self.intercept + x @ self.coefficients
+
+    def nearest_neighbors(self, profile, *, n=10, candidates=None):
+        """Pretrained words most similar to the predicted embedding at ``profile``.
+
+        Returns a list of ``(word, cosine)`` pairs, highest first. ``candidates``, if
+        given, restricts the ranking to that set of words (the paper notes this cuts
+        noise from rare/garbage vocabulary).
+        """
+        if self._pretrained_matrix is None:
+            raise RuntimeError("nearest_neighbors needs the pretrained embeddings kept at fit")
+        yhat = self.predict(profile)
+        return _cosine_topn(yhat, self._pretrained_words, self._pretrained_matrix, n, candidates)
+
+    def nns_ratio(self, profile_a, profile_b, *, n=10, candidates=None):
+        """Contrast two covariate profiles by cosine ratio.
+
+        For each candidate word ``q`` (the union of the two profiles' top-``n``
+        neighbors, or ``candidates`` if given), returns ``(word, ratio)`` with
+        ``ratio = cos(y_a, q) / cos(y_b, q)``; ``ratio > 1`` means ``q`` sits closer
+        to profile ``a``. Sorted by ratio, descending.
+        """
+        if self._pretrained_matrix is None:
+            raise RuntimeError("nns_ratio needs the pretrained embeddings kept at fit")
+        ya, yb = self.predict(profile_a), self.predict(profile_b)
+        words, M = self._pretrained_words, self._pretrained_matrix
+        if candidates is None:
+            top_a = {w for w, _ in _cosine_topn(ya, words, M, n, None)}
+            top_b = {w for w, _ in _cosine_topn(yb, words, M, n, None)}
+            candidates = top_a | top_b
+        idx = [i for i, w in enumerate(words) if w in candidates]
+        Mn = M[idx] / (np.linalg.norm(M[idx], axis=1, keepdims=True) + 1e-12)
+        ca = Mn @ (ya / (np.linalg.norm(ya) + 1e-12))
+        cb = Mn @ (yb / (np.linalg.norm(yb) + 1e-12))
+        ratio = ca / np.where(np.abs(cb) < 1e-12, np.nan, cb)
+        order = np.argsort(-ratio)
+        return [(words[idx[i]], float(ratio[i])) for i in order]
+
+    def summary(self):
+        """A compact text table of covariate, effect size, CI and p-value."""
+        lines = [f"Embedding regression ({self.statistic}, "
+                 f"{int(self.confidence_level * 100)}% CI)"]
+        lines.append(f"{'covariate':<20s} {'estimate':>10s} {'ci_low':>9s} "
+                     f"{'ci_high':>9s} {'p':>7s}")
+        for i, nm in enumerate(self.names):
+            lines.append(f"{nm:<20s} {self.normed_estimate[i]:10.4f} "
+                         f"{self.normed_ci[i, 0]:9.4f} {self.normed_ci[i, 1]:9.4f} "
+                         f"{self.p_value[i]:7.3f}")
+        return "\n".join(lines)
+
+
+def _cosine_topn(vec, words, matrix, n, candidates):
+    if candidates is not None:
+        idx = np.array([i for i, w in enumerate(words) if w in set(candidates)])
+        if idx.size == 0:
+            return []
+    else:
+        idx = np.arange(len(words))
+    M = matrix[idx]
+    sims = (M @ vec) / ((np.linalg.norm(M, axis=1) * np.linalg.norm(vec)) + 1e-12)
+    order = np.argsort(-sims)[:n]
+    return [(words[idx[i]], float(sims[i])) for i in order]
+
+
+def _ols(X, Y):
+    """Multivariate OLS ``B = (X'X)^-1 X'Y``; returns ``B`` and ``(X'X)^-1``."""
+    XtX = X.T @ X
+    XtX_inv = np.linalg.pinv(XtX)
+    B = XtX_inv @ (X.T @ Y)
+    return B, XtX_inv
+
+
+def _effect_size(B, X, Y, XtX_inv, statistic):
+    """Per-covariate effect size from coefficient block ``B[1:]`` (intercept at 0)."""
+    beta = B[1:]  # (p, D)
+    sq = np.sum(beta ** 2, axis=1)  # squared norm per covariate
+    if statistic == "norm":
+        return np.sqrt(sq)
+    if statistic == "squared":
+        return sq
+    if statistic == "squared_deflated":
+        resid = Y - X @ B
+        dof = max(X.shape[0] - X.shape[1], 1)
+        sigma2_tr = np.sum(resid ** 2) / dof  # trace(Sigma_eps) estimate
+        bias = np.diag(XtX_inv)[1:] * sigma2_tr
+        return sq - bias
+    raise ValueError("statistic must be 'norm', 'squared' or 'squared_deflated'")
+
+
+def embedding_regression(
+    docs,
+    covariates,
+    pre_trained,
+    *,
+    names=None,
+    transform="additive",
+    target=None,
+    window=6,
+    statistic="norm",
+    permutations=100,
+    bootstrap=100,
+    confidence_level=0.95,
+    case_insensitive=True,
+    seed=0,
+    keep_pretrained=True,
+):
+    """Regress à la carte document embeddings on covariates (conText).
+
+    Parameters
+    ----------
+    docs : sequence of token lists
+        The tokenized corpus (word order matters).
+    covariates : array-like (N, p) or (N,)
+        The covariate design, one row per document, **without** an intercept
+        (added internally). Rows must align with ``docs`` before ALC dropping.
+    pre_trained : dict or (matrix, vocab)
+        Pretrained word embeddings.
+    names : sequence of str, optional
+        Covariate names; defaults to ``x0, x1, ...``.
+    transform : {"additive", "estimate"}, numpy.ndarray, or None, default "additive"
+        The ALC transform ``A``. ``"additive"``/``None`` uses the identity;
+        ``"estimate"`` calls :func:`compute_transform` on ``docs``; or pass a matrix.
+    target : str, sequence of str, or None
+        Focal term(s) whose context is embedded; ``None`` embeds whole documents.
+    window : int, default 6
+    statistic : {"norm", "squared", "squared_deflated"}, default "norm"
+        Effect-size functional of each covariate coefficient. ``"norm"`` is the
+        paper's Euclidean norm; ``"squared_deflated"`` applies a small-sample bias
+        correction to the squared norm.
+    permutations : int, default 100
+        Covariate permutations for the p-value (paper uses 100). 0 skips.
+    bootstrap : int, default 100
+        Document bootstrap resamples for the CI. 0 skips.
+    confidence_level : float, default 0.95
+    case_insensitive : bool, default True
+    seed : int, default 0
+    keep_pretrained : bool, default True
+        Retain the pretrained matrix on the result so ``nearest_neighbors`` works.
+
+    Returns
+    -------
+    EmbeddingRegression
+    """
+    rng = np.random.default_rng(seed)
+    words, matrix, _ = _as_lookup(pre_trained)
+
+    if transform == "estimate":
+        A = compute_transform(docs, (matrix, words), window=window,
+                              case_insensitive=case_insensitive)
+    elif transform == "additive" or transform is None:
+        A = None
+    else:
+        A = np.asarray(transform, dtype=np.float64)
+
+    Y, kept = alc_embeddings(docs, (matrix, words), transform=A, target=target,
+                             window=window, case_insensitive=case_insensitive)
+
+    Xraw = np.asarray(covariates, dtype=np.float64)
+    if Xraw.ndim == 1:
+        Xraw = Xraw[:, None]
+    if Xraw.shape[0] != len(docs):
+        raise ValueError("covariates must have one row per document")
+    Xraw = Xraw[kept]  # align to documents that produced an embedding
+    p = Xraw.shape[1]
+    if names is None:
+        names = [f"x{i}" for i in range(p)]
+    names = list(names)
+    if len(names) != p:
+        raise ValueError(f"names has {len(names)} entries but there are {p} covariates")
+
+    N = Xraw.shape[0]
+    X = np.column_stack([np.ones(N), Xraw])  # intercept + covariates
+    B, XtX_inv = _ols(X, Y)
+    est = _effect_size(B, X, Y, XtX_inv, statistic)
+
+    # permutation p-value: shuffle covariate rows, refit, recompute effect size.
+    if permutations and permutations > 0:
+        ge = np.zeros(p)
+        for _ in range(permutations):
+            perm = rng.permutation(N)
+            Xp = np.column_stack([np.ones(N), Xraw[perm]])
+            Bp, inv_p = _ols(Xp, Y)
+            ep = _effect_size(Bp, Xp, Y, inv_p, statistic)
+            ge += (ep >= est)
+        p_value = ge / permutations
+    else:
+        p_value = np.full(p, np.nan)
+
+    # bootstrap CI on the effect size: resample documents with replacement.
+    if bootstrap and bootstrap > 0:
+        boot = np.empty((bootstrap, p))
+        for b in range(bootstrap):
+            idx = rng.integers(0, N, size=N)
+            Xb = np.column_stack([np.ones(N), Xraw[idx]])
+            Bb, inv_b = _ols(Xb, Y[idx])
+            boot[b] = _effect_size(Bb, Xb, Y[idx], inv_b, statistic)
+        alpha = (1 - confidence_level) / 2
+        ci = np.column_stack([np.quantile(boot, alpha, axis=0),
+                              np.quantile(boot, 1 - alpha, axis=0)])
+    else:
+        ci = np.full((p, 2), np.nan)
+
+    return EmbeddingRegression(
+        coefficients=B[1:],
+        names=names,
+        normed_estimate=est,
+        p_value=p_value,
+        normed_ci=ci,
+        intercept=B[0],
+        statistic=statistic,
+        confidence_level=confidence_level,
+        _design_names=["(intercept)"] + names,
+        _pretrained_words=words if keep_pretrained else None,
+        _pretrained_matrix=matrix if keep_pretrained else None,
+        _beta_full=B,
+    )

--- a/tests/test_embedding_regression.py
+++ b/tests/test_embedding_regression.py
@@ -207,6 +207,33 @@ def test_squared_deflated_is_default_and_centered_under_null():
     assert abs(r.normed_estimate[0]) < 0.2   # deflated null ~ 0 (not a positive floor)
 
 
+def test_context_inference_ci_brackets_estimate():
+    """The default 'context' inference uses a jackknife t-interval centered on the
+    estimate, so the CI brackets it (unlike the paper bootstrap on a biased norm)."""
+    docs, g, pre = _planted()
+    r = topica.embedding_regression(docs, g, pre, names=["group"], inference="context",
+                                    permutations=50, seed=1)
+    assert r.normed_ci[0, 0] <= r.normed_estimate[0] <= r.normed_ci[0, 1]
+    assert r.p_value[0] < 0.05
+
+
+def test_paper_and_context_inference_both_run():
+    docs, g, pre = _planted()
+    rc = topica.embedding_regression(docs, g, pre, inference="context", permutations=50,
+                                     bootstrap=0, seed=1)
+    rp = topica.embedding_regression(docs, g, pre, inference="paper", permutations=50,
+                                     bootstrap=50, seed=1)
+    # same point estimate, different inference machinery
+    assert np.isclose(rc.normed_estimate[0], rp.normed_estimate[0])
+    assert rc.p_value[0] < 0.1 and rp.p_value[0] < 0.1
+
+
+def test_invalid_inference_raises():
+    docs, g, pre = _planted(n=40)
+    with pytest.raises(ValueError, match="inference"):
+        topica.embedding_regression(docs, g, pre, inference="bogus", permutations=0)
+
+
 def test_multiple_covariates():
     docs, g, pre = _planted()
     rng = np.random.default_rng(5)

--- a/tests/test_embedding_regression.py
+++ b/tests/test_embedding_regression.py
@@ -243,3 +243,41 @@ def test_multiple_covariates():
     assert r.coefficients.shape[0] == 2
     assert r.p_value[0] < 0.05  # real covariate
     assert r.p_value[1] > 0.1   # noise covariate
+
+
+# --- review follow-ups (#669): clearer errors and summary ---------------------
+def test_raw_strings_rejected_with_actionable_error():
+    """Passing raw strings (not token lists) is the most natural beginner mistake;
+    it must fail with the real cause, not the opaque 'no context' message."""
+    _docs, g, pre = _planted()
+    strings = ["this is a document as a raw string"] * len(g)
+    with pytest.raises(ValueError, match="token lists"):
+        topica.embedding_regression(strings, covariates=g, pre_trained=pre,
+                                    permutations=0)
+
+
+def test_missing_target_names_the_term():
+    docs, g, pre = _planted()
+    with pytest.raises(ValueError, match="notaword"):
+        topica.embedding_regression(docs, covariates=g, pre_trained=pre,
+                                    target="notaword", permutations=0)
+
+
+def test_single_level_categorical_rejected():
+    docs, _g, pre = _planted()
+    labels = ["only"] * len(docs)
+    with pytest.raises(ValueError, match="single level"):
+        topica.embedding_regression(docs, covariates=labels, pre_trained=pre,
+                                    permutations=0)
+
+
+def test_summary_reports_reference_level_and_aligns():
+    docs, _g, pre = _planted()
+    labels = ["dem" if i % 2 else "gop" for i in range(len(docs))]
+    fit = topica.embedding_regression(docs, covariates=labels, pre_trained=pre,
+                                      names=["party"], permutations=0)
+    text = fit.summary()
+    assert fit.reference_level == "dem"          # sorted-first level
+    assert "reference level: dem" in text
+    # the numeric columns line up: every data row's header offsets match
+    assert "party_gop" in text

--- a/tests/test_embedding_regression.py
+++ b/tests/test_embedding_regression.py
@@ -1,0 +1,185 @@
+"""Tests for embedding_regression (conText port): à la carte embeddings +
+covariate regression on meaning, after Rodriguez, Spirling & Stewart (2023)."""
+
+import numpy as np
+import pytest
+
+import topica
+from topica.embedding_regression import alc_embeddings, compute_transform
+
+
+def _pretrained(V=60, D=20, seed=0):
+    rng = np.random.default_rng(seed)
+    words = [f"w{i}" for i in range(V)]
+    emb = rng.normal(size=(V, D))
+    return words, emb
+
+
+def _planted(n=200, seed=1):
+    """Group 0 draws words from the first half of the vocab, group 1 from the
+    second half: the covariate genuinely shifts *which words* (meaning) are used."""
+    words, emb = _pretrained()
+    V = len(words)
+    rng = np.random.default_rng(seed)
+    half, other = list(range(V // 2)), list(range(V // 2, V))
+    docs, g = [], []
+    for i in range(n):
+        gi = i % 2
+        pool = half if gi == 0 else other
+        docs.append([words[j] for j in rng.choice(pool, 8)])
+        g.append(float(gi))
+    return docs, np.array(g), (emb, words)
+
+
+def _null(n=200, seed=2):
+    """Covariate unrelated to the text: both groups draw from the whole vocab."""
+    words, emb = _pretrained()
+    rng = np.random.default_rng(seed)
+    docs = [[words[j] for j in rng.integers(0, len(words), 8)] for _ in range(n)]
+    g = np.array([float(i % 2) for i in range(n)])
+    return docs, g, (emb, words)
+
+
+# --- inference behavior -----------------------------------------------------
+def test_planted_signal_is_significant():
+    docs, g, pre = _planted()
+    r = topica.embedding_regression(docs, g, pre, names=["group"],
+                                    permutations=200, bootstrap=0, seed=1)
+    assert r.normed_estimate[0] > 0.5
+    assert r.p_value[0] < 0.05
+
+
+def test_null_covariate_is_not_significant():
+    docs, g, pre = _null()
+    r = topica.embedding_regression(docs, g, pre, names=["group"],
+                                    permutations=200, bootstrap=0, seed=1)
+    assert r.p_value[0] > 0.1
+
+
+def test_permutation_pvalue_is_calibrated_under_null():
+    """Across independent null draws the permutation p-values should not be tiny."""
+    words, emb = _pretrained()
+    rng = np.random.default_rng(0)
+    ps = []
+    for s in range(8):
+        docs = [[words[j] for j in rng.integers(0, len(words), 8)] for _ in range(150)]
+        g = np.array([float(i % 2) for i in range(150)])
+        r = topica.embedding_regression(docs, g, (emb, words), permutations=100,
+                                        bootstrap=0, seed=s)
+        ps.append(r.p_value[0])
+    assert np.mean(ps) > 0.2  # not systematically significant
+
+
+def test_nearest_neighbors_separate_the_pools():
+    docs, g, pre = _planted()
+    r = topica.embedding_regression(docs, g, pre, names=["group"], permutations=0,
+                                    bootstrap=0, seed=1)
+    nn0 = {w for w, _ in r.nearest_neighbors({"group": 0}, n=8)}
+    nn1 = {w for w, _ in r.nearest_neighbors({"group": 1}, n=8)}
+    first = {f"w{i}" for i in range(30)}
+    # group 0's neighbors lean to the first-half pool more than group 1's do
+    assert len(nn0 & first) > len(nn1 & first)
+
+
+# --- ALC / dem mechanics ----------------------------------------------------
+def test_alc_additive_is_mean_of_context_vectors():
+    words, emb = _pretrained(V=5, D=4)
+    docs = [["w0", "w1"], ["w2", "w3", "w4"]]
+    Y, kept = alc_embeddings(docs, (emb, words), transform=None)
+    assert list(kept) == [0, 1]
+    assert np.allclose(Y[0], (emb[0] + emb[1]) / 2)
+    assert np.allclose(Y[1], (emb[0 + 2] + emb[3] + emb[4]) / 3)
+
+
+def test_alc_focal_term_uses_windowed_context_excluding_focal():
+    words, emb = _pretrained(V=6, D=4)
+    docs = [["w0", "target", "w1", "w2"]]  # 'target' not in vocab; window picks neighbors
+    words2 = words + ["target"]
+    emb2 = np.vstack([emb, np.zeros((1, emb.shape[1]))])
+    Y, kept = alc_embeddings(docs, (emb2, words2), transform=None, target="target", window=1)
+    # window=1 around 'target' -> context {w0, w1}, focal excluded
+    assert np.allclose(Y[0], (emb[0] + emb[1]) / 2)
+
+
+def test_alc_drops_docs_without_invocab_context():
+    words, emb = _pretrained(V=5, D=4)
+    docs = [["w0"], ["zzz", "qqq"], ["w2"]]  # middle doc all OOV
+    Y, kept = alc_embeddings(docs, (emb, words), transform=None)
+    assert list(kept) == [0, 2]
+    assert Y.shape == (2, 4)
+
+
+def test_covariates_realigned_to_kept_docs():
+    words, emb = _pretrained(V=5, D=4)
+    docs = [["w0"], ["zzz"], ["w2"], ["w3"]]  # doc 1 dropped
+    g = np.array([0.0, 1.0, 0.0, 1.0])
+    r = topica.embedding_regression(docs, g, (emb, words), permutations=0,
+                                    bootstrap=0, seed=0)
+    # regression ran on 3 kept docs without a row/length mismatch
+    assert r.coefficients.shape == (1, 4)
+
+
+# --- transform estimation ---------------------------------------------------
+def test_compute_transform_shape():
+    words, emb = _pretrained(V=40, D=8)
+    rng = np.random.default_rng(0)
+    docs = [[words[j] for j in rng.integers(0, len(words), 20)] for _ in range(200)]
+    A = compute_transform(docs, (emb, words), window=4, min_count=5)
+    assert A.shape == (8, 8)
+
+
+def test_compute_transform_raises_when_too_few_words():
+    words, emb = _pretrained(V=10, D=8)
+    docs = [["w0", "w1"]]
+    with pytest.raises(ValueError, match="min_count"):
+        compute_transform(docs, (emb, words), min_count=1000)
+
+
+# --- determinism & CIs ------------------------------------------------------
+def test_determinism():
+    docs, g, pre = _planted()
+    a = topica.embedding_regression(docs, g, pre, permutations=100, bootstrap=50, seed=3)
+    b = topica.embedding_regression(docs, g, pre, permutations=100, bootstrap=50, seed=3)
+    assert np.allclose(a.normed_estimate, b.normed_estimate)
+    assert np.allclose(a.p_value, b.p_value)
+    assert np.allclose(a.normed_ci, b.normed_ci)
+
+
+def test_bootstrap_ci_brackets_estimate():
+    docs, g, pre = _planted()
+    r = topica.embedding_regression(docs, g, pre, names=["group"], permutations=0,
+                                    bootstrap=100, seed=1)
+    assert r.normed_ci[0, 0] <= r.normed_estimate[0] <= r.normed_ci[0, 1]
+
+
+@pytest.mark.parametrize("stat", ["norm", "squared", "squared_deflated"])
+def test_statistic_variants_run(stat):
+    docs, g, pre = _planted()
+    r = topica.embedding_regression(docs, g, pre, statistic=stat, permutations=50,
+                                    bootstrap=0, seed=1)
+    assert np.isfinite(r.normed_estimate[0])
+
+
+# --- input validation -------------------------------------------------------
+def test_covariate_row_mismatch_raises():
+    docs, g, pre = _planted(n=50)
+    with pytest.raises(ValueError, match="one row per document"):
+        topica.embedding_regression(docs, g[:10], pre, permutations=0, bootstrap=0)
+
+
+def test_names_length_mismatch_raises():
+    docs, g, pre = _planted(n=50)
+    with pytest.raises(ValueError, match="names"):
+        topica.embedding_regression(docs, g, pre, names=["a", "b"], permutations=0,
+                                    bootstrap=0)
+
+
+def test_multiple_covariates():
+    docs, g, pre = _planted()
+    rng = np.random.default_rng(5)
+    X = np.column_stack([g, rng.normal(size=len(g))])  # real + noise covariate
+    r = topica.embedding_regression(docs, X, pre, names=["group", "noise"],
+                                    permutations=100, bootstrap=0, seed=1)
+    assert r.coefficients.shape[0] == 2
+    assert r.p_value[0] < 0.05  # real covariate
+    assert r.p_value[1] > 0.1   # noise covariate

--- a/tests/test_embedding_regression.py
+++ b/tests/test_embedding_regression.py
@@ -174,6 +174,39 @@ def test_names_length_mismatch_raises():
                                     bootstrap=0)
 
 
+def test_instance_mode_one_row_per_mention():
+    words, emb = _pretrained(V=30, D=8)
+    # doc 0 mentions the target twice, doc 1 once
+    docs = [["a", "tgt", "b", "tgt", "c"], ["d", "tgt", "e"]]
+    words2 = words + ["tgt", "a", "b", "c", "d", "e"]
+    emb2 = np.vstack([emb, np.random.default_rng(0).normal(size=(6, 8))])
+    Y, doc_ids = alc_embeddings(docs, (emb2, words2), target="tgt", window=1,
+                                aggregate="instance")
+    assert Y.shape[0] == 3          # 2 mentions in doc 0 + 1 in doc 1
+    assert list(doc_ids) == [0, 0, 1]
+    Yd, did = alc_embeddings(docs, (emb2, words2), target="tgt", window=1,
+                             aggregate="document")
+    assert Yd.shape[0] == 2         # pooled per document
+    assert list(did) == [0, 1]
+
+
+def test_categorical_covariate_dummy_coded():
+    docs, g, pre = _planted()
+    party = np.array(["D" if gi == 0 else "R" for gi in g])
+    r = topica.embedding_regression(docs, party, pre, names=["party"],
+                                    permutations=100, bootstrap=0, seed=1)
+    assert r.names == ["party_R"]     # first level D dropped as reference
+    assert r.reference_level == "D"
+    assert r.p_value[0] < 0.05
+
+
+def test_squared_deflated_is_default_and_centered_under_null():
+    docs, g, pre = _null()
+    r = topica.embedding_regression(docs, g, pre, permutations=100, bootstrap=0, seed=1)
+    assert r.statistic == "squared_deflated"
+    assert abs(r.normed_estimate[0]) < 0.2   # deflated null ~ 0 (not a positive floor)
+
+
 def test_multiple_covariates():
     docs, g, pre = _planted()
     rng = np.random.default_rng(5)


### PR DESCRIPTION
Adds `topica.embedding_regression`, a numpy-native implementation of the à la carte on text (conText) embedding regression of Rodriguez, Spirling & Stewart (2023, APSR). It answers the covariate-on-**meaning** question that the prevalence topic models (STM, DMR, Scholar) cannot: *does a covariate shift what a word or theme means?* ("Do Republicans and Democrats mean different things by `immigration`?"). It is a **text-as-data analysis tool, not a topic model** — no topics, no `enable_experimental`.

## Validated against the R package (bit-exact)

`parity/embedding_regression_context.py` runs conText's own bundled data (`cr_sample_corpus` / `cr_glove_subset` / `cr_transform`) through both R `conText` and topica and reproduces, to numerical precision:

| quantity | topica | conText |
|---|---|---|
| à la carte embedding (`dem`) | — | max diff **1.1e-13** |
| squared coefficient norm | 9.858888 | **exact** |
| HC1-deflated norm | 8.398819 | **exact** (n = 924 instances) |

Skips cleanly when Rscript / conText / quanteda are unavailable (like the other `parity/*_compare.py`).

## What's in it

- **Pipeline:** `compute_transform` (learn the ALC matrix), `alc_embeddings` (`dem`), `embedding_regression` (multivariate OLS → coefficient-norm effect size), `EmbeddingRegression.nearest_neighbors` / `nns_ratio` (read *what* the shift means).
- **`inference="context"` (default)** matches today's conText package — Freedman-Lane residual permutation + jackknife t-interval; **`inference="paper"`** is the article's covariate-permutation + bootstrap. Jackknife CI is centered on the estimate and runs in ~1s (conText's takes minutes).
- **`statistic="squared_deflated"`** default (conText's headline; null-centered at ~0), plus `squared` and the paper's `norm`.
- Instance-level target mode (one row per mention), categorical dummy-coding (`party`→`party_R`), transpose convention for external conText matrices.

## Review

Went through a three-reviewer gate (faithfulness vs paper/conText source, adversarial, political-scientist-on-real-data); all findings folded in (rank warning on collinear designs, `nns_ratio` negative-cosine handling, p-smoothing, `min_count` semantics, case-insensitive lookup, non-finite guards, docs reframe).

## Tests

27 unit tests + 2 live parity tests; full preflight (fmt + clippy + stub + docs `--strict`) green. Pure Python — no Rust/ABI changes.

Deferred follow-ups (non-blocking): `~` formula interface, document-clustered inference, bootstrapped `nns` CIs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)