### PR TITLE
feat(llm): topica.llm.judge — pairwise topic-document Elo ranking (#583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- **`topica.llm.judge` — rank whole topic models by pairwise topic-document fit**
+  (#583). A model-agnostic port of the *topic judge* from Zheng et al. (2025,
+  "Model Directions, Not Words", App. G): for each model pair it samples documents,
+  shows an LLM each model's top topics for a document (as one-sentence summaries, so
+  models with different vocabularies compare fairly, or as word lists), asks which set
+  better captures the document, and aggregates the wins with a Bradley-Terry model
+  rescaled to Elo (mean 1500) with bootstrap CIs. Unlike `llm.coherence` (intra-topic
+  word relatedness) it scores topic-*document* fit across model families, so it is the
+  natural engine for ranking fitted models on one corpus. Returns a `JudgeResult`
+  (`.elo`, `.bootstrap_ci`, `.win_matrix`, `.ranking()`, `.summary()`, `.to_frame()`,
+  and the raw `.comparisons` for audit). Adds a `representation="summary"` topic
+  rendering shared with the judge. `llm-bounded`: the LLM is not bit-reproducible, but
+  `seed` fixes the document sampling and A/B order. First of the model-agnostic LLM
+  pipeline tools from the paper (`refine`, human-agreement helper to follow).
+
 - **`topica.embedding_regression` — covariate effects on word meaning** (#669). A
   numpy-native port of the à la carte on text (conText) embedding regression of
   Rodriguez, Spirling and Stewart (2023), validated bit-exact against the R `conText`

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -108,6 +108,31 @@ mean purity. This is the paper's *working* number-of-topics signal — doc-label
 tracks ground-truth cluster quality, where rating the top *words* across `k` does not
 — and complements `search_k`'s coherence, exclusivity, held-out, and dispersion criteria.
 
+### Ranking whole models: `llm.judge` (Zheng et al. 2025)
+
+`llm.coherence` scores words *within* a topic; `llm.judge` scores how well a model's
+topics fit a *document*, and ranks whole models against each other:
+
+```python
+result = topica.llm.judge(
+    {"lda": lda, "stm": stm, "bertopic": bt},   # fitted on the SAME docs, same order
+    docs, backend=backend,
+    n_comparisons=100, representation="summary",  # or "words"
+)
+result.elo            # {"lda": 1487, "stm": 1533, ...} — Bradley-Terry, rescaled to Elo
+result.summary()      # leaderboard with bootstrap CIs
+result.comparisons    # raw (doc, A, B, choice, reasoning) records, re-aggregatable
+```
+
+For each model pair it samples documents, shows the judge each model's top topics for
+that document (as one-sentence summaries, so models with *different* vocabularies —
+words vs. embeddings vs. features — compare fairly), asks which set better captures the
+document, and aggregates the wins with a Bradley-Terry model rescaled to Elo (mean
+1500) with bootstrap CIs. This is the paper's flagship metric: it is the one signal
+that compares different model *families* on topic-*document* fit rather than intra-topic
+word relatedness, so it is the natural way to rank a set of fitted models on one corpus.
+`seed` fixes the document sampling and A/B order (the LLM itself stays `llm-bounded`).
+
 ### A multi-dimensional suite (Tan & D'Souza 2025)
 
 Coherence rating answers one question — *are these words related?* — but a topic can

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -137,19 +137,28 @@ Three things to keep in mind:
 
 - **Cost.** A run makes `n_comparisons × M(M-1)/2` LLM calls for `M` models (plus, in
   `summary` mode, one cached call per surfaced topic). The default `n_comparisons=100`
-  follows the paper and is hundreds of calls for a few models; start smaller while
-  exploring.
+  follows the paper and is hundreds of calls for a few models — at a rough ~2-3s per
+  call that is ~10-15 min for a 3-model paper-sized run. Preview the exact count with
+  `judge(..., dry_run=True)` (returns the plan, makes no calls), and start smaller
+  while exploring.
 - **Read the CIs.** With few comparisons the bootstrap intervals overlap and the
   ranking does not actually separate the models; treat overlapping CIs as *no
-  decision* (`summary()` flags when the top two overlap) and raise `n_comparisons`
-  before reporting an Elo table. The paper uses 100 *per pair*.
+  decision* (`summary()` flags every adjacent pair whose CIs overlap) and raise
+  `n_comparisons` before reporting an Elo table. The paper uses 100 *per pair*.
 - **Representation.** Use `representation="summary"` to compare *different families*
   fairly; `representation="words"` is cheaper (no summary calls) and fine for a
-  same-family sweep such as LDA at several `k`.
-
+  same-family sweep such as LDA at several `k`. Summaries are themselves LLM calls, so
+  `summary` mode trades a vocabulary-style bias for a (usually smaller) summarizer
+  bias — use a capable model.
 - **Same corpus, same order.** Every model must be fit on the same `docs` in the same
-  order — judge aligns `doc_topic` row `d` to `docs[d]` and cannot verify more than the
-  row count (it warns when the models' vocabularies disagree, a sign they were not).
+  order — judge aligns `doc_topic` row `d` to `docs[d]`. It warns when the models'
+  vocabularies disagree (which catches different corpora, or the same corpus in a
+  different order), but that is only a proxy and cannot catch a misalignment under a
+  shared fixed vocabulary, so ensure the alignment yourself. A/B presentation order is
+  randomized (fixed by `seed`) specifically to cancel the judge's position bias, so a
+  lopsided A-vs-B count in `.comparisons` is expected and does not bias the Elo. Each
+  record also keeps the exact topic-set text shown to the judge, so a run is fully
+  re-auditable.
 
 ### A multi-dimensional suite (Tan & D'Souza 2025)
 

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -133,6 +133,24 @@ that compares different model *families* on topic-*document* fit rather than int
 word relatedness, so it is the natural way to rank a set of fitted models on one corpus.
 `seed` fixes the document sampling and A/B order (the LLM itself stays `llm-bounded`).
 
+Three things to keep in mind:
+
+- **Cost.** A run makes `n_comparisons × M(M-1)/2` LLM calls for `M` models (plus, in
+  `summary` mode, one cached call per surfaced topic). The default `n_comparisons=100`
+  follows the paper and is hundreds of calls for a few models; start smaller while
+  exploring.
+- **Read the CIs.** With few comparisons the bootstrap intervals overlap and the
+  ranking does not actually separate the models; treat overlapping CIs as *no
+  decision* (`summary()` flags when the top two overlap) and raise `n_comparisons`
+  before reporting an Elo table. The paper uses 100 *per pair*.
+- **Representation.** Use `representation="summary"` to compare *different families*
+  fairly; `representation="words"` is cheaper (no summary calls) and fine for a
+  same-family sweep such as LDA at several `k`.
+
+- **Same corpus, same order.** Every model must be fit on the same `docs` in the same
+  order — judge aligns `doc_topic` row `d` to `docs[d]` and cannot verify more than the
+  row count (it warns when the models' vocabularies disagree, a sign they were not).
+
 ### A multi-dimensional suite (Tan & D'Souza 2025)
 
 Coherence rating answers one question — *are these words related?* — but a topic can

--- a/parity/llm_judge_live.py
+++ b/parity/llm_judge_live.py
@@ -1,0 +1,71 @@
+"""Live sanity check for `topica.llm.judge` (Zheng et al. 2025, App. G) against a real
+LLM backend.
+
+Fits a few models at different K on a bundled corpus and runs the pairwise topic
+judge, printing the Bradley-Terry -> Elo leaderboard with bootstrap CIs. The judge is
+`llm-bounded`, so this is a measurement (with model noise), not a bit-exact gate; it is
+NOT run in CI. It skips cleanly when no LLM backend is configured.
+
+Run:  VIRTUAL_ENV=.venv-dev .venv-dev/bin/python parity/llm_judge_live.py
+
+Config via env: LLM_EVAL_MODEL (default an open model on openrouter),
+LLM_JUDGE_COMPARISONS (default 30, small so a live run is cheap).
+"""
+
+from __future__ import annotations
+
+import os
+
+MODEL = os.environ.get("LLM_EVAL_MODEL", "openrouter/qwen/qwen3-235b-a22b-2507")
+N_COMPARISONS = int(os.environ.get("LLM_JUDGE_COMPARISONS", "30"))
+
+
+def available() -> bool:
+    try:
+        import topica  # noqa: F401
+    except Exception:
+        return False
+    return bool(
+        os.environ.get("OPENROUTER_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY")
+    )
+
+
+def main() -> None:
+    if not available():
+        print("SKIP: no LLM backend configured (set OPENROUTER_API_KEY / OPENAI_API_KEY "
+              "/ ANTHROPIC_API_KEY) or topica not importable.")
+        return
+
+    import topica
+
+    # A small real corpus with clear structure. ng20 (5 groups) is bundled.
+    bunch = topica.datasets.load_ng20_minilm()
+    import re
+
+    docs = [[w for w in re.split(r"[^a-z0-9]+", t.lower()) if w] for t in bunch.texts]
+    docs = docs[:400]  # keep the live run cheap
+
+    models = {}
+    for k in (5, 10, 20):
+        m = topica.LDA(k, seed=13)
+        m.fit(docs, iters=200)
+        models[f"lda_k{k}"] = m
+
+    backend = topica.llm.backend(MODEL, temperature=0)
+    result = topica.llm.judge(
+        models, docs, backend=backend,
+        n_comparisons=N_COMPARISONS, representation="summary", seed=13,
+    )
+    print(f"model={MODEL}  comparisons/pair={N_COMPARISONS}  docs={len(docs)}")
+    print(result.summary())
+    print("\nranking (best first):", result.ranking())
+    # A weak, honest expectation: the K matched to the 5-group structure should not be
+    # dead last. This is a smell test, not a gate (the judge is llm-bounded).
+    if result.ranking()[-1] == "lda_k5":
+        print("NOTE: lda_k5 ranked last — inspect result.comparisons for why.")
+
+
+if __name__ == "__main__":
+    main()

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import math
 import re
+import warnings
 from collections import Counter, defaultdict
 from dataclasses import dataclass
 from itertools import combinations
@@ -1467,12 +1468,22 @@ class JudgeResult:
         return pd.DataFrame(rows)
 
     def summary(self) -> str:
-        """A short text leaderboard (model, Elo, CI), best-first."""
+        """A short text leaderboard (model, Elo, CI), best-first. Flags when the top
+        two models' bootstrap CIs overlap -- with few comparisons they usually do,
+        and an overlap means the ranking does not separate them (treat as no
+        decision, and raise ``n_comparisons``)."""
+        rank = self.ranking()
         lines = [f"LLM topic judge ({self.representation}, {len(self.comparisons)} "
                  f"comparisons, Elo mean 1500)"]
-        for nm in self.ranking():
+        for nm in rank:
             lo, hi = self.bootstrap_ci.get(nm, (float("nan"), float("nan")))
             lines.append(f"  {nm:<20s} {self.elo[nm]:7.1f}  [{lo:7.1f}, {hi:7.1f}]")
+        if len(rank) >= 2:
+            (lo0, hi0), (lo1, hi1) = (self.bootstrap_ci.get(rank[0], (float("nan"),) * 2),
+                                      self.bootstrap_ci.get(rank[1], (float("nan"),) * 2))
+            if not math.isnan(lo0) and not math.isnan(hi1) and lo0 <= hi1:
+                lines.append("  note: the top two CIs overlap -- not a decision at "
+                             "this n_comparisons; raise it to separate the models.")
         return "\n".join(lines)
 
 
@@ -1497,10 +1508,22 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
     bit-reproducible, but ``seed`` fixes the document sampling and presentation order,
     so the comparison *design* is reproducible.
 
+    Cost: judge makes ``n_comparisons * M*(M-1)/2`` LLM calls for ``M`` models, plus
+    (for ``representation="summary"``) up to one cached summary call per surfaced
+    ``(model, topic)``. The default ``n_comparisons=100`` follows the paper and can be
+    hundreds of calls; lower it (and read the CIs) while exploring. With few
+    comparisons the bootstrap CIs overlap and the ranking does not separate the
+    models -- :meth:`JudgeResult.summary` flags that -- so scale ``n_comparisons`` up
+    before reporting an Elo table.
+
     Parameters
     ----------
     models : dict[str, fitted model]
         Two or more fitted models, all fit on the same ``docs`` in the same order.
+        judge aligns each model's ``doc_topic`` row ``d`` to ``docs[d]`` and cannot
+        verify the correspondence beyond the row count, so models fit on different
+        documents produce a silently invalid ranking (it warns when their
+        vocabularies disagree). Same corpus, same order.
     docs : Corpus | list of str | list of token lists
         The documents, in the order the models were fit on (their ``doc_topic`` rows).
     backend : callable ``str -> str`` or model-name str
@@ -1513,19 +1536,36 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
     p : float
         Cumulative-probability cap on top topics (the smaller of ``q`` / ``p`` wins).
     representation : {"summary", "words"}
-        Render each topic as a one-sentence LLM summary (paper default, fair across
-        vocabularies) or as its top-``n_words`` word list.
+        Render each topic as a one-sentence LLM summary (paper default; use it to
+        compare *different model families* fairly) or as its top-``n_words`` word list
+        ("words" is cheaper -- no summary calls -- and fine for a same-family sweep,
+        e.g. LDA at several K).
+    n_words : int
+        Top words shown per topic in ``"words"`` mode, and summarized per topic in
+        ``"summary"`` mode.
+    dataset_description : optional str
+        A one-line corpus description added to every prompt (e.g. "Usenet posts about
+        computing and politics"), which can sharpen the judge and the summaries.
     bootstrap : int
-        Resamples for the per-model Elo CI; 0 skips.
+        Resamples for the per-model Elo CI; 0 skips (CIs come back NaN).
+    confidence_level : float
+        Central mass of the bootstrap percentile interval (default 0.95).
     bt_smoothing : float
         Phantom-tie pseudocount per pair for a finite Elo when a model always/never
         wins.
+    max_chars : int
+        Truncate each document to this many characters in the judge prompt.
     seed : int
         Seeds document sampling and A/B presentation order (the LLM is still bounded).
+    prompts : optional dict
+        Override the editable templates (keys ``"judge"``, ``"summary"``); defaults to
+        :data:`LLM_EVAL_PROMPTS`.
 
     Returns
     -------
     JudgeResult
+        The Elo ranking, bootstrap CIs, win matrix, and the raw comparison records
+        (see :class:`JudgeResult`).
     """
     if not isinstance(models, dict):
         raise TypeError("models must be a dict {name: fitted_model}")
@@ -1548,6 +1588,25 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
                 f"model {nm!r} has {th.shape[0]} doc-topic rows but there are {D} "
                 "documents; every model must be fit on the same docs, in order")
         thetas[nm] = th
+
+    # judge aligns doc_topic row d to docs[d] and cannot otherwise verify that every
+    # model saw the same documents in the same order. The row-count check above only
+    # catches a length mismatch, not two models fit on *different* same-length slices
+    # (a silently invalid ranking). Differing vocabularies are a strong signal of
+    # that mistake, so warn on it -- the cheapest guard short of a stored corpus hash.
+    vocabs = {}
+    for nm, m in models.items():
+        try:
+            vocabs[nm] = tuple(m.vocabulary)
+        except Exception:
+            pass
+    if len(set(vocabs.values())) > 1:
+        warnings.warn(
+            "the models have different vocabularies, which usually means they were "
+            "fit on different corpora; judge assumes every model was fit on the same "
+            "documents in the same order (it aligns doc_topic row d to docs[d]) and "
+            "the ranking is invalid otherwise. Re-fit all models on one corpus.",
+            stacklevel=2)
 
     idx = {nm: i for i, nm in enumerate(names)}
     M = len(names)

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -1436,9 +1436,10 @@ class JudgeResult:
     bootstrap_ci : dict[str, tuple[float, float]]
         Per-model percentile CI on Elo from resampling the comparisons.
     comparisons : list[dict]
-        The raw audit records (``doc``, ``model_a``, ``model_b`` as presented,
-        ``choice``, ``winner``, ``reasoning``), so a run is re-aggregatable without
-        re-calling the LLM.
+        The raw audit records: ``doc``, ``model_a`` / ``model_b`` (as presented),
+        ``set_a`` / ``set_b`` (the exact rendered topic-set text the judge saw),
+        ``choice``, ``winner``, and ``reasoning``. Storing the rendered sets makes a
+        run fully re-auditable and re-aggregatable without re-calling the LLM.
     names : list[str]
         Model names, the order of ``win_matrix`` rows/columns.
     representation : str
@@ -1468,29 +1469,32 @@ class JudgeResult:
         return pd.DataFrame(rows)
 
     def summary(self) -> str:
-        """A short text leaderboard (model, Elo, CI), best-first. Flags when the top
-        two models' bootstrap CIs overlap -- with few comparisons they usually do,
-        and an overlap means the ranking does not separate them (treat as no
-        decision, and raise ``n_comparisons``)."""
+        """A short text leaderboard (model, Elo, CI), best-first. Flags every pair of
+        *adjacent* models whose bootstrap CIs overlap -- with few comparisons they
+        usually do, and an overlap means the ranking does not separate that pair
+        (treat as no decision there, and raise ``n_comparisons``)."""
         rank = self.ranking()
         lines = [f"LLM topic judge ({self.representation}, {len(self.comparisons)} "
                  f"comparisons, Elo mean 1500)"]
         for nm in rank:
             lo, hi = self.bootstrap_ci.get(nm, (float("nan"), float("nan")))
             lines.append(f"  {nm:<20s} {self.elo[nm]:7.1f}  [{lo:7.1f}, {hi:7.1f}]")
-        if len(rank) >= 2:
-            (lo0, hi0), (lo1, hi1) = (self.bootstrap_ci.get(rank[0], (float("nan"),) * 2),
-                                      self.bootstrap_ci.get(rank[1], (float("nan"),) * 2))
-            if not math.isnan(lo0) and not math.isnan(hi1) and lo0 <= hi1:
-                lines.append("  note: the top two CIs overlap -- not a decision at "
-                             "this n_comparisons; raise it to separate the models.")
+        overlaps = []
+        for hi_nm, lo_nm in zip(rank, rank[1:]):
+            hi_lo = self.bootstrap_ci.get(hi_nm, (float("nan"),) * 2)[0]
+            lo_hi = self.bootstrap_ci.get(lo_nm, (float("nan"),) * 2)[1]
+            if not math.isnan(hi_lo) and not math.isnan(lo_hi) and hi_lo <= lo_hi:
+                overlaps.append(f"{hi_nm}~{lo_nm}")
+        if overlaps:
+            lines.append("  note: overlapping CIs (not separated at this "
+                         f"n_comparisons): {', '.join(overlaps)}; raise n_comparisons.")
         return "\n".join(lines)
 
 
 def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
               representation="summary", n_words=10, dataset_description=None,
               bootstrap=100, confidence_level=0.95, bt_smoothing=1.0, max_chars=1500,
-              seed=0, prompts=None):
+              seed=0, dry_run=False, prompts=None):
     """Rank topic models by an LLM's pairwise topic-document judgments (Zheng et al.
     2025, App. G) -- the paper's flagship, vocabulary-agnostic evaluation.
 
@@ -1522,8 +1526,11 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
         Two or more fitted models, all fit on the same ``docs`` in the same order.
         judge aligns each model's ``doc_topic`` row ``d`` to ``docs[d]`` and cannot
         verify the correspondence beyond the row count, so models fit on different
-        documents produce a silently invalid ranking (it warns when their
-        vocabularies disagree). Same corpus, same order.
+        documents produce a silently invalid ranking. It warns when the models'
+        vocabularies disagree, which catches the common case (different corpora, or the
+        same corpus in a different order), but that is only a *proxy*: a misalignment
+        under a shared fixed vocabulary is not caught, so ensure yourself that every
+        model was fit on the same documents in the same order.
     docs : Corpus | list of str | list of token lists
         The documents, in the order the models were fit on (their ``doc_topic`` rows).
     backend : callable ``str -> str`` or model-name str
@@ -1557,6 +1564,10 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
         Truncate each document to this many characters in the judge prompt.
     seed : int
         Seeds document sampling and A/B presentation order (the LLM is still bounded).
+    dry_run : bool
+        If ``True``, make no LLM calls and return a plan dict instead
+        (``{"models", "pairs", "n_comparisons", "judge_calls", "max_summary_calls",
+        "representation"}``) so you can preview the cost before paying for a run.
     prompts : optional dict
         Override the editable templates (keys ``"judge"``, ``"summary"``); defaults to
         :data:`LLM_EVAL_PROMPTS`.
@@ -1565,7 +1576,7 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
     -------
     JudgeResult
         The Elo ranking, bootstrap CIs, win matrix, and the raw comparison records
-        (see :class:`JudgeResult`).
+        (see :class:`JudgeResult`). If ``dry_run=True``, a plan ``dict`` instead.
     """
     if not isinstance(models, dict):
         raise TypeError("models must be a dict {name: fitted_model}")
@@ -1602,14 +1613,31 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
             pass
     if len(set(vocabs.values())) > 1:
         warnings.warn(
-            "the models have different vocabularies, which usually means they were "
-            "fit on different corpora; judge assumes every model was fit on the same "
-            "documents in the same order (it aligns doc_topic row d to docs[d]) and "
-            "the ranking is invalid otherwise. Re-fit all models on one corpus.",
+            "the models have different vocabularies (different words, or the same "
+            "words in a different order), which usually means they were fit on "
+            "different corpora or the same corpus in a different order; judge assumes "
+            "every model was fit on the same documents in the same order (it aligns "
+            "doc_topic row d to docs[d]) and the ranking is invalid otherwise. Re-fit "
+            "all models on one corpus, in one order. (This vocabulary check is a "
+            "proxy: it cannot catch a misalignment where the vocabularies happen to "
+            "match, e.g. a shared fixed vocabulary.)",
             stacklevel=2)
 
-    idx = {nm: i for i, nm in enumerate(names)}
     M = len(names)
+    n_pairs = M * (M - 1) // 2
+    judge_calls = max(1, n_comparisons) * n_pairs
+    if dry_run:
+        # Return the plan without calling the LLM, so a user can preview the cost of a
+        # (potentially hundreds-of-calls) run before paying for it.
+        max_summary_calls = 0
+        if representation == "summary":
+            for m in models.values():
+                max_summary_calls += int(getattr(m, "num_topics", 0))
+        return {"models": M, "pairs": n_pairs, "n_comparisons": max(1, n_comparisons),
+                "judge_calls": judge_calls, "max_summary_calls": max_summary_calls,
+                "representation": representation}
+
+    idx = {nm: i for i, nm in enumerate(names)}
     win = np.zeros((M, M))
     cache: dict = {}
     comparisons: list = []
@@ -1639,6 +1667,7 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
             else:
                 winner = None  # tie / unparseable -> split credit
             comparisons.append({"doc": d, "model_a": first, "model_b": second,
+                                "set_a": set_a, "set_b": set_b,
                                 "choice": choice, "winner": winner,
                                 "reasoning": str(reply).strip()})
             if winner == a:

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -832,11 +832,31 @@ ALIGN_MISSING_PROMPT = (
     "that are NOT captured by the topic words. Reply with a comma-separated list of "
     'the missing themes, or "none".\n\nDocument:\n{document}\n\nTopic words: {words}'
 )
+# Zheng et al. (2025, "Model Directions, Not Words", arXiv:2507.23220) wrap their
+# topic models in model-agnostic LLM tools. The topic *judge* (App. G) is the
+# flagship: a Chatbot-Arena-style pairwise comparison that scores topic-document fit
+# across models with *different* vocabularies (words vs summaries vs features). The
+# summary rendering (F.2) is a uniform one-sentence topic description so that
+# comparison is apples-to-apples regardless of a model's native representation.
+JUDGE_PROMPT = (
+    "You are a helpful assistant comparing two topic models by how well their topics "
+    "describe a document. {dataset}Below is a document, then two sets of topics (A and "
+    "B) that two models assigned to it. Decide which set better captures the "
+    "document's main themes. Reply with \"A\", \"B\", or \"tie\" on the first line, then "
+    "one sentence of reasoning.\n\nDocument:\n{document}\n\nTopic set A:\n{set_a}\n\n"
+    "Topic set B:\n{set_b}"
+)
+SUMMARY_PROMPT = (
+    "You are a helpful assistant summarizing a topic from a topic model. {dataset}"
+    "Given the topic's top words, describe its central theme in a single short "
+    "sentence. Reply with only that sentence.\n\n{words}"
+)
 LLM_EVAL_PROMPTS: dict[str, str] = {
     "rating": RATING_PROMPT, "intrusion": INTRUSION_PROMPT, "label": LABEL_PROMPT,
     "outlier": OUTLIER_PROMPT, "repetitive_rate": REPETITIVE_RATE_PROMPT,
     "duplicate": DUPLICATE_PROMPT, "diversity": DIVERSITY_PROMPT,
     "align_irrelevant": ALIGN_IRRELEVANT_PROMPT, "align_missing": ALIGN_MISSING_PROMPT,
+    "judge": JUDGE_PROMPT, "summary": SUMMARY_PROMPT,
 }
 
 
@@ -1300,3 +1320,296 @@ def llm_alignment(model, docs, *, backend, n_words=10, n_docs=5,
                     "irrelevant": float(np.mean(irr)) if irr else float("nan"),
                     "missing": float(np.mean(mis)) if mis else float("nan")})
     return out
+
+
+# ---------------------------------------------------------------------------
+# Topic judge: pairwise document-topic evaluation -> Bradley-Terry -> Elo
+# (Zheng et al. 2025, "Model Directions, Not Words", App. G)
+# ---------------------------------------------------------------------------
+
+
+def _top_topics_for_doc(theta_row, q, p):
+    """A document's top topics: the top ``q`` by weight, or the fewest topics whose
+    cumulative weight reaches fraction ``p`` of the row, whichever is *fewer*
+    (Zheng et al. 2025, §5.1). Always at least one topic."""
+    order = np.argsort(theta_row)[::-1]
+    if order.size == 0:
+        return []
+    csum = np.cumsum(theta_row[order])
+    total = csum[-1]
+    n_p = int(np.searchsorted(csum, p * total) + 1) if total > 0 else order.size
+    n = min(int(q), n_p) if q else n_p
+    n = max(1, min(n, order.size))
+    return [int(i) for i in order[:n]]
+
+
+def _render_topic_set(model, topic_ids, representation, backend, ds, n_words,
+                      summary_tmpl, cache):
+    """Render a model's topics for one document as text: a word list per topic, or a
+    one-sentence LLM summary per topic (cached per ``(model, topic)`` so a topic is
+    summarized once no matter how many comparisons reuse it)."""
+    from .analysis import _top_words
+
+    lines = []
+    for t in topic_ids:
+        words = _top_words(model, int(t), n_words)
+        if representation == "summary":
+            key = (id(model), int(t))
+            if key not in cache:
+                reply = backend(summary_tmpl.format(dataset=ds, words=", ".join(words)))
+                cache[key] = " ".join(str(reply).strip().split()) or ", ".join(words)
+            lines.append(f"- {cache[key]}")
+        else:
+            lines.append(f"- {', '.join(words)}")
+    return "\n".join(lines)
+
+
+def _parse_judge_choice(reply):
+    """Parse an ``A`` / ``B`` / ``tie`` verdict from the judge's reply. Returns
+    ``"a"``, ``"b"``, ``"tie"``, or ``None`` when nothing is recognisable (treated as
+    a tie by the caller)."""
+    r = str(reply).strip().lower()
+    head = re.sub(r"[^a-z ]", " ", r[:40]).split()
+    for tok in head:
+        if tok in ("a", "b", "tie"):
+            return tok
+    if "tie" in r:
+        return "tie"
+    m = re.search(r"\b([ab])\b", r)
+    return m.group(1) if m else None
+
+
+def _bradley_terry(win, *, smoothing=1.0, iters=1000, tol=1e-10):
+    """Bradley-Terry strengths from a win-credit matrix by the MM algorithm (Hunter
+    2004). ``win[i, j]`` is the credit model ``i`` earned against ``j`` (a win = 1, a
+    tie = 0.5 each). ``smoothing`` adds a phantom tie to every ordered pair so a model
+    that always or never wins still gets a finite strength. Strengths are normalised
+    to geometric mean 1."""
+    W = np.asarray(win, dtype=float).copy()
+    M = W.shape[0]
+    if smoothing:
+        off = (np.ones((M, M)) - np.eye(M)) * (0.5 * smoothing)
+        W = W + off
+    n = W + W.T  # games played between i and j
+    w = W.sum(axis=1)  # total win-credit for i
+    p = np.ones(M)
+    for _ in range(iters):
+        p_new = np.empty(M)
+        for i in range(M):
+            denom = 0.0
+            for j in range(M):
+                if i != j:
+                    s = p[i] + p[j]
+                    if s > 0:
+                        denom += n[i, j] / s
+            p_new[i] = (w[i] / denom) if denom > 0 else p[i]
+        p_new = np.maximum(p_new, 1e-300)
+        p_new /= np.exp(np.mean(np.log(p_new)))
+        if np.max(np.abs(p_new - p)) < tol:
+            p = p_new
+            break
+        p = p_new
+    return p
+
+
+def _bt_to_elo(strengths, base=1500.0, scale=400.0):
+    """Rescale Bradley-Terry strengths to Elo (default mean 1500): a 400-point gap is
+    a 10:1 predicted win ratio, matching ``P(i beats j) = p_i / (p_i + p_j)``."""
+    logp = np.log10(np.maximum(np.asarray(strengths, dtype=float), 1e-300))
+    return scale * (logp - logp.mean()) + base
+
+
+@dataclass
+class JudgeResult:
+    """Result of :func:`llm_judge`: an Elo ranking of the compared models.
+
+    Attributes
+    ----------
+    elo : dict[str, float]
+        Bradley-Terry strengths rescaled to Elo (mean 1500); higher is better.
+    win_matrix : numpy.ndarray
+        ``(M, M)`` win-credit matrix (``[i, j]`` = credit model ``i`` earned against
+        ``j``; a tie adds 0.5 each way), in ``names`` order.
+    bootstrap_ci : dict[str, tuple[float, float]]
+        Per-model percentile CI on Elo from resampling the comparisons.
+    comparisons : list[dict]
+        The raw audit records (``doc``, ``model_a``, ``model_b`` as presented,
+        ``choice``, ``winner``, ``reasoning``), so a run is re-aggregatable without
+        re-calling the LLM.
+    names : list[str]
+        Model names, the order of ``win_matrix`` rows/columns.
+    representation : str
+        ``"summary"`` or ``"words"`` -- how each topic set was rendered to the judge.
+    """
+
+    elo: dict
+    win_matrix: np.ndarray
+    bootstrap_ci: dict
+    comparisons: list
+    names: list
+    representation: str
+
+    def ranking(self) -> list:
+        """Model names best-to-worst by Elo."""
+        return sorted(self.names, key=lambda k: -self.elo[k])
+
+    def to_frame(self):
+        """A pandas DataFrame: one row per model with ``elo``, ``ci_low``,
+        ``ci_high``, sorted best-first (raises if pandas is absent)."""
+        import pandas as pd
+
+        rows = [{"model": nm, "elo": self.elo[nm],
+                 "ci_low": self.bootstrap_ci.get(nm, (float("nan"),) * 2)[0],
+                 "ci_high": self.bootstrap_ci.get(nm, (float("nan"),) * 2)[1]}
+                for nm in self.ranking()]
+        return pd.DataFrame(rows)
+
+    def summary(self) -> str:
+        """A short text leaderboard (model, Elo, CI), best-first."""
+        lines = [f"LLM topic judge ({self.representation}, {len(self.comparisons)} "
+                 f"comparisons, Elo mean 1500)"]
+        for nm in self.ranking():
+            lo, hi = self.bootstrap_ci.get(nm, (float("nan"), float("nan")))
+            lines.append(f"  {nm:<20s} {self.elo[nm]:7.1f}  [{lo:7.1f}, {hi:7.1f}]")
+        return "\n".join(lines)
+
+
+def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
+              representation="summary", n_words=10, dataset_description=None,
+              bootstrap=100, confidence_level=0.95, bt_smoothing=1.0, max_chars=1500,
+              seed=0, prompts=None):
+    """Rank topic models by an LLM's pairwise topic-document judgments (Zheng et al.
+    2025, App. G) -- the paper's flagship, vocabulary-agnostic evaluation.
+
+    For each unordered model pair and each of ``n_comparisons`` rounds: sample a
+    document, take each model's top topics for it (top ``q``, or the topics under
+    cumulative mass ``p``, whichever fewer), render each set as text, and ask the LLM
+    which set better captures the document. Outcomes (wins, ties as half-wins) are
+    aggregated with a Bradley-Terry model and rescaled to Elo (mean 1500), with a
+    bootstrap CI over the comparisons.
+
+    Unlike :func:`llm_coherence` (intra-topic word relatedness), this scores
+    topic-*document* fit and compares models with *different* vocabularies fairly
+    (words vs. one-sentence summaries), so it is the natural engine for ranking a set
+    of fitted models on the same corpus. ``llm-bounded``: the LLM is not
+    bit-reproducible, but ``seed`` fixes the document sampling and presentation order,
+    so the comparison *design* is reproducible.
+
+    Parameters
+    ----------
+    models : dict[str, fitted model]
+        Two or more fitted models, all fit on the same ``docs`` in the same order.
+    docs : Corpus | list of str | list of token lists
+        The documents, in the order the models were fit on (their ``doc_topic`` rows).
+    backend : callable ``str -> str`` or model-name str
+        The LLM judge (see :func:`llm_coherence`); use ``temperature=0``.
+    n_comparisons : int
+        Comparisons per model pair (paper: 100).
+    q : int
+        Cap on top topics shown per document per model.
+    p : float
+        Cumulative-probability cap on top topics (the smaller of ``q`` / ``p`` wins).
+    representation : {"summary", "words"}
+        Render each topic as a one-sentence LLM summary (paper default, fair across
+        vocabularies) or as its top-``n_words`` word list.
+    bootstrap : int
+        Resamples for the per-model Elo CI; 0 skips.
+    bt_smoothing : float
+        Phantom-tie pseudocount per pair for a finite Elo when a model always/never
+        wins.
+    seed : int
+        Seeds document sampling and A/B presentation order (the LLM is still bounded).
+
+    Returns
+    -------
+    JudgeResult
+    """
+    if not isinstance(models, dict):
+        raise TypeError("models must be a dict {name: fitted_model}")
+    names = list(models)
+    if len(names) < 2:
+        raise ValueError("judge needs at least two models to compare")
+    if representation not in ("summary", "words"):
+        raise ValueError("representation must be 'summary' or 'words'")
+    backend = _resolve_llm_call(backend)
+    P = prompts or LLM_EVAL_PROMPTS
+    judge_tmpl, summary_tmpl = P["judge"], P["summary"]
+    ds = _dataset_clause(dataset_description)
+    texts = _doc_texts(docs)
+    D = len(texts)
+    thetas = {}
+    for nm, m in models.items():
+        th = np.asarray(m.doc_topic, dtype=float)
+        if th.shape[0] != D:
+            raise ValueError(
+                f"model {nm!r} has {th.shape[0]} doc-topic rows but there are {D} "
+                "documents; every model must be fit on the same docs, in order")
+        thetas[nm] = th
+
+    idx = {nm: i for i, nm in enumerate(names)}
+    M = len(names)
+    win = np.zeros((M, M))
+    cache: dict = {}
+    comparisons: list = []
+    rng = np.random.RandomState(seed)
+
+    for a, b in combinations(names, 2):
+        for _ in range(max(1, n_comparisons)):
+            d = int(rng.randint(D))
+            flip = bool(rng.randint(2))  # randomize A/B slot to blunt position bias
+            first, second = (b, a) if flip else (a, b)
+            set_a = _render_topic_set(models[first],
+                                      _top_topics_for_doc(thetas[first][d], q, p),
+                                      representation, backend, ds, n_words,
+                                      summary_tmpl, cache)
+            set_b = _render_topic_set(models[second],
+                                      _top_topics_for_doc(thetas[second][d], q, p),
+                                      representation, backend, ds, n_words,
+                                      summary_tmpl, cache)
+            reply = backend(judge_tmpl.format(
+                dataset=ds, document=str(texts[d])[:max_chars],
+                set_a=set_a, set_b=set_b))
+            choice = _parse_judge_choice(reply)
+            if choice == "a":
+                winner = first
+            elif choice == "b":
+                winner = second
+            else:
+                winner = None  # tie / unparseable -> split credit
+            comparisons.append({"doc": d, "model_a": first, "model_b": second,
+                                "choice": choice, "winner": winner,
+                                "reasoning": str(reply).strip()})
+            if winner == a:
+                win[idx[a], idx[b]] += 1.0
+            elif winner == b:
+                win[idx[b], idx[a]] += 1.0
+            else:
+                win[idx[a], idx[b]] += 0.5
+                win[idx[b], idx[a]] += 0.5
+
+    elo_arr = _bt_to_elo(_bradley_terry(win, smoothing=bt_smoothing))
+    elo = {nm: float(elo_arr[i]) for i, nm in enumerate(names)}
+
+    ci = {nm: (float("nan"), float("nan")) for nm in names}
+    if bootstrap and bootstrap > 0 and comparisons:
+        C = len(comparisons)
+        boot = np.empty((bootstrap, M))
+        for bi in range(bootstrap):
+            bw = np.zeros((M, M))
+            for k in rng.randint(0, C, size=C):
+                rec = comparisons[k]
+                w, ma, mb = rec["winner"], rec["model_a"], rec["model_b"]
+                if w is None:
+                    bw[idx[ma], idx[mb]] += 0.5
+                    bw[idx[mb], idx[ma]] += 0.5
+                else:
+                    loser = mb if w == ma else ma
+                    bw[idx[w], idx[loser]] += 1.0
+            boot[bi] = _bt_to_elo(_bradley_terry(bw, smoothing=bt_smoothing))
+        alpha = (1.0 - confidence_level) / 2.0
+        lo, hi = np.quantile(boot, alpha, axis=0), np.quantile(boot, 1 - alpha, axis=0)
+        ci = {nm: (float(lo[i]), float(hi[i])) for i, nm in enumerate(names)}
+
+    return JudgeResult(elo=elo, win_matrix=win, bootstrap_ci=ci,
+                       comparisons=comparisons, names=names,
+                       representation=representation)

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -1367,13 +1367,15 @@ def _render_topic_set(model, topic_ids, representation, backend, ds, n_words,
 def _parse_judge_choice(reply):
     """Parse an ``A`` / ``B`` / ``tie`` verdict from the judge's reply. Returns
     ``"a"``, ``"b"``, ``"tie"``, or ``None`` when nothing is recognisable (treated as
-    a tie by the caller)."""
+    a tie by the caller). The prompt asks for the verdict on the first line, so that
+    is read first; a mention of "tie" then beats a bare stray ``a``/``b`` (e.g. the
+    English article "a" in "it is a tie") so a verbose tie is not misread as an
+    A-win."""
     r = str(reply).strip().lower()
-    head = re.sub(r"[^a-z ]", " ", r[:40]).split()
-    for tok in head:
-        if tok in ("a", "b", "tie"):
-            return tok
-    if "tie" in r:
+    first = re.sub(r"[^a-z]", " ", r.split("\n", 1)[0]).split()
+    if first and first[0] in ("a", "b", "tie"):
+        return first[0]
+    if re.search(r"\btie\b", r):
         return "tie"
     m = re.search(r"\b([ab])\b", r)
     return m.group(1) if m else None
@@ -1506,7 +1508,8 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
     n_comparisons : int
         Comparisons per model pair (paper: 100).
     q : int
-        Cap on top topics shown per document per model.
+        Cap on the number of top topics shown per document per model (``0`` = no
+        cap, use ``p`` alone).
     p : float
         Cumulative-probability cap on top topics (the smaller of ``q`` / ``p`` wins).
     representation : {"summary", "words"}

--- a/python/topica/llm.py
+++ b/python/topica/llm.py
@@ -13,6 +13,7 @@ The namespace collects the suite so it reads as a family and signals the shared
     topica.llm.coherence(model, backend=backend)        # per-topic 1-3 rating (Stammbach et al. 2023)
     topica.llm.intrusion(model, backend=backend)        # LLM picks the planted intruder -> accuracy
     topica.llm.select_k(models, docs, backend=backend)  # number of topics by doc-label purity
+    topica.llm.judge({"lda": lda, "ctm": ctm}, docs, backend=backend)  # Elo ranking by doc-topic fit
     # Tan & D'Souza (2025) multi-dimensional suite:
     topica.llm.outlier(model, backend=backend)          # unsupervised semantic-outlier words
     topica.llm.repetitiveness(model, backend=backend)   # is coherence just redundancy?
@@ -33,16 +34,18 @@ from .coherence import (
     llm_coherence as coherence,
     llm_intrusion as intrusion,
     llm_select_k as select_k,
+    llm_judge as judge,
     llm_outlier as outlier,
     llm_repetitiveness as repetitiveness,
     llm_diversity as diversity,
     llm_adversarial as adversarial,
     llm_alignment as alignment,
+    JudgeResult,
     LLM_EVAL_PROMPTS as PROMPTS,
 )
 from .labeling import llm_backend as backend
 
 __all__ = [
-    "coherence", "intrusion", "select_k", "outlier", "repetitiveness",
-    "diversity", "adversarial", "alignment", "backend", "PROMPTS",
+    "coherence", "intrusion", "select_k", "judge", "outlier", "repetitiveness",
+    "diversity", "adversarial", "alignment", "backend", "JudgeResult", "PROMPTS",
 ]

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -12,7 +12,9 @@ import pytest
 
 import topica
 import topica.llm as L
-from topica.coherence import _bradley_terry, _bt_to_elo, _top_topics_for_doc
+from topica.coherence import (
+    _bradley_terry, _bt_to_elo, _parse_judge_choice, _top_topics_for_doc,
+)
 
 
 # Two clear themes; a model with a dedicated topic per theme should beat one that
@@ -162,6 +164,19 @@ def test_bradley_terry_finite_for_undefeated():
     win = np.array([[0.0, 10.0], [0.0, 0.0]])
     p = _bradley_terry(win, smoothing=1.0)
     assert np.all(np.isfinite(p)) and np.all(p > 0)
+
+
+@pytest.mark.parametrize("reply,expected", [
+    ("A", "a"), ("B\nbecause ...", "b"), ("tie", "tie"),
+    ("A. Set A better captures the document", "a"),
+    ("The answer is B", "b"),
+    # a verbose tie must not be misread as an A-win via the article "a"
+    ("It is a tie between them", "tie"),
+    ("Both are equal, a tie", "tie"),
+    ("neither is clearly better", None),
+])
+def test_parse_judge_choice(reply, expected):
+    assert _parse_judge_choice(reply) == expected
 
 
 def test_top_topics_for_doc_takes_the_fewer_of_q_and_p():

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -1,0 +1,174 @@
+"""LLM topic judge (Zheng et al. 2025, App. G): pairwise doc-topic comparison ->
+Bradley-Terry -> Elo.
+
+Exercised offline with deterministic fake backends (no network), so the pairing
+schedule, A/B rendering, BT/Elo aggregation, bootstrap CI, and audit records are all
+CI-testable. The live behaviour is llm-bounded and validated separately
+(parity/llm_judge_live.py).
+"""
+
+import numpy as np
+import pytest
+
+import topica
+import topica.llm as L
+from topica.coherence import _bradley_terry, _bt_to_elo, _top_topics_for_doc
+
+
+# Two clear themes; a model with a dedicated topic per theme should beat one that
+# lumps them together.
+DOCS = [
+    ["water", "river", "lake", "rain"],
+    ["water", "lake", "ocean", "wave"],
+    ["vote", "senate", "law", "policy"],
+    ["election", "vote", "budget", "law"],
+] * 8
+
+
+@pytest.fixture
+def models():
+    good = topica.LDA(3, seed=13); good.fit(DOCS, iters=40)
+    alt = topica.LDA(4, seed=7); alt.fit(DOCS, iters=40)
+    lumped = topica.LDA(2, seed=1); lumped.fit(DOCS, iters=40)
+    return {"good": good, "alt": alt, "lumped": lumped}
+
+
+class WaterJudge:
+    """A deterministic, model-agnostic judge: prefers whichever topic set mentions
+    'water' more. Records call count."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def __call__(self, prompt: str) -> str:
+        self.calls += 1
+        if "central theme" in prompt.lower():  # a summary request
+            return "water and rivers" if "water" in prompt else "government and law"
+        a = prompt.split("Topic set A:")[1].split("Topic set B:")[0].lower()
+        b = prompt.split("Topic set B:")[1].lower()
+        na, nb = a.count("water"), b.count("water")
+        if na > nb:
+            return "A\nset A better captures the document"
+        if nb > na:
+            return "B\nset B better captures the document"
+        return "tie\nboth are similar"
+
+
+# -- namespace -------------------------------------------------------------
+
+def test_namespace_surface():
+    assert callable(topica.llm.judge)
+    assert hasattr(topica.llm, "JudgeResult")
+    assert "judge" in topica.llm.PROMPTS and "summary" in topica.llm.PROMPTS
+    assert not hasattr(topica, "llm_judge")  # namespaced, not flat
+
+
+# -- end to end (fake backend) ---------------------------------------------
+
+def test_judge_ranks_and_elo_centers(models):
+    j = WaterJudge()
+    res = L.judge(models, DOCS, backend=j, n_comparisons=15, representation="words",
+                  bootstrap=25, seed=0)
+    # 3 pairs x 15 comparisons, one judge call each (words mode -> no summary calls)
+    assert len(res.comparisons) == 3 * 15
+    assert j.calls == 3 * 15
+    # Elo is centered at 1500 and the water-favoring judge ranks 'lumped' last.
+    assert abs(np.mean(list(res.elo.values())) - 1500.0) < 1e-6
+    assert res.ranking()[-1] == "lumped"
+    assert res.elo["good"] > res.elo["lumped"]
+    # win matrix: no self-play, games are symmetric in count
+    assert res.win_matrix.shape == (3, 3)
+    assert np.allclose(np.diag(res.win_matrix), 0.0)
+    # bootstrap CI present and ordered
+    for nm in res.names:
+        lo, hi = res.bootstrap_ci[nm]
+        assert lo <= res.elo[nm] <= hi or lo <= hi  # CI brackets or is at least valid
+
+
+def test_summary_representation_caches_per_topic(models):
+    # Two models; summary mode should summarize each (model, topic) at most once,
+    # regardless of how many comparisons reuse it.
+    two = {"good": models["good"], "lumped": models["lumped"]}
+    j = WaterJudge()
+    res = L.judge(two, DOCS, backend=j, n_comparisons=20, representation="summary",
+                  bootstrap=0, seed=2)
+    # total topics across the two models bounds the number of distinct summaries
+    max_summaries = two["good"].num_topics + two["lumped"].num_topics
+    judge_calls = len(res.comparisons)
+    # calls = judge calls + at most one summary per (model, topic)
+    assert j.calls <= judge_calls + max_summaries
+    assert res.representation == "summary"
+
+
+def test_comparisons_are_auditable(models):
+    j = WaterJudge()
+    res = L.judge(models, DOCS, backend=j, n_comparisons=5, representation="words",
+                  bootstrap=0, seed=0)
+    rec = res.comparisons[0]
+    assert set(rec) == {"doc", "model_a", "model_b", "choice", "winner", "reasoning"}
+    assert rec["model_a"] in models and rec["model_b"] in models
+    assert rec["winner"] in (rec["model_a"], rec["model_b"], None)
+
+
+def test_design_is_reproducible_for_fixed_seed(models):
+    j = WaterJudge()
+    a = L.judge(models, DOCS, backend=j, n_comparisons=10, representation="words",
+                bootstrap=0, seed=7)
+    b = L.judge(models, DOCS, backend=WaterJudge(), n_comparisons=10,
+                representation="words", bootstrap=0, seed=7)
+    # same seed -> same document sampling and A/B presentation schedule
+    assert [(c["doc"], c["model_a"], c["model_b"]) for c in a.comparisons] == \
+           [(c["doc"], c["model_a"], c["model_b"]) for c in b.comparisons]
+
+
+def test_bootstrap_skipped_when_zero(models):
+    res = L.judge(models, DOCS, backend=WaterJudge(), n_comparisons=5,
+                  representation="words", bootstrap=0, seed=0)
+    assert all(np.isnan(res.bootstrap_ci[nm][0]) for nm in res.names)
+
+
+# -- errors ----------------------------------------------------------------
+
+def test_errors(models):
+    j = WaterJudge()
+    with pytest.raises(TypeError, match="dict"):
+        L.judge([models["good"], models["lumped"]], DOCS, backend=j)
+    with pytest.raises(ValueError, match="at least two"):
+        L.judge({"only": models["good"]}, DOCS, backend=j)
+    with pytest.raises(ValueError, match="representation"):
+        L.judge(models, DOCS, backend=j, representation="bogus")
+    with pytest.raises(ValueError, match="same docs|doc-topic rows"):
+        L.judge(models, DOCS[:3], backend=j, n_comparisons=2)
+
+
+# -- the BT / Elo numerics (deterministic, no LLM) -------------------------
+
+def test_bradley_terry_orders_by_wins():
+    # 3 players: 0 beats everyone, 2 loses to everyone.
+    win = np.array([[0.0, 8.0, 9.0],
+                    [2.0, 0.0, 7.0],
+                    [1.0, 3.0, 0.0]])
+    p = _bradley_terry(win, smoothing=1.0)
+    assert p[0] > p[1] > p[2]
+    elo = _bt_to_elo(p)
+    assert abs(elo.mean() - 1500.0) < 1e-6
+    # a 400-pt Elo gap == 10:1 BT strength ratio
+    assert np.isclose(10 ** ((elo[0] - elo[2]) / 400.0), p[0] / p[2])
+
+
+def test_bradley_terry_finite_for_undefeated():
+    # Without smoothing an all-win / all-loss player is degenerate; smoothing keeps
+    # every strength finite and positive.
+    win = np.array([[0.0, 10.0], [0.0, 0.0]])
+    p = _bradley_terry(win, smoothing=1.0)
+    assert np.all(np.isfinite(p)) and np.all(p > 0)
+
+
+def test_top_topics_for_doc_takes_the_fewer_of_q_and_p():
+    row = np.array([0.5, 0.3, 0.15, 0.05])
+    # q=2 caps at 2 even though p=0.9 would take 3
+    assert _top_topics_for_doc(row, q=2, p=0.9) == [0, 1]
+    # p=0.75 reached at the 2nd topic (0.5+0.3=0.8 >= 0.75*1.0); q=3 is looser
+    assert _top_topics_for_doc(row, q=3, p=0.75) == [0, 1]
+    # always at least one
+    assert _top_topics_for_doc(row, q=0, p=0.0) == [0]

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -13,7 +13,7 @@ import pytest
 import topica
 import topica.llm as L
 from topica.coherence import (
-    _bradley_terry, _bt_to_elo, _parse_judge_choice, _top_topics_for_doc,
+    JudgeResult, _bradley_terry, _bt_to_elo, _parse_judge_choice, _top_topics_for_doc,
 )
 
 
@@ -127,6 +127,34 @@ def test_bootstrap_skipped_when_zero(models):
     res = L.judge(models, DOCS, backend=WaterJudge(), n_comparisons=5,
                   representation="words", bootstrap=0, seed=0)
     assert all(np.isnan(res.bootstrap_ci[nm][0]) for nm in res.names)
+
+
+# -- guards from the sample-user review ------------------------------------
+
+def test_warns_when_models_fit_on_different_corpora(models):
+    # Two models fit on DIFFERENT documents of the same length pass the row-count
+    # check but yield a silently invalid ranking; differing vocabularies catch it.
+    other_docs = [["alpha", "beta", "gamma", "delta"],
+                  ["epsilon", "zeta", "eta", "theta"]] * 16
+    assert len(other_docs) == len(DOCS)  # same length -> row check can't catch it
+    good = models["good"]
+    elsewhere = topica.LDA(3, seed=5); elsewhere.fit(other_docs, iters=40)
+    with pytest.warns(UserWarning, match="different vocabularies"):
+        L.judge({"good": good, "elsewhere": elsewhere}, DOCS, backend=WaterJudge(),
+                n_comparisons=2, representation="words", bootstrap=0, seed=0)
+
+
+def test_summary_flags_overlapping_top_cis():
+    overlap = JudgeResult(
+        elo={"a": 1550.0, "b": 1450.0}, win_matrix=np.zeros((2, 2)),
+        bootstrap_ci={"a": (1400.0, 1700.0), "b": (1300.0, 1600.0)},  # overlap
+        comparisons=[{}], names=["a", "b"], representation="words")
+    assert "overlap" in overlap.summary().lower()
+    clear = JudgeResult(
+        elo={"a": 1800.0, "b": 1200.0}, win_matrix=np.zeros((2, 2)),
+        bootstrap_ci={"a": (1750.0, 1850.0), "b": (1150.0, 1250.0)},  # disjoint
+        comparisons=[{}], names=["a", "b"], representation="words")
+    assert "overlap" not in clear.summary().lower()
 
 
 # -- errors ----------------------------------------------------------------

--- a/tests/test_llm_judge.py
+++ b/tests/test_llm_judge.py
@@ -107,9 +107,28 @@ def test_comparisons_are_auditable(models):
     res = L.judge(models, DOCS, backend=j, n_comparisons=5, representation="words",
                   bootstrap=0, seed=0)
     rec = res.comparisons[0]
-    assert set(rec) == {"doc", "model_a", "model_b", "choice", "winner", "reasoning"}
+    assert set(rec) == {"doc", "model_a", "model_b", "set_a", "set_b",
+                        "choice", "winner", "reasoning"}
     assert rec["model_a"] in models and rec["model_b"] in models
     assert rec["winner"] in (rec["model_a"], rec["model_b"], None)
+    # the exact rendered topic sets the judge saw are retained (re-auditable)
+    assert isinstance(rec["set_a"], str) and isinstance(rec["set_b"], str)
+    assert rec["set_a"] and rec["set_b"]
+
+
+def test_dry_run_previews_cost_without_calling(models):
+    class Boom:
+        def __call__(self, prompt):
+            raise AssertionError("dry_run must not call the backend")
+    plan = L.judge(models, DOCS, backend=Boom(), n_comparisons=10,
+                   representation="words", dry_run=True)
+    assert plan["models"] == 3 and plan["pairs"] == 3
+    assert plan["judge_calls"] == 10 * 3  # n_comparisons * M(M-1)/2
+    assert plan["max_summary_calls"] == 0  # words mode
+    # summary mode reports a nonzero summary-call ceiling
+    plan2 = L.judge(models, DOCS, backend=Boom(), n_comparisons=5,
+                    representation="summary", dry_run=True)
+    assert plan2["max_summary_calls"] == sum(m.num_topics for m in models.values())
 
 
 def test_design_is_reproducible_for_fixed_seed(models):


### PR DESCRIPTION
## What

Implements the flagship, model-agnostic **topic judge** from Zheng et al. (2025, App. G) — PR 1 of #583.

`topica.llm.judge({"lda": lda, "stm": stm, ...}, docs, backend=backend)` ranks whole topic models by how well their topics fit documents. For each model pair × `n_comparisons` rounds it samples a document, takes each model's top topics for it (top `q`, or the topics under cumulative mass `p`, whichever fewer), renders each set (**one-sentence LLM summaries** by default so different-vocabulary models compare fairly, or `representation="words"`), and asks the LLM which set better captures the document. Wins (ties = half) are aggregated with a **Bradley-Terry** MM fit, rescaled to **Elo** (mean 1500), with **bootstrap CIs**.

Returns a `JudgeResult`: `.elo`, `.bootstrap_ci`, `.win_matrix`, `.ranking()`, `.summary()`, `.to_frame()`, and the raw `.comparisons` (doc, A, B, choice, reasoning) for audit. Unlike `llm.coherence` (intra-topic word relatedness) it scores topic-*document* fit across model families — the natural engine for ranking fitted models on one corpus (and for `topica.compare`, #415). Adds a `representation="summary"` topic rendering shared by the judge. A/B order is randomized per comparison to blunt position bias.

`llm-bounded`: not bit-reproducible, but `seed` fixes the document sampling and A/B order.

## Testing (fake backend + real opt-in)

- `tests/test_llm_judge.py` — deterministic fake-backend unit tests: ranking + Elo centering, summary caching, audit records, design reproducibility, the Bradley-Terry/Elo numerics (ordering, 400-pt = 10:1, finite under smoothing), top-topics selection, error paths. 10 tests, no network.
- `parity/llm_judge_live.py` — opt-in live check against an open model (openrouter); skips without a key; not in CI.

`pytest` (judge + llm_eval + coherence) green; `preflight` and `mkdocs --strict` green. No Rust/ABI change.

## Scope

PR 1 of #583. `llm.refine` and the ratings/intrusion parity + Spearman human-agreement helper are follow-up PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)