### PR TITLE
feat(eval): cross-validation framework — fold engine + topic path (#701, PR1)

### DIFF
--- a/docs/guides/cross-validation.md
+++ b/docs/guides/cross-validation.md
@@ -1,0 +1,161 @@
+# Cross-validation
+
+Cross-validation gives you shared, reproducible evidence about a model's
+*predictive* behavior: refit a fresh model on each training fold, then score the
+held-out documents it never saw. `topica.cross_validate` runs the whole loop and
+records the fold assignments and every seed so a rerun reproduces the result.
+
+It reports evidence; it does not adjudicate. Cross-validation here never picks `K`
+for you or declares a topic substantively valid — those stay your decisions.
+
+## The short version
+
+`cross_validate` wants `docs` as a list of token lists (`list[list[str]]`). A bundled
+dataset gives you a DataFrame whose `text` column is a space-joined string, so split it
+first:
+
+```python
+import topica
+
+df = topica.datasets.load_poliblog()      # a real bundled dataset
+docs = [t.split() for t in df["text"]]    # -> list[list[str]]
+
+result = topica.cross_validate(
+    lambda seed: topica.LDA(10, seed=seed),   # a factory: seed -> fresh model
+    docs,
+    folds=5,
+    seed=13,
+    fit_kwargs={"iters": 500},
+)
+
+print(result.summary())
+result.to_frame()   # per-fold metrics as a DataFrame
+```
+
+`docs` may also be a `Corpus` (build one with `topica.Corpus.from_documents(docs)`),
+though for the leakage-free default you want raw token lists — see
+[Vocabulary and comparability](#vocabulary-and-comparability).
+
+The first argument is a **factory**, not a fitted model: `cross_validate` calls it
+once per fold with a derived seed so every fold trains a fresh, reproducible model.
+Thread the seed into the constructor — `lambda seed: topica.STM(10, seed=seed)`.
+
+## What it reports
+
+For each fold, on the **held-out** test documents:
+
+- **Held-out document-completion perplexity** — half of each test document's tokens
+  infer its topic mixture and the other half are scored under it. Lower is better.
+  Because the scored tokens are withheld from the estimate, it does not fall
+  trivially as `K` grows, so it is a fair quantity to compare across `K`.
+- **Fold coherence and exclusivity** — computed on that fold's training text.
+- **Cross-fold topic stability** — the mean matched-topic cosine across every pair
+  of folds, aligned vocabulary-aware (fold vocabularies differ; see below).
+
+`result.aggregate` gives the macro mean ± std of each metric across folds;
+`result.per_fold` is the per-fold detail.
+
+## Fold strategies
+
+`make_folds` (called for you, or usable directly) offers three ways to split, and it
+is the single place leakage is guarded:
+
+| `strategy` | Split | Requires | Guard |
+|---|---|---|---|
+| `"kfold"` | shuffle, K test blocks | — | no document in train and test of a fold |
+| `"grouped"` | whole groups held out together | `groups=` | no group id straddles a fold (authors, blogs, threads) |
+| `"temporal"` | ordered, test always after train | `times=` | `max(train) < min(test)`; tied timestamps stay together |
+
+```python
+folds = topica.make_folds(len(docs), strategy="grouped", folds=5, groups=author_id)
+result = topica.cross_validate(factory, docs, folds=folds)
+```
+
+For `temporal`, the training window **expands** by default; pass `window=` for a
+rolling window. The earliest documents form the initial training block and are never
+tested, so they are marked `False` in `result.folds.oof_mask`.
+
+## Covariates
+
+Covariate models take per-document covariates aligned to the documents.
+`cross_validate` sub-indexes them to each fold and conditions the held-out inference
+on the fold's *test* covariates, so the evaluation is leakage-free. Pass them as a
+dict keyed by the model's fit keyword:
+
+```python
+# Covariates must be a numeric matrix. Encode a categorical column first:
+X = topica.one_hot(df["rating"])            # or topica.design_matrix(...)
+
+result = topica.cross_validate(
+    lambda seed: topica.STM(10, seed=seed),
+    docs,
+    covariates={"prevalence": X},           # D x P, aligned to docs
+    folds=5,
+)
+```
+
+Recognized out of the box: STM `prevalence` / `content` / `content_time`, DMR and
+GDMR `features`, keyATM `covariates` / `times`. Each per-document array is
+length-checked against the corpus up front — a length mismatch is a hard error, never
+a silent truncation. Passing a covariate a model does not accept (e.g. `prevalence`
+to a plain LDA) is also a hard error, not a silent drop.
+
+**Watch the conditioning flag.** When a family's `transform` cannot take covariates
+(keyATM), the held-out score falls back to the *marginal* path — it does **not**
+condition on your covariate, so the reported perplexity does not reflect it.
+`cross_validate` warns at run time when this happens, `result.summary()` prints a
+`covariates:` status line, and every fold carries `covariate_conditioned` in
+`result.to_frame()`. STM `prevalence` conditions correctly (`covariate_conditioned=True`);
+do not report a keyATM-covariate CV as if it conditioned on the covariate.
+
+For anything the named routing does not cover, supply both an
+`fit_fn(train_docs, train_idx, seed_fold) -> model` and a
+`score_fn(model, test_docs, test_idx, seed_fold) -> dict` and own the sub-indexing on
+both sides; `cross_validate` still handles folds, seeds, aggregation, and the record.
+
+## Vocabulary and comparability
+
+By default (`vocab="per_fold"`) the vocabulary and its frequency pruning are learned
+on **each training fold only** and the test documents are vectorized into that
+vocabulary, with out-of-vocabulary tokens dropped. This is leakage-free: no test-set
+word frequency ever informs a fold's feature selection.
+
+The tradeoff is that per-fold vocabularies differ, so the probability space each
+perplexity is measured over differs. `cross_validate` reports each fold's perplexity
+and their **macro mean** (`perplexity: 1121 +/- 5`), but never a single *token-pooled*
+perplexity that concatenates held-out tokens across folds — that would be a false
+comparison across different vocabularies. The macro mean is still the right number to
+**compare across models or across K at a fixed `seed`**: the same seed gives identical
+folds, and within each fold the two models are scored on the identical held-out tokens,
+so the comparison is valid. "Not pooled" refers only to the token-concatenation, not to
+comparing the reported means.
+
+If you would rather share one vocabulary across folds (comparable, poolable
+perplexity) and accept that global pruning lets test frequencies inform feature
+selection, pass `vocab="fixed"`. This is standard practice in much of the
+topic-model literature; `cross_validate` emits a warning so the tradeoff is explicit.
+
+For a genuinely per-fold vocabulary, pass **raw token lists**, not a pre-built
+`Corpus`. A `Corpus` already had its vocabulary and frequency pruning learned on the
+whole corpus, and rebuilding per fold cannot undo that; `cross_validate` warns when
+you pass a pre-pruned `Corpus` on the `per_fold` path.
+
+An unrecognized covariate key is a hard error, not a silent drop: passing
+`covariates={"prevalence": X}` to a model that has no prevalence covariate (an LDA,
+say) raises with the list of keys that model does accept.
+
+## Reproducibility
+
+`seed` fixes both the fold shuffle and every per-fold fit seed, derived with
+`numpy.random.SeedSequence` so they are stable across interpreter runs. With
+`manifest=True` (the default) the returned `result.manifest` records the document
+count and order hash, the exact fold indices, the splitter parameters, and every
+derived seed, so a rerun reproduces the folds and fits. Save it alongside your
+results:
+
+```python
+result.manifest.save("cv_manifest.json")
+```
+
+Bit-for-bit reproducibility is claimed only when you do not pass an opaque
+`fit_fn`/`score_fn`; with a user callback the manifest records `replayable=False`.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,7 @@ nav:
       - Visualization: guides/visualization.md
       - Distinguishing words: guides/keywords.md
       - Held-out inference: guides/transform.md
+      - Cross-validation: guides/cross-validation.md
   - Benchmarks: benchmarks.md
   - Examples:
       - Du Bois in The Crisis: examples/dubois.md

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -296,6 +296,12 @@ from .validation import (  # noqa: E402  general, model-agnostic post-hoc analys
     align_topics,
     topic_stability,
 )
+from .crossval import (  # noqa: E402  (#701 cross-validation evaluation framework)
+    cross_validate,
+    make_folds,
+    Folds,
+    CrossValResult,
+)
 from .ensemble import ensemble, EnsembleResult, cross_ensemble  # noqa: E402  (consensus across runs)
 from .compare import (  # noqa: E402  (statistical two-fit topic-drift comparison, #415)
     compare,
@@ -459,6 +465,10 @@ __all__ = [
     "TopicDendrogram",
     "align_topics",
     "topic_stability",
+    "cross_validate",
+    "make_folds",
+    "Folds",
+    "CrossValResult",
     "compare",
     "CompareResult",
     "MatchedPair",

--- a/python/topica/crossval.py
+++ b/python/topica/crossval.py
@@ -1,0 +1,962 @@
+"""Cross-validation evaluation framework (#701).
+
+Reproducible, shared cross-validation as evidence about *predictive behavior* for
+both topic models and supervised/measurement models. Document-level folds (ordinary
+k-fold, grouped, temporal) with fixed seeds recorded in an :class:`AnalysisManifest`;
+refit a fresh model per fold via a factory; evaluate held-out.
+
+Non-goal: this never auto-chooses ``K`` or declares a topic substantively valid. It
+reports evidence; the researcher adjudicates.
+
+Public surface
+--------------
+- :func:`make_folds` — the fold engine (the single leakage guard).
+- :func:`cross_validate` — the orchestrator (PR2 adds the supervised path).
+- :class:`Folds`, :class:`CrossValResult` — the returned dataclasses.
+
+Design notes (Gate A, #701)
+---------------------------
+- Fold seeds come from :class:`numpy.random.SeedSequence`, never ``hash()`` (which is
+  non-deterministic across interpreter runs).
+- Temporal ties are atomic: documents sharing a timestamp never straddle the
+  train/test boundary, and the guard is a *strict* ``max(train) < min(test)``.
+- Vocabulary is rebuilt per fold by default (leakage-free), so held-out perplexity is
+  comparable only *within* a fold and is never pooled across folds.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import numpy as np
+
+__all__ = ["make_folds", "Folds", "cross_validate", "CrossValResult"]
+
+
+# ---------------------------------------------------------------------------
+# Folds — the fold engine and its dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Folds:
+    """A reproducible set of ``(train_idx, test_idx)`` document splits.
+
+    The only place leakage is guarded. Every index array is ``int64``, in-bounds,
+    and unique within itself; train and test are disjoint and nonempty.
+
+    Attributes
+    ----------
+    splits : list of ``(train_idx, test_idx)`` int64 arrays.
+    strategy : "kfold" | "grouped" | "temporal".
+    seed : the base seed the split was derived from.
+    fold_seeds : per-fold derived seeds (from ``SeedSequence(seed).spawn``), the
+        integer each fold's ``factory(seed_fold)`` receives.
+    oof_mask : boolean array over ``n_docs``; True where a document is tested in
+        some fold. Always all-True for kfold/grouped (exactly-once test coverage);
+        for temporal the initial training window is never tested, so those entries
+        are False and are excluded from pooled out-of-fold metrics.
+    n_docs : the document count these folds index.
+    window : temporal rolling-window size, or None for an expanding window.
+    groups_hash / times_hash : provenance hashes recorded in the manifest.
+    """
+
+    splits: list[tuple[np.ndarray, np.ndarray]]
+    strategy: str
+    seed: int
+    fold_seeds: list[int]
+    oof_mask: np.ndarray
+    n_docs: int
+    window: int | None = None
+    groups_hash: str | None = None
+    times_hash: str | None = None
+
+    def __len__(self) -> int:
+        return len(self.splits)
+
+    def __iter__(self):
+        return iter(self.splits)
+
+    def __getitem__(self, i):
+        return self.splits[i]
+
+    def __repr__(self) -> str:
+        return (
+            f"Folds(strategy={self.strategy!r}, folds={len(self.splits)}, "
+            f"n_docs={self.n_docs}, tested={int(self.oof_mask.sum())}/{self.n_docs})"
+        )
+
+
+def _hash_array(a) -> str | None:
+    """A short stable content hash for manifest provenance (order-sensitive)."""
+    if a is None:
+        return None
+    import hashlib
+
+    arr = np.asarray(a)
+    return hashlib.sha256(arr.tobytes() + str(arr.dtype).encode() + str(arr.shape).encode()).hexdigest()[:16]
+
+
+def _derive_fold_seeds(seed: int, k: int) -> tuple[np.random.SeedSequence, list[int]]:
+    """Base SeedSequence + K reproducible child seeds. No ``hash()`` anywhere."""
+    ss = np.random.SeedSequence(int(seed))
+    children = ss.spawn(k)
+    # A stable, human-readable integer seed per fold (uint32, positive).
+    fold_seeds = [int(c.generate_state(1, dtype=np.uint32)[0]) for c in children]
+    return ss, fold_seeds
+
+
+def _validate_split(train, test, n_docs):
+    """Enforce the per-fold invariants (Gate A-A3)."""
+    for name, idx in (("train", train), ("test", test)):
+        if idx.dtype != np.int64:
+            raise ValueError(f"{name} indices must be int64, got {idx.dtype}")
+        if idx.size == 0:
+            raise ValueError(f"a fold has an empty {name} set")
+        if idx.min() < 0 or idx.max() >= n_docs:
+            raise ValueError(f"{name} index out of bounds [0, {n_docs})")
+        if np.unique(idx).size != idx.size:
+            raise ValueError(f"duplicate indices within a fold {name} set")
+    if np.intersect1d(train, test).size:
+        raise ValueError("a document appears in both train and test of a fold")
+
+
+def _validate_folds_obj(fold_obj, n_docs):
+    """Re-run the per-fold invariants + seed-count check on a user-supplied Folds,
+    so an externally constructed (or hand-edited) Folds can never smuggle a leak in."""
+    if len(fold_obj.fold_seeds) != len(fold_obj.splits):
+        raise ValueError(
+            f"Folds has {len(fold_obj.splits)} splits but "
+            f"{len(fold_obj.fold_seeds)} fold seeds; they must match"
+        )
+    for train, test in fold_obj.splits:
+        _validate_split(np.asarray(train), np.asarray(test), n_docs)
+    if fold_obj.strategy in ("kfold", "grouped"):
+        tested = np.concatenate([np.asarray(test) for _, test in fold_obj.splits])
+        if np.unique(tested).size != n_docs or tested.size != n_docs:
+            raise ValueError(
+                f"{fold_obj.strategy} Folds must test every document exactly once"
+            )
+
+
+def _make_kfold(n_docs, folds, rng):
+    perm = rng.permutation(n_docs)
+    test_blocks = np.array_split(perm, folds)
+    splits = []
+    for block in test_blocks:
+        test = np.sort(block).astype(np.int64)
+        train = np.setdiff1d(np.arange(n_docs, dtype=np.int64), test, assume_unique=False)
+        splits.append((train, test))
+    return splits
+
+
+def _make_grouped(n_docs, folds, groups, rng):
+    groups = np.asarray(groups)
+    if groups.shape[0] != n_docs:
+        raise ValueError(f"groups has length {groups.shape[0]}, expected {n_docs}")
+    # Missing group ids are not allowed (they cannot be held out coherently).
+    missing = np.array([g is None or (isinstance(g, float) and np.isnan(g)) for g in groups])
+    if missing.any():
+        raise ValueError(f"{int(missing.sum())} documents have a missing group id")
+
+    uniq, counts = np.unique(groups, return_counts=True)
+    if uniq.size < folds:
+        raise ValueError(
+            f"grouped CV needs at least folds={folds} distinct groups, got {uniq.size}"
+        )
+    # Dominant-group guard (Gate A-B6): greedily bin groups into K folds by
+    # descending size (multiway partition); if the largest group alone forces a
+    # fold to swallow more than a balanced share we still proceed, but if a single
+    # group exceeds what leaves K nonempty folds, fail loudly.
+    order = np.argsort(-counts)
+    bins = [[] for _ in range(folds)]
+    bin_sizes = np.zeros(folds, dtype=np.int64)
+    for gi in order:
+        target = int(np.argmin(bin_sizes))
+        bins[target].append(uniq[gi])
+        bin_sizes[target] += counts[gi]
+    if (bin_sizes == 0).any():
+        biggest = uniq[order[0]]
+        raise ValueError(
+            f"cannot build {folds} group-disjoint folds: group {biggest!r} holds "
+            f"{counts[order[0]]}/{n_docs} documents, leaving an empty fold. Reduce "
+            "folds or merge groups."
+        )
+    # A dominant group produces valid but severely imbalanced folds; the split is
+    # honest (no leakage, no dropped fold), but the researcher should know their
+    # held-out sizes are lopsided (Gate A-B6).
+    balanced = n_docs / folds
+    if bin_sizes.max() > 2.0 * balanced:
+        import warnings
+
+        biggest = uniq[order[0]]
+        warnings.warn(
+            f"grouped folds are imbalanced: the largest test fold holds "
+            f"{int(bin_sizes.max())} docs vs a balanced ~{balanced:.0f} (group "
+            f"{biggest!r} alone is {counts[order[0]]}/{n_docs}). Held-out metrics "
+            "will weight that fold heavily.",
+            stacklevel=2,
+        )
+    all_idx = np.arange(n_docs, dtype=np.int64)
+    splits = []
+    for b in bins:
+        test_mask = np.isin(groups, b)
+        test = all_idx[test_mask]
+        train = all_idx[~test_mask]
+        splits.append((train, test))
+    return splits
+
+
+def _make_temporal(n_docs, folds, times, window):
+    times = np.asarray(times)
+    if times.shape[0] != n_docs:
+        raise ValueError(f"times has length {times.shape[0]}, expected {n_docs}")
+    # NaN sorts unpredictably and defeats the strict-ordering guard (NaN comparisons
+    # are always False), so reject missing timestamps outright.
+    if times.dtype.kind == "f" and np.isnan(times).any():
+        raise ValueError(
+            f"{int(np.isnan(times).sum())} documents have a missing (NaN) timestamp"
+        )
+    order = np.argsort(times, kind="stable")
+    sorted_times = times[order]
+    # Tie groups: contiguous runs of equal timestamp in sorted order. A tie group
+    # is atomic — never split across the train/test boundary (Gate A-A2/B4).
+    boundaries = np.flatnonzero(sorted_times[1:] != sorted_times[:-1]) + 1
+    tie_starts = np.concatenate(([0], boundaries))
+    tie_ends = np.concatenate((boundaries, [n_docs]))
+    n_ties = tie_starts.size
+    if n_ties < folds + 1:
+        raise ValueError(
+            f"temporal CV with folds={folds} needs at least {folds + 1} distinct "
+            f"timestamps, got {n_ties}"
+        )
+    # Split the tie groups into folds+1 contiguous blocks: block 0 is the initial
+    # training window; folds f=1..K test on block f, training on all earlier blocks.
+    block_of_tie = np.array_split(np.arange(n_ties), folds + 1)
+    # Map tie-block -> the sorted positions it covers.
+    def tie_block_positions(tie_ids):
+        lo = tie_starts[tie_ids[0]]
+        hi = tie_ends[tie_ids[-1]]
+        return lo, hi
+
+    splits = []
+    for f in range(1, folds + 1):
+        test_lo, test_hi = tie_block_positions(block_of_tie[f])
+        if window is None:
+            train_lo = 0
+        else:
+            # rolling window: the `window` tie-blocks immediately before this test.
+            first_train_block = max(0, f - window)
+            train_lo, _ = tie_block_positions(block_of_tie[first_train_block])
+        train_hi = test_lo
+        train = np.sort(order[train_lo:train_hi]).astype(np.int64)
+        test = np.sort(order[test_lo:test_hi]).astype(np.int64)
+        # Strict-ordering guard: no timestamp shared across the boundary.
+        if train.size and times[train].max() >= times[test].min():
+            raise ValueError(
+                "temporal split would place a shared timestamp in both train and "
+                "test; a single tie group is larger than a fold block"
+            )
+        splits.append((train, test))
+
+    # Ties are atomic (split over tie-group ids, never positions), so a shared
+    # timestamp can never straddle the boundary — the guard above is defensive. But
+    # a tie group larger than a balanced block yields a valid, lopsided test fold;
+    # surface that rather than let it pass silently.
+    test_sizes = np.array([e.size for _, e in splits])
+    balanced = n_docs / (folds + 1)
+    if test_sizes.max() > 3.0 * balanced:
+        import warnings
+
+        warnings.warn(
+            f"temporal folds are imbalanced: a tied-timestamp block gives a test "
+            f"fold of {int(test_sizes.max())} docs vs a balanced ~{balanced:.0f}. "
+            "Held-out metrics will weight that fold heavily.",
+            stacklevel=2,
+        )
+    return splits
+
+
+def make_folds(
+    n_docs: int,
+    *,
+    strategy: str = "kfold",
+    folds: int = 5,
+    groups=None,
+    times=None,
+    window: int | None = None,
+    seed: int = 13,
+) -> Folds:
+    """Build a reproducible :class:`Folds` object — the CV leakage guard.
+
+    Parameters
+    ----------
+    n_docs : number of documents to split.
+    strategy : "kfold" (shuffle + K contiguous test blocks), "grouped" (whole
+        groups held out together; requires ``groups``), or "temporal" (ordered by
+        ``times``, test always strictly after train; requires ``times``).
+    folds : number of folds K.
+    groups : per-document group id (length ``n_docs``), required for "grouped".
+    times : per-document order key (length ``n_docs``), required for "temporal".
+    window : temporal only — None for an expanding training window (default), or an
+        int rolling-window size in tie-blocks.
+    seed : base seed; per-fold seeds are derived via ``SeedSequence(seed).spawn``.
+
+    Returns
+    -------
+    Folds
+    """
+    if not isinstance(n_docs, (int, np.integer)) or n_docs < 2:
+        raise ValueError(f"n_docs must be an int >= 2, got {n_docs!r}")
+    if not isinstance(folds, (int, np.integer)) or folds < 2:
+        raise ValueError(f"folds must be an int >= 2, got {folds!r}")
+    if folds > n_docs:
+        raise ValueError(f"folds={folds} exceeds n_docs={n_docs}")
+
+    ss, fold_seeds = _derive_fold_seeds(seed, folds)
+    rng = np.random.default_rng(ss)
+
+    if strategy == "kfold":
+        splits = _make_kfold(n_docs, folds, rng)
+    elif strategy == "grouped":
+        if groups is None:
+            raise ValueError("strategy='grouped' requires groups=")
+        splits = _make_grouped(n_docs, folds, groups, rng)
+    elif strategy == "temporal":
+        if times is None:
+            raise ValueError("strategy='temporal' requires times=")
+        splits = _make_temporal(n_docs, folds, times, window)
+    else:
+        raise ValueError(
+            f"unknown strategy {strategy!r}; use 'kfold', 'grouped', or 'temporal'"
+        )
+
+    for train, test in splits:
+        _validate_split(train, test, n_docs)
+
+    # Exactly-once test coverage for kfold/grouped (Gate A-A3).
+    tested = np.concatenate([test for _, test in splits])
+    if strategy in ("kfold", "grouped"):
+        if np.unique(tested).size != n_docs or tested.size != n_docs:
+            raise ValueError(
+                f"{strategy} folds must test every document exactly once "
+                f"(covered {np.unique(tested).size}/{n_docs})"
+            )
+    oof_mask = np.zeros(n_docs, dtype=bool)
+    oof_mask[np.unique(tested)] = True
+
+    return Folds(
+        splits=splits,
+        strategy=strategy,
+        seed=int(seed),
+        fold_seeds=fold_seeds,
+        oof_mask=oof_mask,
+        n_docs=int(n_docs),
+        window=window,
+        groups_hash=_hash_array(groups),
+        times_hash=_hash_array(times),
+    )
+
+
+# ---------------------------------------------------------------------------
+# cross_validate — the topic-model orchestrator (PR1)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CrossValResult:
+    """Result of :func:`cross_validate`.
+
+    Attributes
+    ----------
+    per_fold : one dict per fold (fold index, train/test sizes, seed_fold,
+        vocab_size, oov_dropped, and each metric).
+    aggregate : macro mean/std per metric across folds. Perplexity is macro-only
+        with a different-vocabulary caveat (per-fold vocabularies differ under the
+        default ``vocab="per_fold"``, so pooling perplexity is not meaningful).
+    folds : the :class:`Folds` object (assignments + per-fold seeds).
+    manifest : the :class:`~topica.manifest.AnalysisManifest`, or None.
+    vocab : the vocabulary mode used ("per_fold" or "fixed").
+    """
+
+    per_fold: list[dict]
+    aggregate: dict
+    folds: Folds
+    manifest: Any = None
+    vocab: str = "per_fold"
+    stability: dict | None = None
+    """Cross-fold topic stability (mean +/- std matched-topic cosine over all fold
+    pairs), computed vocabulary-aware via align_topics since fold vocabularies
+    differ. None when there are too few comparable fits."""
+
+    def to_frame(self):
+        """Per-fold metrics as a pandas DataFrame (a results-appendix table)."""
+        import pandas as pd
+
+        return pd.DataFrame(self.per_fold)
+
+    def summary(self) -> str:
+        lines = [
+            f"cross_validate: {len(self.per_fold)} folds, "
+            f"strategy={self.folds.strategy}, vocab={self.vocab}",
+        ]
+        for m, agg in self.aggregate.items():
+            lines.append(f"  {m}: {agg['mean']:.4g} +/- {agg['std']:.4g}")
+        # Surface covariate conditioning in the headline: a researcher who passed
+        # covariates must see whether held-out scoring actually conditioned on them,
+        # not have to dig into to_frame() to discover a marginal fallback.
+        cond = [r["covariate_conditioned"] for r in self.per_fold
+                if "covariate_conditioned" in r]
+        if cond:
+            if all(cond):
+                lines.append("  covariates: conditioned held-out inference")
+            elif not any(cond):
+                lines.append(
+                    "  covariates: MARGINAL fallback — held-out scoring did NOT "
+                    "condition on them (this model's transform ignores covariates)"
+                )
+            else:
+                lines.append(
+                    f"  covariates: conditioned on {sum(cond)}/{len(cond)} folds "
+                    "(marginal on the rest)"
+                )
+        if self.stability is not None:
+            lines.append(
+                f"  stability (cross-fold cosine): {self.stability['mean']:.4g} "
+                f"+/- {self.stability['std']:.4g}"
+            )
+        if self.vocab == "per_fold":
+            lines.append(
+                "  (perplexity is per-fold; vocabularies differ so it is not pooled)"
+            )
+        return "\n".join(lines)
+
+    def __repr__(self) -> str:
+        return f"CrossValResult(folds={len(self.per_fold)}, metrics={list(self.aggregate)})"
+
+
+# Named covariate routing: how each family takes covariates at fit time and how it
+# conditions held-out inference on test covariates (Gate A-A5). Families absent here
+# are scored marginally (documents only), which is labeled honestly.
+def _route_transform(model, est_docs, cov_slice, seed):
+    """Covariate-aware theta for held-out inference. Returns (theta, conditioned).
+
+    ``conditioned`` is False when the model's transform cannot take covariates, so
+    the held-out score is marginal and must be labeled as such.
+    """
+    name = type(model).__name__
+    if name == "STM":
+        from . import stm as _stm
+
+        prev = cov_slice.get("prevalence")
+        theta = _stm.transform(model, est_docs, prevalence=prev)
+        return np.asarray(theta, dtype=np.float64), prev is not None
+    if name in ("DMR", "GDMR"):
+        feats = cov_slice.get("features")
+        if name == "GDMR":
+            feats = cov_slice.get("metadata", feats)
+        theta = model.transform(est_docs, feats) if feats is not None else model.transform(est_docs)
+        return np.asarray(theta, dtype=np.float64), feats is not None
+    # Marginal path (LDA, CTM, HDP, keyATM, ...): documents only.
+    fn = getattr(model, "transform", None)
+    if not callable(fn):
+        raise ValueError(
+            f"{name} has no transform(); held-out completion needs a generative "
+            "model that infers topics for new documents"
+        )
+    from .validation import _accepts_kwarg
+
+    theta = fn(est_docs, seed=seed) if _accepts_kwarg(fn, "seed") else fn(est_docs)
+    return np.asarray(theta, dtype=np.float64), False
+
+
+# Which fit kwargs each family accepts as per-document covariates, with aliases.
+# Keys are the exact public class names (type(model).__name__).
+_FIT_COV = {
+    "STM": (("prevalence", "content", "content_time"), {"covariates": "prevalence"}),
+    "DMR": (("features", "offset"), {"covariates": "features"}),
+    "GDMR": (("features", "metadata"), {"covariates": "features"}),
+    "KeyATM": (("covariates", "times", "prior_offset"), {"timestamps": "times"}),
+}
+
+
+def _canonical_family_cov(cov, model_name):
+    """Resolve user covariate keys to a family's canonical fit kwargs, hard-failing
+    any key the model does not accept. The same canonical dict drives both the fit
+    and the held-out scorer, so an aliased covariate conditions test inference too."""
+    if not cov:
+        return {}
+    names, aliases = _FIT_COV.get(model_name, ((), {}))
+    canon = {}
+    for key, val in cov.items():
+        target = aliases.get(key, key)
+        if target not in names:
+            raise ValueError(
+                f"{model_name} does not accept covariate {key!r}; recognized keys "
+                f"for this model: {names or '(none — this model has no covariates)'}"
+            )
+        canon[target] = val
+    return canon
+
+
+def _resolve_covariates(covariates, n_docs):
+    """Normalize ``covariates=`` to a dict of length-n_docs arrays; assert lengths."""
+    if covariates is None:
+        return {}
+    if hasattr(covariates, "columns"):  # a DataFrame bound to a single named kwarg
+        raise ValueError(
+            "pass covariates as a dict keyed by the model's fit kwarg, e.g. "
+            "{'prevalence': X}; a bare DataFrame is ambiguous (STM prevalence is one "
+            "design matrix, not one kwarg per column)"
+        )
+    if not isinstance(covariates, dict):
+        raise ValueError("covariates must be a dict {kwarg_name: array}")
+    out = {}
+    for key, arr in covariates.items():
+        a = np.asarray(arr)
+        if a.shape[0] != n_docs:
+            raise ValueError(
+                f"covariate {key!r} has length {a.shape[0]}, expected n_docs={n_docs}"
+            )
+        out[key] = a
+    return out
+
+
+def _slice_cov(cov, idx):
+    return {k: v[idx] for k, v in cov.items()}
+
+
+def _heldout_completion(model, test_docs, cov_slice, seed):
+    """Document-completion held-out likelihood on the fold's test docs.
+
+    Mirrors :func:`topica.validation.perplexity` (even tokens infer theta, odd
+    tokens are scored) but conditions theta on the doc's test covariates, and keeps
+    the covariate rows aligned to the docs it actually scores (Gate A-A7/B3: short
+    docs are co-dropped with their covariate rows). Returns a dict with per-fold
+    perplexity, scored-token count, and OOV info.
+    """
+    from .validation import _as_topic_word
+
+    phi = _as_topic_word(model)
+    if phi.shape[0] == 0:
+        raise ValueError("the model has no topics (empty topic_word)")
+    vocab = {w: i for i, w in enumerate(model.vocabulary)}
+
+    est, ev, kept = [], [], []
+    oov_dropped = 0
+    for i, d in enumerate(test_docs):
+        # Drop OOV *before* the completion split (design §3a), so both the theta
+        # estimate and the scored half are over the fold vocabulary, and the
+        # 2-token minimum is measured in in-vocabulary tokens.
+        in_vocab = [w for w in d if w in vocab]
+        oov_dropped += len(d) - len(in_vocab)
+        if len(in_vocab) < 2:
+            continue
+        est.append(in_vocab[0::2])
+        ev.append(in_vocab[1::2])
+        kept.append(i)
+    if not est:
+        raise ValueError("no test document had at least 2 tokens")
+
+    kept = np.asarray(kept, dtype=np.int64)
+    cov_kept = _slice_cov(cov_slice, kept)
+    theta, conditioned = _route_transform(model, est, cov_kept, seed)
+
+    logp, n = 0.0, 0
+    for j, evdoc in enumerate(ev):
+        ids = [vocab[w] for w in evdoc if w in vocab]
+        if not ids:
+            continue
+        pw = np.clip(theta[j] @ phi[:, ids], 1e-12, None)
+        logp += float(np.log(pw).sum())
+        n += len(ids)
+    if n == 0:
+        raise ValueError("no held-out token was in the fold vocabulary")
+    return {
+        "perplexity": float(np.exp(-logp / n)),
+        "heldout_loglik": logp,
+        "n_eval_tokens": n,
+        "n_scored_docs": int(kept.size),
+        "oov_dropped": int(oov_dropped),
+        "covariate_conditioned": bool(conditioned),
+    }
+
+
+def _fold_quality(model, train_docs, coherence_type, topn):
+    """Coherence + exclusivity on the fold's *training* text (the reference corpus
+    the topics were estimated on — Gate A-A12). A metric that raises is dropped from
+    the record with a one-time warning, so a broken metric is visible, not silent."""
+    import warnings
+
+    out = {}
+    try:
+        topics = model.top_words(topn)
+    except Exception as exc:
+        warnings.warn(f"fold quality skipped: top_words failed ({exc})", stacklevel=3)
+        return out
+    try:
+        from .coherence import coherence as _coh
+
+        out["coherence"] = float(
+            np.mean(_coh(topics, train_docs, coherence_type=coherence_type, n=topn))
+        )
+    except Exception as exc:
+        warnings.warn(f"fold coherence dropped ({exc})", stacklevel=3)
+    try:
+        from .coherence import exclusivity as _excl
+
+        out["exclusivity"] = float(np.mean(_excl(model, n=topn)))
+    except Exception as exc:
+        warnings.warn(f"fold exclusivity dropped ({exc})", stacklevel=3)
+    return out
+
+
+def cross_validate(
+    factory,
+    docs,
+    *,
+    y=None,
+    covariates=None,
+    folds=5,
+    strategy="kfold",
+    groups=None,
+    times=None,
+    window=None,
+    vocab="per_fold",
+    seed=13,
+    fit_kwargs=None,
+    metrics=None,
+    fit_fn=None,
+    score_fn=None,
+    coherence_type="c_v",
+    topn=10,
+    manifest=True,
+    preprocessing=None,
+):
+    """Cross-validate a topic model's held-out predictive behavior (#701, PR1).
+
+    Refits a fresh model per fold (via ``factory(seed_fold)``) on the training
+    documents, rebuilds the vocabulary per fold by default (leakage-free), and
+    scores held-out document-completion on the test documents, conditioning on the
+    fold's test covariates where the family supports it.
+
+    Parameters
+    ----------
+    factory : ``callable(seed_fold) -> unfitted model``. The seed MUST be threaded
+        into the constructor, e.g. ``lambda s: topica.STM(10, seed=s)``.
+    docs : list[list[str]] or a Corpus.
+    covariates : dict ``{fit_kwarg: array}`` of per-document covariates (length
+        n_docs), e.g. ``{"prevalence": X}`` for STM. Sub-indexed per fold.
+    y : supervised response (reserved for PR2; unsupported here).
+    folds, strategy, groups, times, window, seed : see :func:`make_folds`. ``folds``
+        may also be a prebuilt :class:`Folds` object (takes precedence).
+    vocab : "per_fold" (default, leakage-free; perplexity not pooled) or "fixed"
+        (shared vocabulary, comparable perplexity, but feature-selection leakage —
+        emits a warning).
+    fit_kwargs : static hyperparameters passed to ``model.fit`` every fold.
+    fit_fn / score_fn : escape hatch. ``fit_fn(train_docs, train_idx, seed_fold) ->
+        model`` and ``score_fn(model, test_docs, test_idx, seed_fold) -> dict`` let
+        you own covariate handling the named routing does not cover.
+    coherence_type, topn : fold-quality coherence settings.
+    manifest : record fold assignments + seeds in an AnalysisManifest.
+
+    Returns
+    -------
+    CrossValResult
+    """
+    import warnings
+
+    if y is not None:
+        raise NotImplementedError(
+            "the supervised out-of-fold path (y=) lands in PR2; PR1 covers the "
+            "topic-model held-out path"
+        )
+    if metrics is not None:
+        raise NotImplementedError(
+            "custom metric selection (metrics=) lands in PR2; PR1 reports the default "
+            "held-out perplexity + fold coherence/exclusivity/stability"
+        )
+    if fit_fn is not None and score_fn is None:
+        raise ValueError("fit_fn requires a matching score_fn (test-time inference)")
+    if score_fn is not None and fit_fn is None:
+        raise ValueError("score_fn requires a matching fit_fn (the escape hatch is both)")
+
+    # Normalize documents to token lists.
+    if hasattr(docs, "documents"):
+        # A pre-built Corpus already had its vocabulary/frequency pruning learned on
+        # the WHOLE corpus, which per-fold rebuilding cannot undo — so this is not the
+        # leakage-free path the default implies. Warn; pass token lists for a truly
+        # per-fold vocabulary.
+        if vocab == "per_fold" and getattr(docs, "preprocessing", None):
+            warnings.warn(
+                "cross_validate received a pre-built Corpus whose vocabulary was "
+                "pruned on the full corpus; per-fold vocabulary rebuilding cannot "
+                "undo that global feature selection, so this is not fully leakage-"
+                "free. Pass raw token lists (list[list[str]]) for a truly per-fold "
+                "vocabulary.",
+                stacklevel=2,
+            )
+        doc_lists = [list(d) for d in docs.documents()]
+    else:
+        doc_lists = [list(d) for d in docs]
+    n_docs = len(doc_lists)
+
+    cov = _resolve_covariates(covariates, n_docs)
+    fit_kwargs = dict(fit_kwargs or {})
+    preprocessing = dict(preprocessing or {})
+    for k in cov:
+        if k in fit_kwargs:
+            raise ValueError(f"covariate {k!r} collides with a fit_kwargs key")
+
+    if vocab not in ("per_fold", "fixed"):
+        raise ValueError("vocab must be 'per_fold' or 'fixed'")
+    if vocab == "fixed":
+        warnings.warn(
+            "vocab='fixed': the vocabulary is learned once on the full corpus, so "
+            "test-fold word frequencies leak into feature selection. Perplexity is "
+            "comparable across folds, but this is not fully leakage-free.",
+            stacklevel=2,
+        )
+
+    # Build folds (or accept a prebuilt Folds).
+    if isinstance(folds, Folds):
+        fold_obj = folds
+        if fold_obj.n_docs != n_docs:
+            raise ValueError(
+                f"prebuilt Folds is for {fold_obj.n_docs} docs, got {n_docs}"
+            )
+        # Re-check the leakage invariants on a user-supplied Folds — never trust it
+        # blind (the whole point of the guard is that it always runs).
+        _validate_folds_obj(fold_obj, n_docs)
+        # A supplied Folds takes precedence; splitter arguments are then inert.
+        if any(a is not None for a in (groups, times, window)) or strategy != "kfold":
+            warnings.warn(
+                "a prebuilt Folds was supplied; strategy/groups/times/window are "
+                "ignored (the Folds object already fixes the split).",
+                stacklevel=2,
+            )
+    else:
+        fold_obj = make_folds(
+            n_docs, strategy=strategy, folds=folds, groups=groups, times=times,
+            window=window, seed=seed,
+        )
+
+    from . import Corpus  # local import to avoid a cycle at module load
+
+    fixed_corpus = None
+    if vocab == "fixed":
+        fixed_corpus = Corpus.from_documents(doc_lists, **preprocessing)
+
+    per_fold = []
+    fold_models = []
+    for f, ((train_idx, test_idx), seed_fold) in enumerate(
+        zip(fold_obj.splits, fold_obj.fold_seeds)
+    ):
+        train_docs = [doc_lists[i] for i in train_idx]
+        test_docs = [doc_lists[i] for i in test_idx]
+        model = factory(seed_fold)
+
+        rec = {
+            "fold": f,
+            "n_train": int(train_idx.size),
+            "n_test": int(test_idx.size),
+            "seed_fold": int(seed_fold),
+        }
+
+        if fit_fn is not None:
+            model = fit_fn(train_docs, train_idx, seed_fold)
+            rec.update(score_fn(model, test_docs, test_idx, seed_fold) or {})
+            per_fold.append(rec)
+            fold_models.append(model)
+            continue
+
+        # Per-fold (or fixed) vocabulary rebuild.
+        if vocab == "per_fold":
+            train_corpus = Corpus.from_documents(train_docs, **preprocessing)
+        else:
+            train_corpus = fixed_corpus.transform(train_docs)
+        # Resolve the family's covariate kwargs (aliases -> canonical names) once,
+        # hard-failing any key the model does not accept, and use the SAME canonical
+        # dict for both fitting and held-out scoring so a covariate passed under an
+        # alias still conditions test inference (not just the fit).
+        canon = _canonical_family_cov(cov, type(model).__name__)
+
+        # Align train covariates to the corpus rows that survived pruning.
+        kept = np.asarray(train_corpus.kept_indices, dtype=np.int64)
+        fit_cov = {k: v[train_idx][kept] for k, v in canon.items()}
+        rec["vocab_size"] = int(train_corpus.num_words)
+
+        model.fit(train_corpus, **fit_cov, **fit_kwargs)
+
+        # Held-out completion on the test docs, conditioned on test covariates.
+        test_cov = {k: v[test_idx] for k, v in canon.items()}
+        rec.update(_heldout_completion(model, test_docs, test_cov, seed_fold))
+        rec.update(_fold_quality(model, train_docs, coherence_type, topn))
+        per_fold.append(rec)
+        fold_models.append(model)
+
+    # Aggregate: macro mean/std over folds for genuine quality metrics only, not
+    # the bookkeeping fields (sizes, seeds, token counts, flags). heldout_loglik is
+    # kept per-fold but NOT aggregated: raw log-likelihood totals scale with each
+    # fold's test-token count, so a macro mean mixes denominators (use perplexity).
+    _METRICS = ("perplexity", "coherence", "exclusivity")
+    aggregate = {}
+    for k in _METRICS:
+        vals = np.array(
+            [r[k] for r in per_fold if isinstance(r.get(k), (int, float)) and not isinstance(r.get(k), bool)],
+            dtype=np.float64,
+        )
+        if vals.size:
+            aggregate[k] = {"mean": float(vals.mean()), "std": float(vals.std())}
+
+    # If the user supplied covariates but the model's transform ignored them at
+    # scoring time (e.g. keyATM), warn loudly — otherwise a marginal held-out score
+    # looks identical to a conditioned one and the researcher would over-claim.
+    if cov:
+        cond_flags = [r.get("covariate_conditioned") for r in per_fold
+                      if "covariate_conditioned" in r]
+        if cond_flags and not any(cond_flags):
+            warnings.warn(
+                f"covariates were supplied but {type(fold_models[0]).__name__}'s "
+                "transform cannot condition held-out inference on them, so the "
+                "held-out scores are MARGINAL (not conditioned). Reported perplexity "
+                "does not reflect the covariate. See covariate_conditioned in "
+                "result.per_fold / result.summary().",
+                stacklevel=2,
+            )
+
+    stability = _cross_fold_stability(fold_models)
+
+    # Capture the fitted model's class + settings for the manifest (constant across
+    # folds; the factory itself is an opaque callable).
+    model_spec = None
+    if fold_models and fold_models[0] is not None:
+        m0 = fold_models[0]
+        model_spec = {
+            "class": type(m0).__name__,
+            "settings": getattr(m0, "settings", None),
+        }
+    mani = (
+        _record_cv_manifest(
+            fold_obj, doc_lists, cov, fit_kwargs, preprocessing, vocab,
+            fit_fn is not None, model_spec, coherence_type, topn,
+        )
+        if manifest
+        else None
+    )
+
+    return CrossValResult(
+        per_fold=per_fold,
+        aggregate=aggregate,
+        folds=fold_obj,
+        manifest=mani,
+        vocab=vocab,
+        stability=stability,
+    )
+
+
+def _cross_fold_stability(models):
+    """Mean +/- std matched-topic cosine similarity over all fold pairs, aligned
+    vocabulary-aware (fold vocabularies differ under per-fold rebuild — Gate A-A12)."""
+    usable = [m for m in models if m is not None and hasattr(m, "topic_word")]
+    if len(usable) < 2:
+        return None
+    from .validation import align_topics
+
+    sims = []
+    for i in range(len(usable)):
+        for j in range(i + 1, len(usable)):
+            try:
+                res = align_topics(usable[i], usable[j], metric="cosine")
+                # `.matches` yields (topic_a, topic_b, similarity) — the cosine
+                # itself (1.0 for a self-match), NOT a distance. Use it directly.
+                matches = res.matches
+                if len(matches):
+                    sims.append(np.mean([s for _, _, s in matches]))
+            except Exception as exc:
+                import warnings
+
+                warnings.warn(
+                    f"cross-fold stability skipped a fold pair ({exc})", stacklevel=3
+                )
+                continue
+    if not sims:
+        return None
+    sims = np.array(sims, dtype=np.float64)
+    return {"mean": float(sims.mean()), "std": float(sims.std()), "n_pairs": int(sims.size)}
+
+
+@dataclass
+class CVManifest:
+    """A reproducibility record for one :func:`cross_validate` run (Gate A-A13).
+
+    Records fold assignments, every derived seed, splitter parameters, and the
+    callback provenance so a rerun reproduces the same folds and fits. Distinct from
+    :class:`~topica.manifest.AnalysisManifest`, which records a *single* fit; a CV
+    run has K fits, so it gets its own record.
+    """
+
+    cv: dict
+
+    def to_dict(self) -> dict:
+        return {"schema": "topica.crossval", "schema_version": 1, "cv": self.cv}
+
+    def to_json(self) -> str:
+        import json
+
+        return json.dumps(self.to_dict(), indent=2, sort_keys=True, default=str)
+
+    def save(self, path: str) -> None:
+        from pathlib import Path
+
+        Path(path).write_text(self.to_json(), encoding="utf-8")
+
+
+def _record_cv_manifest(
+    fold_obj, doc_lists, cov, fit_kwargs, preprocessing, vocab, callback,
+    model_spec, coherence_type, topn,
+):
+    """Record fold assignments + seeds + splitter params + fit/metric config so a
+    rerun reproduces the folds and fits (Gate A-A13)."""
+    import hashlib
+
+    # Hash the actual document CONTENT (order-sensitive), not just lengths, so a
+    # reordering or a different same-length corpus produces a different identity.
+    hasher = hashlib.sha256()
+    for d in doc_lists:
+        hasher.update(("\x1f".join(d) + "\x1e").encode("utf-8"))
+    content_hash = hasher.hexdigest()[:16]
+
+    try:
+        from . import __version__ as _ver
+    except Exception:
+        _ver = None
+
+    cv_section = {
+        "n_docs": fold_obj.n_docs,
+        "doc_content_hash": content_hash,
+        "topica_version": _ver,
+        "strategy": fold_obj.strategy,
+        "window": fold_obj.window,
+        "vocab": vocab,
+        "preprocessing": {k: repr(v) for k, v in preprocessing.items()},
+        "seed": fold_obj.seed,
+        "fold_seeds": list(fold_obj.fold_seeds),
+        "splits": [
+            {"train": t.tolist(), "test": e.tolist()} for t, e in fold_obj.splits
+        ],
+        "oof_mask": fold_obj.oof_mask.tolist(),
+        "groups_hash": fold_obj.groups_hash,
+        "times_hash": fold_obj.times_hash,
+        "covariate_kwargs": sorted(cov.keys()),
+        "fit_kwargs": {k: repr(v) for k, v in fit_kwargs.items()},
+        "model": model_spec,
+        "metric_params": {"coherence_type": coherence_type, "topn": topn,
+                          "completion_split": "even_odd_deterministic"},
+        # Bit-for-bit reproducibility is claimed only without opaque user callbacks
+        # AND only for a factory whose model determinism contract supports it.
+        "replayable": not callback,
+        "callback": "fit_fn/score_fn" if callback else None,
+    }
+    return CVManifest(cv=cv_section)

--- a/tests/test_crossval.py
+++ b/tests/test_crossval.py
@@ -1,0 +1,393 @@
+"""Orchestrator tests for cross_validate (#701, PR1) — topic-model path."""
+
+import numpy as np
+import pytest
+
+import topica
+
+
+def _synthetic_corpus(n_docs=60, seed=0):
+    """Two clearly separated topics so a fit is meaningful on small folds."""
+    rng = np.random.default_rng(seed)
+    topic_a = ["cat", "dog", "pet", "fur", "paw", "tail"]
+    topic_b = ["bank", "loan", "money", "rate", "cash", "debt"]
+    docs = []
+    labels = []
+    for i in range(n_docs):
+        vocab = topic_a if i % 2 == 0 else topic_b
+        docs.append(list(rng.choice(vocab, size=rng.integers(8, 16))))
+        labels.append(i % 2)
+    return docs, np.array(labels)
+
+
+def test_cross_validate_lda_basic():
+    docs, _ = _synthetic_corpus()
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s),
+        docs,
+        folds=5,
+        seed=13,
+        fit_kwargs={"iters": 50},
+    )
+    assert len(result.per_fold) == 5
+    assert "perplexity" in result.aggregate
+    for rec in result.per_fold:
+        assert rec["perplexity"] > 0
+        assert rec["n_eval_tokens"] > 0
+        assert rec["covariate_conditioned"] is False  # LDA has no covariates
+        assert rec["vocab_size"] > 0
+
+
+def test_cross_validate_deterministic():
+    docs, _ = _synthetic_corpus()
+    make = lambda: topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=4, seed=13, fit_kwargs={"iters": 30}
+    )
+    a, b = make(), make()
+    pa = [r["perplexity"] for r in a.per_fold]
+    pb = [r["perplexity"] for r in b.per_fold]
+    assert pa == pb
+
+
+def test_cross_validate_per_fold_vocab_default():
+    docs, _ = _synthetic_corpus()
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=5, fit_kwargs={"iters": 30}
+    )
+    assert result.vocab == "per_fold"
+    # Per-fold perplexity present; aggregate is macro-only.
+    assert result.aggregate["perplexity"]["mean"] > 0
+    assert "per-fold" in result.summary()
+
+
+def test_cross_validate_fixed_vocab_warns():
+    docs, _ = _synthetic_corpus()
+    with pytest.warns(UserWarning, match="feature selection"):
+        result = topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s),
+            docs,
+            folds=4,
+            vocab="fixed",
+            fit_kwargs={"iters": 30},
+        )
+    assert result.vocab == "fixed"
+
+
+def test_cross_validate_stm_prevalence_conditioned():
+    docs, labels = _synthetic_corpus()
+    X = labels.reshape(-1, 1).astype(float)
+    result = topica.cross_validate(
+        lambda s: topica.STM(2, seed=s),
+        docs,
+        covariates={"prevalence": X},
+        folds=4,
+        seed=13,
+        fit_kwargs={"iters": 40},
+    )
+    for rec in result.per_fold:
+        assert rec["covariate_conditioned"] is True  # STM conditioned on prevalence
+
+
+def test_stm_covariate_status_in_summary():
+    docs, labels = _synthetic_corpus()
+    X = labels.reshape(-1, 1).astype(float)
+    result = topica.cross_validate(
+        lambda s: topica.STM(2, seed=s),
+        docs,
+        covariates={"prevalence": X},
+        folds=4,
+        fit_kwargs={"iters": 40},
+    )
+    assert "conditioned held-out inference" in result.summary()
+
+
+def test_marginal_covariate_warns_and_labels():
+    """keyATM cannot condition held-out scoring on covariates; the marginal fallback
+    must warn AND say so in summary() (the Tier-1 sample-user trap)."""
+    docs, labels = _synthetic_corpus()
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    X = labels.reshape(-1, 1).astype(float)
+    with pytest.warns(UserWarning, match="MARGINAL|did not condition|cannot condition"):
+        result = topica.cross_validate(
+            lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
+            docs,
+            covariates={"covariates": X},
+            folds=3,
+            fit_kwargs={"iters": 30},
+        )
+    assert "MARGINAL" in result.summary()
+    assert all(r["covariate_conditioned"] is False for r in result.per_fold)
+
+
+def test_covariate_length_mismatch_errors():
+    docs, labels = _synthetic_corpus(n_docs=60)
+    with pytest.raises(ValueError, match="expected n_docs"):
+        topica.cross_validate(
+            lambda s: topica.STM(2, seed=s),
+            docs,
+            covariates={"prevalence": labels[:50].reshape(-1, 1).astype(float)},
+            folds=4,
+        )
+
+
+def test_bare_dataframe_covariate_rejected():
+    pd = pytest.importorskip("pandas")
+    docs, labels = _synthetic_corpus()
+    with pytest.raises(ValueError, match="dict keyed"):
+        topica.cross_validate(
+            lambda s: topica.STM(2, seed=s),
+            docs,
+            covariates=pd.DataFrame({"x": labels}),
+            folds=4,
+        )
+
+
+def test_covariate_fit_kwargs_collision():
+    docs, labels = _synthetic_corpus()
+    X = labels.reshape(-1, 1).astype(float)
+    with pytest.raises(ValueError, match="collides"):
+        topica.cross_validate(
+            lambda s: topica.STM(2, seed=s),
+            docs,
+            covariates={"prevalence": X},
+            fit_kwargs={"prevalence": X},
+            folds=4,
+        )
+
+
+def test_supplied_folds_leak_rejected():
+    """A hand-built Folds with an overlapping split must be re-validated, not trusted."""
+    from topica.crossval import Folds
+
+    docs, _ = _synthetic_corpus(n_docs=20)
+    bad = Folds(
+        splits=[
+            (np.array([0, 1, 2], dtype=np.int64), np.array([1, 3], dtype=np.int64)),  # 1 in both
+            (np.array([3, 4], dtype=np.int64), np.array([0, 2], dtype=np.int64)),
+        ],
+        strategy="kfold",
+        seed=13,
+        fold_seeds=[1, 2],
+        oof_mask=np.ones(20, dtype=bool),
+        n_docs=20,
+    )
+    with pytest.raises(ValueError, match="both train and test"):
+        topica.cross_validate(lambda s: topica.LDA(2, seed=s), docs, folds=bad)
+
+
+def test_supplied_folds_seed_count_mismatch_rejected():
+    from topica.crossval import make_folds
+    from dataclasses import replace
+
+    docs, _ = _synthetic_corpus(n_docs=20)
+    f = make_folds(20, folds=4, seed=13)
+    broken = replace(f, fold_seeds=f.fold_seeds[:2])  # too few seeds
+    with pytest.raises(ValueError, match="fold seeds"):
+        topica.cross_validate(lambda s: topica.LDA(2, seed=s), docs, folds=broken)
+
+
+def test_unknown_covariate_key_hard_fails():
+    docs, labels = _synthetic_corpus()
+    X = labels.reshape(-1, 1).astype(float)
+    with pytest.raises(ValueError, match="does not accept covariate"):
+        topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s),  # LDA has no covariates
+            docs,
+            covariates={"prevalence": X},
+            folds=4,
+        )
+
+
+def test_stm_covariates_alias_conditions_scoring():
+    """A covariate passed under the 'covariates' alias must still condition held-out
+    inference (not just the fit) — the alias is canonicalized for both."""
+    docs, labels = _synthetic_corpus()
+    X = labels.reshape(-1, 1).astype(float)
+    result = topica.cross_validate(
+        lambda s: topica.STM(2, seed=s),
+        docs,
+        covariates={"covariates": X},  # alias for prevalence
+        folds=4,
+        fit_kwargs={"iters": 40},
+    )
+    assert all(r["covariate_conditioned"] is True for r in result.per_fold)
+
+
+def test_score_fn_without_fit_fn_rejected():
+    docs, _ = _synthetic_corpus()
+    with pytest.raises(ValueError, match="score_fn requires"):
+        topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s),
+            docs,
+            score_fn=lambda m, td, ti, s: {},
+            folds=4,
+        )
+
+
+def test_metrics_param_not_yet_supported():
+    docs, _ = _synthetic_corpus()
+    with pytest.raises(NotImplementedError, match="metric selection"):
+        topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s), docs, metrics=["perplexity"], folds=4
+        )
+
+
+def test_nan_times_rejected():
+    docs, _ = _synthetic_corpus(n_docs=30)
+    times = np.arange(30, dtype=float)
+    times[5] = np.nan
+    with pytest.raises(ValueError, match="missing .*timestamp"):
+        topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s), docs, strategy="temporal", times=times, folds=4
+        )
+
+
+def test_prebuilt_corpus_per_fold_warns():
+    docs, _ = _synthetic_corpus()
+    corpus = topica.Corpus.from_documents(docs, min_doc_freq=2)
+    with pytest.warns(UserWarning, match="pre-built Corpus"):
+        topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s), corpus, folds=4, fit_kwargs={"iters": 30}
+        )
+
+
+def test_manifest_records_content_and_model():
+    docs, _ = _synthetic_corpus()
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=4, fit_kwargs={"iters": 30}
+    )
+    cv = result.manifest.cv
+    assert "doc_content_hash" in cv
+    assert cv["model"]["class"] == "LDA"
+    assert cv["metric_params"]["topn"] == 10
+
+
+def test_supervised_y_not_yet_supported():
+    docs, labels = _synthetic_corpus()
+    with pytest.raises(NotImplementedError, match="PR2"):
+        topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s), docs, y=labels, folds=4
+        )
+
+
+def test_fit_fn_requires_score_fn():
+    docs, _ = _synthetic_corpus()
+    with pytest.raises(ValueError, match="score_fn"):
+        topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s),
+            docs,
+            fit_fn=lambda td, ti, s: None,
+            folds=4,
+        )
+
+
+def test_fit_fn_score_fn_escape_hatch():
+    docs, _ = _synthetic_corpus()
+
+    def fit_fn(train_docs, train_idx, seed_fold):
+        m = topica.LDA(2, seed=seed_fold)
+        m.fit(topica.Corpus.from_documents(train_docs), iters=30)
+        return m
+
+    def score_fn(model, test_docs, test_idx, seed_fold):
+        return {"perplexity": topica.perplexity(model, test_docs, seed=seed_fold)}
+
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, fit_fn=fit_fn, score_fn=score_fn, folds=4
+    )
+    assert all(r["perplexity"] > 0 for r in result.per_fold)
+
+
+def test_manifest_records_cv():
+    docs, _ = _synthetic_corpus()
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=4, fit_kwargs={"iters": 30}
+    )
+    cv = getattr(result.manifest, "cv", None)
+    assert cv is not None
+    assert cv["strategy"] == "kfold"
+    assert len(cv["splits"]) == 4
+    assert len(cv["fold_seeds"]) == 4
+
+
+def test_temporal_oof_mask_excludes_initial_window():
+    docs, _ = _synthetic_corpus()
+    times = np.arange(len(docs))
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s),
+        docs,
+        strategy="temporal",
+        times=times,
+        folds=5,
+        fit_kwargs={"iters": 30},
+    )
+    assert not result.folds.oof_mask.all()  # initial window never tested
+
+
+def test_grouped_end_to_end():
+    docs, _ = _synthetic_corpus()
+    groups = np.repeat(np.arange(12), 5)
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s),
+        docs,
+        strategy="grouped",
+        groups=groups,
+        folds=4,
+        fit_kwargs={"iters": 30},
+    )
+    assert len(result.per_fold) == 4
+
+
+def test_short_doc_covariate_codrop():
+    """A test doc with <2 tokens is skipped in scoring; its covariate row must be
+    co-dropped so STM's prevalence transform stays aligned (Gate A-B3)."""
+    docs, labels = _synthetic_corpus(n_docs=60)
+    docs[1] = ["cat"]  # a 1-token doc that scoring will skip
+    docs[3] = []  # an empty doc
+    X = labels.reshape(-1, 1).astype(float)
+    result = topica.cross_validate(
+        lambda s: topica.STM(2, seed=s),
+        docs,
+        covariates={"prevalence": X},
+        folds=4,
+        seed=13,
+        fit_kwargs={"iters": 30},
+    )
+    # No crash and every fold scored some docs.
+    assert all(r["n_scored_docs"] > 0 for r in result.per_fold)
+
+
+def test_cross_fold_stability_present():
+    docs, _ = _synthetic_corpus()
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=4, fit_kwargs={"iters": 50}
+    )
+    assert result.stability is not None
+    assert 0.0 <= result.stability["mean"] <= 1.0
+    # Direction check: cleanly-separated two-topic folds must be SIMILAR across
+    # folds, not distant. (A 1 - cosine inversion would report ~0.1 here.)
+    assert result.stability["mean"] > 0.5
+    assert result.stability["n_pairs"] == 6  # C(4, 2)
+    assert "stability" in result.summary()
+
+
+def test_cross_fold_stability_is_cosine_not_distance():
+    """A self-pair must score ~1.0 (identical topics), not ~0.0 (the inverted bug)."""
+    from topica.crossval import _cross_fold_stability
+
+    docs, _ = _synthetic_corpus(n_docs=40)
+    m = topica.LDA(2, seed=1)
+    m.fit(topica.Corpus.from_documents(docs), iters=50)
+    stab = _cross_fold_stability([m, m])
+    assert stab["mean"] > 0.99  # identical fits are maximally stable
+
+
+def test_to_frame():
+    pytest.importorskip("pandas")
+    docs, _ = _synthetic_corpus()
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=4, fit_kwargs={"iters": 30}
+    )
+    df = result.to_frame()
+    assert len(df) == 4
+    assert "perplexity" in df.columns

