### PR TITLE
feat(eval): plot_cv + keyATM covariate-effect fold-stability (#705)

### DIFF
--- a/docs/guides/cross-validation.md
+++ b/docs/guides/cross-validation.md
@@ -73,12 +73,45 @@ over raw coefficient cells: one Pearson correlation over pooled cells is dominat
 the highest-variance covariate and would hide instability in a smaller or null one. Get
 the per-covariate table with `result.covariate_stability_frame()`.
 
+A covariate model needs enough fit iterations before its coefficients mean anything: an
+under-trained keyATM returns effects of ~0 for every topic, which is not a stable effect
+but the *absence* of one. When the largest learned effect is ~0, `cross_validate` reports
+`covariate_stability["effects_near_zero"] = True` and `summary()` prints
+`covariate-effect stability: UNDEFINED` rather than a spurious sign-agreement of 1.0.
+keyATM covariate effects typically need several hundred iterations to warm up
+(`fit_kwargs={"iters": 800}` or more), well above the ~200 that suffices for the topic
+assignments — check `covariate_stability["max_effect_magnitude"]` if in doubt.
+
+A worked keyATM factory (the first argument is a keyword dict, so it does not match the
+plain `topica.LDA(K, seed=s)` pattern):
+
+```python
+keywords = {"econ": ["market", "tax"], "social": ["family", "church"]}
+X, names = topica.one_hot(df["rating"])   # (matrix, names) — unpack it
+result = topica.cross_validate(
+    lambda s: topica.KeyATM(keywords, num_topics=10, seed=s),
+    docs,
+    covariates={"covariates": X},         # D x F numeric matrix
+    covariate_names=names,                # label the effect table/plot
+    folds=5, fit_kwargs={"iters": 800},
+)
+print(result.covariate_stability_frame())
+```
+
+Pass `covariate_names=` (a flat list, or a dict keyed by the covariate kwarg) so the
+per-covariate table and the plot show your column names instead of positional
+`covariates[0]` / `covariates[1]` placeholders — keyATM does not preserve covariate
+names on its own.
+
 **Reading the numbers.** Sign-agreement near **0.5 is chance** (the folds disagree on
 direction as often as not); values toward **1.0** mean the folds consistently recover the
 same sign. Magnitude correlation near **0 (or negative)** means the folds do *not* recover
 consistent effect *sizes*; toward **1.0** means they do. A genuinely null covariate will
 often show ~0.5 sign-agreement and ~0 magnitude correlation — that is the diagnostic
-correctly reporting "no stable effect," not a bug. The statistics are computed over few
+correctly reporting "no stable effect," not a bug. A magnitude correlation of **`NaN`**
+(shown as `n/a (no variance)` in `summary()` and the plot) means that covariate's learned
+effect had no variance across the compared cells, so there is nothing to correlate — not
+an error. The statistics are computed over few
 cells (topics × fold pairs), so at small `K` or few folds treat them as directional, not
 precise; `result.covariate_stability["topics_compared"]` reports how many topics each
 pair actually compared, and `partial_alignment` flags when unaligned topics were dropped
@@ -162,8 +195,9 @@ on the fold's *test* covariates, so the evaluation is leakage-free. Pass them as
 dict keyed by the model's fit keyword:
 
 ```python
-# Covariates must be a numeric matrix. Encode a categorical column first:
-X = topica.one_hot(df["rating"])            # or topica.design_matrix(...)
+# Covariates must be a numeric matrix. Encode a categorical column first.
+# one_hot returns (matrix, names) — unpack it; passing the tuple raises.
+X, names = topica.one_hot(df["rating"])     # or topica.design_matrix(...)
 
 result = topica.cross_validate(
     lambda seed: topica.STM(10, seed=seed),

--- a/docs/guides/cross-validation.md
+++ b/docs/guides/cross-validation.md
@@ -55,6 +55,27 @@ For each fold, on the **held-out** test documents:
 `result.aggregate` gives the macro mean ± std of each metric across folds;
 `result.per_fold` is the per-fold detail.
 
+### Covariate-effect stability (keyATM, DMR, GDMR)
+
+For a model that learns covariate coefficients (keyATM covariate, DMR, GDMR),
+`cross_validate` also reports whether those effects hold up across folds, in
+`result.covariate_stability`. After aligning topics across every fold pair
+(vocabulary-aware, since fold vocabularies differ), it compares the fold-aligned
+coefficients (λ) two ways:
+
+- **sign-agreement rate** — the fraction of (topic, covariate) cells where two folds
+  agree on the sign of the effect, and
+- **magnitude correlation** — the Pearson correlation of the aligned coefficients.
+
+Both are reported pooled and per covariate (`result.covariate_stability["per_feature"]`).
+
+This is deliberately **not** a predictive-coverage statistic, and it is never stored in
+a `coverage_*` field. λ has no per-document ground truth, and the conditional
+`feature_effect_se` is under-dispersed, so a ±2·SE-overlap "stability" would read as
+spuriously stable. Sign-agreement and magnitude correlation ask the honest question
+instead: do the folds recover effects of the same direction and relative size? Do not
+report this number as if it were held-out predictive accuracy for the covariate.
+
 ## Supervised models (out-of-fold prediction)
 
 For a supervised/measurement model with a numeric response — `SupervisedLDA` — pass
@@ -148,7 +169,9 @@ condition on your covariate, so the reported perplexity does not reflect it.
 `cross_validate` warns at run time when this happens, `result.summary()` prints a
 `covariates:` status line, and every fold carries `covariate_conditioned` in
 `result.to_frame()`. STM `prevalence` conditions correctly (`covariate_conditioned=True`);
-do not report a keyATM-covariate CV as if it conditioned on the covariate.
+do not report a keyATM-covariate CV as if it conditioned on the covariate. For keyATM
+(and DMR/GDMR) the fold-stability of the learned effect itself is reported separately in
+`result.covariate_stability` — see [Covariate-effect stability](#covariate-effect-stability-keyatm-dmr-gdmr).
 
 For anything the named routing does not cover, supply both an
 `fit_fn(train_docs, train_idx, seed_fold) -> model` and a
@@ -185,6 +208,27 @@ you pass a pre-pruned `Corpus` on the `per_fold` path.
 An unrecognized covariate key is a hard error, not a silent drop: passing
 `covariates={"prevalence": X}` to a model that has no prevalence covariate (an LDA,
 say) raises with the list of keys that model does accept.
+
+## Plotting
+
+`topica.viz.plot_cv(result)` turns a run into a figure, switching on the path:
+
+```python
+import topica.viz as viz
+
+result = topica.cross_validate(lambda s: topica.LDA(10, seed=s), docs, folds=5)
+viz.plot_cv(result).to_png("cv.pdf")   # or .to_frame() for the numbers
+```
+
+- **Topic path** — the per-fold distribution of each held-out metric (perplexity,
+  coherence, exclusivity): each fold is a point, with the macro mean and ±1 std
+  overlaid, so the fold-to-fold spread the aggregate hides is visible.
+- **Supervised path** — the out-of-fold reliability plot (binned observed vs predicted
+  with the 45° line, from `result.calibration_table`) beside the per-fold RMSE / R²
+  spread.
+
+Like every `topica.viz` panel it also exposes `.to_frame()` (the per-fold table) and
+`.to_png(path)` / `.to_pdf(path)`.
 
 ## Reproducibility
 

--- a/docs/guides/cross-validation.md
+++ b/docs/guides/cross-validation.md
@@ -67,14 +67,30 @@ coefficients (λ) two ways:
   agree on the sign of the effect, and
 - **magnitude correlation** — the Pearson correlation of the aligned coefficients.
 
-Both are reported pooled and per covariate (`result.covariate_stability["per_feature"]`).
+Both headline numbers are **macro-averaged over covariates** (the mean of the
+per-covariate statistics in `result.covariate_stability["per_feature"]`), not pooled
+over raw coefficient cells: one Pearson correlation over pooled cells is dominated by
+the highest-variance covariate and would hide instability in a smaller or null one. Get
+the per-covariate table with `result.covariate_stability_frame()`.
+
+**Reading the numbers.** Sign-agreement near **0.5 is chance** (the folds disagree on
+direction as often as not); values toward **1.0** mean the folds consistently recover the
+same sign. Magnitude correlation near **0 (or negative)** means the folds do *not* recover
+consistent effect *sizes*; toward **1.0** means they do. A genuinely null covariate will
+often show ~0.5 sign-agreement and ~0 magnitude correlation — that is the diagnostic
+correctly reporting "no stable effect," not a bug. The statistics are computed over few
+cells (topics × fold pairs), so at small `K` or few folds treat them as directional, not
+precise; `result.covariate_stability["topics_compared"]` reports how many topics each
+pair actually compared, and `partial_alignment` flags when unaligned topics were dropped
+(which can bias stability upward).
 
 This is deliberately **not** a predictive-coverage statistic, and it is never stored in
 a `coverage_*` field. λ has no per-document ground truth, and the conditional
 `feature_effect_se` is under-dispersed, so a ±2·SE-overlap "stability" would read as
-spuriously stable. Sign-agreement and magnitude correlation ask the honest question
-instead: do the folds recover effects of the same direction and relative size? Do not
-report this number as if it were held-out predictive accuracy for the covariate.
+spuriously stable. The effects are learned per fold at *fit* time, so this diagnostic is
+unaffected by the marginal held-out fallback that keyATM's perplexity is subject to (a
+separate concern — see the conditioning flag above). Do not report this number as if it
+were held-out predictive accuracy for the covariate.
 
 ## Supervised models (out-of-fold prediction)
 
@@ -226,6 +242,11 @@ viz.plot_cv(result).to_png("cv.pdf")   # or .to_frame() for the numbers
 - **Supervised path** — the out-of-fold reliability plot (binned observed vs predicted
   with the 45° line, from `result.calibration_table`) beside the per-fold RMSE / R²
   spread.
+
+When the run carries covariate-effect stability (keyATM / DMR / GDMR), the topic-path
+figure adds a second band: per-covariate sign-agreement bars (with the 0.5 chance line)
+and magnitude-correlation bars (centered at 0). `import topica.viz` is required before
+`topica.viz.plot_cv` (a bare `import topica` does not pull in the submodule).
 
 Like every `topica.viz` panel it also exposes `.to_frame()` (the per-fold table) and
 `.to_png(path)` / `.to_pdf(path)`.

--- a/python/topica/crossval.py
+++ b/python/topica/crossval.py
@@ -483,14 +483,22 @@ class CrossValResult:
             )
         if self.covariate_stability is not None:
             cs = self.covariate_stability
-            lines.append(
-                f"  covariate-effect stability: sign-agreement "
-                f"{cs['sign_agreement']:.3f}, magnitude corr "
-                f"{cs['magnitude_correlation']:.3f} (feature-macro over "
-                f"{cs['n_features']} covariate(s), {cs['n_pairs']} fold pairs; "
-                f"NOT predictive coverage; effects are learned per fold — this is "
-                f"unaffected by any marginal held-out fallback)"
-            )
+            if cs.get("effects_near_zero"):
+                lines.append(
+                    "  covariate-effect stability: UNDEFINED — the learned effects "
+                    "are ~0 (the model likely needs more fit iterations before its "
+                    "covariate effects mean anything)"
+                )
+            else:
+                mc = cs["magnitude_correlation"]
+                mc_str = ("n/a (no variance)" if not np.isfinite(mc) else f"{mc:.3f}")
+                lines.append(
+                    f"  covariate-effect stability: sign-agreement "
+                    f"{cs['sign_agreement']:.3f}, magnitude corr {mc_str} "
+                    f"(feature-macro over {cs['n_features']} covariate(s), "
+                    f"{cs['n_pairs']} fold pairs; NOT predictive coverage; effects are "
+                    f"learned per fold — unaffected by any marginal held-out fallback)"
+                )
             if cs.get("partial_alignment"):
                 tc = cs["topics_compared"]
                 lines.append(
@@ -621,7 +629,22 @@ def _resolve_covariates(covariates, n_docs):
         raise ValueError("covariates must be a dict {kwarg_name: array}")
     out = {}
     for key, arr in covariates.items():
+        # topica.one_hot / design_matrix return (matrix, names); a common first-timer
+        # mistake is to pass that tuple straight through. np.asarray on it yields a
+        # ragged object array and a cryptic downstream error — catch it here.
+        if isinstance(arr, tuple):
+            raise ValueError(
+                f"covariate {key!r} is a tuple, not an array — did you forget to "
+                f"unpack one_hot()/design_matrix()? They return (matrix, names); pass "
+                f"the matrix, e.g. `X, names = topica.one_hot(...)` then "
+                f"`covariates={{'{key}': X}}`"
+            )
         a = np.asarray(arr)
+        if a.dtype == object or not np.issubdtype(a.dtype, np.number):
+            raise ValueError(
+                f"covariate {key!r} must be a numeric array, got dtype {a.dtype}; "
+                "encode categoricals with topica.one_hot(...) first"
+            )
         if a.shape[0] != n_docs:
             raise ValueError(
                 f"covariate {key!r} has length {a.shape[0]}, expected n_docs={n_docs}"
@@ -725,6 +748,7 @@ def cross_validate(
     *,
     y=None,
     covariates=None,
+    covariate_names=None,
     folds=5,
     strategy="kfold",
     groups=None,
@@ -758,6 +782,11 @@ def cross_validate(
     docs : list[list[str]] or a Corpus.
     covariates : dict ``{fit_kwarg: array}`` of per-document covariates (length
         n_docs), e.g. ``{"prevalence": X}`` for STM. Sub-indexed per fold.
+    covariate_names : optional names for the covariate columns, used to label the
+        covariate-effect stability table/plot (keyATM/DMR/GDMR). A flat sequence
+        (``["Liberal", "day_z"]``) or a dict keyed by the covariate kwarg. Length must
+        equal the number of covariate effects (intercept excluded); handy because
+        ``one_hot`` returns the names separately from the matrix.
     y : per-document numeric response (length n_docs). When given, runs the
         supervised out-of-fold path (regression): fit on each training fold, predict
         the held-out response, assemble an out-of-fold vector, and report pooled +
@@ -961,7 +990,7 @@ def cross_validate(
             )
 
     stability = _cross_fold_stability(fold_models)
-    covariate_stability = _covariate_effect_stability(fold_models, cov)
+    covariate_stability = _covariate_effect_stability(fold_models, cov, covariate_names)
 
     # Capture the fitted model's class + settings for the manifest (constant across
     # folds; the factory itself is an opaque callable).
@@ -1035,7 +1064,36 @@ def _placeholder_names(cov_names):
     )
 
 
-def _covariate_effect_stability(models, cov=None):
+def _resolve_covariate_names(covariate_names, cov, n_feat):
+    """Turn the user's ``covariate_names=`` into a length-``n_feat`` list, or None.
+
+    Accepts a flat sequence (``["Liberal", "day_z"]``) or a dict keyed by the covariate
+    kwarg (``{"covariates": ["Liberal", "day_z"]}``). Any other length is a hard error —
+    a silent mismatch would mislabel effects."""
+    if covariate_names is None:
+        return None
+    names = covariate_names
+    if isinstance(covariate_names, dict):
+        keys = list(cov.keys()) if cov else []
+        if len(keys) == 1 and keys[0] in covariate_names:
+            names = covariate_names[keys[0]]
+        elif len(covariate_names) == 1:
+            names = next(iter(covariate_names.values()))
+        else:
+            raise ValueError(
+                "covariate_names as a dict must key the single covariate kwarg "
+                f"(got keys {list(covariate_names)} vs covariates {list(cov or [])})"
+            )
+    names = list(names)
+    if len(names) != n_feat:
+        raise ValueError(
+            f"covariate_names has {len(names)} names but the model learned {n_feat} "
+            "covariate effect(s); they must match (intercept is not named)"
+        )
+    return [str(x) for x in names]
+
+
+def _covariate_effect_stability(models, cov=None, covariate_names=None):
     """Covariate-effect fold-stability for models with a learned lambda (keyATM
     covariate, DMR, GDMR).
 
@@ -1105,7 +1163,10 @@ def _covariate_effect_stability(models, cov=None):
     n_feat = usable[0][1].shape[1] - 1
     ref_names = usable[0][2]
     cov_names = list(ref_names[1:]) if len(ref_names) == n_feat + 1 else []
-    if cov_names and not _placeholder_names(cov_names):
+    user_names = _resolve_covariate_names(covariate_names, cov, n_feat)
+    if user_names is not None:
+        feat_names = user_names  # explicit names win over anything the model reports
+    elif cov_names and not _placeholder_names(cov_names):
         feat_names = cov_names
     else:
         # A single covariate kwarg maps to the whole F-column matrix; label columns
@@ -1159,15 +1220,27 @@ def _covariate_effect_stability(models, cov=None):
     if n_pairs == 0:
         return None
 
+    # "Near zero" tolerance, relative to the largest learned effect anywhere: an
+    # unconverged keyATM returns lambda == 0 for every topic (it has not warmed up),
+    # and a zero coefficient has no sign to agree on. Scoring sign(0)==sign(0) as
+    # agreement would report an all-zero (learned-nothing) model as perfectly stable
+    # — the exact trap a first-time user hit (#705). Exclude ~0 cells instead.
+    _all = np.array(
+        [v for f in range(n_feat) for v in (per_feat_a[f] + per_feat_b[f])],
+        dtype=np.float64,
+    )
+    scale = float(np.max(np.abs(_all))) if _all.size else 0.0
+    tol = max(1e-12, 1e-8 * scale)
+    effects_near_zero = scale <= tol  # the model learned essentially no covariate effect
+
     def _sign_agree(a, b):
-        a, b = np.asarray(a), np.asarray(b)
-        if a.size == 0:
+        a, b = np.asarray(a, dtype=np.float64), np.asarray(b, dtype=np.float64)
+        # A coefficient at (or near) 0 has no sign to agree on; count agreement only over
+        # cells where at least one fold learned a nonzero effect. No such cell -> undefined.
+        mask = (np.abs(a) > tol) | (np.abs(b) > tol)
+        if not mask.any():
             return float("nan")
-        # np.sign(0)==np.sign(0) is True, so two exactly-zero coefficients count as
-        # agreement (they agree there is no effect); a lone zero (0 vs nonzero) is a
-        # disagreement. For continuous lambda exact zeros are vanishingly rare, so this
-        # reduces to "do the two folds agree on the direction of the effect".
-        return float(np.mean(np.sign(a) == np.sign(b)))
+        return float(np.mean(np.sign(a[mask]) == np.sign(b[mask])))
 
     def _corr(a, b):
         a, b = np.asarray(a), np.asarray(b)
@@ -1178,15 +1251,17 @@ def _covariate_effect_stability(models, cov=None):
     per_feature = {}
     for f in range(n_feat):
         a, b = per_feat_a[f], per_feat_b[f]
+        mag = np.abs(np.concatenate([a, b])) if a else np.array([])
         per_feature[feat_names[f]] = {
             "sign_agreement": _sign_agree(a, b),
             "magnitude_correlation": _corr(a, b),
+            "effect_magnitude": float(mag.mean()) if mag.size else float("nan"),
             "n": int(len(a)),
         }
 
     # Macro headline: mean of the per-feature statistics (equal weight per covariate),
     # NOT a single correlation over pooled raw cells. Skip NaN per-feature values
-    # (constant columns) so one degenerate covariate does not blank the headline.
+    # (constant/near-zero columns) so one degenerate covariate does not blank the headline.
     sa = np.array([v["sign_agreement"] for v in per_feature.values()], dtype=np.float64)
     mc = np.array([v["magnitude_correlation"] for v in per_feature.values()],
                   dtype=np.float64)
@@ -1194,9 +1269,18 @@ def _covariate_effect_stability(models, cov=None):
     mc = mc[np.isfinite(mc)]
     tc = np.array(topics_compared, dtype=np.float64)
 
+    note = ("covariate-effect fold-stability (feature-macro sign-agreement + "
+            "magnitude correlation of aligned lambda); NOT predictive coverage")
+    if effects_near_zero:
+        note += (". WARNING: the learned covariate effects are ~0, so stability is "
+                 "undefined — the model likely needs more fit iterations before its "
+                 "covariate effects mean anything")
+
     return {
         "sign_agreement": float(sa.mean()) if sa.size else float("nan"),
         "magnitude_correlation": float(mc.mean()) if mc.size else float("nan"),
+        "effects_near_zero": bool(effects_near_zero),
+        "max_effect_magnitude": scale,
         "n_pairs": int(n_pairs),
         "n_features": int(n_feat),
         "n_topics": n_topics,
@@ -1206,8 +1290,7 @@ def _covariate_effect_stability(models, cov=None):
         "partial_alignment": bool(tc.min() < n_topics),
         "per_feature": per_feature,
         "caveat": caveat,
-        "note": "covariate-effect fold-stability (feature-macro sign-agreement + "
-                "magnitude correlation of aligned lambda); NOT predictive coverage",
+        "note": note,
     }
 
 

--- a/python/topica/crossval.py
+++ b/python/topica/crossval.py
@@ -435,6 +435,20 @@ class CrossValResult:
 
         return pd.DataFrame(self.per_fold)
 
+    def covariate_stability_frame(self):
+        """Per-feature covariate-effect stability as a pandas DataFrame (one row per
+        covariate: feature, sign_agreement, magnitude_correlation, n). None when this
+        run has no covariate-effect stability (see :attr:`covariate_stability`)."""
+        if self.covariate_stability is None:
+            return None
+        import pandas as pd
+
+        rows = [
+            {"feature": name, **stat}
+            for name, stat in self.covariate_stability["per_feature"].items()
+        ]
+        return pd.DataFrame(rows)
+
     def summary(self) -> str:
         if self.kind == "supervised":
             return self._supervised_summary()
@@ -472,9 +486,20 @@ class CrossValResult:
             lines.append(
                 f"  covariate-effect stability: sign-agreement "
                 f"{cs['sign_agreement']:.3f}, magnitude corr "
-                f"{cs['magnitude_correlation']:.3f} (aligned lambda over "
-                f"{cs['n_pairs']} fold pairs; NOT predictive coverage)"
+                f"{cs['magnitude_correlation']:.3f} (feature-macro over "
+                f"{cs['n_features']} covariate(s), {cs['n_pairs']} fold pairs; "
+                f"NOT predictive coverage; effects are learned per fold — this is "
+                f"unaffected by any marginal held-out fallback)"
             )
+            if cs.get("partial_alignment"):
+                tc = cs["topics_compared"]
+                lines.append(
+                    f"    (partial alignment: some fold pairs compared as few as "
+                    f"{tc['min']}/{cs['n_topics']} topics — unaligned topics are "
+                    f"excluded, which can bias stability upward)"
+                )
+            if cs.get("caveat"):
+                lines.append(f"    (caveat: {cs['caveat']})")
         if self.vocab == "per_fold":
             lines.append(
                 "  (perplexity is per-fold; vocabularies differ so it is not pooled)"
@@ -936,7 +961,7 @@ def cross_validate(
             )
 
     stability = _cross_fold_stability(fold_models)
-    covariate_stability = _covariate_effect_stability(fold_models)
+    covariate_stability = _covariate_effect_stability(fold_models, cov)
 
     # Capture the fitted model's class + settings for the manifest (constant across
     # folds; the factory itself is an opaque callable).
@@ -998,7 +1023,19 @@ def _cross_fold_stability(models):
     return {"mean": float(sims.mean()), "std": float(sims.std()), "n_pairs": int(sims.size)}
 
 
-def _covariate_effect_stability(models):
+def _placeholder_names(cov_names):
+    """True when the model handed back positional placeholders (keyATM emits
+    ``feature_0``/``feature_1``/... for the covariate columns when the covariate
+    arrives as a bare matrix), so the caller should substitute a kwarg label instead.
+    ``cov_names`` is the covariate columns only (intercept already dropped)."""
+    import re
+
+    return bool(cov_names) and all(
+        re.fullmatch(r"feature_\d+", str(nm)) for nm in cov_names
+    )
+
+
+def _covariate_effect_stability(models, cov=None):
     """Covariate-effect fold-stability for models with a learned lambda (keyATM
     covariate, DMR, GDMR).
 
@@ -1010,12 +1047,25 @@ def _covariate_effect_stability(models):
       agree on the sign of the effect, and
     - **magnitude correlation**: the Pearson correlation of the matched effects.
 
+    Both headline numbers are **macro-averaged over features** (mean of the per-feature
+    statistics), not pooled over raw cells: pooling one Pearson correlation across
+    features of different scales lets the highest-variance covariate dominate and hide
+    instability in a smaller or null one (adversarial review, #705). Per-feature detail
+    is in ``per_feature``.
+
+    Partial topic alignment is disclosed, not hidden: ``align_topics`` may match fewer
+    than K topics (an unstable topic whose word distribution also drifts can fall below
+    the alignment threshold), and comparing only the topics that happened to align would
+    bias stability upward. ``topics_compared``/``n_topics`` report the coverage so a
+    reader can see when a fold pair dropped topics.
+
     The intercept column (0) is excluded — it is a per-topic baseline, not a covariate
     effect. This is NOT predictive coverage (lambda has no per-doc truth), and the
     caller must never fold it into a ``coverage_*`` field.
 
-    Returns a dict (pooled + per-feature) or None when fewer than two fold models expose
-    ``feature_effects`` or the folds disagree on the number of covariate columns.
+    Returns a dict (macro headline + per-feature) or None when fewer than two fold
+    models expose ``feature_effects`` or the folds disagree on the number of covariate
+    columns.
     """
     import warnings
 
@@ -1048,19 +1098,44 @@ def _covariate_effect_stability(models):
 
     from .validation import align_topics
 
-    # Covariate columns are 1..F (drop the intercept at 0). Feature names, when present,
-    # are aligned to the effect columns ('intercept' first), so name the covariate cols.
+    # Covariate columns are 1..F (drop the intercept at 0). Prefer the model's own
+    # feature names; when it hands back positional placeholders (keyATM with a bare
+    # covariate matrix), fall back to the covariate kwarg the user actually passed, so
+    # a two-covariate model is not reported as feature_0/feature_1 (usability, #705).
     n_feat = usable[0][1].shape[1] - 1
     ref_names = usable[0][2]
-    feat_names = (
-        ref_names[1:] if len(ref_names) == n_feat + 1
-        else [f"feature_{j}" for j in range(n_feat)]
-    )
+    cov_names = list(ref_names[1:]) if len(ref_names) == n_feat + 1 else []
+    if cov_names and not _placeholder_names(cov_names):
+        feat_names = cov_names
+    else:
+        # A single covariate kwarg maps to the whole F-column matrix; label columns
+        # kwarg[0..F-1]. With 0 or >1 kwargs, keep the neutral feature_j.
+        keys = list(cov.keys()) if cov else []
+        prefix = keys[0] if len(keys) == 1 else None
+        feat_names = (
+            [f"{prefix}[{j}]" for j in range(n_feat)] if prefix is not None
+            else [f"feature_{j}" for j in range(n_feat)]
+        )
 
-    # Accumulate matched (fold_a, fold_b) coefficient values per feature over all pairs.
+    # GDMR coefficients are Legendre-basis terms whose affine map depends on each fold's
+    # own covariate range (metadata_range=None infers it per fold), so column j means a
+    # different function in different folds. The diagnostic still runs, but say so.
+    caveat = None
+    if any(type(m).__name__ == "GDMR" for m, _, _ in usable):
+        caveat = (
+            "GDMR coefficients are basis-expansion terms on a per-fold covariate range; "
+            "aligning column j across folds compares different basis functions unless "
+            "metadata_range= is fixed. Interpret magnitude correlation cautiously."
+        )
+        warnings.warn("covariate-effect stability: " + caveat, stacklevel=3)
+
+    # Accumulate matched (fold_a, fold_b) coefficient values per feature over all pairs,
+    # and track how many of K topics each pair actually compared.
+    n_topics = int(usable[0][1].shape[0])
     per_feat_a = [[] for _ in range(n_feat)]
     per_feat_b = [[] for _ in range(n_feat)]
     n_pairs = 0
+    topics_compared = []
     for i in range(len(usable)):
         for j in range(i + 1, len(usable)):
             (mi, fei, _), (mj, fej, _) = usable[i], usable[j]
@@ -1075,6 +1150,7 @@ def _covariate_effect_stability(models):
             if not matches:
                 continue
             n_pairs += 1
+            topics_compared.append(len(matches))
             for ta, tb, _sim in matches:
                 for f in range(n_feat):
                     per_feat_a[f].append(fei[ta, f + 1])
@@ -1087,8 +1163,10 @@ def _covariate_effect_stability(models):
         a, b = np.asarray(a), np.asarray(b)
         if a.size == 0:
             return float("nan")
-        # A coefficient at exactly 0 has no sign to agree on; count agreement only where
-        # both are nonzero, and treat a lone zero as a disagreement (conservative).
+        # np.sign(0)==np.sign(0) is True, so two exactly-zero coefficients count as
+        # agreement (they agree there is no effect); a lone zero (0 vs nonzero) is a
+        # disagreement. For continuous lambda exact zeros are vanishingly rare, so this
+        # reduces to "do the two folds agree on the direction of the effect".
         return float(np.mean(np.sign(a) == np.sign(b)))
 
     def _corr(a, b):
@@ -1098,25 +1176,38 @@ def _covariate_effect_stability(models):
         return float(np.corrcoef(a, b)[0, 1])
 
     per_feature = {}
-    all_a, all_b = [], []
     for f in range(n_feat):
         a, b = per_feat_a[f], per_feat_b[f]
-        all_a.extend(a)
-        all_b.extend(b)
         per_feature[feat_names[f]] = {
             "sign_agreement": _sign_agree(a, b),
             "magnitude_correlation": _corr(a, b),
             "n": int(len(a)),
         }
 
+    # Macro headline: mean of the per-feature statistics (equal weight per covariate),
+    # NOT a single correlation over pooled raw cells. Skip NaN per-feature values
+    # (constant columns) so one degenerate covariate does not blank the headline.
+    sa = np.array([v["sign_agreement"] for v in per_feature.values()], dtype=np.float64)
+    mc = np.array([v["magnitude_correlation"] for v in per_feature.values()],
+                  dtype=np.float64)
+    sa = sa[np.isfinite(sa)]
+    mc = mc[np.isfinite(mc)]
+    tc = np.array(topics_compared, dtype=np.float64)
+
     return {
-        "sign_agreement": _sign_agree(all_a, all_b),
-        "magnitude_correlation": _corr(all_a, all_b),
+        "sign_agreement": float(sa.mean()) if sa.size else float("nan"),
+        "magnitude_correlation": float(mc.mean()) if mc.size else float("nan"),
         "n_pairs": int(n_pairs),
         "n_features": int(n_feat),
+        "n_topics": n_topics,
+        "topics_compared": {
+            "mean": float(tc.mean()), "min": int(tc.min()), "max": int(tc.max()),
+        },
+        "partial_alignment": bool(tc.min() < n_topics),
         "per_feature": per_feature,
-        "note": "covariate-effect fold-stability (sign-agreement + magnitude "
-                "correlation of aligned lambda); NOT predictive coverage",
+        "caveat": caveat,
+        "note": "covariate-effect fold-stability (feature-macro sign-agreement + "
+                "magnitude correlation of aligned lambda); NOT predictive coverage",
     }
 
 

--- a/python/topica/crossval.py
+++ b/python/topica/crossval.py
@@ -402,6 +402,19 @@ class CrossValResult:
     """Cross-fold topic stability (mean +/- std matched-topic cosine over all fold
     pairs), computed vocabulary-aware via align_topics since fold vocabularies
     differ. None when there are too few comparable fits."""
+    covariate_stability: dict | None = None
+    """Covariate-effect fold-stability for models that learn covariate coefficients
+    (keyATM covariate, DMR, GDMR): after aligning topics across every fold pair,
+    the sign-agreement rate and magnitude (Pearson) correlation of the fold-aligned
+    covariate effects (lambda), per feature and pooled.
+
+    This is deliberately NOT a predictive-coverage statistic and is never stored in
+    a ``coverage_*`` field: lambda has no per-document ground truth, and the
+    conditional ``feature_effect_se`` is under-dispersed, so a +/-2*SE-overlap
+    "stability" would read as spuriously stable. Sign-agreement + magnitude
+    correlation ask the honest question instead — do the folds recover effects of
+    the same direction and relative size? None when fewer than two fold models
+    expose ``feature_effects``."""
     kind: str = "topic"
     """"topic" (held-out completion) or "supervised" (out-of-fold prediction)."""
     oof_predictions: Any = None
@@ -453,6 +466,14 @@ class CrossValResult:
             lines.append(
                 f"  stability (cross-fold cosine): {self.stability['mean']:.4g} "
                 f"+/- {self.stability['std']:.4g}"
+            )
+        if self.covariate_stability is not None:
+            cs = self.covariate_stability
+            lines.append(
+                f"  covariate-effect stability: sign-agreement "
+                f"{cs['sign_agreement']:.3f}, magnitude corr "
+                f"{cs['magnitude_correlation']:.3f} (aligned lambda over "
+                f"{cs['n_pairs']} fold pairs; NOT predictive coverage)"
             )
         if self.vocab == "per_fold":
             lines.append(
@@ -915,6 +936,7 @@ def cross_validate(
             )
 
     stability = _cross_fold_stability(fold_models)
+    covariate_stability = _covariate_effect_stability(fold_models)
 
     # Capture the fitted model's class + settings for the manifest (constant across
     # folds; the factory itself is an opaque callable).
@@ -941,6 +963,7 @@ def cross_validate(
         manifest=mani,
         vocab=vocab,
         stability=stability,
+        covariate_stability=covariate_stability,
     )
 
 
@@ -973,6 +996,128 @@ def _cross_fold_stability(models):
         return None
     sims = np.array(sims, dtype=np.float64)
     return {"mean": float(sims.mean()), "std": float(sims.std()), "n_pairs": int(sims.size)}
+
+
+def _covariate_effect_stability(models):
+    """Covariate-effect fold-stability for models with a learned lambda (keyATM
+    covariate, DMR, GDMR).
+
+    For every pair of fold models, align their topics (vocabulary-aware, since fold
+    vocabularies differ), reorder the second fold's ``feature_effects`` rows onto the
+    first's topics, then compare the matched covariate coefficients two ways:
+
+    - **sign-agreement**: the fraction of (topic, covariate) cells where the two folds
+      agree on the sign of the effect, and
+    - **magnitude correlation**: the Pearson correlation of the matched effects.
+
+    The intercept column (0) is excluded — it is a per-topic baseline, not a covariate
+    effect. This is NOT predictive coverage (lambda has no per-doc truth), and the
+    caller must never fold it into a ``coverage_*`` field.
+
+    Returns a dict (pooled + per-feature) or None when fewer than two fold models expose
+    ``feature_effects`` or the folds disagree on the number of covariate columns.
+    """
+    import warnings
+
+    usable = []
+    for m in models:
+        if m is None or not hasattr(m, "topic_word"):
+            continue
+        try:
+            fe = np.asarray(m.feature_effects, dtype=np.float64)
+        except Exception:
+            continue  # not a covariate model (feature_effects raises without covariates)
+        if fe.ndim != 2 or fe.shape[1] < 2:
+            continue  # need at least one covariate column beyond the intercept
+        names = list(getattr(m, "feature_names", []))
+        usable.append((m, fe, names))
+    if len(usable) < 2:
+        return None
+
+    # All folds must share the covariate design (same coefficient columns); otherwise
+    # aligning effects across folds compares different quantities.
+    ncols = {fe.shape[1] for _, fe, _ in usable}
+    if len(ncols) != 1:
+        warnings.warn(
+            "covariate-effect stability skipped: fold models have different numbers "
+            f"of covariate coefficients ({sorted(ncols)}); the covariate design must "
+            "match across folds to compare effects.",
+            stacklevel=3,
+        )
+        return None
+
+    from .validation import align_topics
+
+    # Covariate columns are 1..F (drop the intercept at 0). Feature names, when present,
+    # are aligned to the effect columns ('intercept' first), so name the covariate cols.
+    n_feat = usable[0][1].shape[1] - 1
+    ref_names = usable[0][2]
+    feat_names = (
+        ref_names[1:] if len(ref_names) == n_feat + 1
+        else [f"feature_{j}" for j in range(n_feat)]
+    )
+
+    # Accumulate matched (fold_a, fold_b) coefficient values per feature over all pairs.
+    per_feat_a = [[] for _ in range(n_feat)]
+    per_feat_b = [[] for _ in range(n_feat)]
+    n_pairs = 0
+    for i in range(len(usable)):
+        for j in range(i + 1, len(usable)):
+            (mi, fei, _), (mj, fej, _) = usable[i], usable[j]
+            try:
+                matches = align_topics(mi, mj, metric="cosine").matches
+            except Exception as exc:
+                warnings.warn(
+                    f"covariate-effect stability skipped a fold pair ({exc})",
+                    stacklevel=3,
+                )
+                continue
+            if not matches:
+                continue
+            n_pairs += 1
+            for ta, tb, _sim in matches:
+                for f in range(n_feat):
+                    per_feat_a[f].append(fei[ta, f + 1])
+                    per_feat_b[f].append(fej[tb, f + 1])
+
+    if n_pairs == 0:
+        return None
+
+    def _sign_agree(a, b):
+        a, b = np.asarray(a), np.asarray(b)
+        if a.size == 0:
+            return float("nan")
+        # A coefficient at exactly 0 has no sign to agree on; count agreement only where
+        # both are nonzero, and treat a lone zero as a disagreement (conservative).
+        return float(np.mean(np.sign(a) == np.sign(b)))
+
+    def _corr(a, b):
+        a, b = np.asarray(a), np.asarray(b)
+        if a.size < 2 or np.std(a) == 0 or np.std(b) == 0:
+            return float("nan")  # a constant column has no magnitude to correlate
+        return float(np.corrcoef(a, b)[0, 1])
+
+    per_feature = {}
+    all_a, all_b = [], []
+    for f in range(n_feat):
+        a, b = per_feat_a[f], per_feat_b[f]
+        all_a.extend(a)
+        all_b.extend(b)
+        per_feature[feat_names[f]] = {
+            "sign_agreement": _sign_agree(a, b),
+            "magnitude_correlation": _corr(a, b),
+            "n": int(len(a)),
+        }
+
+    return {
+        "sign_agreement": _sign_agree(all_a, all_b),
+        "magnitude_correlation": _corr(all_a, all_b),
+        "n_pairs": int(n_pairs),
+        "n_features": int(n_feat),
+        "per_feature": per_feature,
+        "note": "covariate-effect fold-stability (sign-agreement + magnitude "
+                "correlation of aligned lambda); NOT predictive coverage",
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/python/topica/viz/__init__.py
+++ b/python/topica/viz/__init__.py
@@ -31,6 +31,7 @@ from .inspector import DocumentInspector
 from .content import ContentCovariate
 from .dashboard import Dashboard, dashboard
 from .permtest import PermutationTestPlot
+from .crossval import CrossValidationPlot
 
 
 def coherence_frontier(model, texts=None, *, n=10, coherence_type=None) -> CoherenceFrontier:
@@ -112,6 +113,16 @@ def permutation_test_plot(results, *, covariate_name=None) -> PermutationTestPlo
     return PermutationTestPlot(results, covariate_name=covariate_name)
 
 
+def plot_cv(result) -> CrossValidationPlot:
+    """Cross-validation results as a figure.
+
+    Pass the output of :func:`topica.cross_validate`. Renders the per-fold metric
+    distribution for the topic path, or the out-of-fold calibration scatter plus
+    per-fold RMSE/R2 spread for the supervised path.
+    """
+    return CrossValidationPlot(result)
+
+
 __all__ = [
     "Panel",
     "Capabilities",
@@ -147,4 +158,6 @@ __all__ = [
     "dashboard",
     "PermutationTestPlot",
     "permutation_test_plot",
+    "CrossValidationPlot",
+    "plot_cv",
 ]

--- a/python/topica/viz/crossval.py
+++ b/python/topica/viz/crossval.py
@@ -69,15 +69,38 @@ class CrossValidationPlot(Panel):
         return out
 
     # --- layout -------------------------------------------------------------
+    def _has_covariate(self):
+        return getattr(self._result, "covariate_stability", None) is not None
+
     def _figsize(self):
         if self._kind == "supervised":
             return (9.0, 4.0)
         n = max(1, len(self._topic_metric_values()))
-        return (3.6 * n, 4.0)
+        h = 4.0 + (3.0 if self._has_covariate() else 0.0)
+        return (3.6 * n, h)
+
+    def _figure(self, *, figsize=None, **kwargs):
+        # The covariate band uses subfigures with differing column counts, where
+        # figure.tight_layout() cannot solve and warns. Use the constrained-layout
+        # engine for that case (subfigure-aware); the plain paths keep tight_layout.
+        if self._kind != "supervised" and self._has_covariate():
+            from .base import _require
+
+            plt = _require("matplotlib.pyplot", "viz")
+            fig = plt.figure(figsize=figsize or self._figsize(), layout="constrained")
+            self._draw(fig, **kwargs)
+            return fig
+        return super()._figure(figsize=figsize, **kwargs)
 
     def _draw(self, fig, **kwargs):
         if self._kind == "supervised":
             self._draw_supervised(fig)
+        elif self._has_covariate():
+            # Two stacked bands: the held-out metric distributions on top, the
+            # covariate-effect stability below (the reason a covariate model was run).
+            top, bottom = fig.subfigures(2, 1, height_ratios=[4.0, 3.0])
+            self._draw_topic(top)
+            self._draw_covariate(bottom)
         else:
             self._draw_topic(fig)
         fig.suptitle(
@@ -116,6 +139,60 @@ class CrossValidationPlot(Panel):
             ax.set_ylabel(label, fontsize=8)
             ax.tick_params(labelsize=7)
             ax.legend(fontsize=7, loc="best")
+
+    # --- covariate-effect stability (keyATM / DMR / GDMR) -------------------
+    def _draw_covariate(self, fig):
+        import numpy as np
+
+        cs = self._result.covariate_stability
+        per = cs["per_feature"]
+        names = list(per.keys())
+        sign = [per[n]["sign_agreement"] for n in names]
+        corr = [per[n]["magnitude_correlation"] for n in names]
+
+        axes = fig.subplots(1, 2, squeeze=False)[0]
+        y = np.arange(len(names))
+
+        # (1) sign-agreement — a probability in [0, 1]; 0.5 is chance (dashed line).
+        ax = axes[0]
+        ax.barh(y, np.nan_to_num(sign, nan=0.0), color=_C_POINT, alpha=0.85,
+                edgecolor="white")
+        ax.axvline(0.5, color=_C_REF, ls="--", lw=1.0, label="chance (0.5)")
+        ax.set_xlim(0, 1)
+        ax.set_yticks(y)
+        ax.set_yticklabels(names, fontsize=7)
+        ax.invert_yaxis()
+        ax.set_xlabel("sign-agreement", fontsize=8)
+        ax.set_title("Covariate-effect sign-agreement", fontsize=8)
+        ax.tick_params(labelsize=7)
+        ax.legend(fontsize=6, loc="lower right")
+
+        # (2) magnitude correlation — Pearson r in [-1, 1]; 0 (no relation) at center.
+        ax = axes[1]
+        vals = np.nan_to_num(corr, nan=0.0)
+        colors = [_C_MEAN if v < 0 else "#55A868" for v in vals]
+        ax.barh(y, vals, color=colors, alpha=0.85, edgecolor="white")
+        ax.axvline(0.0, color=_C_REF, lw=1.0)
+        # A NaN correlation (a covariate whose lambda has no variance) has no bar; say so.
+        for yi, c in zip(y, corr):
+            if not np.isfinite(c):
+                ax.text(0.02, yi, "n/a (no variance)", fontsize=6, va="center",
+                        color=_C_REF)
+        ax.set_xlim(-1, 1)
+        ax.set_yticks(y)
+        ax.set_yticklabels(names, fontsize=7)
+        ax.invert_yaxis()
+        ax.set_xlabel("magnitude correlation (Pearson r)", fontsize=8)
+        ax.set_title("Covariate-effect magnitude correlation", fontsize=8)
+        ax.tick_params(labelsize=7)
+
+        sub = (f"covariate-effect stability (NOT predictive coverage) - "
+               f"{cs['n_pairs']} fold pairs, feature-macro headline "
+               f"{cs['sign_agreement']:.2f} / {cs['magnitude_correlation']:.2f}")
+        if cs.get("partial_alignment"):
+            sub += f"  (partial: min {cs['topics_compared']['min']}/{cs['n_topics']} topics)"
+        # Caption below the band (a suptitle here would collide with the metric row).
+        fig.supxlabel(sub, fontsize=7.5)
 
     # --- supervised path ----------------------------------------------------
     def _draw_supervised(self, fig):

--- a/python/topica/viz/crossval.py
+++ b/python/topica/viz/crossval.py
@@ -145,6 +145,14 @@ class CrossValidationPlot(Panel):
         import numpy as np
 
         cs = self._result.covariate_stability
+        if cs.get("effects_near_zero"):
+            ax = fig.subplots(1, 1)
+            ax.text(0.5, 0.5,
+                    "covariate-effect stability undefined:\nlearned effects are ~0 "
+                    "(the model likely needs more fit iterations)",
+                    ha="center", va="center", fontsize=9, color=_C_MEAN)
+            ax.set_axis_off()
+            return
         per = cs["per_feature"]
         names = list(per.keys())
         sign = [per[n]["sign_agreement"] for n in names]

--- a/python/topica/viz/crossval.py
+++ b/python/topica/viz/crossval.py
@@ -1,0 +1,190 @@
+"""Panel: cross-validation results for :func:`topica.cross_validate`.
+
+One panel, two shapes, switched on ``result.kind``:
+
+- **topic path** — the per-fold distribution of each held-out quality metric
+  (perplexity / coherence / exclusivity), each fold a point with the macro mean
+  and +/- std overlaid, so a reader sees both the level and the fold-to-fold
+  spread the aggregate hides.
+- **supervised path** — the out-of-fold reliability plot: binned observed vs
+  predicted with the 45-degree line (built from ``result.calibration_table``),
+  beside the per-fold RMSE / R-squared spread.
+
+Like every :class:`~topica.viz.base.Panel`, it also exposes ``.to_frame()`` (the
+numbers) and ``.to_png()`` (the figure).
+"""
+
+from __future__ import annotations
+
+from .base import Panel
+
+# Shared palette, consistent with the other panels.
+_C_POINT = "#4C72B0"
+_C_MEAN = "#C44E52"
+_C_REF = "0.5"
+
+# The metrics the topic path reports, in display order, with a "higher is better?"
+# hint used only for the axis label (never to reorder or rescore).
+_TOPIC_METRICS = [
+    ("perplexity", "held-out perplexity", "lower better"),
+    ("coherence", "coherence", "higher better"),
+    ("exclusivity", "exclusivity", "higher better"),
+]
+
+
+class CrossValidationPlot(Panel):
+    """Per-fold cross-validation results, produced by :func:`topica.viz.plot_cv`.
+
+    Renders the topic-path metric distributions or the supervised-path OOF
+    calibration + error spread, depending on ``result.kind``.
+    """
+
+    title = "Cross-validation"
+
+    def __init__(self, result):
+        """
+        Parameters
+        ----------
+        result : CrossValResult
+            The output of :func:`topica.cross_validate`.
+        """
+        self._result = result
+        self._kind = getattr(result, "kind", "topic")
+
+    # --- data ---------------------------------------------------------------
+    def to_frame(self):
+        """The per-fold table behind the figure (``result.to_frame()``)."""
+        return self._result.to_frame()
+
+    def _topic_metric_values(self):
+        """Available metrics -> list of per-fold values (skipping folds that lack it)."""
+        out = []
+        for key, label, hint in _TOPIC_METRICS:
+            vals = [
+                r[key] for r in self._result.per_fold
+                if isinstance(r.get(key), (int, float)) and not isinstance(r.get(key), bool)
+            ]
+            if vals:
+                out.append((key, label, hint, vals))
+        return out
+
+    # --- layout -------------------------------------------------------------
+    def _figsize(self):
+        if self._kind == "supervised":
+            return (9.0, 4.0)
+        n = max(1, len(self._topic_metric_values()))
+        return (3.6 * n, 4.0)
+
+    def _draw(self, fig, **kwargs):
+        if self._kind == "supervised":
+            self._draw_supervised(fig)
+        else:
+            self._draw_topic(fig)
+        fig.suptitle(
+            f"{self.title}: {len(self._result.per_fold)} folds, "
+            f"strategy={self._result.folds.strategy}",
+            fontsize=9, y=1.02,
+        )
+
+    # --- topic path ---------------------------------------------------------
+    def _draw_topic(self, fig):
+        import numpy as np
+
+        metrics = self._topic_metric_values()
+        if not metrics:
+            ax = fig.subplots(1, 1)
+            ax.text(0.5, 0.5, "no per-fold metrics to plot", ha="center", va="center")
+            ax.set_axis_off()
+            return
+        axes = fig.subplots(1, len(metrics), squeeze=False)[0]
+        agg = self._result.aggregate
+        for ax, (key, label, hint, vals) in zip(axes, metrics):
+            vals = np.asarray(vals, dtype=float)
+            # Jitter the folds horizontally so overlapping values stay legible.
+            x = np.linspace(-0.18, 0.18, vals.size) if vals.size > 1 else np.zeros(1)
+            ax.scatter(x, vals, s=42, color=_C_POINT, alpha=0.85, zorder=3,
+                       edgecolor="white", linewidth=0.6, label="fold")
+            a = agg.get(key)
+            mean = float(a["mean"]) if a else float(vals.mean())
+            std = float(a["std"]) if a else float(vals.std())
+            ax.axhline(mean, color=_C_MEAN, lw=1.8, zorder=2,
+                       label=f"mean {mean:.4g}")
+            ax.axhspan(mean - std, mean + std, color=_C_MEAN, alpha=0.12, zorder=1)
+            ax.set_xlim(-0.5, 0.5)
+            ax.set_xticks([])
+            ax.set_title(f"{label}\n({hint})", fontsize=8)
+            ax.set_ylabel(label, fontsize=8)
+            ax.tick_params(labelsize=7)
+            ax.legend(fontsize=7, loc="best")
+
+    # --- supervised path ----------------------------------------------------
+    def _draw_supervised(self, fig):
+        import numpy as np
+
+        axes = fig.subplots(1, 2, squeeze=False)[0]
+
+        # (1) OOF reliability: binned observed vs predicted, with the 45-degree line.
+        ax = axes[0]
+        tbl = self._result.calibration_table
+        if tbl is not None and len(tbl):
+            pred = np.asarray(tbl["mean_pred"], dtype=float)
+            obs = np.asarray(tbl["mean_obs"], dtype=float)
+            n = np.asarray(tbl["n"], dtype=float)
+            sizes = 30 + 220 * (n / n.max()) if n.max() > 0 else 60
+            lo = float(min(pred.min(), obs.min()))
+            hi = float(max(pred.max(), obs.max()))
+            pad = 0.05 * (hi - lo + 1e-9)
+            ax.plot([lo - pad, hi + pad], [lo - pad, hi + pad], ls="--",
+                    color=_C_REF, lw=1.2, label="perfect (y = x)", zorder=1)
+            ax.scatter(pred, obs, s=sizes, color=_C_POINT, alpha=0.85, zorder=3,
+                       edgecolor="white", linewidth=0.6, label="bin (size = n)")
+            a = self._result.aggregate
+            slope = a.get("calibration_slope")
+            intc = a.get("calibration_intercept")
+            if slope is not None and np.isfinite(slope):
+                xs = np.array([lo - pad, hi + pad])
+                ax.plot(xs, intc + slope * xs, color=_C_MEAN, lw=1.6, zorder=2,
+                        label=f"fit (slope {slope:.2f})")
+            ax.set_xlabel("predicted (out-of-fold)", fontsize=8)
+            ax.set_ylabel("observed", fontsize=8)
+            ax.set_title("OOF calibration", fontsize=8)
+            ax.tick_params(labelsize=7)
+            ax.legend(fontsize=7, loc="best")
+        else:
+            ax.text(0.5, 0.5, "no calibration table\n(constant or too few predictions)",
+                    ha="center", va="center", fontsize=8)
+            ax.set_axis_off()
+
+        # (2) Per-fold error spread: RMSE and R-squared, each fold a point + mean line.
+        ax = axes[1]
+        self._draw_fold_spread(ax)
+
+    def _draw_fold_spread(self, ax):
+        import numpy as np
+
+        specs = [("rmse", "RMSE", _C_POINT), ("r2", "R2", "#55A868")]
+        available = []
+        for key, label, color in specs:
+            vals = [r[key] for r in self._result.per_fold
+                    if isinstance(r.get(key), float) and np.isfinite(r[key])]
+            if vals:
+                available.append((label, color, np.asarray(vals, dtype=float)))
+        if not available:
+            ax.text(0.5, 0.5, "no per-fold error metrics", ha="center", va="center",
+                    fontsize=8)
+            ax.set_axis_off()
+            return
+        for i, (label, color, vals) in enumerate(available):
+            x = i + (np.linspace(-0.14, 0.14, vals.size) if vals.size > 1 else np.zeros(1))
+            ax.scatter(x, vals, s=42, color=color, alpha=0.85, zorder=3,
+                       edgecolor="white", linewidth=0.6)
+            m = float(vals.mean())
+            ax.hlines(m, i - 0.25, i + 0.25, color=_C_MEAN, lw=1.8, zorder=2)
+            ax.annotate(f"{m:.3g}", (i, m), textcoords="offset points", xytext=(18, 0),
+                        fontsize=7, va="center", color=_C_MEAN)
+        ax.set_xticks(range(len(available)))
+        ax.set_xticklabels([label for label, _, _ in available], fontsize=8)
+        ax.set_xlim(-0.5, len(available) - 0.5)
+        ax.set_ylabel("per-fold value", fontsize=8)
+        ax.set_title("Per-fold error spread", fontsize=8)
+        ax.tick_params(labelsize=7)

--- a/tests/test_crossval.py
+++ b/tests/test_crossval.py
@@ -584,7 +584,7 @@ def test_covariate_effect_stability_keyatm():
             docs,
             covariates={"covariates": X},
             folds=3,
-            fit_kwargs={"iters": 40},
+            fit_kwargs={"iters": 300},
         )
     cs = result.covariate_stability
     assert cs is not None
@@ -616,7 +616,7 @@ def test_covariate_effect_stability_self_pair_agrees():
     keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
     X = labels.reshape(-1, 1).astype(float)
     m = topica.KeyATM(keywords, num_topics=2, seed=1)
-    m.fit(topica.Corpus.from_documents(docs), covariates=X, iters=60)
+    m.fit(topica.Corpus.from_documents(docs), covariates=X, iters=300)
     cs = _covariate_effect_stability([m, m])
     assert cs is not None
     assert cs["sign_agreement"] == 1.0
@@ -634,7 +634,7 @@ def test_covariate_effect_stability_headline_is_feature_macro():
     with pytest.warns(UserWarning):
         result = topica.cross_validate(
             lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
-            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 40},
+            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 300},
         )
     cs = result.covariate_stability
     per = cs["per_feature"]
@@ -648,6 +648,61 @@ def test_covariate_effect_stability_headline_is_feature_macro():
         assert cs["magnitude_correlation"] == pytest.approx(float(np.mean(mc)))
 
 
+def test_covariate_effect_stability_near_zero_is_undefined():
+    """An under-trained keyATM learns all-zero effects; the diagnostic must report
+    UNDEFINED, not a spurious sign-agreement of 1.0 (the fresh-user trap, #705)."""
+    from topica.crossval import _covariate_effect_stability
+
+    docs, labels = _synthetic_corpus(n_docs=60)
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    X = labels.reshape(-1, 1).astype(float)
+    # A tiny number of iterations leaves keyATM's feature_effects at exactly 0.
+    models = []
+    for s in (1, 2):
+        m = topica.KeyATM(keywords, num_topics=2, seed=s)
+        m.fit(topica.Corpus.from_documents(docs), covariates=X, iters=5)
+        models.append(m)
+    if not all(np.all(m.feature_effects[:, 1:] == 0) for m in models):
+        pytest.skip("keyATM warmed up faster than expected; not the near-zero regime")
+    cs = _covariate_effect_stability(models)
+    assert cs["effects_near_zero"] is True
+    assert np.isnan(cs["sign_agreement"])  # NOT 1.0
+    assert "WARNING" in cs["note"] and "more fit iterations" in cs["note"]
+
+
+def test_covariate_effect_stability_names_and_labels():
+    """covariate_names= flows into the per-feature table and wins over placeholders."""
+    docs, labels = _synthetic_corpus(n_docs=90)
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    X = np.column_stack([labels.astype(float), (1 - labels).astype(float)])
+    with pytest.warns(UserWarning):
+        result = topica.cross_validate(
+            lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
+            docs, covariates={"covariates": X}, covariate_names=["party", "not_party"],
+            folds=3, fit_kwargs={"iters": 300},
+        )
+    assert list(result.covariate_stability["per_feature"].keys()) == ["party", "not_party"]
+
+
+def test_covariate_names_length_mismatch_errors():
+    from topica.crossval import _resolve_covariate_names
+
+    with pytest.raises(ValueError, match="must match|learned"):
+        _resolve_covariate_names(["a", "b", "c"], {"covariates": None}, 2)
+
+
+def test_covariate_tuple_gives_clear_error():
+    """Passing the (matrix, names) tuple from one_hot straight through is caught with
+    an actionable message, not a raw numpy error (fresh-user docs trap, #705)."""
+    docs, labels = _synthetic_corpus(n_docs=40)
+    tup = (labels.reshape(-1, 1).astype(float), ["x"])
+    with pytest.raises(ValueError, match="unpack one_hot|is a tuple"):
+        topica.cross_validate(
+            lambda s: topica.STM(2, seed=s), docs,
+            covariates={"prevalence": tup}, folds=3, fit_kwargs={"iters": 20},
+        )
+
+
 def test_covariate_effect_stability_reports_topics_compared():
     """topics_compared / n_topics / partial_alignment expose how many of K topics each
     fold pair actually compared (so a silent topic-drop can't inflate stability)."""
@@ -657,7 +712,7 @@ def test_covariate_effect_stability_reports_topics_compared():
     with pytest.warns(UserWarning):
         result = topica.cross_validate(
             lambda s: topica.KeyATM(keywords, num_topics=3, seed=s),
-            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 40},
+            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 300},
         )
     cs = result.covariate_stability
     assert cs["n_topics"] == 3
@@ -676,7 +731,7 @@ def test_covariate_stability_frame_and_labels():
     with pytest.warns(UserWarning):
         result = topica.cross_validate(
             lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
-            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 40},
+            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 300},
         )
     frame = result.covariate_stability_frame()
     assert isinstance(frame, pd.DataFrame)
@@ -746,7 +801,7 @@ def test_plot_cv_covariate_panel():
     with pytest.warns(UserWarning):
         result = topica.cross_validate(
             lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
-            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 40},
+            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 300},
         )
     panel = viz.plot_cv(result)
     assert panel._has_covariate() is True

--- a/tests/test_crossval.py
+++ b/tests/test_crossval.py
@@ -624,6 +624,72 @@ def test_covariate_effect_stability_self_pair_agrees():
     assert np.isnan(cs["magnitude_correlation"]) or cs["magnitude_correlation"] > 0.99
 
 
+def test_covariate_effect_stability_headline_is_feature_macro():
+    """The headline must be the mean of the per-feature stats, not a pooled corr over
+    raw cells (which a high-variance covariate would dominate — adversarial finding)."""
+    docs, labels = _synthetic_corpus(n_docs=90)
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    # Two covariates on wildly different scales; the fix must weight them equally.
+    X = np.column_stack([labels.astype(float), 1000.0 * labels.astype(float)])
+    with pytest.warns(UserWarning):
+        result = topica.cross_validate(
+            lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
+            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 40},
+        )
+    cs = result.covariate_stability
+    per = cs["per_feature"]
+    assert len(per) == 2
+    sa = [v["sign_agreement"] for v in per.values() if np.isfinite(v["sign_agreement"])]
+    mc = [v["magnitude_correlation"] for v in per.values()
+          if np.isfinite(v["magnitude_correlation"])]
+    if sa:
+        assert cs["sign_agreement"] == pytest.approx(float(np.mean(sa)))
+    if mc:
+        assert cs["magnitude_correlation"] == pytest.approx(float(np.mean(mc)))
+
+
+def test_covariate_effect_stability_reports_topics_compared():
+    """topics_compared / n_topics / partial_alignment expose how many of K topics each
+    fold pair actually compared (so a silent topic-drop can't inflate stability)."""
+    docs, labels = _synthetic_corpus(n_docs=90)
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    X = labels.reshape(-1, 1).astype(float)
+    with pytest.warns(UserWarning):
+        result = topica.cross_validate(
+            lambda s: topica.KeyATM(keywords, num_topics=3, seed=s),
+            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 40},
+        )
+    cs = result.covariate_stability
+    assert cs["n_topics"] == 3
+    tc = cs["topics_compared"]
+    assert 1 <= tc["min"] <= tc["max"] <= 3
+    assert cs["partial_alignment"] == bool(tc["min"] < 3)
+
+
+def test_covariate_stability_frame_and_labels():
+    """covariate_stability_frame() is a per-feature DataFrame; a bare covariate matrix
+    gets a kwarg-based label, never a placeholder feature_0 with >1 covariate."""
+    pd = pytest.importorskip("pandas")
+    docs, labels = _synthetic_corpus(n_docs=90)
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    X = np.column_stack([labels.astype(float), (1 - labels).astype(float)])
+    with pytest.warns(UserWarning):
+        result = topica.cross_validate(
+            lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
+            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 40},
+        )
+    frame = result.covariate_stability_frame()
+    assert isinstance(frame, pd.DataFrame)
+    assert list(frame.columns[:2]) == ["feature", "sign_agreement"]
+    # Names fall back to the covariate kwarg, indexed — not positional feature_0.
+    assert list(frame["feature"]) == ["covariates[0]", "covariates[1]"]
+    # No-covariate run returns None from the frame accessor.
+    plain = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=3, fit_kwargs={"iters": 20}
+    )
+    assert plain.covariate_stability_frame() is None
+
+
 # ---------------------------------------------------------------------------
 # plot_cv (#705) — the viz panel
 # ---------------------------------------------------------------------------
@@ -663,4 +729,27 @@ def test_plot_cv_supervised_path():
     assert fig is not None
     import matplotlib.pyplot as plt
 
+    plt.close(fig)
+
+
+def test_plot_cv_covariate_panel():
+    """When the run carries covariate-effect stability, the topic figure adds the
+    covariate band (the reason a covariate model was run)."""
+    pytest.importorskip("matplotlib")
+    import matplotlib.pyplot as plt
+
+    import topica.viz as viz
+
+    docs, labels = _synthetic_corpus(n_docs=90)
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    X = labels.reshape(-1, 1).astype(float)
+    with pytest.warns(UserWarning):
+        result = topica.cross_validate(
+            lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
+            docs, covariates={"covariates": X}, folds=3, fit_kwargs={"iters": 40},
+        )
+    panel = viz.plot_cv(result)
+    assert panel._has_covariate() is True
+    fig = panel.to_png()
+    assert fig is not None
     plt.close(fig)

--- a/tests/test_crossval.py
+++ b/tests/test_crossval.py
@@ -565,3 +565,102 @@ def test_to_frame():
     df = result.to_frame()
     assert len(df) == 4
     assert "perplexity" in df.columns
+
+
+# ---------------------------------------------------------------------------
+# Covariate-effect fold-stability (#705) — keyATM covariate lambda
+# ---------------------------------------------------------------------------
+
+
+def test_covariate_effect_stability_keyatm():
+    """keyATM covariate lambda gets a sign-agreement + magnitude-correlation surface,
+    NOT predictive coverage, and never lands in a coverage_ field."""
+    docs, labels = _synthetic_corpus(n_docs=90)
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    X = labels.reshape(-1, 1).astype(float)
+    with pytest.warns(UserWarning):  # the marginal-covariate warning still fires
+        result = topica.cross_validate(
+            lambda s: topica.KeyATM(keywords, num_topics=2, seed=s),
+            docs,
+            covariates={"covariates": X},
+            folds=3,
+            fit_kwargs={"iters": 40},
+        )
+    cs = result.covariate_stability
+    assert cs is not None
+    assert -1.0 <= cs["sign_agreement"] <= 1.0
+    assert cs["n_pairs"] == 3  # 3 fold pairs from 3 folds
+    assert "per_feature" in cs and len(cs["per_feature"]) == cs["n_features"]
+    # It is explicitly NOT coverage and must not leak into any coverage_ field.
+    assert "not predictive coverage" in cs["note"].lower()
+    assert not any(k.startswith("coverage_") for k in result.aggregate)
+    assert not any(k.startswith("coverage") for k in cs)
+    assert "covariate-effect stability" in result.summary()
+    assert "NOT predictive coverage" in result.summary()
+
+
+def test_covariate_effect_stability_none_without_covariates():
+    """Plain LDA has no lambda, so there is nothing to report."""
+    docs, _ = _synthetic_corpus(n_docs=40)
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=3, fit_kwargs={"iters": 30}
+    )
+    assert result.covariate_stability is None
+
+
+def test_covariate_effect_stability_self_pair_agrees():
+    """Identical covariate fits must have perfect sign-agreement and magnitude corr."""
+    from topica.crossval import _covariate_effect_stability
+
+    docs, labels = _synthetic_corpus(n_docs=60)
+    keywords = {"animals": ["cat", "dog", "pet"], "finance": ["bank", "loan", "money"]}
+    X = labels.reshape(-1, 1).astype(float)
+    m = topica.KeyATM(keywords, num_topics=2, seed=1)
+    m.fit(topica.Corpus.from_documents(docs), covariates=X, iters=60)
+    cs = _covariate_effect_stability([m, m])
+    assert cs is not None
+    assert cs["sign_agreement"] == 1.0
+    # A self-pair is a perfect line; corr is 1.0 (or NaN only if lambda is constant).
+    assert np.isnan(cs["magnitude_correlation"]) or cs["magnitude_correlation"] > 0.99
+
+
+# ---------------------------------------------------------------------------
+# plot_cv (#705) — the viz panel
+# ---------------------------------------------------------------------------
+
+
+def test_plot_cv_topic_path():
+    pytest.importorskip("matplotlib")
+    import topica.viz as viz
+
+    docs, _ = _synthetic_corpus()
+    result = topica.cross_validate(
+        lambda s: topica.LDA(2, seed=s), docs, folds=4, fit_kwargs={"iters": 30}
+    )
+    panel = viz.plot_cv(result)
+    df = panel.to_frame()
+    assert len(df) == 4
+    fig = panel.to_png()
+    assert fig is not None
+    import matplotlib.pyplot as plt
+
+    plt.close(fig)
+
+
+def test_plot_cv_supervised_path():
+    pytest.importorskip("matplotlib")
+    pytest.importorskip("pandas")
+    import topica.viz as viz
+
+    docs, y = _supervised_corpus(n_docs=80)
+    result = topica.cross_validate(
+        lambda s: topica.SupervisedLDA(2, seed=s), docs, y=y, folds=4,
+        fit_kwargs={"iters": 25},
+    )
+    panel = viz.plot_cv(result)
+    assert panel._kind == "supervised"
+    fig = panel.to_png()
+    assert fig is not None
+    import matplotlib.pyplot as plt
+
+    plt.close(fig)


### PR DESCRIPTION
Closes #705. Lands the two additive follow-ups scoped in the #701 cross-validation design and deferred from #703/#704 to keep those diffs reviewable.

## 1. `topica.viz.plot_cv(result)`
A `Panel` that switches on `result.kind`:
- **Topic path** — per-fold distribution of each held-out metric (perplexity / coherence / exclusivity), each fold a point with the macro mean and ±1 std overlaid, so the fold-to-fold spread the aggregate hides is visible.
- **Supervised path** — the out-of-fold reliability plot (binned observed vs predicted with the 45° line, from `result.calibration_table`) beside the per-fold RMSE / R² spread.

Like every `topica.viz` panel it exposes `.to_frame()` and `.to_png()`/`.to_pdf()`.

## 2. keyATM covariate-effect fold-stability
`result.covariate_stability` for models that learn a λ (keyATM covariate, DMR, GDMR). After aligning topics across every fold pair (vocabulary-aware), it reports the **sign-agreement rate** and **magnitude (Pearson) correlation** of the fold-aligned coefficients, pooled and per feature.

Per both Gate A/B reviewers, this is deliberately **not** predictive coverage and is **never** stored in a `coverage_*` field: λ has no per-document truth, and the conditional `feature_effect_se` is under-dispersed, so a ±2·SE-overlap statistic would read as spuriously "stable". `summary()` labels it "NOT predictive coverage".

## Tests / gates
- New tests cover both `plot_cv` paths, the covariate-stability self-pair sanity check (perfect sign-agreement + magnitude corr), the no-covariate `None` case, and the coverage-field guard. `tests/test_crossval.py` + `tests/test_viz*.py`: 76 passed.
- `mkdocs build --strict` clean; `scripts/preflight.sh` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)