### PR TITLE
feat(llm): topica.llm.human_agreement + coherence/intrusion parity note (#583)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- **`topica.llm.human_agreement` — validate an LLM metric against human ratings**
+  (#583). The Spearman (default; also Pearson / Kendall) rank correlation between a
+  per-item LLM metric (e.g. the `llm.coherence` array) and a matching vector of human
+  ratings — the paper's Fig. 2 / Stammbach et al. (2023) validation move. Purely
+  numeric (no LLM call), drops NaN pairs, and reports the correlation, p-value, and n
+  used. It is the honesty knob for the `llm-bounded` metrics: a high rank correlation
+  on a labeled subset is what lets you report the LLM metric on the rest. Completes the
+  model-agnostic LLM pipeline tools of #583 (`judge`, `refine`, human-agreement); the
+  existing `llm.coherence` (3-point scale) and `llm.intrusion` (top-5 + 1 intruder)
+  already match the paper's §5.2 / App. F.3 rating and intrusion protocol.
+
 - **`topica.llm.refine` — LLM-cleaned top words per topic** (#583). Ports the
   top-word refinement of Zheng et al. (2025, App. A.2 / F.1): for each topic it shows
   the LLM the top ``n + m`` words, drops up to ``m`` that are oddly specific or out of

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -99,7 +99,24 @@ topica.llm.select_k(models, docs, backend=backend, n_docs=10)   # number-of-topi
 `llm.coherence` is the one to lead with: in the paper it beats NPMI/c_v at tracking
 human topic *rankings* (and on the Hoyle 2021 gold, `parity/llm_coherence_compare.py`
 reproduces that here). `llm.intrusion` matches human accuracy on the *task* but is a
-weaker ranking signal, so report it alongside, not instead.
+weaker ranking signal, so report it alongside, not instead. Both follow the same
+protocol Zheng et al. (2025, §5.2 / App. F.3) use: a 3-point relatedness scale
+(`scale=(1, 3)`) for `coherence`, and a top-5-words-plus-one-intruder task
+(`n_words=5`, the default) for `intrusion`, at `temperature=0`.
+
+Because these are `llm-bounded`, validate them on *your* data before trusting them:
+
+```python
+llm = topica.llm.coherence(model, backend=backend)         # per-topic LLM ratings
+agree = topica.llm.human_agreement(llm, human_ratings)     # human_ratings: one per topic
+agree["correlation"], agree["pvalue"], agree["n"]          # Spearman rho by default
+```
+
+`llm.human_agreement` is the paper's Fig. 2 check (Stammbach et al. 2023): the Spearman
+rank correlation between an LLM metric and a matching vector of human ratings. It makes
+no LLM call (purely numeric), drops NaN pairs, and takes `method="spearman"` (default),
+`"pearson"`, or `"kendall"`. A high rank correlation on a labeled subset is the evidence
+that lets you report the LLM metric on the rest.
 
 `llm.select_k` chooses the number of topics: for each candidate model it labels each
 topic's top documents with the LLM and scores by **label purity** (the fraction of a

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -1774,3 +1774,61 @@ def llm_judge(models, docs, *, backend, n_comparisons=100, q=2, p=0.75,
     return JudgeResult(elo=elo, win_matrix=win, bootstrap_ci=ci,
                        comparisons=comparisons, names=names,
                        representation=representation)
+
+
+# ---------------------------------------------------------------------------
+# LLM-vs-human agreement (Zheng et al. 2025 Fig. 2; Stammbach et al. 2023):
+# does an LLM metric track human judgment on *your* data?
+# ---------------------------------------------------------------------------
+
+
+def llm_human_agreement(llm_scores, human_scores, *, method="spearman"):
+    """Correlate an LLM metric with human ratings -- the paper's Fig. 2 validation.
+
+    The LLM metrics here (:func:`llm_coherence`, :func:`llm_intrusion`, ...) are
+    ``llm-bounded``: they are only trustworthy insofar as they track human judgment.
+    This is the honesty knob: pass a per-item LLM metric (e.g. the per-topic array
+    from :func:`llm_coherence`) and a matching vector of human ratings, and it reports
+    how well they agree. Following Stammbach et al. (2023) and Zheng et al. (2025), the
+    default is Spearman rank correlation (their headline: an LLM tracks human topic
+    *rankings*).
+
+    Purely numeric -- it makes no LLM call and is deterministic. Item pairs where
+    either score is NaN (e.g. an LLM rating that failed to parse) are dropped, and the
+    number actually used is reported.
+
+    Parameters
+    ----------
+    llm_scores, human_scores : array-like
+        Matching per-item vectors (same length, same order): the LLM metric and the
+        human ratings to validate it against.
+    method : {"spearman", "pearson", "kendall"}
+        Correlation coefficient. ``"spearman"`` (default) and ``"kendall"`` are rank
+        correlations (track ordering); ``"pearson"`` is linear.
+
+    Returns
+    -------
+    dict
+        ``{"correlation", "pvalue", "n", "method"}`` -- the coefficient, its two-sided
+        p-value, the number of item pairs used (after dropping NaNs), and the method.
+    """
+    funcs = {"spearman": "spearmanr", "pearson": "pearsonr", "kendall": "kendalltau"}
+    if method not in funcs:
+        raise ValueError(f"method must be one of {sorted(funcs)}; got {method!r}")
+    a = np.asarray(llm_scores, dtype=float).ravel()
+    b = np.asarray(human_scores, dtype=float).ravel()
+    if a.shape != b.shape:
+        raise ValueError(
+            f"llm_scores and human_scores must be the same length; got {a.size} and "
+            f"{b.size}. Pass matching per-item vectors (e.g. the per-topic "
+            "llm_coherence array and one human rating per topic).")
+    keep = np.isfinite(a) & np.isfinite(b)
+    n = int(keep.sum())
+    if n < 2:
+        raise ValueError(
+            f"need at least 2 non-NaN item pairs to correlate; got {n}.")
+    from scipy import stats
+
+    corr, pvalue = getattr(stats, funcs[method])(a[keep], b[keep])
+    return {"correlation": float(corr), "pvalue": float(pvalue), "n": n,
+            "method": method}

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -1811,6 +1811,8 @@ def llm_human_agreement(llm_scores, human_scores, *, method="spearman"):
     dict
         ``{"correlation", "pvalue", "n", "method"}`` -- the coefficient, its two-sided
         p-value, the number of item pairs used (after dropping NaNs), and the method.
+        ``correlation`` is ``nan`` if either vector is constant (no ranking to
+        correlate). Requires SciPy (``pip install topica[viz]``).
     """
     funcs = {"spearman": "spearmanr", "pearson": "pearsonr", "kendall": "kendalltau"}
     if method not in funcs:
@@ -1827,8 +1829,16 @@ def llm_human_agreement(llm_scores, human_scores, *, method="spearman"):
     if n < 2:
         raise ValueError(
             f"need at least 2 non-NaN item pairs to correlate; got {n}.")
-    from scipy import stats
+    try:
+        from scipy import stats
+    except ImportError:
+        raise ImportError(
+            "SciPy is required for llm.human_agreement. Install it via "
+            "`pip install scipy` or `pip install topica[viz]`."
+        )
 
+    # A constant vector (e.g. every topic rated identically) has no ranking to
+    # correlate, so scipy returns nan (with a ConstantInputWarning); passed through.
     corr, pvalue = getattr(stats, funcs[method])(a[keep], b[keep])
     return {"correlation": float(corr), "pvalue": float(pvalue), "n": n,
             "method": method}

--- a/python/topica/llm.py
+++ b/python/topica/llm.py
@@ -21,6 +21,7 @@ The namespace collects the suite so it reads as a family and signals the shared
     topica.llm.diversity(model, backend=backend)        # pairwise cross-topic distinctiveness
     topica.llm.alignment(model, docs, backend=backend)  # irrelevant words / missing themes vs docs
     topica.llm.adversarial(model, backend=backend)      # gold-free capability self-check
+    topica.llm.human_agreement(llm_scores, human_scores)  # does the LLM metric track humans? (Spearman)
 
 The implementations live in :mod:`topica.coherence` (the metrics) and
 :mod:`topica.labeling` (the backend); this module is the curated public surface.
@@ -42,6 +43,7 @@ from .coherence import (
     llm_diversity as diversity,
     llm_adversarial as adversarial,
     llm_alignment as alignment,
+    llm_human_agreement as human_agreement,
     JudgeResult,
     LLM_EVAL_PROMPTS as PROMPTS,
 )
@@ -49,6 +51,6 @@ from .labeling import llm_backend as backend
 
 __all__ = [
     "coherence", "intrusion", "select_k", "judge", "outlier", "refine",
-    "repetitiveness", "diversity", "adversarial", "alignment", "backend",
-    "JudgeResult", "PROMPTS",
+    "repetitiveness", "diversity", "adversarial", "alignment", "human_agreement",
+    "backend", "JudgeResult", "PROMPTS",
 ]

--- a/tests/test_llm_human_agreement.py
+++ b/tests/test_llm_human_agreement.py
@@ -1,0 +1,71 @@
+"""llm.human_agreement: correlate an LLM metric with human ratings (Zheng et al. 2025
+Fig. 2 / Stammbach et al. 2023). Purely numeric and deterministic -- no LLM call."""
+
+import numpy as np
+import pytest
+
+import topica
+import topica.llm as L
+from topica.coherence import llm_human_agreement
+
+
+def test_namespace_surface():
+    assert callable(topica.llm.human_agreement)
+    assert "human_agreement" in L.__all__
+    assert not hasattr(topica, "llm_human_agreement")  # namespaced
+
+
+def test_perfect_rank_agreement():
+    llm = [1.0, 2.0, 3.0, 4.0, 5.0]
+    human = [10, 20, 30, 40, 50]           # monotone -> Spearman 1.0
+    r = llm_human_agreement(llm, human)
+    assert r["method"] == "spearman"
+    assert r["n"] == 5
+    assert r["correlation"] == pytest.approx(1.0)
+    assert r["pvalue"] <= 0.05
+
+
+def test_spearman_is_rank_based_not_linear():
+    llm = [1.0, 2.0, 3.0, 4.0]
+    human = [1, 4, 9, 16]                   # monotone but nonlinear
+    assert llm_human_agreement(llm, human, method="spearman")["correlation"] == pytest.approx(1.0)
+    # pearson is < 1 on the same nonlinear pair
+    assert llm_human_agreement(llm, human, method="pearson")["correlation"] < 1.0
+
+
+def test_anti_correlation():
+    r = llm_human_agreement([1, 2, 3, 4], [4, 3, 2, 1])
+    assert r["correlation"] == pytest.approx(-1.0)
+
+
+def test_nan_pairs_are_dropped():
+    # an LLM rating that failed to parse comes back NaN and must be dropped, not crash.
+    llm = [1.0, np.nan, 3.0, 4.0, 5.0]
+    human = [1, 2, 3, 4, 5]
+    r = llm_human_agreement(llm, human)
+    assert r["n"] == 4                       # the NaN pair dropped
+    assert r["correlation"] == pytest.approx(1.0)
+
+
+def test_methods_supported():
+    llm = [3.0, 1.0, 2.0, 5.0, 4.0]
+    human = [3, 1, 2, 5, 4]
+    for m in ("spearman", "pearson", "kendall"):
+        assert llm_human_agreement(llm, human, method=m)["correlation"] == pytest.approx(1.0)
+
+
+def test_errors():
+    with pytest.raises(ValueError, match="same length"):
+        llm_human_agreement([1, 2, 3], [1, 2])
+    with pytest.raises(ValueError, match="method"):
+        llm_human_agreement([1, 2, 3], [1, 2, 3], method="bogus")
+    with pytest.raises(ValueError, match="at least 2"):
+        llm_human_agreement([1.0, np.nan], [np.nan, 2.0])  # only 0 usable pairs
+
+
+def test_accepts_llm_coherence_style_array():
+    # the intended call: feed the per-topic llm_coherence output + human ratings.
+    llm = np.array([3.0, 3.0, 1.0, 2.0])     # e.g. from topica.llm.coherence(model, ...)
+    human = np.array([2.8, 2.9, 1.2, 2.1])
+    r = llm_human_agreement(llm, human)
+    assert 0.0 < r["correlation"] <= 1.0 and r["n"] == 4


### PR DESCRIPTION
## What

Final piece of #583 (the model-agnostic LLM pipeline tools from Zheng et al. 2025).

**`topica.llm.human_agreement(llm_scores, human_scores, method="spearman")`** — the Spearman (default; also `pearson`/`kendall`) rank correlation between a per-item LLM metric (e.g. the per-topic `llm.coherence` array) and a matching vector of human ratings. This is the paper's Fig. 2 / Stammbach et al. (2023) validation move — the honesty knob for the `llm-bounded` metrics: a high rank correlation on a labeled subset is what lets you report an LLM metric on the rest.

```python
llm = topica.llm.coherence(model, backend=backend)      # per-topic LLM ratings
agree = topica.llm.human_agreement(llm, human_ratings)  # one human rating per topic
agree["correlation"], agree["pvalue"], agree["n"]
```

Purely numeric — **no LLM call, deterministic**. Drops NaN pairs (e.g. an LLM rating that failed to parse), validates matching lengths, and reports `{correlation, pvalue, n, method}`.

**Parity note (item 4a):** verified the existing `llm.coherence` (3-point relatedness scale, `scale=(1,3)`) and `llm.intrusion` (top-5 words + 1 intruder, `n_words=5`) already match the paper's §5.2 / App. F.3 rating and intrusion protocol; documented in the guide.

## Tests

`tests/test_llm_human_agreement.py` — 8 tests: perfect/anti rank agreement, Spearman-is-rank-not-linear, NaN-pair dropping, all three methods, error paths (length mismatch, bad method, <2 usable pairs), and the intended `llm.coherence`-array call shape. `preflight` + `mkdocs --strict` green. No Rust/ABI change.

## Scope

Completes #583: `judge` (#675), `refine` (#677), and now `human_agreement` + the parity note. (Deeper follow-up: model-level corpus fingerprint for judge alignment, #676.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)