--- a/tests/test_crossval_folds.py
+++ b/tests/test_crossval_folds.py
@@ -1,0 +1,184 @@
+"""Fold-engine tests for the cross-validation framework (#701, PR1).
+
+Covers the Gate A guards: deterministic seeds across interpreter restarts, group
+isolation + dominant-group error, temporal ordering with atomic ties, exactly-once
+test coverage, oof_mask, and the per-fold invariants.
+"""
+
+import subprocess
+import sys
+
+import numpy as np
+import pytest
+
+from topica.crossval import make_folds, Folds
+
+
+# --------------------------------------------------------------------------- kfold
+
+
+def test_kfold_covers_every_doc_exactly_once():
+    f = make_folds(50, strategy="kfold", folds=5, seed=13)
+    assert len(f) == 5
+    tested = np.concatenate([test for _, test in f])
+    assert np.array_equal(np.sort(tested), np.arange(50))
+    assert f.oof_mask.all()
+
+
+def test_kfold_train_test_disjoint_and_nonempty():
+    f = make_folds(37, strategy="kfold", folds=4, seed=7)
+    for train, test in f:
+        assert train.dtype == np.int64 and test.dtype == np.int64
+        assert train.size and test.size
+        assert not np.intersect1d(train, test).size
+        assert train.size + test.size == 37
+
+
+def test_kfold_deterministic_same_seed():
+    a = make_folds(40, folds=5, seed=13)
+    b = make_folds(40, folds=5, seed=13)
+    for (t1, e1), (t2, e2) in zip(a, b):
+        assert np.array_equal(t1, t2) and np.array_equal(e1, e2)
+    assert a.fold_seeds == b.fold_seeds
+
+
+def test_kfold_different_seed_differs():
+    a = make_folds(40, folds=5, seed=13)
+    b = make_folds(40, folds=5, seed=99)
+    assert a.fold_seeds != b.fold_seeds
+
+
+def test_seeds_reproducible_across_interpreter_restart():
+    """The Gate A-B5 guard: SeedSequence, not hash() — stable across processes."""
+    code = (
+        "from topica.crossval import make_folds;"
+        "f=make_folds(30, folds=5, seed=13);"
+        "print(f.fold_seeds);"
+        "print([e.tolist() for _,e in f])"
+    )
+    out1 = subprocess.check_output([sys.executable, "-c", code], text=True)
+    out2 = subprocess.check_output([sys.executable, "-c", code], text=True)
+    assert out1 == out2
+
+
+# --------------------------------------------------------------------------- grouped
+
+
+def test_grouped_isolates_groups():
+    groups = np.repeat(np.arange(10), 5)  # 10 groups of 5 docs
+    f = make_folds(50, strategy="grouped", folds=5, groups=groups, seed=13)
+    for train, test in f:
+        assert not (set(groups[train]) & set(groups[test]))
+    tested = np.concatenate([test for _, test in f])
+    assert np.array_equal(np.sort(tested), np.arange(50))
+
+
+def test_grouped_requires_groups():
+    with pytest.raises(ValueError, match="requires groups"):
+        make_folds(20, strategy="grouped", folds=4)
+
+
+def test_grouped_too_few_groups():
+    groups = np.repeat(np.arange(3), 10)
+    with pytest.raises(ValueError, match="at least folds"):
+        make_folds(30, strategy="grouped", folds=5, groups=groups)
+
+
+def test_grouped_dominant_group_warns_on_imbalance():
+    # One group is 60% of the corpus: folds are valid (group 0 = one whole fold)
+    # but heavily imbalanced, which must be surfaced loudly.
+    groups = np.array([0] * 60 + list(range(1, 41)))
+    with pytest.warns(UserWarning, match="imbalanced"):
+        f = make_folds(100, strategy="grouped", folds=5, groups=groups)
+    # Still a valid, group-disjoint, exactly-once split.
+    for train, test in f:
+        assert not (set(groups[train]) & set(groups[test]))
+    tested = np.concatenate([test for _, test in f])
+    assert np.array_equal(np.sort(tested), np.arange(100))
+
+
+def test_grouped_impossible_empty_fold_errors():
+    # Group 0 swallows so much that fewer than K groups remain to fill the bins.
+    groups = np.array([0] * 96 + [1, 2, 3, 4])
+    with pytest.raises(ValueError, match="empty fold|at least folds"):
+        make_folds(100, strategy="grouped", folds=6, groups=groups)
+
+
+def test_grouped_missing_group_id_errors():
+    groups = np.array([0.0, 1.0, np.nan] + [2.0] * 17)
+    with pytest.raises(ValueError, match="missing group"):
+        make_folds(20, strategy="grouped", folds=3, groups=groups)
+
+
+# --------------------------------------------------------------------------- temporal
+
+
+def test_temporal_test_strictly_after_train():
+    times = np.arange(60)
+    f = make_folds(60, strategy="temporal", folds=5, times=times)
+    for train, test in f:
+        if train.size:
+            assert times[train].max() < times[test].min()
+
+
+def test_temporal_expanding_window_grows():
+    times = np.arange(60)
+    f = make_folds(60, strategy="temporal", folds=5, times=times)
+    sizes = [train.size for train, _ in f]
+    assert sizes == sorted(sizes)  # monotonically nondecreasing
+
+
+def test_temporal_initial_window_not_tested():
+    times = np.arange(60)
+    f = make_folds(60, strategy="temporal", folds=5, times=times)
+    # The earliest docs (block 0) are never in any test set.
+    assert not f.oof_mask.all()
+    tested = np.concatenate([test for _, test in f])
+    assert 0 not in tested
+
+
+def test_temporal_ties_stay_together():
+    # Two big tie groups: timestamp 0 (30 docs) then timestamp 1..K.
+    times = np.array([0] * 30 + list(range(1, 31)))
+    f = make_folds(60, strategy="temporal", folds=5, times=times)
+    for train, test in f:
+        if train.size:
+            # No shared timestamp across the boundary.
+            assert times[train].max() < times[test].min()
+
+
+def test_temporal_rolling_window():
+    times = np.arange(60)
+    exp = make_folds(60, strategy="temporal", folds=5, times=times, window=None)
+    roll = make_folds(60, strategy="temporal", folds=5, times=times, window=1)
+    # Rolling window trains on fewer docs in the later folds than expanding.
+    assert roll[-1][0].size < exp[-1][0].size
+
+
+def test_temporal_requires_times():
+    with pytest.raises(ValueError, match="requires times"):
+        make_folds(20, strategy="temporal", folds=4)
+
+
+def test_temporal_too_few_distinct_times():
+    times = np.array([0, 0, 0, 1, 1, 1])
+    with pytest.raises(ValueError, match="distinct timestamps"):
+        make_folds(6, strategy="temporal", folds=5, times=times)
+
+
+# --------------------------------------------------------------------------- misc
+
+
+def test_unknown_strategy():
+    with pytest.raises(ValueError, match="unknown strategy"):
+        make_folds(20, strategy="bogus", folds=4)
+
+
+def test_folds_exceed_docs():
+    with pytest.raises(ValueError, match="exceeds n_docs"):
+        make_folds(3, folds=5)
+
+
+def test_repr():
+    f = make_folds(50, folds=5, seed=13)
+    assert "Folds(" in repr(f) and "kfold" in repr(f)


