### PR TITLE
docs: remove stale comments that outlived their refactors

### DIFF
--- a/benchmarks/model_coverage.md
+++ b/benchmarks/model_coverage.md
@@ -19,14 +19,9 @@ Two independent axes:
 Fresh side-by-side fit is possible, so these carry both an agreement number and a
 wall-clock speedup.
 
-**Wired now (the table's current rows):** LDA, DMR, GDMR, PA, DTM, LabeledLDA,
-OnlineLDA, KeyATM, STM, STM/content, SupervisedLDA (var), SupervisedLDA (gibbs),
-NMF, LSA, FASTopic, ProdLDA, BERTopic, SemanticSignalSeparation.
-
-**Being added (this pass):** CTM, HDP*, HLDA*, SeededLDA.  (*K discovered.)
-
-**Runnable locally but not yet wired (candidates to add):** ETM, DETM, InfoCTM,
-PT, RTM, Scholar, TBIP, Wordfish, EmbeddingLDA.
+The table below is the list of wired models — it is the single source of truth, so
+new rows do not need a second edit here. HDP and HLDA discover K rather than
+taking it as input.
 
 | Model | Reference | Local? | Frozen gold |
 |---|---|:--:|:--:|

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -16,8 +16,9 @@ them by path + digest rather than embedding them.
 Scope: the manifest, the fingerprint-v1 contract below, ``record_fit`` for the
 count-based and structural models, ``verify`` with a textual report, and (V2) an
 HTML / Markdown *analysis card* via :meth:`AnalysisManifest.render` /
-:meth:`~AnalysisManifest.to_markdown`. Generic diagnostic auto-capture and
-manifest comparison remain future work.
+:meth:`~AnalysisManifest.to_markdown` plus manifest-to-manifest comparison via
+:meth:`AnalysisManifest.compare`. Generic diagnostic auto-capture remains future
+work.
 
 Fingerprint-v1 contract ("fp1")
 -------------------------------

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -1,7 +1,7 @@
 //! Rust-side estimator conformance — the analog of `python/topica/conformance.py`.
 //! Catches contract gaps in `cargo test --lib`, at the source, before the Python
-//! layer or a release. The full multi-model registry and EXEMPT set are populated
-//! in a later step; this file establishes the check.
+//! layer or a release. The multi-model registry and its structural exemptions
+//! live in `RUST_ESTIMATORS` below.
 
 use crate::estimator::{DirichletModel, Estimator, ModelFamily};
 use crate::variational::LogisticNormalModel;

--- a/src/rtm.rs
+++ b/src/rtm.rs
@@ -28,7 +28,6 @@
 //!
 //! Pure Rust, no PyO3. Fitted state stores matrices as `Vec<Vec<f64>>`.
 
-use crate::corpus::Corpus;
 use crate::estimator::{Estimator, ModelFamily};
 use crate::mathfun::log_gamma as lgamma;
 use crate::optimize::digamma;
@@ -915,12 +914,8 @@ impl Estimator for RTMModel {
     }
 }
 
