### PR TITLE
test(invariants): count-table reconstruction from token assignments (#420)

### DIFF
--- a/src/model.rs
+++ b/src/model.rs
@@ -447,9 +447,11 @@ mod tests {
     /// Rebuild the count tables from the token assignments and assert they exactly
     /// equal the incrementally-maintained ones. The packed `type_topic_counts` and
     /// `tokens_per_topic` are updated in place every token; `doc_topics` is the
-    /// ground-truth assignment. A packed-count or increment/decrement bug corrupts
-    /// the tables while `doc_topics` stays correct, so it moves φ/θ only slightly and
-    /// slips past parity's central-tendency thresholds -- this catches it exactly.
+    /// consistency reference (this checks the tables stay consistent with the
+    /// assignments, not that the assignments are a correct posterior draw). A
+    /// packed-count or increment/decrement bug corrupts the tables while `doc_topics`
+    /// stays intact, so it moves φ/θ only slightly and slips past parity's
+    /// central-tendency thresholds -- this catches it exactly.
     fn assert_counts_reconstruct(m: &TopicModel, corpus: &Corpus, sweep: usize) {
         let (k, v) = (m.num_topics, m.num_types);
         let mut dense = vec![vec![0u32; k]; v];
@@ -469,10 +471,31 @@ mod tests {
         // every real entry must have an in-range topic, the rebuilt count, and no
         // duplicate slot; every nonzero rebuilt count must have a packed entry.
         for w in 0..v {
+            let entries = &m.type_topic_counts[w];
+            // Structural invariant the sparse readers depend on (they break at the
+            // first zero): nonzero entries are descending and all zeros are trailing.
+            // A stranded nonzero after a zero would make production silently drop that
+            // topic's mass, so guard it explicitly rather than skipping past zeros.
+            let mut zero_seen = false;
+            for i in 0..entries.len() {
+                if entries[i] == 0 {
+                    zero_seen = true;
+                } else {
+                    assert!(
+                        !zero_seen,
+                        "sweep {sweep}: word {w} has a nonzero packed entry after a \
+                         zero slot (broken zeros-at-tail)"
+                    );
+                    assert!(
+                        i == 0 || entries[i - 1] >= entries[i],
+                        "sweep {sweep}: word {w} packed entries are not descending"
+                    );
+                }
+            }
             let mut seen = vec![false; k];
-            for &entry in &m.type_topic_counts[w] {
+            for &entry in entries {
                 if entry == 0 {
-                    continue; // emptied slot (decrement sinks zeros to the tail)
+                    break; // matches the sparse readers: zeros are trailing (asserted)
                 }
                 let t = (entry & m.topic_mask) as usize;
                 let c = entry >> m.topic_bits;

--- a/src/model.rs
+++ b/src/model.rs
@@ -444,6 +444,85 @@ mod tests {
         assert!(dir.is_empty(), "check_dirichlet: {:?}", dir);
     }
 
+    /// Rebuild the count tables from the token assignments and assert they exactly
+    /// equal the incrementally-maintained ones. The packed `type_topic_counts` and
+    /// `tokens_per_topic` are updated in place every token; `doc_topics` is the
+    /// ground-truth assignment. A packed-count or increment/decrement bug corrupts
+    /// the tables while `doc_topics` stays correct, so it moves φ/θ only slightly and
+    /// slips past parity's central-tendency thresholds -- this catches it exactly.
+    fn assert_counts_reconstruct(m: &TopicModel, corpus: &Corpus, sweep: usize) {
+        let (k, v) = (m.num_topics, m.num_types);
+        let mut dense = vec![vec![0u32; k]; v];
+        let mut tpt = vec![0u32; k];
+        for (doc, topics) in corpus.docs.iter().zip(m.doc_topics.iter()) {
+            assert_eq!(
+                doc.len(),
+                topics.len(),
+                "sweep {sweep}: doc/assignment length mismatch"
+            );
+            for (&w, &t) in doc.iter().zip(topics.iter()) {
+                dense[w as usize][t as usize] += 1;
+                tpt[t as usize] += 1;
+            }
+        }
+        // Decode the packed table directly (entry = (count << topic_bits) | topic):
+        // every real entry must have an in-range topic, the rebuilt count, and no
+        // duplicate slot; every nonzero rebuilt count must have a packed entry.
+        for w in 0..v {
+            let mut seen = vec![false; k];
+            for &entry in &m.type_topic_counts[w] {
+                if entry == 0 {
+                    continue; // emptied slot (decrement sinks zeros to the tail)
+                }
+                let t = (entry & m.topic_mask) as usize;
+                let c = entry >> m.topic_bits;
+                assert!(
+                    t < k,
+                    "sweep {sweep}: word {w} packed entry topic {t} >= K={k}"
+                );
+                assert!(
+                    !seen[t],
+                    "sweep {sweep}: word {w} has two packed entries for topic {t}"
+                );
+                seen[t] = true;
+                assert_eq!(
+                    c, dense[w][t],
+                    "sweep {sweep}: type_topic_counts[{w}][{t}] = {c} != rebuilt {}",
+                    dense[w][t]
+                );
+            }
+            for t in 0..k {
+                assert!(
+                    seen[t] || dense[w][t] == 0,
+                    "sweep {sweep}: word {w} topic {t} has rebuilt count {} but no packed entry",
+                    dense[w][t]
+                );
+            }
+        }
+        assert_eq!(
+            m.tokens_per_topic, tpt,
+            "sweep {sweep}: tokens_per_topic drifted"
+        );
+    }
+
+    #[test]
+    fn counts_reconstruct_from_assignments_every_sweep() {
+        // Both packing regimes: K=4 (power of two -> exact-width mask) and K=5
+        // (not -> the ceil-log2 mask), across init and 15 sweeps.
+        for &k in &[4usize, 5usize] {
+            let mut rng = ChaCha8Rng::seed_from_u64(42);
+            let corpus = small_corpus();
+            let v = corpus.num_types();
+            let mut m = TopicModel::new(k, k as f64 * 0.1, 0.1, v);
+            m.initialize(&corpus, &mut rng);
+            assert_counts_reconstruct(&m, &corpus, 0);
+            for sweep in 1..=15 {
+                run_iteration(&mut m, &corpus, &mut rng);
+                assert_counts_reconstruct(&m, &corpus, sweep);
+            }
+        }
+    }
+
     #[test]
     fn max_packable_count_matches_the_high_bit_width() {
         // Count occupies the high (32 - topic_bits) bits.


### PR DESCRIPTION
## What

Rust follow-up to #679, adding the **reconstruction invariant** from #420 for the core SparseLDA sampler.

After `initialize` and every sweep, it rebuilds the `(word, topic)` counts and `tokens_per_topic` from `doc_topics` (the ground-truth per-token assignments) and asserts they *exactly* equal the incrementally-maintained packed `type_topic_counts` and `tokens_per_topic`. It decodes the packed table directly (`entry = (count << topic_bits) | topic`): every entry must have an in-range topic, the rebuilt count, and no duplicate slot; every nonzero rebuilt count must have a packed entry. Runs both packing regimes — `K=4` (power-of-two mask) and `K=5` (ceil-log2 mask).

## Why it catches what parity can't

A packed-count or increment/decrement bug corrupts the count tables while `doc_topics` stays correct, so φ/θ move only slightly — below any parity threshold (the #417 class). This asserts exact table integrity. Verified non-vacuous: injecting `tokens_per_topic[0] += 1` fails the guard with "tokens_per_topic drifted."

## Scope

- Sequential sampler, `#[cfg(test)]` in `src/model.rs` (no Python feature, no ABI change).
- The **parallel merge** path (`reconcile_worker_outs`) is guarded at the Python level by #679's threaded-vs-serial topic comparison.
- The **exact-dense-conditional** invariant (per-token sampling weight vs a dense collapsed-conditional formula) remains a follow-up — it needs a test-only hook into the sampler's per-token distribution.

`cargo test --lib` green; `fmt` + `clippy` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)