### PR DESCRIPTION
Closes part of #701 (PR1 of 2). Adds `topica.cross_validate` and `topica.make_folds`: reproducible, leakage-free cross-validation for topic models. The supervised out-of-fold path (regression metrics, calibration, interval coverage) is **PR2**.

Built with add-topic-model rigor per Neal's directive ("treat 701 like a new model"): design → **Gate A** dual review → implement → **Gate B** dual review + sample-user audit → PR.

## What ships

**`make_folds(n_docs, *, strategy, folds, groups, times, window, seed)` → `Folds`** — the single leakage guard:
- `kfold` / `grouped` (whole groups held out together) / `temporal` (test strictly after train, expanding or rolling `window=`).
- Per-fold seeds from `numpy.random.SeedSequence` (reproducible across interpreter runs — never `hash()`).
- Atomic temporal ties + strict `max(train) < min(test)`; dominant-group and imbalance warnings; `oof_mask` (temporal initial window is never tested); full per-fold invariants, re-validated even on a user-supplied `Folds`.

**`cross_validate(factory, docs, *, covariates, folds, strategy, vocab, seed, fit_kwargs, fit_fn, score_fn, ...)` → `CrossValResult`**:
- `factory(seed_fold)` refits a fresh model per fold with the derived seed.
- **`vocab="per_fold"` (default)**: vocabulary rebuilt on each train fold, test docs vectorized into it, OOV dropped — leakage-free. Per-fold perplexity is reported and macro-averaged but **never token-pooled** (vocabularies differ). `vocab="fixed"` is opt-in with a loud warning.
- **Covariate-aware held-out completion**: STM `prevalence` (via `stm.transform`), DMR/GDMR `features`; keyATM has no covariate transform → marginal path, **warned at runtime + flagged in `summary()`** so it can't be mistaken for conditioned. Named routing canonicalizes aliases for both fit and scoring, and hard-fails unknown covariate keys.
- Fold coherence/exclusivity + vocab-aware cross-fold topic stability (via `align_topics`).
- `fit_fn`/`score_fn` escape hatch for bespoke covariate handling.
- Replay-grade `CVManifest` (doc content hash, per-fold seeds, splits, model class/settings, metric params, preprocessing, version).
- `CrossValResult.to_frame()` / `.summary()`.

