### PR TITLE
feat(eval): cross-validation supervised out-of-fold path (#701, PR2)

### DIFF
--- a/docs/guides/cross-validation.md
+++ b/docs/guides/cross-validation.md
@@ -55,6 +55,48 @@ For each fold, on the **held-out** test documents:
 `result.aggregate` gives the macro mean ± std of each metric across folds;
 `result.per_fold` is the per-fold detail.
 
+## Supervised models (out-of-fold prediction)
+
+For a supervised/measurement model with a numeric response — `SupervisedLDA` — pass
+`y=` and `cross_validate` switches to the out-of-fold path: fit on each training fold,
+predict the held-out response, assemble the out-of-fold (OOF) prediction vector, and
+report regression error, calibration, and interval coverage.
+
+```python
+result = topica.cross_validate(
+    lambda seed: topica.SupervisedLDA(10, seed=seed),
+    docs,
+    y=response,                 # per-document numeric response, length n_docs
+    folds=5, seed=13,
+    fit_kwargs={"iters": 25},
+)
+print(result.summary())
+result.oof_predictions          # assembled OOF y-hat (NaN where a doc wasn't scored)
+```
+
+What you get:
+
+- **Pooled RMSE / MAE / R²** over every out-of-fold prediction (`aggregate["rmse_pooled"]`,
+  etc.), plus per-fold `*_macro` summaries (`{mean, std, n_valid_folds}`).
+- **Interval coverage** (`coverage_90`, `coverage_95`): does a nominal 90% interval
+  cover ~90% of held-out truths? The interval uses the model's predictive standard
+  deviation from `predict(return_std=True)`, which propagates the document's topic
+  uncertainty *plus* the residual σ². This is a **conditional Gaussian** interval built
+  from the *training* σ², so out-of-fold coverage tends to sit a little **below**
+  nominal — that is partly the approximation, not proof the model is miscalibrated.
+- **Calibration**: `calibration_intercept` / `calibration_slope` (ideal 0 and 1) from
+  regressing observed on predicted, plus a `result.calibration_table` reliability table.
+
+The authoritative evaluated population is `result.scored_mask`. A test document that is
+empty after per-fold vocabulary pruning, or that falls in a temporal initial-training
+window, is **NaN** in `oof_predictions` and excluded from every metric — never scored as
+a fabricated 0. Folds are independent, so `n_jobs>1` runs them on a thread pool
+(deterministic; the result is identical to `n_jobs=1`).
+
+Classification metrics are not offered: no model in the roster exposes `predict_proba`.
+An unsupervised model passed with `y=` (or a model with no `predict`) raises a clear
+error rather than fabricating a score.
+
 ## Fold strategies
 
 `make_folds` (called for you, or usable directly) offers three ways to split, and it

--- a/python/topica/crossval.py
+++ b/python/topica/crossval.py
@@ -132,12 +132,25 @@ def _validate_folds_obj(fold_obj, n_docs):
         )
     for train, test in fold_obj.splits:
         _validate_split(np.asarray(train), np.asarray(test), n_docs)
-    if fold_obj.strategy in ("kfold", "grouped"):
-        tested = np.concatenate([np.asarray(test) for _, test in fold_obj.splits])
-        if np.unique(tested).size != n_docs or tested.size != n_docs:
-            raise ValueError(
-                f"{fold_obj.strategy} Folds must test every document exactly once"
-            )
+    tested = np.concatenate([np.asarray(test) for _, test in fold_obj.splits])
+    # Every strategy needs test indices unique ACROSS folds: a document tested in two
+    # folds would make the out-of-fold scatter overwrite one prediction (temporal is
+    # the sneaky case — its blocks are disjoint when generated, but a supplied Folds
+    # could overlap them).
+    if np.unique(tested).size != tested.size:
+        raise ValueError(
+            "a document is a test document in more than one fold; test blocks must be "
+            "disjoint across folds (out-of-fold assembly needs one prediction per doc)"
+        )
+    if fold_obj.strategy in ("kfold", "grouped") and np.unique(tested).size != n_docs:
+        raise ValueError(
+            f"{fold_obj.strategy} Folds must test every document exactly once"
+        )
+    # oof_mask must equal the set of tested documents.
+    expected = np.zeros(n_docs, dtype=bool)
+    expected[np.unique(tested)] = True
+    if not np.array_equal(np.asarray(fold_obj.oof_mask, dtype=bool), expected):
+        raise ValueError("Folds.oof_mask does not match the union of test indices")
 
 
 def _make_kfold(n_docs, folds, rng):
