### PR TITLE
Dataset loader uniformity + polymorphic topic_table (#686)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+### Changed
+
+- **Dataset loaders now offer a uniform shape** (#686). Text-table loaders
+  (`load_gadarian`/`load_poliblog`/`load_dubois`) still return a pandas DataFrame by
+  default, but accept `as_bunch=True` to return a `Bunch` whose `.df` is the table —
+  the same shape `load_ng20_minilm` returns (now with a `.df` view alongside its
+  embedding arrays). So `load_X(as_bunch=True).df` is one idiom across the roster. The
+  two-shape contract is documented in every loader's docstring and the module.
+- **`topic_table` is now polymorphic** (#686). It accepts either a fitted model or a
+  bare `(K, V)` topic-word array plus `vocabulary`, matching its siblings `frex` /
+  `relevance` (the previous model-only signature crashed on the natural matrix guess).
+  Pass `doc_topic=` with a bare array to get the prevalence column; otherwise it is
+  `None`. The model form is unchanged.
+
 ### Fixed
 
 - **`compare` no longer reports a one-sided fingerprint as a difference** (#672

--- a/python/topica/datasets/__init__.py
+++ b/python/topica/datasets/__init__.py
@@ -2,19 +2,32 @@
 
 Small datasets ship inside the wheel and load instantly, offline. Larger ones
 are downloaded once from GitHub on first use and cached locally, so the wheel
-stays lean. Every loader returns a :mod:`pandas` DataFrame ready for
-:func:`topica.from_dataframe`::
+stays lean.
+
+**Return shapes.** There are two, by dataset kind:
+
+- **Text-table loaders** (:func:`load_gadarian`, :func:`load_poliblog`,
+  :func:`load_dubois`) return a :mod:`pandas` DataFrame by default.
+- **The embedding loader** (:func:`load_ng20_minilm`) returns a :class:`Bunch`
+  (attribute-access dict) because it carries embedding arrays alongside the text.
+
+For a **uniform shape across the roster**, pass ``as_bunch=True`` to a text-table
+loader: every loader then returns a :class:`Bunch`, and **every Bunch exposes a
+``.df``** DataFrame view (plus any extra arrays). So ``load_X(as_bunch=True).df``
+and ``load_ng20_minilm().df`` are the same idiom everywhere::
 
     import topica
 
-    df = topica.datasets.load_gadarian()           # vendored, instant, offline
+    df = topica.datasets.load_gadarian()                    # DataFrame (default)
+    b = topica.datasets.load_gadarian(as_bunch=True)         # Bunch; b.df is the table
+    b = topica.datasets.load_ng20_minilm()                  # Bunch; b.df + b.doc_embeddings
+
     corpus = topica.from_dataframe(
         df, text_col="open.ended.response", stopwords=topica.ENGLISH_STOPWORDS
     )
     model = topica.STM(num_topics=10).fit(corpus, prevalence=corpus.metadata[["treatment"]])
 
-Pass ``return_path=True`` to get the cached CSV path instead of a DataFrame
-(no pandas required).
+Pass ``return_path=True`` to get the cached file path instead (no pandas required).
 
 The cache lives under ``~/.cache/topica/datasets`` by default; set the
 ``TOPICA_DATA_HOME`` environment variable to relocate it. Downloads are pinned
@@ -46,6 +59,10 @@ class Bunch(dict):
     Returned by loaders that carry more than a text table — e.g.
     :func:`load_ng20_minilm`, which bundles documents, labels, and precomputed
     embedding arrays. ``b["texts"]`` and ``b.texts`` are the same thing.
+
+    Every loader can return a Bunch (``as_bunch=True`` for the text-table
+    loaders; :func:`load_ng20_minilm` always does), and every Bunch exposes a
+    ``.df`` DataFrame view for a uniform shape across the roster.
     """
 
     def __getattr__(self, key):
@@ -227,14 +244,17 @@ def _read_csv(path: Path):
     return pd.read_csv(path)
 
 
-def _load(name: str, return_path: bool):
+def _load(name: str, return_path: bool, as_bunch: bool = False):
     path = _resolve(name)
     if return_path:
         return path
-    return _read_csv(path)
+    df = _read_csv(path)
+    if as_bunch:
+        return Bunch(df=df)
+    return df
 
 
-def load_gadarian(*, return_path: bool = False):
+def load_gadarian(*, return_path: bool = False, as_bunch: bool = False):
     """Load the Gadarian & Albertson immigration experiment (341 documents).
 
     The canonical ``stm`` prevalence example. Open-ended survey responses with
@@ -248,12 +268,14 @@ def load_gadarian(*, return_path: bool = False):
         )
 
     This dataset is bundled in the wheel and loads offline. Pass
-    ``return_path=True`` for the CSV path instead of a DataFrame.
+    ``return_path=True`` for the CSV path instead of a DataFrame, or
+    ``as_bunch=True`` for a :class:`Bunch` whose ``.df`` is this table (the
+    uniform shape shared with :func:`load_ng20_minilm`).
     """
-    return _load("gadarian", return_path)
+    return _load("gadarian", return_path, as_bunch)
 
 
-def load_poliblog(*, return_path: bool = False):
+def load_poliblog(*, return_path: bool = False, as_bunch: bool = False):
     """Load the CMU 2008 political blog corpus (a 2,000-document sample).
 
     The text in the ``text`` column is already tokenized and stemmed
@@ -264,12 +286,13 @@ def load_poliblog(*, return_path: bool = False):
         corpus = topica.from_dataframe(df, text_col="text")
 
     Covariates: ``rating`` (Liberal/Conservative), ``day``, ``blog``. Downloaded
-    once and cached. Pass ``return_path=True`` for the CSV path.
+    once and cached. Pass ``return_path=True`` for the CSV path, or
+    ``as_bunch=True`` for a :class:`Bunch` whose ``.df`` is this table.
     """
-    return _load("poliblog", return_path)
+    return _load("poliblog", return_path, as_bunch)
 
 
-def load_dubois(*, return_path: bool = False):
+def load_dubois(*, return_path: bool = False, as_bunch: bool = False):
     """Load Du Bois-era articles from The Crisis, 1910-1934 (704 documents).
 
     Raw text in the ``text`` column; covariates ``year``, ``decade``,
@@ -291,8 +314,12 @@ def load_dubois(*, return_path: bool = False):
     ``"Du Bois, W.E.B."``). Split composites (``[s.split("; ") for s in df.author]``)
     and normalize variants before using it as an author-topic input, or a co-authored
     article becomes a phantom author and one person splits across several rows.
+
+    Pass ``return_path=True`` for the CSV path, or ``as_bunch=True`` for a
+    :class:`Bunch` whose ``.df`` is this table (the uniform shape shared with
+    :func:`load_ng20_minilm`).
     """
-    return _load("dubois", return_path)
+    return _load("dubois", return_path, as_bunch)
 
 
 def load_ng20_minilm(*, return_path: bool = False):
@@ -334,11 +361,22 @@ def load_ng20_minilm(*, return_path: bool = False):
     import numpy as np
 
     with np.load(path, allow_pickle=True) as npz:
-        return Bunch(
-            texts=list(npz["texts"]),
-            labels=npz["labels"],
+        texts = list(npz["texts"])
+        labels = npz["labels"]
+        bunch = Bunch(
+            texts=texts,
+            labels=labels,
             doc_embeddings=npz["doc_embeddings"],
             vocab=list(npz["vocab"]),
             word_embeddings=npz["word_embeddings"],
             meta=str(npz["meta"]),
         )
+    # `.df` gives the uniform DataFrame view every loader's Bunch exposes (the
+    # per-document text table; the embedding arrays stay as attributes).
+    try:
+        import pandas as pd
+
+        bunch["df"] = pd.DataFrame({"text": texts, "label": labels})
+    except ImportError:  # pandas optional; the arrays are still available
+        pass
+    return bunch

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -648,7 +648,7 @@ def label_topics(topic_word, vocabulary=None, *, n=10, word_counts=None, corpus=
     return out
 
 
-def topic_table(model, *, n=7):
+def topic_table(model, vocabulary=None, *, doc_topic=None, n=7):
     """A publication-ready topic table: one row per topic with its prevalence and
     its top probability and FREX words.
 
@@ -657,17 +657,30 @@ def topic_table(model, *, n=7):
     usually the better label). Hand it to ``pandas.DataFrame`` for the table that
     goes in a results section.
 
-    `model` is any fitted model exposing ``topic_word``, ``doc_topic``, and
-    ``vocabulary``.
+    Accepts either a **fitted model** (uses its ``topic_word``, ``doc_topic``, and
+    ``vocabulary``) or a bare ``(K, V)`` **topic-word array**, matching the sibling
+    helpers :func:`frex` / :func:`relevance`::
+
+        topic_table(model)                      # from a fitted model
+        topic_table(model.topic_word, vocab)    # from matrices
+
+    With a bare array, pass ``vocabulary``; prevalence needs the document-topic
+    matrix, so pass ``doc_topic=`` to get it, otherwise the ``prevalence`` column
+    is ``None``.
     """
     phi = _as_topic_word(model)
-    prevalence = _as_doc_topic(model).mean(axis=0)
-    vocab = list(model.vocabulary)
+    vocab = _vocabulary_of(model, vocabulary)
+    if doc_topic is not None:
+        prevalence = np.asarray(doc_topic, dtype=np.float64).mean(axis=0)
+    elif hasattr(model, "doc_topic") and not isinstance(model, np.ndarray):
+        prevalence = _as_doc_topic(model).mean(axis=0)
+    else:
+        prevalence = None  # a bare topic-word array carries no prevalence
     labels = label_topics(phi, vocab, n=n)
     return [
         {
             "topic": t,
-            "prevalence": float(prevalence[t]),
+            "prevalence": float(prevalence[t]) if prevalence is not None else None,
             "prob": [w for w, _ in labels[t]["prob"]],
             "frex": [w for w, _ in labels[t]["frex"]],
         }

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -30,6 +30,18 @@ def test_load_gadarian_dataframe():
         assert col in df.columns
 
 
+def test_load_gadarian_as_bunch_uniform_df():
+    # as_bunch gives the uniform shape: a Bunch whose .df is the table (#686).
+    import pandas as pd
+
+    b = datasets.load_gadarian(as_bunch=True)
+    assert isinstance(b, datasets.Bunch)
+    assert isinstance(b.df, pd.DataFrame)
+    assert len(b.df) == 341
+    # default is still a bare DataFrame (non-breaking)
+    assert isinstance(datasets.load_gadarian(), pd.DataFrame)
+
+
 def test_load_gadarian_return_path():
     path = datasets.load_gadarian(return_path=True)
     assert path.exists()

--- a/tests/test_topics_for_term.py
+++ b/tests/test_topics_for_term.py
@@ -244,3 +244,26 @@ class TestModelPath:
         j = list(m.vocabulary).index("cat")
         expected = int(np.argmax(phi[:, j]))
         assert topica.topics_for_term(m, "cat")[0][0] == expected
+
+
+class TestTopicTablePolymorphic:
+    """topic_table accepts a model OR bare matrices, matching frex/relevance (#686)."""
+
+    def test_matrix_form_no_prevalence(self):
+        rows = topica.topic_table(PHI, VOCAB, n=2)
+        assert len(rows) == 3
+        assert rows[0]["prevalence"] is None  # bare matrix carries no doc-topic
+        assert set(rows[0]) == {"topic", "prevalence", "prob", "frex"}
+        assert "a" in rows[0]["prob"]  # topic 0 loves "a"
+
+    def test_matrix_with_doc_topic_gives_prevalence(self):
+        doc_topic = np.array([[0.8, 0.1, 0.1], [0.2, 0.7, 0.1]])
+        rows = topica.topic_table(PHI, VOCAB, doc_topic=doc_topic, n=2)
+        assert rows[0]["prevalence"] == pytest.approx(0.5)  # mean of col 0
+
+    def test_model_form_unchanged(self):
+        docs = [["a", "b", "c"], ["a", "a", "b"], ["c", "d", "d"], ["d", "c", "c"]] * 6
+        m = topica.LDA(3, seed=13).fit(docs, iters=40)
+        rows = topica.topic_table(m, n=3)
+        assert len(rows) == 3
+        assert isinstance(rows[0]["prevalence"], float)


### PR DESCRIPTION
Addresses the cross-cutting (non-GuidedNMF-specific) API friction from the GuidedNMF sample-user audit (#686). The GuidedNMF-specific Tier-1 traps were fixed in #684; these are the roster-wide ones both sample-user agents hit.

## Tier 2 — inconsistent dataset loader shapes
Text-table loaders returned a DataFrame; `load_ng20_minilm` returned a `Bunch`, so a `docs, meta = load_dubois()` mental model crashed and there was no uniform shape.

- Text-table loaders (`load_gadarian`/`load_poliblog`/`load_dubois`) gain **`as_bunch=True`** → a `Bunch` whose **`.df`** is the table.
- `load_ng20_minilm` gains a **`.df`** view (text+label table) alongside its embedding arrays.
- So **`load_X(as_bunch=True).df`** is one idiom across the whole roster. Defaults are unchanged (non-breaking). The two-shape contract is now documented in every loader docstring and the module (the module docstring previously claimed, inaccurately, that every loader returns a DataFrame).

## Tier 3 — `topic_table` was model-only
`topic_table(model, *, n=7)` crashed on the natural `topic_table(topic_word, vocabulary)` guess, even though siblings `frex`/`relevance` take matrices.

- Now **polymorphic**: `topic_table(model, vocabulary=None, *, doc_topic=None, n=7)` accepts a fitted model **or** a bare `(K, V)` array + `vocabulary`. Prevalence comes from `doc_topic=` (or the model); `None` for a bare array. The model form is unchanged; all existing consumers use it.

## Deferred
Tier 4 (standardize the ~41 per-model `coherence()` docstrings with a sign/scale/alignment note) is a separate binding-docstring sweep, not bundled here.

## Gates
`pytest` (datasets/validation/topics_for_term/frames/rtm/s3/diagnostics, 132 passing incl. new tests), full suite, and `mkdocs --strict` pass. Python-only change; no rebuild.

🤖 Generated with [Claude Code](https://claude.com/claude-code)