## Validation
Two review gates + a real-data usability audit, all synthesized and blockers fixed + re-verified:
- **Gate A (design)** — Codex (faithful) + Gemini (adversarial): 17 findings, all closed before code.
- **Gate B (diff)** — Codex (faithful) + Claude (adversarial fallback; Gemini headless hit a read-permission wall): found the cross-fold stability metric was inverted (reported `1 − cosine`), a supplied-`Folds` leakage-guard bypass, a `keyATM`/`KeyATM` class-name routing bug, alias-not-canonicalized-for-scoring, OOV-split ordering, and manifest replay gaps — all fixed.
- **Reviewer D (sample-user, real poliblog data, docs-only)** — a first-time researcher found one Tier-1 analytical trap: a marginal covariate fallback was silent in `summary()`, so a keyATM-covariate CV could be over-claimed as conditioned. Fixed: runtime warning + headline status line + docs. Confirmed the leakage guards genuinely fire.

Deferred to PR2: supervised OOF path, `n_jobs`, `plot_cv`, covariate-effect stability diagnostic.

## Tests / docs
- 50 new tests (`tests/test_crossval_folds.py` + `tests/test_crossval.py`): fold determinism across interpreter restart, group isolation + dominant-group, temporal ordering/ties, per-fold OOV, covariate sub-index + short-doc co-drop, supplied-Folds rejection, unknown-covariate hard-fail, marginal-covariate warning, manifest content.
- Full local suite green (4717 passed, 37 skipped). New guide `docs/guides/cross-validation.md`; `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkRm7ah87rBzVnLCgVRn43