### PR TITLE
fix(manifest): one-sided fingerprint is incomparable, not a difference (#672 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Fixed
 
+- **`compare` no longer reports a one-sided fingerprint as a difference** (#672
+  follow-up). Comparing a `content_fingerprint=True` run with a default
+  `privacy="minimal"` run (which records no content fingerprint) reported the
+  `corpus_fingerprint` field as `only_in_a` / `only_in_b`, so two runs of the *same*
+  corpus read as "differences found". A fingerprint present on only one side is an
+  absence of evidence, not a mismatch, so it is now `incomparable` (symmetric with
+  `verify`'s `unverifiable`): it lands in `ManifestDiff.incomparable`, not
+  `.differences`. `only_in_*` still flags a genuinely recorded plain value (a count,
+  a setting) present in one run but not the other.
+
 - **`verify` no longer reports a clean re-verification as "differences found"**
   (#649 follow-up). At the default `privacy="minimal"` no content fingerprint is
   recorded, so a perfect re-check leaves `corpus_fingerprint` `unverifiable` — an

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,11 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
   corpus read as "differences found". A fingerprint present on only one side is an
   absence of evidence, not a mismatch, so it is now `incomparable` (symmetric with
   `verify`'s `unverifiable`): it lands in `ManifestDiff.incomparable`, not
-  `.differences`. `only_in_*` still flags a genuinely recorded plain value (a count,
-  a setting) present in one run but not the other.
+  `.differences`. `only_in_*` still flags a genuine difference: a recorded plain
+  value (a count, a setting) present in one run but not the other, or a one-sided
+  *input* fingerprint (inputs are recorded unconditionally, so conditioning on a
+  covariate in one run and not the other is a real difference, unlike the
+  privacy-gated corpus fingerprint).
 
 - **`verify` no longer reports a clean re-verification as "differences found"**
   (#649 follow-up). At the default `privacy="minimal"` no content fingerprint is

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -272,10 +272,13 @@ class ManifestDiff:
     As in :class:`VerifyResult`, ``incomparable`` is an *inability to tell* rather
     than a mismatch, and is reported apart from real differences. ``changed`` and
     the ``only_in_*`` statuses are genuine differences: one run recorded a plain
-    value (a count, a setting) the other did not. A *fingerprint* present on only
-    one side is not a difference, though: it is an absence of evidence (a
-    ``privacy="minimal"`` run records none), so it is reported ``incomparable``, not
-    ``only_in_*``.
+    value (a count, a setting) the other did not. A one-sided *corpus/model*
+    fingerprint is not a difference, though: it is an absence of evidence (a
+    ``privacy="minimal"`` run records no corpus content fingerprint), so it is
+    reported ``incomparable``, not ``only_in_*``. Inputs are the exception: they are
+    recorded unconditionally, so a one-sided ``input_*`` fingerprint (one run
+    conditioned on a covariate the other did not) is a genuine ``only_in_*``
+    difference.
     """
 
     fields: dict[str, str]
@@ -506,7 +509,11 @@ class AnalysisManifest:
             self.corpus.get("fingerprint"), other.corpus.get("fingerprint"))
 
         for name in sorted(set(self.inputs) | set(other.inputs)):
-            f[f"input_{name}"] = _cmp_fp(self.inputs.get(name), other.inputs.get(name))
+            # Inputs are recorded unconditionally, so a one-sided input fingerprint
+            # is a genuine difference (one run conditioned on an input the other did
+            # not), not a privacy absence-of-evidence like corpus_fingerprint.
+            f[f"input_{name}"] = _cmp_fp(
+                self.inputs.get(name), other.inputs.get(name), one_sided_is_difference=True)
         return ManifestDiff(f)
 
     # -- rendering (V2): a human-facing "analysis card" ---------------------
@@ -714,16 +721,24 @@ def _read_bundle_manifest(zf) -> dict:
     return d
 
 
-def _cmp_fp(a: dict | None, b: dict | None) -> str:
+def _cmp_fp(a: dict | None, b: dict | None, *, one_sided_is_difference: bool = False) -> str:
     if a is None and b is None:
         return "same"
-    # A fingerprint recorded on only one side is an *absence of evidence*, not a
-    # difference: a `privacy="minimal"` run records no content fingerprint, so
-    # comparing it with a `content_fingerprint=True` run gives nothing to check the
-    # content against. Report it as incomparable (symmetric with `verify`'s
-    # `unverifiable`), never as a difference -- an identical corpus must not read as
-    # changed just because one run chose not to fingerprint it.
     if a is None or b is None:
+        # A fingerprint on only one side is, by default, an *absence of evidence*
+        # rather than a difference: a `privacy="minimal"` run records no corpus
+        # content fingerprint, so comparing it with a `content_fingerprint=True` run
+        # gives nothing to check the content against (report `incomparable`,
+        # symmetric with `verify`'s `unverifiable`; an identical corpus must not read
+        # as changed just because one run chose not to fingerprint it).
+        #
+        # `one_sided_is_difference` flips this for fields that are recorded
+        # *unconditionally*, where absence is a real structural choice, not a privacy
+        # opt-out: an `input_*` fingerprint is written whenever that input was passed
+        # to `record_fit`, so one run conditioning on a covariate the other did not
+        # is a genuine `only_in_*` difference, not an inability to tell.
+        if one_sided_is_difference:
+            return "only_in_a" if a is not None else "only_in_b"
         return "incomparable"
     # Different fingerprint specs, or a keyed digest, cannot be compared for
     # equality of content -- do not guess.

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -264,15 +264,18 @@ class ManifestDiff:
 
     Compares two manifests directly (no corpus or model needed), so it answers
     "did these two runs differ, and where?". ``fields`` maps each field to
-    ``same``, ``changed``, ``only_in_a`` / ``only_in_b`` (recorded in one but not
-    the other), or ``incomparable`` (e.g. fingerprints from different specs, or a
-    keyed digest). ``same`` is a convenience for "every field same"; the summary
-    always shows the breakdown.
+    ``same``, ``changed``, ``only_in_a`` / ``only_in_b`` (a recorded value present
+    in one run but not the other), or ``incomparable`` (fingerprints from different
+    specs, a keyed digest, or a fingerprint recorded on only one side). ``same`` is
+    a convenience for "every field same"; the summary always shows the breakdown.
 
     As in :class:`VerifyResult`, ``incomparable`` is an *inability to tell* rather
-    than a mismatch, and is reported apart from real differences (``changed`` and
-    the ``only_in_*`` statuses, which are genuine: one run recorded a field the
-    other did not).
+    than a mismatch, and is reported apart from real differences. ``changed`` and
+    the ``only_in_*`` statuses are genuine differences: one run recorded a plain
+    value (a count, a setting) the other did not. A *fingerprint* present on only
+    one side is not a difference, though: it is an absence of evidence (a
+    ``privacy="minimal"`` run records none), so it is reported ``incomparable``, not
+    ``only_in_*``.
     """
 
     fields: dict[str, str]
@@ -714,10 +717,14 @@ def _read_bundle_manifest(zf) -> dict:
 def _cmp_fp(a: dict | None, b: dict | None) -> str:
     if a is None and b is None:
         return "same"
-    if a is None:
-        return "only_in_b"
-    if b is None:
-        return "only_in_a"
+    # A fingerprint recorded on only one side is an *absence of evidence*, not a
+    # difference: a `privacy="minimal"` run records no content fingerprint, so
+    # comparing it with a `content_fingerprint=True` run gives nothing to check the
+    # content against. Report it as incomparable (symmetric with `verify`'s
+    # `unverifiable`), never as a difference -- an identical corpus must not read as
+    # changed just because one run chose not to fingerprint it.
+    if a is None or b is None:
+        return "incomparable"
     # Different fingerprint specs, or a keyed digest, cannot be compared for
     # equality of content -- do not guess.
     if a.get("spec") != b.get("spec") or a.get("keyed") or b.get("keyed"):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -784,12 +784,22 @@ def test_compare_localizes_a_changed_input(fitted):
     assert diff.fields["model_topic_word"] == "same"
 
 
-def test_compare_only_in_one(fitted):
+def test_compare_one_sided_fingerprint_is_incomparable_not_a_difference(fitted):
+    # One run fingerprinted the corpus, the other (default privacy) did not. That
+    # is an absence of evidence, not a difference: an identical corpus must not read
+    # as changed, symmetric with verify's `unverifiable`.
     corpus, model = fitted
     with_fp = record_fit(model, corpus, content_fingerprint=True, iters=50)
     without = record_fit(model, corpus, iters=50)
-    assert with_fp.compare(without).fields["corpus_fingerprint"] == "only_in_a"
-    assert without.compare(with_fp).fields["corpus_fingerprint"] == "only_in_b"
+    ab = with_fp.compare(without)
+    ba = without.compare(with_fp)
+    assert ab.fields["corpus_fingerprint"] == "incomparable"
+    assert ba.fields["corpus_fingerprint"] == "incomparable"
+    # ... so it lands in .incomparable, not .differences, and the headline does not
+    # cry "differences found" for two runs of the same corpus.
+    assert "corpus_fingerprint" in ab.incomparable
+    assert "corpus_fingerprint" not in ab.differences
+    assert not ab.same  # but incomparable still never reads as a match
 
 
 def test_compare_incomparable_across_specs(fitted):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -802,6 +802,21 @@ def test_compare_one_sided_fingerprint_is_incomparable_not_a_difference(fitted):
     assert not ab.same  # but incomparable still never reads as a match
 
 
+def test_compare_one_sided_input_is_a_real_difference(fitted):
+    # Inputs are recorded unconditionally, so conditioning on a covariate in one run
+    # and not the other is a genuine difference, not an absence-of-evidence: it must
+    # stay only_in_*, unlike the privacy-gated corpus fingerprint above.
+    corpus, model = fitted
+    with_cov = record_fit(model, corpus, prevalence=X, iters=50)
+    without = record_fit(model, corpus, iters=50)
+    ab = with_cov.compare(without)
+    ba = without.compare(with_cov)
+    assert ab.fields["input_prevalence"] == "only_in_a"
+    assert ba.fields["input_prevalence"] == "only_in_b"
+    assert "input_prevalence" in ab.differences
+    assert "input_prevalence" not in ab.incomparable
+
+
 def test_compare_incomparable_across_specs(fitted):
     corpus, model = fitted
     a = record_fit(model, corpus, content_fingerprint=True, iters=50)


### PR DESCRIPTION
## What

Follow-up to #672 (which fixed the same class of false alarm in `verify`). `compare()` reported the `corpus_fingerprint` field as `only_in_a` / `only_in_b` when one run recorded a content fingerprint and the other (default `privacy="minimal"`) did not, so **two runs of the same corpus read as "differences found."**

A fingerprint present on only one side is an *absence of evidence*, not a mismatch: there is nothing to check the content against. `_cmp_fp` now returns `incomparable` for it, symmetric with `verify`'s `unverifiable`. It lands in `ManifestDiff.incomparable`, not `.differences`, and no longer drives the headline.

`_cmp_value`'s `only_in_*` (a recorded plain value — a count, a setting — present in one run but not the other) stays a genuine difference; only fingerprint asymmetry changed.

## Tests

Updated `test_compare_only_in_one` → `test_compare_one_sided_fingerprint_is_incomparable_not_a_difference` (asserts `incomparable` both directions, lands in `.incomparable` not `.differences`, and `same` stays `False`). 105 manifest/compare tests pass; preflight + mkdocs `--strict` green. Pure Python, no Rust/ABI change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)