### PR TITLE
feat(llm): topica.llm.refine — LLM-cleaned top words per topic (#583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,11 +38,13 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 - **`topica.llm.refine` — LLM-cleaned top words per topic** (#583). Ports the
   top-word refinement of Zheng et al. (2025, App. A.2 / F.1): for each topic it shows
   the LLM the top ``n + m`` words, drops up to ``m`` that are oddly specific or out of
-  place, and returns the cleaned top-``n`` list (plus the ``dropped`` words). Where
-  `llm.outlier` *detects* incoherent words, `refine` *produces* the de-noised
-  representation to feed to `label_topics`, `llm.judge`, or a report. `n_samples > 1`
-  drops a word only on a majority vote. `llm-bounded`. Second of the model-agnostic
-  LLM pipeline tools from the paper (after `llm.judge`).
+  place, and returns the cleaned top-``n`` list (plus the ``dropped`` words) for
+  review. Where `llm.outlier` *detects* incoherent words, `refine` *proposes* a pruned
+  list. It is a suggestion to review, not an automatic cleaner: on peaky topics the LLM
+  can flag a defining word, so ``protect`` (default 1) refuses to drop the
+  top-most-probable word(s). Cost is ``num_topics * n_samples`` calls; ``n_samples > 1``
+  drops a word only when flagged in at least half the runs. `llm-bounded`. Second of
+  the model-agnostic LLM pipeline tools from the paper (after `llm.judge`).
 
 - **`topica.llm.judge` — rank whole topic models by pairwise topic-document fit**
   (#583). A model-agnostic port of the *topic judge* from Zheng et al. (2025,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- **`topica.llm.refine` — LLM-cleaned top words per topic** (#583). Ports the
+  top-word refinement of Zheng et al. (2025, App. A.2 / F.1): for each topic it shows
+  the LLM the top ``n + m`` words, drops up to ``m`` that are oddly specific or out of
+  place, and returns the cleaned top-``n`` list (plus the ``dropped`` words). Where
+  `llm.outlier` *detects* incoherent words, `refine` *produces* the de-noised
+  representation to feed to `label_topics`, `llm.judge`, or a report. `n_samples > 1`
+  drops a word only on a majority vote. `llm-bounded`. Second of the model-agnostic
+  LLM pipeline tools from the paper (after `llm.judge`).
+
 - **`topica.llm.judge` — rank whole topic models by pairwise topic-document fit**
   (#583). A model-agnostic port of the *topic judge* from Zheng et al. (2025,
   "Model Directions, Not Words", App. G): for each model pair it samples documents,

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -180,14 +180,21 @@ topica.llm.adversarial(model, backend=backend)                        # gold-fre
 `n_samples` runs), so it surfaces the specific words making a topic incoherent.
 `llm.refine` is its actionable counterpart (Zheng et al. 2025): it shows the LLM the top
 `n + m` words, drops up to `m` that are out of place, and returns the cleaned top-`n`
-list per topic (plus which words it `dropped`) — a de-noised representation you can feed
-to `label_topics`, `llm.judge`, or a report:
+list per topic (plus which words it `dropped`):
 
 ```python
 cleaned = topica.llm.refine(model, backend=backend, n=10, m=2)
 cleaned[0]["words"]     # topic 0's top 10 with up to 2 intruders removed
-cleaned[0]["dropped"]   # the words it removed
+cleaned[0]["dropped"]   # the words it removed (review these!)
 ```
+
+Treat it as a **suggestion to review, not an automatic cleaner**: on a peaky or small
+topic the LLM can flag a *defining* word as out of place and weaken the topic, so read
+`dropped` beside the raw top words per topic rather than applying it blind. `protect`
+(default 1) refuses to drop the top-most-probable word(s), which prevents the worst case
+(deleting a topic's anchor). Cost is `num_topics × n_samples` LLM calls. The output is a
+list of dicts (not the list-of-lists `top_words` returns), for reporting or for building
+labels by hand.
 
 `llm.repetitiveness` checks the failure coherence rating misses — a topic of near-synonyms
 scores high on relatedness but is uninformative; it returns a 1-3 rate (3 = distinctive)

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -178,6 +178,17 @@ topica.llm.adversarial(model, backend=backend)                        # gold-fre
 `llm.outlier` is the unsupervised sibling of `llm.intrusion`: no planted answer, just a
 5-runs vote on *which* top words don't belong (kept when flagged in `threshold` of
 `n_samples` runs), so it surfaces the specific words making a topic incoherent.
+`llm.refine` is its actionable counterpart (Zheng et al. 2025): it shows the LLM the top
+`n + m` words, drops up to `m` that are out of place, and returns the cleaned top-`n`
+list per topic (plus which words it `dropped`) — a de-noised representation you can feed
+to `label_topics`, `llm.judge`, or a report:
+
+```python
+cleaned = topica.llm.refine(model, backend=backend, n=10, m=2)
+cleaned[0]["words"]     # topic 0's top 10 with up to 2 intruders removed
+cleaned[0]["dropped"]   # the words it removed
+```
+
 `llm.repetitiveness` checks the failure coherence rating misses — a topic of near-synonyms
 scores high on relatedness but is uninformative; it returns a 1-3 rate (3 = distinctive)
 plus the duplicate word pairs. `llm.diversity` rates every topic *pair* for thematic

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -1203,31 +1203,41 @@ def llm_outlier(model, *, backend, n_words=10, n_samples=5, threshold=3,
     return out
 
 
-def llm_refine(model, *, backend, n=10, m=2, n_samples=1, dataset_description=None,
-               seed=0, prompts=None):
-    """LLM top-word refinement (Zheng et al. 2025, App. A.2 / F.1): return a de-noised
-    top-``n`` word list per topic.
+def llm_refine(model, *, backend, n=10, m=2, protect=1, n_samples=1,
+               dataset_description=None, seed=0, prompts=None):
+    """LLM top-word refinement (Zheng et al. 2025, App. A.2 / F.1): a *suggested*
+    cleanup of each topic's top words, for review.
 
     For each topic it shows the LLM the top ``n + m`` words, asks it to flag up to
     ``m`` that are oddly specific or clearly out of place, drops those, and keeps the
     top ``n`` of what remains. Where :func:`llm_outlier` *detects* incoherent words,
-    ``refine`` *produces the cleaned representation* you can feed to
-    :func:`~topica.label_topics`, :func:`llm_judge`, or a report. The paper applies it
-    uniformly to every model (``n=10``, ``m=2``) so coherence is not biased toward any
-    one family. ``llm-bounded``; see :func:`llm_coherence` for ``backend`` /
-    ``n_samples`` semantics.
+    ``refine`` returns the pruned list plus the words it ``dropped`` per topic. The
+    paper applies it uniformly to every model (``n=10``, ``m=2``) so coherence is not
+    biased toward any one family. ``llm-bounded``; see :func:`llm_coherence` for
+    ``backend`` / ``n_samples`` semantics.
 
-    With ``n_samples > 1`` a word is dropped only if flagged in a majority of runs
-    (tames the LLM's per-call variation). Fewer than ``m`` flagged keeps more of the
-    original top words (truncated to ``n``); more than ``m`` flagged drops only the
-    ``m`` highest-ranked of them, so exactly ``n`` words come back when the topic has
-    at least ``n + m``.
+    **Treat the output as a suggestion to review, not an automatic cleaner.** On peaky
+    or small topics the LLM can flag a *defining* term as "out of place" and weaken the
+    topic, so inspect ``dropped`` per topic (show the raw top words beside it) rather
+    than applying it blind. ``protect`` (default 1) refuses to drop the top-``protect``
+    most-probable words, which prevents the worst case (deleting a topic's anchor word);
+    raise it to protect more, or set 0 to disable.
+
+    Cost: ``num_topics * n_samples`` LLM calls (one prompt per topic per sample).
+
+    With ``n_samples > 1`` a word is dropped only if flagged in at least half the runs
+    (``ceil(n_samples / 2)``; tames the LLM's per-call variation). Fewer than ``m``
+    flagged keeps more of the original top words (truncated to ``n``); more than ``m``
+    flagged drops only the ``m`` highest-ranked of them, so exactly ``n`` words come
+    back when the topic has at least ``n + m``. Only the top ``n + m`` words are shown
+    to the LLM, so an intruder ranked below that window is never screened (this matches
+    the paper's protocol).
 
     Returns
     -------
     list[dict]
         One dict per topic: ``topic``, ``words`` (the cleaned top-``n`` list), and
-        ``dropped`` (the removed intruders, in rank order).
+        ``dropped`` (the removed words, in rank order; may be fewer than ``m``).
     """
     backend = _resolve_llm_call(backend)
     tmpl = (prompts or LLM_EVAL_PROMPTS)["refine"]
@@ -1236,12 +1246,17 @@ def llm_refine(model, *, backend, n=10, m=2, n_samples=1, dataset_description=No
     out = []
     for t, words in enumerate(_extract_topics(model, n + m)):
         allowed = {w.lower() for w in words}
+        # Never drop the top-`protect` words: the most-probable word(s) are usually the
+        # topic's anchor, and the LLM sometimes flags the single dominant term as "out
+        # of place" and guts the topic (e.g. dropping "gun" from a gun-control topic).
+        protected = {w.lower() for w in words[:max(0, protect)]}
         votes = Counter()
         for _ in range(max(1, n_samples)):
             reply = backend(tmpl.format(dataset=ds, words=", ".join(words), m=m))
             votes.update(set(_parse_word_list(reply, allowed)))
         # flagged words in the topic's own rank order, capped to at most m dropped.
-        flagged = [w for w in words if votes[w.lower()] >= thresh]
+        flagged = [w for w in words
+                   if votes[w.lower()] >= thresh and w.lower() not in protected]
         dropped = flagged[:m]
         dropped_lower = {w.lower() for w in dropped}
         kept = [w for w in words if w.lower() not in dropped_lower][:n]

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -852,12 +852,21 @@ SUMMARY_PROMPT = (
     "Given the topic's top words, describe its central theme in a single short "
     "sentence. Reply with only that sentence.\n\n{words}"
 )
+# Post-training top-word cleanup (Zheng et al. 2025, App. A.2 / F.1): flag up to m
+# oddly-specific / out-of-place words and drop them, keeping the top n. Applied
+# uniformly to every model so coherence is not biased toward any one family.
+REFINE_PROMPT = (
+    "You are a helpful assistant cleaning up the top words of a topic model output "
+    "for a given topic. {dataset}Below are the topic's top words. Identify up to {m} "
+    "words that are oddly specific or clearly out of place relative to the rest of the "
+    'list. Reply with a comma-separated list of only those words, or "none".\n\n{words}'
+)
 LLM_EVAL_PROMPTS: dict[str, str] = {
     "rating": RATING_PROMPT, "intrusion": INTRUSION_PROMPT, "label": LABEL_PROMPT,
     "outlier": OUTLIER_PROMPT, "repetitive_rate": REPETITIVE_RATE_PROMPT,
     "duplicate": DUPLICATE_PROMPT, "diversity": DIVERSITY_PROMPT,
     "align_irrelevant": ALIGN_IRRELEVANT_PROMPT, "align_missing": ALIGN_MISSING_PROMPT,
-    "judge": JUDGE_PROMPT, "summary": SUMMARY_PROMPT,
+    "judge": JUDGE_PROMPT, "summary": SUMMARY_PROMPT, "refine": REFINE_PROMPT,
 }
 
 
@@ -1191,6 +1200,52 @@ def llm_outlier(model, *, backend, n_words=10, n_samples=5, threshold=3,
             votes.update(set(flagged))
         outliers = [w for w, c in votes.items() if c >= threshold]
         out.append({"topic": t, "outliers": outliers, "count": len(outliers)})
+    return out
+
+
+def llm_refine(model, *, backend, n=10, m=2, n_samples=1, dataset_description=None,
+               seed=0, prompts=None):
+    """LLM top-word refinement (Zheng et al. 2025, App. A.2 / F.1): return a de-noised
+    top-``n`` word list per topic.
+
+    For each topic it shows the LLM the top ``n + m`` words, asks it to flag up to
+    ``m`` that are oddly specific or clearly out of place, drops those, and keeps the
+    top ``n`` of what remains. Where :func:`llm_outlier` *detects* incoherent words,
+    ``refine`` *produces the cleaned representation* you can feed to
+    :func:`~topica.label_topics`, :func:`llm_judge`, or a report. The paper applies it
+    uniformly to every model (``n=10``, ``m=2``) so coherence is not biased toward any
+    one family. ``llm-bounded``; see :func:`llm_coherence` for ``backend`` /
+    ``n_samples`` semantics.
+
+    With ``n_samples > 1`` a word is dropped only if flagged in a majority of runs
+    (tames the LLM's per-call variation). Fewer than ``m`` flagged keeps more of the
+    original top words (truncated to ``n``); more than ``m`` flagged drops only the
+    ``m`` highest-ranked of them, so exactly ``n`` words come back when the topic has
+    at least ``n + m``.
+
+    Returns
+    -------
+    list[dict]
+        One dict per topic: ``topic``, ``words`` (the cleaned top-``n`` list), and
+        ``dropped`` (the removed intruders, in rank order).
+    """
+    backend = _resolve_llm_call(backend)
+    tmpl = (prompts or LLM_EVAL_PROMPTS)["refine"]
+    ds = _dataset_clause(dataset_description)
+    thresh = (max(1, n_samples) + 1) // 2  # majority of the samples
+    out = []
+    for t, words in enumerate(_extract_topics(model, n + m)):
+        allowed = {w.lower() for w in words}
+        votes = Counter()
+        for _ in range(max(1, n_samples)):
+            reply = backend(tmpl.format(dataset=ds, words=", ".join(words), m=m))
+            votes.update(set(_parse_word_list(reply, allowed)))
+        # flagged words in the topic's own rank order, capped to at most m dropped.
+        flagged = [w for w in words if votes[w.lower()] >= thresh]
+        dropped = flagged[:m]
+        dropped_lower = {w.lower() for w in dropped}
+        kept = [w for w in words if w.lower() not in dropped_lower][:n]
+        out.append({"topic": t, "words": kept, "dropped": dropped})
     return out
 
 

--- a/python/topica/llm.py
+++ b/python/topica/llm.py
@@ -16,6 +16,7 @@ The namespace collects the suite so it reads as a family and signals the shared
     topica.llm.judge({"lda": lda, "ctm": ctm}, docs, backend=backend)  # Elo ranking by doc-topic fit
     # Tan & D'Souza (2025) multi-dimensional suite:
     topica.llm.outlier(model, backend=backend)          # unsupervised semantic-outlier words
+    topica.llm.refine(model, backend=backend)           # drop up to m out-of-place words -> cleaned top-n
     topica.llm.repetitiveness(model, backend=backend)   # is coherence just redundancy?
     topica.llm.diversity(model, backend=backend)        # pairwise cross-topic distinctiveness
     topica.llm.alignment(model, docs, backend=backend)  # irrelevant words / missing themes vs docs
@@ -36,6 +37,7 @@ from .coherence import (
     llm_select_k as select_k,
     llm_judge as judge,
     llm_outlier as outlier,
+    llm_refine as refine,
     llm_repetitiveness as repetitiveness,
     llm_diversity as diversity,
     llm_adversarial as adversarial,
@@ -46,6 +48,7 @@ from .coherence import (
 from .labeling import llm_backend as backend
 
 __all__ = [
-    "coherence", "intrusion", "select_k", "judge", "outlier", "repetitiveness",
-    "diversity", "adversarial", "alignment", "backend", "JudgeResult", "PROMPTS",
+    "coherence", "intrusion", "select_k", "judge", "outlier", "refine",
+    "repetitiveness", "diversity", "adversarial", "alignment", "backend",
+    "JudgeResult", "PROMPTS",
 ]

--- a/tests/test_llm_refine.py
+++ b/tests/test_llm_refine.py
@@ -79,6 +79,18 @@ def test_dropped_preserves_rank_order():
     assert res[0]["dropped"] == ["banana", "guitar"]
 
 
+def test_protect_keeps_the_anchor_word():
+    # The LLM flags the topic's #1 word (the "gut the topic" failure). protect=1
+    # (default) refuses to drop it; protect=0 lets it go.
+    topic = [["gun", "guns", "law", "policy", "control", "right", "banana", "state"]]
+    flag_gun = lambda p: "gun" if "gun" in p.lower() else "none"
+    default = llm_refine(topic, backend=flag_gun, n=6, m=2)          # protect=1
+    assert "gun" not in default[0]["dropped"]
+    assert "gun" in default[0]["words"]
+    unprotected = llm_refine(topic, backend=flag_gun, n=6, m=2, protect=0)
+    assert "gun" in unprotected[0]["dropped"]
+
+
 def test_majority_vote_over_samples():
     # A flaky backend flags the intruder only half the time; majority of 4 needs >=2.
     calls = {"n": 0}

--- a/tests/test_llm_refine.py
+++ b/tests/test_llm_refine.py
@@ -1,0 +1,92 @@
+"""LLM top-word refinement (Zheng et al. 2025, App. A.2 / F.1): drop up to m
+out-of-place words, keep the top n.
+
+Deterministic fake backends (no network), so the ranking, cap-at-m, majority vote,
+and truncation are all CI-testable. The live behaviour is llm-bounded.
+"""
+
+import pytest
+
+import topica
+import topica.llm as L
+from topica.coherence import llm_refine
+
+# Two clean themes, each with planted out-of-place words at known ranks.
+TOPICS = [
+    ["water", "river", "lake", "ocean", "rain", "flood", "banana", "guitar"],
+    ["vote", "senate", "law", "policy", "budget", "election", "telescope", "asphalt"],
+]
+
+INTRUDERS = {"banana", "guitar", "telescope", "asphalt"}
+
+
+def _flagger(intruders=INTRUDERS):
+    """A backend that flags any planted intruder present in the prompt."""
+    def be(prompt):
+        hits = [w for w in intruders if w in prompt.lower()]
+        return ", ".join(hits) if hits else "none"
+    return be
+
+
+def test_namespace_surface():
+    assert callable(topica.llm.refine)
+    assert "refine" in topica.llm.PROMPTS
+    assert "refine" in L.__all__
+
+
+def test_drops_intruders_and_keeps_top_n():
+    # n+m = 8 covers both planted intruders (at ranks 6 and 7).
+    res = llm_refine(TOPICS, backend=_flagger(), n=6, m=2)
+    assert [r["topic"] for r in res] == [0, 1]
+    for r in res:
+        assert len(r["words"]) == 6           # exactly n back (topic has n+m=8 words)
+        assert len(r["dropped"]) <= 2
+        # no dropped word survives in the cleaned list
+        kept = {w.lower() for w in r["words"]}
+        assert not (kept & {w.lower() for w in r["dropped"]})
+    # the planted intruders within the top n+m are the ones dropped
+    assert set(res[0]["dropped"]) == {"banana", "guitar"}
+    assert "banana" not in res[0]["words"] and "guitar" not in res[0]["words"]
+
+
+def test_none_flagged_returns_top_n_unchanged():
+    res = llm_refine(TOPICS, backend=lambda p: "none", n=4, m=2)
+    assert res[0]["dropped"] == []
+    assert res[0]["words"] == TOPICS[0][:4]   # just the top n, in order
+
+
+def test_fewer_than_m_flagged_truncates_to_n():
+    # only one intruder flagged; n+m=8 words, drop 1 -> 7 remain -> truncate to n=6
+    res = llm_refine(TOPICS, backend=_flagger({"banana"}), n=6, m=2)
+    assert res[0]["dropped"] == ["banana"]
+    assert len(res[0]["words"]) == 6
+    assert "banana" not in res[0]["words"]
+
+
+def test_more_than_m_flagged_drops_only_m_in_rank_order():
+    # flag three words; m=2 caps the drop to the two highest-ranked flagged.
+    topic = [["a", "bad1", "b", "bad2", "c", "bad3", "d", "e"]]
+    res = llm_refine(topic, backend=_flagger({"bad1", "bad2", "bad3"}), n=4, m=2)
+    # highest-ranked flagged are bad1 (idx1) and bad2 (idx3); bad3 survives ranking
+    assert res[0]["dropped"] == ["bad1", "bad2"]
+    assert len(res[0]["words"]) == 4
+    assert "bad1" not in res[0]["words"] and "bad2" not in res[0]["words"]
+
+
+def test_dropped_preserves_rank_order():
+    res = llm_refine(TOPICS, backend=_flagger(), n=6, m=2)
+    # banana (idx 6) precedes guitar (idx 7) in the topic, so that is the drop order
+    assert res[0]["dropped"] == ["banana", "guitar"]
+
+
+def test_majority_vote_over_samples():
+    # A flaky backend flags the intruder only half the time; majority of 4 needs >=2.
+    calls = {"n": 0}
+
+    def flaky(prompt):
+        calls["n"] += 1
+        return "banana" if (calls["n"] % 2 == 0 and "banana" in prompt.lower()) else "none"
+
+    res = llm_refine([TOPICS[0]], backend=flaky, n=6, m=2, n_samples=4)
+    # 2 of 4 flag banana -> meets the majority threshold (>=2), so it is dropped
+    assert "banana" in res[0]["dropped"]


### PR DESCRIPTION
## What

Ports the top-word **refinement** step of Zheng et al. (2025, App. A.2 / F.1) — PR 2 of #583, after `llm.judge`.

`topica.llm.refine(model, backend=backend, n=10, m=2)` returns a de-noised top-`n` word list per topic: it shows the LLM the top `n + m` words, asks it to flag up to `m` that are oddly specific or clearly out of place, drops those, and keeps the top `n`.

```python
cleaned = topica.llm.refine(model, backend=backend, n=10, m=2)
cleaned[0]["words"]     # topic 0's cleaned top-10
cleaned[0]["dropped"]   # the intruders it removed (rank order)
```

Where `llm.outlier` *detects* incoherent words, `refine` *produces* the cleaned representation — feed it to `label_topics`, `llm.judge`, or a report. Behavior at the edges: fewer than `m` flagged → keep the top `n` (truncate the tail); more than `m` flagged → drop only the `m` highest-ranked; `n_samples > 1` → drop a word only on a majority vote. `llm-bounded` (LLM not bit-reproducible).

## Tests

`tests/test_llm_refine.py` — 7 deterministic fake-backend tests: drops planted intruders + keeps exactly `n`, none-flagged returns the top `n` unchanged, fewer-than-`m` truncates, more-than-`m` caps at the `m` highest-ranked, dropped preserves rank order, majority vote over `n_samples`, namespace surface. `preflight` + `mkdocs --strict` green. No Rust/ABI change.

## Scope

PR 2 of #583. Remaining: the ratings/intrusion parity note + Spearman human-agreement helper. The judge's deeper alignment guarantee is tracked in #676.

🤖 Generated with [Claude Code](https://claude.com/claude-code)