@@ -389,6 +402,19 @@ class CrossValResult:
     """Cross-fold topic stability (mean +/- std matched-topic cosine over all fold
     pairs), computed vocabulary-aware via align_topics since fold vocabularies
     differ. None when there are too few comparable fits."""
+    kind: str = "topic"
+    """"topic" (held-out completion) or "supervised" (out-of-fold prediction)."""
+    oof_predictions: Any = None
+    """Supervised path: assembled out-of-fold y-hat, length n_docs, NaN off the
+    scored population."""
+    oof_std: Any = None
+    """Supervised path: per-doc predictive std from predict(return_std=True)."""
+    scored_mask: Any = None
+    """Supervised path: bool array (n_docs) — the authoritative evaluated population
+    (tested AND survived per-fold pruning). Drives every pooled metric, calibration,
+    and coverage identically."""
+    calibration_table: Any = None
+    """Supervised path: reliability table (DataFrame) of binned predicted vs observed."""
 
     def to_frame(self):
         """Per-fold metrics as a pandas DataFrame (a results-appendix table)."""
@@ -397,6 +423,8 @@ class CrossValResult:
         return pd.DataFrame(self.per_fold)
 
     def summary(self) -> str:
+        if self.kind == "supervised":
+            return self._supervised_summary()
         lines = [
             f"cross_validate: {len(self.per_fold)} folds, "
             f"strategy={self.folds.strategy}, vocab={self.vocab}",
@@ -430,6 +458,39 @@ class CrossValResult:
             lines.append(
                 "  (perplexity is per-fold; vocabularies differ so it is not pooled)"
             )
+        return "\n".join(lines)
+
+    def _supervised_summary(self) -> str:
+        a = self.aggregate
+        n = int(self.scored_mask.sum()) if self.scored_mask is not None else 0
+        lines = [
+            f"cross_validate (supervised): {len(self.per_fold)} folds, "
+            f"strategy={self.folds.strategy}, {n} out-of-fold predictions",
+            f"  RMSE (pooled): {a.get('rmse_pooled', float('nan')):.4g}   "
+            f"MAE: {a.get('mae_pooled', float('nan')):.4g}   "
+            f"R2: {a.get('r2_pooled', float('nan')):.4g}",
+        ]
+        if "rmse_macro" in a:
+            m = a["rmse_macro"]
+            lines.append(
+                f"  RMSE (per-fold): {m['mean']:.4g} +/- {m['std']:.4g} "
+                f"over {m['n_valid_folds']} folds"
+            )
+        if "coverage_90" in a:
+            lines.append(
+                f"  interval coverage: 90% -> {a['coverage_90']:.3f}, "
+                f"95% -> {a.get('coverage_95', float('nan')):.3f}"
+            )
+        if "calibration_slope" in a:
+            lines.append(
+                f"  calibration: intercept {a['calibration_intercept']:.3g}, "
+                f"slope {a['calibration_slope']:.3g} (ideal 0, 1)"
+            )
+        lines.append(
+            "  (coverage uses a conditional Gaussian interval with in-sample sigma^2; "
+            "out-of-fold coverage below nominal is partly expected, not proof of "
+            "miscalibration)"
+        )
         return "\n".join(lines)
 
     def __repr__(self) -> str:
@@ -631,6 +692,9 @@ def cross_validate(
     score_fn=None,
     coherence_type="c_v",
     topn=10,
+    coverage_levels=(0.90, 0.95),
+    predict_kwargs=None,
+    n_jobs=1,
     manifest=True,
     preprocessing=None,
 ):
@@ -648,7 +712,11 @@ def cross_validate(
     docs : list[list[str]] or a Corpus.
     covariates : dict ``{fit_kwarg: array}`` of per-document covariates (length
         n_docs), e.g. ``{"prevalence": X}`` for STM. Sub-indexed per fold.
-    y : supervised response (reserved for PR2; unsupported here).
+    y : per-document numeric response (length n_docs). When given, runs the
+        supervised out-of-fold path (regression): fit on each training fold, predict
+        the held-out response, assemble an out-of-fold vector, and report pooled +
+        per-fold RMSE/MAE/R2, interval coverage, and calibration. The model must
+        expose ``predict(docs, return_std=True)`` (e.g. SupervisedLDA).
     folds, strategy, groups, times, window, seed : see :func:`make_folds`. ``folds``
         may also be a prebuilt :class:`Folds` object (takes precedence).
     vocab : "per_fold" (default, leakage-free; perplexity not pooled) or "fixed"
@@ -667,15 +735,13 @@ def cross_validate(
     """
     import warnings
 
-    if y is not None:
-        raise NotImplementedError(
-            "the supervised out-of-fold path (y=) lands in PR2; PR1 covers the "
-            "topic-model held-out path"
-        )
     if metrics is not None:
         raise NotImplementedError(
-            "custom metric selection (metrics=) lands in PR2; PR1 reports the default "
-            "held-out perplexity + fold coherence/exclusivity/stability"
+            "custom metric selection (metrics=) is not implemented. The topic path "
+            "reports held-out perplexity + fold coherence/exclusivity/stability; the "
+            "supervised path (y=) reports regression RMSE/MAE/R2, interval coverage, "
+            "and calibration. Classification metrics (accuracy/F1/log-loss) are not "
+            "available: no model in the roster exposes predict_proba."
         )
     if fit_fn is not None and score_fn is None:
         raise ValueError("fit_fn requires a matching score_fn (test-time inference)")
@@ -704,10 +770,25 @@ def cross_validate(
 
     cov = _resolve_covariates(covariates, n_docs)
     fit_kwargs = dict(fit_kwargs or {})
+    predict_kwargs = dict(predict_kwargs or {})
     preprocessing = dict(preprocessing or {})
     for k in cov:
         if k in fit_kwargs:
             raise ValueError(f"covariate {k!r} collides with a fit_kwargs key")
+
+    # Validate the supervised response up front (it bypasses _resolve_covariates, so a
+    # truncated/off-by-one y would otherwise slip through — the classic covariate-CV
+    # bug PR1 guards for covariates).
+    if y is not None:
+        y = np.asarray(y, dtype=np.float64)
+        if y.ndim != 1:
+            raise ValueError(f"y must be 1-D, got shape {y.shape}")
+        if y.shape[0] != n_docs:
+            raise ValueError(f"y has length {y.shape[0]}, expected n_docs={n_docs}")
+        if not np.all(np.isfinite(y)):
+            raise ValueError("y contains NaN or inf; the response must be finite")
+        if fit_fn is not None:
+            raise ValueError("the supervised path (y=) does not use fit_fn/score_fn")
 
     if vocab not in ("per_fold", "fixed"):
         raise ValueError("vocab must be 'per_fold' or 'fixed'")
@@ -747,6 +828,13 @@ def cross_validate(
     fixed_corpus = None
     if vocab == "fixed":
         fixed_corpus = Corpus.from_documents(doc_lists, **preprocessing)
+
+    # Supervised out-of-fold path (PR2) — a separate loop + aggregation.
+    if y is not None:
+        return _supervised_cv(
+            factory, doc_lists, y, cov, fold_obj, vocab, fixed_corpus, Corpus,
+            fit_kwargs, predict_kwargs, preprocessing, coverage_levels, n_jobs, manifest,
+        )
 
     per_fold = []
     fold_models = []
@@ -887,6 +975,262 @@ def _cross_fold_stability(models):
     return {"mean": float(sims.mean()), "std": float(sims.std()), "n_pairs": int(sims.size)}
 
 
+# ---------------------------------------------------------------------------
+# Supervised out-of-fold path (PR2)
+# ---------------------------------------------------------------------------
+
+
+def _fit_predict_fold(factory, seed_fold, train_docs, test_docs, y, train_idx,
+                      test_idx, cov, vocab, fixed_corpus, Corpus, fit_kwargs,
+                      predict_kwargs, preprocessing):
+    """One supervised fold: fit on the pruned train corpus, predict on the pruned
+    test corpus, return (destination_indices, yhat, std, y_test, per_fold_record).
+
+    Predicting on the TRANSFORMED test corpus (not raw docs) is the correctness
+    crux: SupervisedLDA.predict returns a fabricated (0.0, sigma2) for an empty/
+    all-OOV doc, so those docs must be dropped BEFORE predict, never scored. The
+    survivor map (Corpus.transform kept_indices) gives the scatter destination."""
+    model = factory(seed_fold)
+    name = type(model).__name__
+
+    if vocab == "per_fold":
+        train_corpus = Corpus.from_documents(train_docs, **preprocessing)
+    else:
+        train_corpus = fixed_corpus.transform(train_docs)
+    train_keep = np.asarray(train_corpus.kept_indices, dtype=np.int64)
+    y_train = y[train_idx[train_keep]]
+
+    canon = _canonical_family_cov(cov, name)
+    fit_cov = {k: v[train_idx][train_keep] for k, v in canon.items()}
+
+    if not hasattr(model, "predict"):
+        raise ValueError(
+            f"{name} has no predict(); the supervised out-of-fold path needs a "
+            "response model such as SupervisedLDA. For unsupervised held-out "
+            "evaluation, omit y=."
+        )
+    model.fit(train_corpus, y_train, **fit_cov, **fit_kwargs)
+
+    # Drop zero-in-vocab test docs via the shared vocabulary, then predict only on
+    # survivors so no fabricated 0.0 prediction can enter the OOF vector.
+    test_corpus = train_corpus.transform(test_docs)
+    test_keep = np.asarray(test_corpus.kept_indices, dtype=np.int64)
+    destination = test_idx[test_keep]
+    out = model.predict(test_corpus, return_std=True, **predict_kwargs)
+    yhat, std = out
+    yhat = np.asarray(yhat, dtype=np.float64)
+    std = np.asarray(std, dtype=np.float64)
+    if not (len(yhat) == len(std) == len(destination)):
+        raise ValueError(
+            f"supervised fold length mismatch: {len(yhat)} predictions for "
+            f"{len(destination)} surviving test docs"
+        )
+    y_test = y[destination]
+    rec = {
+        "model_class": name,
+        "n_train": int(train_idx.size),
+        "n_test": int(test_idx.size),
+        "n_oof": int(destination.size),
+        "yhat_std": float(np.std(yhat)) if yhat.size else float("nan"),
+    }
+    if destination.size >= 1:
+        # RMSE/MAE are valid even for a constant response; only R2 is undefined when
+        # the response has no variance to explain (ss_tot == 0).
+        rec["rmse"] = float(np.sqrt(np.mean((y_test - yhat) ** 2)))
+        rec["mae"] = float(np.mean(np.abs(y_test - yhat)))
+        ss_res = float(np.sum((y_test - yhat) ** 2))
+        ss_tot = float(np.sum((y_test - np.mean(y_test)) ** 2))
+        rec["r2"] = float("nan") if ss_tot == 0 else 1.0 - ss_res / ss_tot
+    else:
+        rec["rmse"] = rec["mae"] = rec["r2"] = float("nan")
+    return destination, yhat, std, rec
+
+
+def _supervised_cv(factory, doc_lists, y, cov, fold_obj, vocab, fixed_corpus, Corpus,
+                   fit_kwargs, predict_kwargs, preprocessing, coverage_levels, n_jobs,
+                   manifest):
+    import warnings
+
+    n_docs = len(doc_lists)
+    oof_pred = np.full(n_docs, np.nan)
+    oof_std = np.full(n_docs, np.nan)
+
+    jobs = []
+    for (train_idx, test_idx), seed_fold in zip(fold_obj.splits, fold_obj.fold_seeds):
+        train_docs = [doc_lists[i] for i in train_idx]
+        test_docs = [doc_lists[i] for i in test_idx]
+        jobs.append((seed_fold, train_docs, test_docs, train_idx, test_idx))
+
+    def run(job):
+        seed_fold, train_docs, test_docs, train_idx, test_idx = job
+        return _fit_predict_fold(
+            factory, seed_fold, train_docs, test_docs, y, train_idx, test_idx, cov,
+            vocab, fixed_corpus, Corpus, fit_kwargs, predict_kwargs, preprocessing,
+        )
+
+    # Folds are independent. A thread pool parallelizes them (the Rust fit releases
+    # the GIL); results scatter by destination index, so completion order can't change
+    # the OOF vector — determinism holds. A process pool is not used: it can't pickle
+    # the documented lambda factory.
+    if n_jobs and n_jobs != 1:
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=n_jobs) as ex:
+            results = list(ex.map(run, jobs))
+    else:
+        results = [run(job) for job in jobs]
+
+    per_fold = []
+    for f, (destination, yhat, std, rec) in enumerate(results):
+        oof_pred[destination] = yhat
+        oof_std[destination] = std
+        per_fold.append({"fold": f, "seed_fold": int(fold_obj.fold_seeds[f]), **rec})
+
+    scored_mask = ~np.isnan(oof_pred)
+    aggregate, calibration_table = _supervised_aggregate(
+        y, oof_pred, oof_std, scored_mask, per_fold, coverage_levels
+    )
+
+    dropped = int(fold_obj.oof_mask.sum() - scored_mask.sum())
+    if dropped > 0:
+        warnings.warn(
+            f"{dropped} tested documents were dropped from out-of-fold scoring "
+            "(empty after per-fold vocabulary pruning); they are NaN in "
+            "oof_predictions and excluded from every metric.",
+            stacklevel=3,
+        )
+
+    mani = None
+    if manifest:
+        # Probe the factory (unfitted) for the full constructor settings, not just the
+        # class — so the manifest can actually reconstruct the model.
+        model_spec = None
+        try:
+            probe = factory(int(fold_obj.fold_seeds[0]))
+            model_spec = {
+                "class": type(probe).__name__,
+                "settings": getattr(probe, "settings", None),
+            }
+        except Exception:
+            if per_fold:
+                model_spec = {"class": per_fold[0].get("model_class"), "settings": None}
+        from statistics import NormalDist
+
+        _nd = NormalDist()
+        mani = _record_cv_manifest(
+            fold_obj, doc_lists, cov, fit_kwargs, preprocessing, vocab, False,
+            model_spec, None, None, supervised={
+                "response_hash": _hash_array(y),
+                "response_shape": list(np.shape(y)),
+                "response_dtype": str(np.asarray(y).dtype),
+                "covariate_hashes": {k: _hash_array(v) for k, v in cov.items()},
+                "coverage_levels": list(coverage_levels),
+                "coverage_z": {str(lvl): _nd.inv_cdf((1.0 + lvl) / 2.0)
+                               for lvl in coverage_levels},
+                "predict_kwargs": {k: repr(v) for k, v in predict_kwargs.items()},
+                "calibration_rule": "up-to-10 quantile bins, deduped edges; "
+                                    "OLS intercept/slope when >=10 scored rows",
+                "n_jobs": n_jobs,
+                "backend": "thread" if (n_jobs and n_jobs != 1) else "serial",
+                "scored_mask": scored_mask.tolist(),
+            },
+        )
+
+    return CrossValResult(
+        per_fold=per_fold,
+        aggregate=aggregate,
+        folds=fold_obj,
+        manifest=mani,
+        vocab=vocab,
+        kind="supervised",
+        oof_predictions=oof_pred,
+        oof_std=oof_std,
+        scored_mask=scored_mask,
+        calibration_table=calibration_table,
+    )
+
+
+def _supervised_aggregate(y, oof_pred, oof_std, scored_mask, per_fold, coverage_levels):
+    """Pooled + macro regression metrics, calibration table, and interval coverage,
+    all over the single `scored_mask` population."""
+    yt = y[scored_mask]
+    yp = oof_pred[scored_mask]
+    ys = oof_std[scored_mask]
+    agg = {}
+    if yt.size:
+        agg["rmse_pooled"] = float(np.sqrt(np.mean((yt - yp) ** 2)))
+        agg["mae_pooled"] = float(np.mean(np.abs(yt - yp)))
+        ss_tot = float(np.sum((yt - np.mean(yt)) ** 2))
+        ss_res = float(np.sum((yt - yp) ** 2))
+        agg["r2_pooled"] = float("nan") if ss_tot == 0 else 1.0 - ss_res / ss_tot
+
+    # Macro over per-fold values (ddof=1), skipping NaN (constant-y or tiny folds).
+    for metric in ("rmse", "mae", "r2"):
+        vals = np.array([r[metric] for r in per_fold
+                         if isinstance(r.get(metric), float) and np.isfinite(r[metric])])
+        if vals.size:
+            agg[f"{metric}_macro"] = {
+                "mean": float(vals.mean()),
+                # ddof=1 sample std; undefined (NaN) for a single valid fold — NOT 0.0,
+                # which would read as "zero variance".
+                "std": float(vals.std(ddof=1)) if vals.size > 1 else float("nan"),
+                "n_valid_folds": int(vals.size),
+            }
+
+    # Interval coverage from the predictive std (includes sigma^2). Two-sided
+    # Gaussian z for a central level lvl: z = Phi^-1((1 + lvl) / 2).
+    from statistics import NormalDist
+
+    _nd = NormalDist()
+    for lvl in coverage_levels:
+        z = _nd.inv_cdf((1.0 + lvl) / 2.0)
+        if yt.size:
+            covered = np.abs(yt - yp) <= z * ys
+            agg[f"coverage_{int(round(lvl * 100))}"] = float(np.mean(covered))
+
+    # Calibration. The OLS intercept/slope need >= min_calib points and varying
+    # predictions to be identifiable; the reliability TABLE is independent of that
+    # threshold and is built whenever predictions vary over >= 2 scored rows.
+    min_calib = 10
+    calibration_table = None
+    if yt.size >= 2 and np.var(yp) > 0:
+        calibration_table = _calibration_table(yp, yt)
+    if yt.size >= min_calib and np.var(yp) > 0:
+        b, a = np.polyfit(yp, yt, 1)
+        agg["calibration_intercept"] = float(a)
+        agg["calibration_slope"] = float(b)
+    else:
+        # Undefined: too few scored rows or a constant predictor (no identifiable slope).
+        agg["calibration_intercept"] = float("nan")
+        agg["calibration_slope"] = float("nan")
+    return agg, calibration_table
+
+
+def _calibration_table(yp, yt):
+    """Up-to-10 quantile bins of y_hat with deduplicated edges; columns bin, n,
+    mean_pred, mean_obs."""
+    try:
+        import pandas as pd
+    except Exception:
+        return None
+    edges = np.unique(np.quantile(yp, np.linspace(0, 1, 11)))
+    if edges.size < 2:
+        return None
+    bin_idx = np.clip(np.digitize(yp, edges[1:-1]), 0, edges.size - 2)
+    rows = []
+    for b in range(edges.size - 1):
+        m = bin_idx == b
+        if not m.any():
+            continue
+        rows.append({
+            "bin": b,
+            "n": int(m.sum()),
+            "mean_pred": float(yp[m].mean()),
+            "mean_obs": float(yt[m].mean()),
+        })
+    return pd.DataFrame(rows)
+
+
 @dataclass
 class CVManifest:
     """A reproducibility record for one :func:`cross_validate` run (Gate A-A13).
@@ -915,7 +1259,7 @@ class CVManifest:
 
 def _record_cv_manifest(
     fold_obj, doc_lists, cov, fit_kwargs, preprocessing, vocab, callback,
-    model_spec, coherence_type, topn,
+    model_spec, coherence_type, topn, supervised=None,
 ):
     """Record fold assignments + seeds + splitter params + fit/metric config so a
     rerun reproduces the folds and fits (Gate A-A13)."""
@@ -954,9 +1298,17 @@ def _record_cv_manifest(
         "model": model_spec,
         "metric_params": {"coherence_type": coherence_type, "topn": topn,
                           "completion_split": "even_odd_deterministic"},
-        # Bit-for-bit reproducibility is claimed only without opaque user callbacks
-        # AND only for a factory whose model determinism contract supports it.
-        "replayable": not callback,
+        # Replayable only when there is no opaque user callback AND the model's full
+        # constructor settings were captured (so the factory can be reconstructed).
+        # A factory whose settings we could not read is recorded not-replayable.
+        "replayable": (not callback) and bool(
+            model_spec and model_spec.get("settings") is not None
+        ),
         "callback": "fit_fn/score_fn" if callback else None,
     }
+    if supervised is not None:
+        cv_section["path"] = "supervised"
+        cv_section["supervised"] = supervised
+    else:
+        cv_section["path"] = "topic"
     return CVManifest(cv=cv_section)

--- a/tests/test_crossval.py
+++ b/tests/test_crossval.py
@@ -262,12 +262,186 @@ def test_manifest_records_content_and_model():
     assert cv["metric_params"]["topn"] == 10
 
 
-def test_supervised_y_not_yet_supported():
-    docs, labels = _synthetic_corpus()
-    with pytest.raises(NotImplementedError, match="PR2"):
-        topica.cross_validate(
-            lambda s: topica.LDA(2, seed=s), docs, y=labels, folds=4
+def _supervised_corpus(n_docs=80, seed=0):
+    """Two topics whose response means are far apart, so a fit predicts y well."""
+    rng = np.random.default_rng(seed)
+    ta = ["cat", "dog", "pet", "fur", "paw", "tail"]
+    tb = ["bank", "loan", "money", "rate", "cash", "debt"]
+    docs, y = [], []
+    for i in range(n_docs):
+        if i % 2 == 0:
+            docs.append(list(rng.choice(ta, size=rng.integers(8, 16))))
+            y.append(rng.normal(2.0, 0.5))
+        else:
+            docs.append(list(rng.choice(tb, size=rng.integers(8, 16))))
+            y.append(rng.normal(8.0, 0.5))
+    return docs, np.array(y)
+
+
+def test_supervised_oof_basic():
+    docs, y = _supervised_corpus()
+    result = topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4,
+        seed=13, fit_kwargs={"iters": 20},
+    )
+    assert result.kind == "supervised"
+    assert result.oof_predictions.shape == (len(docs),)
+    assert result.scored_mask.all()  # kfold, no drops on this dense corpus
+    # Topics separate the two response regimes -> strong OOF R2.
+    assert result.aggregate["r2_pooled"] > 0.5
+    assert 0.0 <= result.aggregate["coverage_90"] <= 1.0
+    assert "R2" in result.summary()
+
+
+def test_supervised_deterministic():
+    docs, y = _supervised_corpus()
+    make = lambda: topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4,
+        seed=13, fit_kwargs={"iters": 20},
+    )
+    a, b = make(), make()
+    np.testing.assert_array_equal(
+        np.nan_to_num(a.oof_predictions), np.nan_to_num(b.oof_predictions)
+    )
+
+
+def test_supervised_empty_doc_not_polluting_metrics():
+    """The Gate A blocker: SupervisedLDA.predict returns (0.0, sigma2) for an empty/
+    all-OOV doc. Predicting on the transformed corpus must DROP those docs, not score
+    a fabricated 0.0 against a response near 8."""
+    docs, y = _supervised_corpus(n_docs=80)
+    # Make several docs empty; they must be excluded from the OOF metrics, not scored 0.
+    for i in (1, 3, 5, 7):
+        docs[i] = []
+    with pytest.warns(UserWarning, match="dropped from out-of-fold"):
+        result = topica.cross_validate(
+            lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4,
+            seed=13, fit_kwargs={"iters": 20},
         )
+    # The empty docs are NaN in the OOF vector (never a fabricated 0.0).
+    for i in (1, 3, 5, 7):
+        assert np.isnan(result.oof_predictions[i])
+    assert not result.scored_mask[[1, 3, 5, 7]].any()
+    # And the pooled RMSE is still sane (a 0.0-vs-8 leak would blow it up).
+    assert result.aggregate["rmse_pooled"] < 2.0
+
+
+def test_supervised_y_length_assert():
+    docs, y = _supervised_corpus(n_docs=80)
+    with pytest.raises(ValueError, match="expected n_docs"):
+        topica.cross_validate(
+            lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y[:70], folds=4
+        )
+
+
+def test_supervised_y_nonfinite_rejected():
+    docs, y = _supervised_corpus(n_docs=80)
+    y = y.copy()
+    y[2] = np.nan
+    with pytest.raises(ValueError, match="finite"):
+        topica.cross_validate(
+            lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4
+        )
+
+
+def test_supervised_needs_predict():
+    docs, y = _supervised_corpus(n_docs=60)
+    with pytest.raises(ValueError, match="no predict"):
+        topica.cross_validate(
+            lambda s: topica.LDA(2, seed=s), docs, y=y, folds=4, fit_kwargs={"iters": 20}
+        )
+
+
+def test_supervised_n_jobs_bit_identical_to_serial():
+    docs, y = _supervised_corpus(n_docs=80)
+    serial = topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4,
+        seed=13, fit_kwargs={"iters": 20}, n_jobs=1,
+    )
+    parallel = topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4,
+        seed=13, fit_kwargs={"iters": 20}, n_jobs=3,
+    )
+    # Thread pool must be bit-identical to serial, not merely close.
+    np.testing.assert_array_equal(
+        np.nan_to_num(serial.oof_predictions), np.nan_to_num(parallel.oof_predictions)
+    )
+    np.testing.assert_array_equal(
+        np.nan_to_num(serial.oof_std), np.nan_to_num(parallel.oof_std)
+    )
+    assert serial.aggregate["rmse_pooled"] == parallel.aggregate["rmse_pooled"]
+
+
+def test_supervised_constant_y_fold_keeps_rmse_mae():
+    """A constant-response fold has a valid RMSE/MAE (only R2 is undefined); those
+    folds must stay in the macro population (Gate B)."""
+    from topica.crossval import _supervised_aggregate
+
+    # Two folds' worth of per-fold records: one normal, one constant-y (r2 NaN).
+    per_fold = [
+        {"fold": 0, "rmse": 1.0, "mae": 0.8, "r2": 0.5},
+        {"fold": 1, "rmse": 2.0, "mae": 1.6, "r2": float("nan")},
+    ]
+    y = np.array([1.0, 2.0, 3.0, 4.0])
+    oof = np.array([1.1, 2.1, 2.9, 4.2])
+    std = np.full(4, 0.5)
+    mask = np.ones(4, bool)
+    agg, _ = _supervised_aggregate(y, oof, std, mask, per_fold, (0.9,))
+    # Both folds contribute to macro RMSE/MAE; only R2 drops the constant fold.
+    assert agg["rmse_macro"]["n_valid_folds"] == 2
+    assert agg["mae_macro"]["n_valid_folds"] == 2
+    assert agg["r2_macro"]["n_valid_folds"] == 1
+
+
+def test_supervised_calibration_well_calibrated():
+    """On a clean linear-response synthetic, calibration slope ~ 1, intercept ~ 0."""
+    docs, y = _supervised_corpus(n_docs=120)
+    result = topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=5,
+        seed=13, fit_kwargs={"iters": 25},
+    )
+    assert 0.7 < result.aggregate["calibration_slope"] < 1.3
+    assert abs(result.aggregate["calibration_intercept"]) < 2.0
+    assert result.calibration_table is not None
+    assert set(result.calibration_table.columns) >= {"bin", "n", "mean_pred", "mean_obs"}
+
+
+def test_supervised_manifest_records_settings_and_replayable():
+    docs, y = _supervised_corpus(n_docs=60)
+    result = topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4,
+        fit_kwargs={"iters": 20},
+    )
+    cv = result.manifest.cv
+    assert cv["model"]["settings"] is not None       # full constructor settings
+    assert cv["replayable"] is True                  # settings captured, no callback
+    assert "coverage_z" in cv["supervised"]          # exact Gaussian quantiles
+    assert "calibration_rule" in cv["supervised"]
+
+
+def test_supervised_manifest_records_response():
+    docs, y = _supervised_corpus(n_docs=60)
+    result = topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4,
+        fit_kwargs={"iters": 20},
+    )
+    cv = result.manifest.cv
+    assert cv["path"] == "supervised"
+    assert cv["supervised"]["response_shape"] == [60]
+    assert "response_hash" in cv["supervised"]
+    assert cv["supervised"]["coverage_levels"] == [0.90, 0.95]
+
+
+def test_supervised_temporal_oof_mask_excluded():
+    docs, y = _supervised_corpus(n_docs=80)
+    times = np.arange(80)
+    result = topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y,
+        strategy="temporal", times=times, folds=5, fit_kwargs={"iters": 20},
+    )
+    # Initial-window docs are never tested -> NaN OOF, excluded from scored_mask.
+    assert not result.scored_mask.all()
+    assert np.isnan(result.oof_predictions[0])
 
 
 def test_fit_fn_requires_score_fn():