-// A thin wrapper matching the scaffold's `fit(corpus, ...)` shape is intentionally
-// omitted: RTM needs the link graph, so the binding calls `fit_rtm` directly.
-#[allow(dead_code)]
-pub fn fit<R: Rng>(_corpus: &Corpus, _num_topics: usize, _iters: usize, _rng: &mut R) -> RTMModel {
-    unreachable!("RTM is fit via fit_rtm(docs, edges, params, rng)")
-}
+// RTM needs the link graph, so there is no `fit(corpus, ...)` wrapper matching the
+// scaffold shape: the binding calls `fit_rtm(docs, edges, params, rng)` directly.
 
 #[cfg(test)]
 mod tests {

--- a/topica-core/src/variational/laplace.rs
+++ b/topica-core/src/variational/laplace.rs
@@ -1,6 +1,6 @@
 //! The parallel Laplace variational E-step driver shared by the logistic-normal
-//! models (CTM/STM, and STS in a later step). It owns only the parallel iteration
-//! and ordering: per-document inference is independent, so it runs under rayon,
+//! models (CTM/STM and STS). It owns only the parallel iteration and ordering:
+//! per-document inference is independent, so it runs under rayon,
 //! but results are collected in DOCUMENT ORDER and returned that way, so the
 //! caller's serial sufficient-statistic reduce sums in the exact same order as a
 //! single-threaded loop would — the fit stays bit-for-bit deterministic

--- a/topica-core/src/variational/mod.rs
+++ b/topica-core/src/variational/mod.rs
@@ -1,8 +1,7 @@
 //! Shared kernels for the logistic-normal variational family (CTM/STM/STS/ETM):
-//! L-BFGS, the Laplace E-step driver, the Σ/Γ M-step, and sparse-doc prep. In
-//! later steps the submodules `lbfgs`, `laplace`, `mstep`, `sparse` are added and
-//! the model fits are rewired through them; for now this module only declares the
-//! family trait.
+//! L-BFGS, the Laplace E-step driver, the Σ/Γ M-step, and sparse-doc prep. The
+//! submodules `lbfgs`, `laplace`, `mstep`, `sparse` and `svi` own those kernels;
+//! this module re-exports them and declares the family trait.
 
 pub mod lbfgs;
 pub use lbfgs::{lbfgs_minimize, lbfgs_minimize_status, lbfgs_minimize_status_capped};

--- a/topica-core/src/variational/svi.rs
+++ b/topica-core/src/variational/svi.rs
@@ -1,6 +1,6 @@
-//! Shared scaffolding for stochastic variational inference (SVI / minibatch EM)
-//! across the logistic-normal family (CTM/STM, STS). The per-model fits own
-//! their sufficient statistics and (non-conjugate) topic-word M-steps; this module
+//! Shared scaffolding for stochastic variational inference (SVI / minibatch EM).
+//! Used by the logistic-normal CTM/STM fits and by OnlineLDA. The per-model fits
+//! own their sufficient statistics and (non-conjugate) topic-word M-steps; this module
 //! owns only the two pieces that are identical everywhere: the Robbins-Monro
 //! learning-rate schedule and the deterministic per-epoch document shuffle. Both
 //! draw from the model's own `Rng`, so an SVI fit is seed-reproducible.


### PR DESCRIPTION
## What

An audit for comments that no longer describe the code found seven. Comments only, apart from one dead function.

The headline result is that hygiene here is good: **zero** TODO/FIXME/XXX/HACK markers across 185 Rust/Python source files, no docstring↔signature drift (every numpydoc `Parameters` block checked against the real AST signature), and no doc-claimed default that contradicts its `#[pyo3(signature = ...)]`. Eight numeric claims in comments ("defaults to 0.1", "clamped at N") were each chased to the constant and all were accurate. What did rot was concentrated in one place: **module headers written mid-refactor that were never revisited when the refactor finished.**

Closes #

## How

Four staged-refactor headers whose migration completed:

- **`topica-core/src/variational/mod.rs`** claimed the module "only declares the family trait" and that `lbfgs`/`laplace`/`mstep`/`sparse` would arrive "in later steps". All four are declared immediately below it and ~10 models import them.
- **`topica-core/src/variational/laplace.rs`** listed STS as arriving "in a later step". STS calls `laplace_estep` at `sts.rs:460` and `sts.rs:1079`.
- **`src/conformance.rs`** said the registry and EXEMPT set are "populated in a later step". `RUST_ESTIMATORS` carries 37 entries with `exempt` fields plus a `registry_is_well_formed` test.
- **`topica-core/src/variational/svi.rs`** was wrong in both directions: it named STS as a consumer (STS has none) and omitted OnlineLDA, which uses `svi::rho` and `svi::shuffled_order`.

Three comments contradicted by the code they annotate:

- **`src/rtm.rs`** said a scaffold-shaped `fit(corpus, ...)` wrapper "is intentionally omitted" — while defining exactly that wrapper on the next line as an `unreachable!` stub, silenced with `#[allow(dead_code)]` and called from nowhere. Dropped the stub and the `crate::corpus::Corpus` import that existed solely to type its unused parameter. The note now records why no wrapper exists.
- **`python/topica/manifest.py`** said manifest comparison "remain[s] future work". `AnalysisManifest.compare` is implemented and returns a populated `ManifestDiff`. Diagnostic auto-capture, the other half of that sentence, genuinely is still pending and is kept.
- **`benchmarks/model_coverage.md`** carried three prose lists ("wired now", "being added", "not yet wired") that its own table below had overtaken — every model in the latter two is a table row.

One deliberate scope call on that last file. The obvious fix is to restate the table correctly in prose, and that is what I first wrote — then rebasing onto current `main` showed the table had grown 23 → 29 rows (CombinedTM, ZeroShotTM, GSDMM, BTM, Top2Vec, STS) while the prose stayed frozen, so the restated list was *already* stale before it shipped. Duplicating a table immediately above that table is the mechanism of the drift, so the prose now points at the table as the single source of truth instead. Net −5 lines of prose that no longer needs a second edit per model.

Negative-space comments were audited too and mostly **left alone** — roughly 35 of the "we don't do X" kind turned out to be load-bearing, each sitting next to a guard and naming the failure it prevents ("would silently corrupt an existing count", "would silently return all-zeros", "`np.True_ is True` is False, which would silently drop the flag"). The `pa.rs:481` → header cross-reference was chased and resolves correctly. Only the `rtm.rs` one described a decision with nothing to point at.

## Validation

Nothing here changes behavior, so the bar is that the dead-code removal is genuinely dead and the tree still builds and passes.

- [x] `cargo test --lib` passes — **331 passed, 0 failed, 1 ignored**
- [x] `python -m pytest tests/ -q` — **4672 passed, 75 skipped, 1 failed** (pre-existing, see below)
- [ ] `./scripts/preflight.sh` clean — fails on that same pre-existing test, nothing else
- [x] docs build clean (`mkdocs build --strict`) — a module docstring changed, so this was run
- [x] the `.pyi` stub is in sync — no binding signature changed

`rtm::fit` was confirmed dead before removal: no caller anywhere in `src`, `topica-core`, or `tests`. `cargo test --lib rtm` passes all 9 RTM tests. `cargo fmt --check` and `cargo clippy --lib` are clean, with no new warnings in any touched file.

**The one failure is not from this branch.** `test_stub_sync.py::test_no_members_missing_from_stub[Corpus]` reports `compiled members missing from stub: ['from_matrix', 'kept_features', 'n_tokens']`. Those come from the checked-in `python/topica/_topica.abi3.so`, built from the `claude/issue-575-mtm-from-matrix` branch (PR #685), which adds them to `Corpus` — while `main`'s `_topica.pyi` has no such feature yet. I confirmed it by checking out pristine `main` (`7fa85bf`) with this commit absent and getting the identical failure. This diff touches no stub and no `Corpus`.

Two honesty notes on the numbers above. Because that prebuilt `.so` is what is on the path, the pytest run exercised a binary from a different branch rather than a fresh compile of this one — acceptable for a comment-only change, but it is not a clean-room run. And `cargo clippy --lib` does emit one warning, `DEFAULT_CONCENTRATION_MAX` is never used, which also reproduces on pristine `main`; the constant is live at `src/python/mod.rs:296`, behind a feature gate a bare `--lib` build does not activate.

## Notes

Worth a lint. This repo does large staged refactors, and the module header is where the plan gets written and then forgotten — a CI grep for `later step|for now this|not yet wired` inside `//!` blocks would have caught four of the seven. Happy to add it if you want it.

Two things I found and deliberately did **not** change, as they are judgement calls rather than stale facts:

- `manifest.py` labels sections `(V2)` at lines 484/519/543 while `SCHEMA_VERSION = 1`. Not false — "V2" reads as a feature wave, not the schema version — but it invites exactly the misreading the module docstring above it had already fallen into.
- `scripts/new_model.py` and `tests/test_scaffold_guard.py` are full of `SCAFFOLD(...)` markers. Those are a code generator's template and its guard test, working as intended.

---
_Generated by [Claude Code](https://claude.ai/code/session_011LSRmXE8QX4znuxX5DCEYv)_