### PR DESCRIPTION
Closes the rest of #701 (PR2 of 2), building on the merged PR1 (#703). Adds the **supervised out-of-fold (OOF) regression path** to `topica.cross_validate` via `y=`.

Built with add-topic-model rigor: design → **Gate A** dual review → implement → **Gate B** dual review → PR.

## What ships
Pass `y=` (a per-doc numeric response) and `cross_validate` fits each training fold, predicts the held-out response, assembles an OOF vector, and reports:
- **Pooled RMSE / MAE / R²** over every OOF prediction + per-fold `*_macro` summaries (`{mean, std (ddof=1), n_valid_folds}`).
- **Interval coverage** (`coverage_90`/`coverage_95`) from `predict(return_std=True)` — the predictive std `√(ηᵀCov(z̄)η + σ²)`, NOT `coefficient_se` — with a required below-nominal caveat (in-sample σ² → expected slight undercoverage).
- **Calibration**: OLS intercept/slope (ideal 0, 1) + a `calibration_table` reliability table.
- `result.oof_predictions` / `oof_std` / `scored_mask` / `calibration_table`.

## Correctness crux (Gate A, both reviewers read `src/slda.rs`)
`SupervisedLDA.predict` returns a fabricated `(0.0, σ²)` for an empty/all-OOV doc — **not NaN**. So the path predicts on `train_corpus.transform(test_docs)` (dropping zero-in-vocab docs), scatters by survivor index `destination = test_idx[test_keep]`, and one `scored_mask = ~isnan(oof_pred)` (tested AND survived pruning) drives every pooled metric, calibration, and coverage identically. Empty and temporal-initial-window docs are NaN, never scored. `y` is validated up front (1-D, finite, length n_docs). Supplied-`Folds` now also checks cross-fold test-index uniqueness. `n_jobs>1` runs folds on a thread pool (bit-identical to serial). Manifest records response/covariate hashes, scored_mask, coverage levels + exact quantiles, predict params, model settings, `n_jobs`; `replayable` only when settings were captured.

## Validation
- **Gate A (design)** — Codex (faithful) + Claude (adversarial, read `src/slda.rs`): 5 blockers, all closed in the design before code (the `predict`-returns-0.0 pollution, `y` length-assert, supplied-Folds uniqueness, calibration spec, manifest schema).
- **Gate B (diff)** — Codex (faithful) + Claude (adversarial, verified against the Rust binding): the leakage-critical axes (destination scatter, single scored_mask, predictive-std coverage, thread-safety, cross-fold uniqueness) all confirmed **sound**. Fixed the honesty bugs both flagged: constant-`y` folds wrongly NaN'd RMSE/MAE (only R² is undefined), 1-fold macro std → NaN not 0.0, calibration table decoupled from the OLS threshold, manifest now records model settings + narrows `replayable`, `metrics=` error names the classification/`predict_proba` gap.

Deferred to a small follow-up (documented): `plot_cv`, keyATM covariate-effect fold-stability diagnostic.

## Tests / docs
- 61 crossval tests (incl. the empty-doc-pollution guard, `n_jobs` bit-identical, constant-`y` macro, calibration slope≈1, manifest settings/replayable).
- Full local suite green; docs guide gains a supervised section; `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EkRm7ah87rBzVnLCgVRn43