### PR TITLE
Move EmbeddingLDA to experimental + validation-status audit (#660)

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ The right first choice when your design calls for one: short text, change over t
 | `ETM` | text, embeddings | variational | seed-reproducible | Embedded topic model: topic-word distributions factored through word embeddings. |
 | `GaussianLDA` | text, embeddings | gibbs | seed-reproducible | Gaussian LDA (Das, Zaheer & Dyer 2015): each topic is a Gaussian over the word-embedding space (Normal-Inverse-Wishart prior), so topics generalize over semantically similar words. Collapsed Gibbs with a Student-t posterior predictive and rank-1 Cholesky up/downdates. |
 | `FASTopic` | text, embeddings | optimal-transport | seed-reproducible | Topics from optimal-transport plans between document, topic, and word embeddings. |
-| `EmbeddingLDA` | text, embeddings, seeds | gibbs | seed-reproducible | Seeded LDA whose seed sets are expanded with nearest neighbors in an embedding space. |
 | `CombinedTM` | text, embeddings | vae | seed-reproducible | Contextualized ProdLDA: encoder reads the bag of words plus a document embedding. |
 | `ZeroShotTM` | text, embeddings | vae | seed-reproducible | Contextualized ProdLDA: encoder reads the document embedding alone, enabling cross-lingual transfer. |
 | `InfoCTM` | text, dictionary | vae | seed-reproducible | Cross-lingual: two ProdLDA models aligned by a bilingual dictionary through a mutual-information term. |
@@ -197,7 +196,7 @@ The right first choice when your design calls for one: short text, change over t
 
 ### Experimental
 
-Shipped before a published paper and reference-implementation parity (topica's bar for a validated model). Gated: call `topica.enable_experimental()` (or set `TOPICA_EXPERIMENTAL=1`) before use. These may change or be removed without a deprecation cycle.
+Not (yet) on the validated roster, on one of two grounds: the model is unpublished (a topica original with no paper), or it is a published method whose benefit has not held up against a simpler baseline. A published method with faithful inference stays validated even when its basis is planted-recovery, so planted validation alone does not land a model here. Gated: call `topica.enable_experimental()` (or set `TOPICA_EXPERIMENTAL=1`) before use. These may change or be removed without a deprecation cycle. For the triple gate a model clears to graduate to the validated roster, and where every model stands on validation evidence, see [Validation & graduation](https://nealcaren.github.io/topica/contributing/validation/).
 
 | Model | Brings | Inference | Reproducibility | Summary |
 |---|---|---|---|---|
@@ -205,6 +204,7 @@ Shipped before a published paper and reference-implementation parity (topica's b
 | `NarrativeTM` | text | gibbs | seed-reproducible | Intra-document narrative trajectory model: captures how topic prevalence shifts across the progress of a text. |
 | `IdealPointTM` | text, embeddings | variational | seed-reproducible | Topic model with a latent ideal-point head: each author gets a low-dimensional position that shifts within-topic word choice, with a per-topic discrimination. Consumes word tokens as counts (Wordfish with topics) or, when word embeddings are supplied to fit, factored through them as in ETM. The unsupervised, latent-trait twin of the STM content covariate. |
 | `IdealPointSentenceTM` | text, embeddings | em | seed-reproducible | Continuous ideal-point topic model over sentence/document embeddings: topics are Gaussian clusters whose centroids are displaced by a latent author position. The sentence-embedding sibling of IdealPointTM, fit by EM. |
+| `EmbeddingLDA` | text, embeddings | gibbs | seed-reproducible | LDA anchored by pre-trained embeddings: k-means clusters the vocabulary embeddings, seeds each topic with the words nearest a cluster centroid, and (optionally) biases each document's mixture toward its own embedding. A topica original; validated by planted-recovery only. |
 
 <!-- END MODEL TABLE -->
 

--- a/docs/contributing/model-map.md
+++ b/docs/contributing/model-map.md
@@ -110,7 +110,7 @@ Column meanings:
 | `IdealPointTM` | `src/idealpoint.rs` | `src/python/idealpoint.rs` | variational EM + ideal-point head | default | `tests/test_idealpoint.py`, `tests/test_idealpoint_counts.py` |
 | `IdealPointSentenceTM` | `src/sentence_ideal.rs` | `src/python/sentence_ideal.rs` | Gaussian-cluster EM over embeddings | default | `tests/test_sentence_ideal.py` |
 | `FASTopic` | `src/fastopic.rs` | `src/python/mod.rs` | reverse-mode Sinkhorn optimal transport | default | `parity/fastopic_gold.py`, `parity/fastopic_compare.py` |
-| `EmbeddingLDA` | `python/topica/embedding.py` | — _(Python)_ | seeded Gibbs + embedding NN expansion (Python) | default | `parity/embeddinglda_gold.py`, `tests/test_embedding_lda.py` |
+| `EmbeddingLDA` | `python/topica/embedding.py` | — _(Python)_ | k-means embedding seeding over a SeededLDA Gibbs core (Python); planted-recovery gold only, no external reference | default | `parity/embeddinglda_gold.py`, `tests/test_embedding_lda.py` |
 | `CombinedTM` | `src/prodlda.rs` | `src/python/neural.rs` | contextualized ProdLDA VAE (prodlda.rs) | default | `parity/combinedtm_gold.py`, `parity/combinedtm_compare.py` |
 | `ZeroShotTM` | `src/prodlda.rs` | `src/python/neural.rs` | contextualized ProdLDA VAE (prodlda.rs) | default | `parity/zeroshot_gold.py`, `parity/zeroshot_compare.py` |
 | `InfoCTM` | `src/infoctm.rs` | `src/python/neural.rs` | two ProdLDA VAEs + TAMI alignment (prodlda.rs) | default | `parity/infoctm_gold.py`, `parity/infoctm_compare.py` |

--- a/docs/contributing/validation.md
+++ b/docs/contributing/validation.md
@@ -1,0 +1,185 @@
+# Validation status and experimental graduation
+
+Every model topica ships is validated before it enters the roster, but the
+*evidence* behind that word varies. Some models are checked bit-for-bit against a
+maintained reference implementation (MALLET, gensim, R `stm`, tomotopy, the
+`bertopic`/`fastopic`/`corextopic` packages, a paper-faithful PyTorch or NumPy
+port). Others have no runnable reference to check against, so they are validated
+by *planted recovery*: we fit on a synthetic corpus with a known, identifiable
+structure, freeze the solution, and assert the fit reproduces it and recovers the
+planted topics. This page states the bar for graduating a model from the
+experimental tier to the validated roster, and records where every model stands.
+
+## The experimental tier
+
+A model is **experimental** when it has not earned a place on the validated
+roster, on either of two grounds:
+
+- it is **unpublished** — a topica original with no paper, so it can only ever be
+  validated by planted recovery, never against an independent yardstick; or
+- it is a **published method whose benefit has not held up** — topica ships it,
+  its inference is faithful, but it does not demonstrably beat a simpler baseline,
+  so shipping it as validated would overstate what it buys a user.
+
+A published method with faithful inference stays **validated** even when its
+accuracy basis is planted-recovery, because for many methods no maintained
+reference implementation exists to check against; planted-recovery is a
+validation *basis*, not an experimental marker. So the experimental flag is about
+whether the model has *earned the roster* (a paper and a demonstrated benefit),
+not about code quality: an experimental model's inference can be faithful,
+deterministic, and fully tested and still be experimental.
+
+Experimental models are gated at construction (call
+`topica.enable_experimental()`, or set `TOPICA_EXPERIMENTAL=1`) and listed apart
+from the validated roster; they may change or be removed without a deprecation
+cycle.
+
+## The triple gate
+
+A model graduates from experimental to validated only when it passes all three
+gates. Each maps onto machinery topica already runs when a model is added.
+
+1. **Accuracy gate.** Cross-implementation reference parity where a reference
+   exists (the `parity/*_gold.py` / `*_compare.py` bar); planted-recovery plus the
+   reference-free invariant suite (`tests/test_model_invariants.py`, issue #420)
+   where none does, with the limitation documented. A planted gold that a fixed
+   corpus cannot use to distinguish the model from a simpler baseline does not
+   clear this gate on its own.
+2. **Adversarial gate.** The `add-topic-model` dual review: one faithful-parity
+   reviewer and one adversarial reviewer, run independently, with every finding
+   in the code, the metadata, or the validation layer resolved.
+3. **User gate.** The `sample-user` two-agent first-time-researcher usability
+   audit, run on a real dataset end to end (vocabulary, choosing K, fit,
+   robustness, validation, covariate effects, reporting), with the friction it
+   surfaces filed and the blockers fixed.
+
+All three green is the graduation criterion. A model that clears accuracy and
+adversarial but not the user gate is validated-but-rough, not ready to graduate;
+one that clears the user gate on a model whose planted gold cannot tell it apart
+from a baseline has not cleared accuracy.
+
+## Evidence levels
+
+The audit below records each model on three axes.
+
+- **Paper** — whether the method has a published paper. A *topica original* is a
+  construction with no paper; it can only ever be validated by planted recovery,
+  so it starts experimental by definition.
+- **Validation basis** — how the accuracy gate is met:
+    - *cross-impl* — checked against a maintained, runnable reference
+      implementation.
+    - *paper-oracle* — checked against a result computed directly from the
+      paper's equations (a hand-written reference), not a maintained library.
+    - *planted* — planted-recovery / self-consistency gold only; no external
+      reference exists to benchmark against.
+    - *behavioral* — exercised for correct orchestration but not numeric parity
+      (the LLM-driven model, whose output is model-bounded).
+- **Experimental** — whether the model is gated, and whether that status is
+  justified by the first two columns.
+
+*planted* is a defensible basis, not a defect: for most of the models that carry
+it, no maintained or deterministic reference implementation exists (gensim,
+tomotopy, and R do not implement SAGE, HDP as a fit-and-freeze target, HLDA, PA,
+PT, SupervisedLDA, ETM, DETM, or Topics-over-Time in a form we can pin). The point
+of the audit is honesty about the two evidence levels the single word "validated"
+spans, not a claim that the planted-basis models are wrong; prior review deemed
+their cores faithful.
+
+## Per-model audit (topica 0.55.0)
+
+Validated roster, by validation basis.
+
+### Cross-implementation reference parity
+
+| Model | Paper | Reference checked against |
+|---|---|---|
+| `LDA` | Blei et al. 2003 | Java MALLET |
+| `OnlineLDA` | Hoffman et al. 2010 | gensim |
+| `CTM` | Blei & Lafferty 2007 | R `stm` (as CTM) |
+| `ProdLDA` | Srivastava & Sutton 2017 | PyTorch AVITM |
+| `NMF` | Lee & Seung 1999 | scikit-learn |
+| `LSA` | Deerwester et al. 1990 | scikit-learn |
+| `AnchorLDA` | Arora et al. 2013 | `anchor-topic` (Q + given-anchor L2 recovery; the default KL + tempering is a topica extension, not reference-checked) |
+| `PolylingualLDA` | Mimno et al. 2009 | topica cross-lingual parity harness |
+| `STM` | Roberts et al. 2014 | R `stm` |
+| `STS` | Chen & Mankad 2024 | R `stm` / `sts` |
+| `DMR` | Mimno & McCallum 2008 | Java MALLET |
+| `GDMR` | Terragni et al. 2020 | tomotopy |
+| `RTM` | Chang & Blei 2010 | NumPy reference (variational + Gibbs) |
+| `FactorialLDA` | Paul & Dredze 2012 | reference Java (finite-difference + planted recovery) |
+| `KeyATM` | Eshima et al. 2024 | R `keyATM` |
+| `SeededLDA` | Watanabe & Baturo 2024 | R `seededlda` |
+| `GuidedNMF` | Vendrow et al. 2021 | `ssnmf` |
+| `KeyNMF` | Kristensen-McLachlan 2024 | `turftopic` (method-level, corrected) |
+| `CorEx` | Gallagher et al. 2017 | `corextopic` |
+| `AuthorTopic` | Rosen-Zvi et al. 2004 | gensim |
+| `MGLDA` | Titov & McDonald 2008 | tomotopy |
+| `LabeledLDA` | Ramage et al. 2009 | Java MALLET |
+| `BTM` | Yan et al. 2013 | reference BTM |
+| `DTM` | Blei & Lafferty 2006 | gensim `LdaSeqModel` |
+| `BERTopic` | Grootendorst 2022 | `bertopic` package |
+| `Top2Vec` | Angelov 2020 | `bertopic` / `top2vec` |
+| `SemanticSignalSeparation` | Kristensen-McLachlan et al. 2024 | `turftopic` |
+| `GaussianLDA` | Das et al. 2015 | Java oracle |
+| `Wordfish` | Slapin & Proksch 2008 | R |
+| `TopicalNGrams` | Wang et al. 2007 | Java MALLET |
+| `TBIP` | Vafa et al. 2020 | paper-derived reference |
+| `PartyEmbeddings` | Rheault & Cochrane 2020 | comparison harness |
+| `FASTopic` | Wu et al. 2024 | `fastopic` package |
+| `CombinedTM` | Bianchi et al. 2021 | PyTorch AVITM |
+| `ZeroShotTM` | Bianchi et al. 2021 | PyTorch AVITM |
+| `InfoCTM` | Wu et al. 2023 | paper-derived PyTorch |
+
+### Paper-oracle parity
+
+| Model | Paper | Oracle |
+|---|---|---|
+| `DiscLDA` | Lacoste-Julien et al. 2008 | paper's 20-Newsgroups protocol, replicated |
+| `Wordshoal` | Lauderdale & Herzog 2016 | from-paper R oracle (no installable reference) |
+
+### Planted-recovery only (no external reference)
+
+These are validated, but by planted recovery / self-consistency plus the invariant
+suite, because no maintained reference implementation exists to benchmark against.
+This is the two-evidence-levels gap issue #660 opened; it is recorded here rather
+than hidden.
+
+| Model | Paper | Note |
+|---|---|---|
+| `SAGE` | Eisenstein et al. 2011 | no gensim/tomotopy/R implementation |
+| `HDP` | Teh et al. 2006 | Dirichlet-process mixture; concentration equations faithful to blei-lab/hdp |
+| `HLDA` | Blei et al. 2003 | learns a topic tree; no fit-and-freeze reference |
+| `PA` | Li & McCallum 2006 | super/sub-topic DAG |
+| `PT` | Zuo et al. 2016 | pseudo-document short-text model |
+| `GSDMM` | Yin & Wang 2014 | short-text DMM |
+| `SupervisedLDA` | Blei & McAuliffe 2007 | supervised response head |
+| `ETM` | Dieng et al. 2020 | embedded topic model (variational-EM path) |
+| `DETM` | Dieng et al. 2019 | dynamic embedded topic model |
+| `TopicsOverTime` | Wang & McCallum 2006 | per-topic Beta over time; validated by planted + NumPy method-of-moments + SciPy |
+| `Scholar` | Card et al. 2018 | VAE core shares ProdLDA's AVITM validation; the label/covariate heads are planted-recovery only |
+
+### Behavioral
+
+| Model | Paper | Note |
+|---|---|---|
+| `TopicGPT` | Pham et al. 2024 | LLM-driven; validated for orchestration with a deterministic fake backend, not numeric parity (output is model-bounded) |
+
+### Experimental tier
+
+Gated behind `enable_experimental()`. The right-hand column records whether the
+experimental status is justified and what would let the model graduate.
+
+| Model | Paper | Basis | Status |
+|---|---|---|---|
+| `TensorLDA` | Kangaslahti et al. 2026 | planted gold + opt-in TensorLy compare | **Graduation candidate.** It has a paper and an opt-in cross-implementation compare (`parity/tlda_compare.py` against `tensorly/tlda`, run when `TOPICA_TLDA_REF` points at a checkout). Running that compare as the standing accuracy gate, plus the adversarial and user gates, would clear the triple gate. |
+| `NarrativeTM` | topica original | planted / tests | Justified. No paper (an original GDMR-over-position construction), so planted-only by nature; cannot graduate under the current definition. |
+| `IdealPointTM` | topica original | planted / tests | Justified. A Wordfish-with-topics construction with no dedicated paper; the word-topic variants are reliable, bare-scaling is not. |
+| `IdealPointSentenceTM` | topica original | planted / tests | Justified. The sentence-embedding sibling of `IdealPointTM`, same no-paper status. |
+| `EmbeddingLDA` | topica original | planted only | Justified (issue #660). A topica original with no paper and no external reference; its planted gold cannot distinguish it from plain LDA (on the planted corpus, plain LDA and shuffled/random embeddings score the same block purity), and on real labeled text its recovery sits below plain LDA. The `SeededLDA` core it delegates to is validated; the embedding-seeding benefit is what is unproven. |
+
+## Following up
+
+Running the four current experimental models through the full triple gate
+(graduate or keep-gated per the result) is tracked in issue #660. `TensorLDA` is
+the nearest candidate, since it is the only experimental model with both a paper
+and a cross-implementation reference already in the tree.

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -295,6 +295,19 @@ transport problems (reference defaults 3.0 and 2.0); larger is sharper.
 
 ## EmbeddingLDA
 
+!!! warning "Experimental — validated by planted-recovery only"
+    `EmbeddingLDA` is a topica original: it ships before a published paper and a
+    reference-implementation parity check (topica's bar for a validated model). Its
+    gold (`parity/embeddinglda_gold.py`) is a planted-recovery/determinism lock,
+    not cross-implementation parity — on the planted corpus, plain LDA and even
+    shuffled/random embeddings score the same block purity, and on real labeled
+    text (20 Newsgroups) `EmbeddingLDA`'s label recovery sits *below* plain LDA. It
+    is sound but not demonstrably superior. It is **gated**: call
+    `topica.enable_experimental()` (or set `TOPICA_EXPERIMENTAL=1`) before
+    constructing or loading it. It may change or be removed without a deprecation
+    cycle (issue #660). The `SeededLDA` core it delegates to is itself validated;
+    what is unproven is the embedding-seeding *benefit*.
+
 `EmbeddingLDA` is a fixed-K, every-document LDA anchored by embeddings on **both
 sides**. The *word* embeddings define the topics: k-means clusters them into
 `num_topics` groups and seeds each topic with the `top_m` words nearest its
@@ -322,6 +335,7 @@ matrix with its aligned vocabulary, so nothing calls an embedding model:
 import topica
 import numpy as np
 
+topica.enable_experimental()              # EmbeddingLDA is experimental and gated
 ng = topica.datasets.load_ng20_minilm()   # documents + labels + MiniLM embeddings
 docs = [t.split() for t in ng["texts"]]
 
@@ -635,10 +649,10 @@ somewhere. Two ways out:
   labels = theta.argmax(1)          # == model.labels
   ```
 
-- **Use a fixed-K, every-document model.** [`EmbeddingLDA`](#embeddinglda),
-  `FASTopic`, and `ETM` are embedding-driven but give every document a full topic
-  distribution `θ` with no noise bucket. In our testing `EmbeddingLDA` gave the
-  best recovery when the `-1` bucket was the problem.
+- **Use a fixed-K, every-document model.** [`EmbeddingLDA`](#embeddinglda)
+  (experimental), `FASTopic`, and `ETM` are embedding-driven but give every
+  document a full topic distribution `θ` with no noise bucket, so no document is
+  dropped into a `-1` outlier bucket in the first place.
 
 `reduce_outliers()` (below) is the third option: keep HDBSCAN, then reassign the
 `-1` documents after the fact.

--- a/docs/guides/guided.md
+++ b/docs/guides/guided.md
@@ -129,6 +129,14 @@ against `time_labels` to see a topic's trajectory.
 
 ## Embedding-guided topics (EmbeddingLDA)
 
+!!! warning "Experimental — validated by planted-recovery only"
+    `EmbeddingLDA` is a topica original with no published paper or reference
+    implementation; its gold cannot distinguish it from plain LDA, whose label
+    recovery it does not beat on real text. It is **gated** behind
+    `topica.enable_experimental()` (or `TOPICA_EXPERIMENTAL=1`) and may change or
+    be removed without a deprecation cycle (issue #660). Its `SeededLDA` core is
+    validated; the embedding-seeding *benefit* is what remains unproven.
+
 `SeededLDA` and `KeyATM` ask you to name the seed words. `EmbeddingLDA` instead
 discovers them from a pre-trained embedding space: it clusters the vocabulary's
 embeddings into `num_topics` semantic groups, seeds each topic with the words
@@ -143,6 +151,7 @@ the vocabulary:
 from sentence_transformers import SentenceTransformer
 import topica
 
+topica.enable_experimental()   # EmbeddingLDA is experimental and gated
 vocab = sorted({w for d in docs for w in d})
 emb = SentenceTransformer("all-MiniLM-L6-v2").encode(vocab)
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -118,7 +118,6 @@ The right first choice when your design calls for one: short text, change over t
 | `ETM` | text, embeddings | variational | seed-reproducible | Embedded topic model: topic-word distributions factored through word embeddings. |
 | `GaussianLDA` | text, embeddings | gibbs | seed-reproducible | Gaussian LDA (Das, Zaheer & Dyer 2015): each topic is a Gaussian over the word-embedding space (Normal-Inverse-Wishart prior), so topics generalize over semantically similar words. Collapsed Gibbs with a Student-t posterior predictive and rank-1 Cholesky up/downdates. |
 | `FASTopic` | text, embeddings | optimal-transport | seed-reproducible | Topics from optimal-transport plans between document, topic, and word embeddings. |
-| `EmbeddingLDA` | text, embeddings, seeds | gibbs | seed-reproducible | Seeded LDA whose seed sets are expanded with nearest neighbors in an embedding space. |
 | `CombinedTM` | text, embeddings | vae | seed-reproducible | Contextualized ProdLDA: encoder reads the bag of words plus a document embedding. |
 | `ZeroShotTM` | text, embeddings | vae | seed-reproducible | Contextualized ProdLDA: encoder reads the document embedding alone, enabling cross-lingual transfer. |
 | `InfoCTM` | text, dictionary | vae | seed-reproducible | Cross-lingual: two ProdLDA models aligned by a bilingual dictionary through a mutual-information term. |
@@ -140,7 +139,7 @@ The right first choice when your design calls for one: short text, change over t
 
 ### Experimental
 
-Shipped before a published paper and reference-implementation parity (topica's bar for a validated model). Gated: call `topica.enable_experimental()` (or set `TOPICA_EXPERIMENTAL=1`) before use. These may change or be removed without a deprecation cycle.
+Not (yet) on the validated roster, on one of two grounds: the model is unpublished (a topica original with no paper), or it is a published method whose benefit has not held up against a simpler baseline. A published method with faithful inference stays validated even when its basis is planted-recovery, so planted validation alone does not land a model here. Gated: call `topica.enable_experimental()` (or set `TOPICA_EXPERIMENTAL=1`) before use. These may change or be removed without a deprecation cycle. For the triple gate a model clears to graduate to the validated roster, and where every model stands on validation evidence, see [Validation & graduation](https://nealcaren.github.io/topica/contributing/validation/).
 
 | Model | Brings | Inference | Reproducibility | Summary |
 |---|---|---|---|---|
@@ -148,6 +147,7 @@ Shipped before a published paper and reference-implementation parity (topica's b
 | `NarrativeTM` | text | gibbs | seed-reproducible | Intra-document narrative trajectory model: captures how topic prevalence shifts across the progress of a text. |
 | `IdealPointTM` | text, embeddings | variational | seed-reproducible | Topic model with a latent ideal-point head: each author gets a low-dimensional position that shifts within-topic word choice, with a per-topic discrimination. Consumes word tokens as counts (Wordfish with topics) or, when word embeddings are supplied to fit, factored through them as in ETM. The unsupervised, latent-trait twin of the STM content covariate. |
 | `IdealPointSentenceTM` | text, embeddings | em | seed-reproducible | Continuous ideal-point topic model over sentence/document embeddings: topics are Gaussian clusters whose centroids are displaced by a latent author position. The sentence-embedding sibling of IdealPointTM, fit by EM. |
+| `EmbeddingLDA` | text, embeddings | gibbs | seed-reproducible | LDA anchored by pre-trained embeddings: k-means clusters the vocabulary embeddings, seeds each topic with the words nearest a cluster centroid, and (optionally) biases each document's mixture toward its own embedding. A topica original; validated by planted-recovery only. |
 
 <!-- END MODEL TABLE -->
 

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -295,6 +295,7 @@ coherence-vs-diversity sweep by hand:
 ```python
 import numpy as np, topica
 
+topica.enable_experimental()   # EmbeddingLDA is experimental and gated
 b = topica.datasets.load_ng20_minilm()
 docs = [t.split() for t in b.texts]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -137,5 +137,6 @@ nav:
       - API conventions: contributing/conventions.md
       - Estimator contract: contributing/estimator-contract.md
       - Model implementation map: contributing/model-map.md
+      - Validation & graduation: contributing/validation.md
       - Release checklist: contributing/release-checklist.md
   - Citing: citing.md

--- a/parity/wave2.py
+++ b/parity/wave2.py
@@ -166,6 +166,7 @@ def emb_embeddinglda():
 
 def fit_embeddinglda(iters=300):
     import topica
+    topica.enable_experimental(True)  # EmbeddingLDA is experimental and gated (#660)
 
     docs, vocab = tmi._planted_blocks(k=K, block=8, n=300, seed=0)
     _, word_emb = tmi._planted_embeddings(k=K, block=8, seed=0)

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -19,11 +19,22 @@ and the matching vocabulary list; it does the clustering and seeding.
     from sentence_transformers import SentenceTransformer
     import topica
 
+    topica.enable_experimental()  # EmbeddingLDA is experimental (see note below)
     vocab = sorted({w for d in docs for w in d})
     emb = SentenceTransformer("all-MiniLM-L6-v2").encode(vocab)
     model = topica.EmbeddingLDA(num_topics=10, embeddings=emb, vocabulary=vocab)
     model.fit(docs, iters=1000)
     print(model.top_words(8))
+
+Validation status (experimental). EmbeddingLDA is a topica original: it has no
+published paper and no external reference implementation, so it is validated by a
+*planted-recovery / determinism* gold only (``parity/embeddinglda_gold.py``), not
+by cross-implementation parity. That gold cannot distinguish EmbeddingLDA from
+plain LDA — on the planted corpus, plain LDA and even shuffled/random embeddings
+score the same block purity — and on real labeled text (20 Newsgroups) its label
+recovery sits *below* plain LDA, so it is sound but not demonstrably superior. It
+is therefore gated behind :func:`~topica.enable_experimental` and may change or be
+removed without a deprecation cycle (issue #660).
 """
 
 from __future__ import annotations
@@ -254,6 +265,15 @@ def llm_embed(texts, model="text-embedding-3-small", *, key=None, batch=True, ca
 class EmbeddingLDA:
     """LDA whose topics are anchored by pre-trained embeddings, on both sides.
 
+    .. note::
+       **Experimental** (issue #660). EmbeddingLDA is a topica original with no
+       published paper and no external reference; its gold is planted-recovery
+       only and cannot tell it apart from plain LDA, whose label recovery it does
+       not beat on real text. It is gated behind
+       :func:`~topica.enable_experimental` and may change without a deprecation
+       cycle. The inference core it delegates to (:class:`~topica.SeededLDA`) is
+       itself validated; what is unproven is the embedding-seeding *benefit*.
+
     The vocabulary embeddings define the topics: k-means clusters them into
     ``num_topics`` semantic groups, and each topic is seeded with the ``top_m``
     words nearest its centroid (a prior on the **topic-word** side, via
@@ -326,7 +346,17 @@ class EmbeddingLDA:
         beta: float = 0.01,
         seed: int = 13,
     ) -> None:
-        from . import SeededLDA
+        from . import SeededLDA, experimental_enabled
+
+        if not experimental_enabled():
+            raise RuntimeError(
+                "EmbeddingLDA is experimental: it is a topica original with no "
+                "published paper and no reference-implementation parity (its gold "
+                "is planted-recovery only, and cannot distinguish it from plain "
+                "LDA). Enable experimental models with `topica.enable_experimental()` "
+                "or set the environment variable TOPICA_EXPERIMENTAL=1. Experimental "
+                "models may change or be removed without a deprecation cycle."
+            )
 
         if len(vocabulary) != np.asarray(embeddings).shape[0]:
             raise ValueError("vocabulary length must match the number of embedding rows")

--- a/python/topica/registry.py
+++ b/python/topica/registry.py
@@ -36,11 +36,19 @@ class ModelInfo:
         ``"nonparametric"``, ``"temporal"``, ``"hierarchical"``, ``"cross-lingual"``).
     summary : a one-line description for tables.
     doc : the docs anchor, relative to the docs root.
-    experimental : ``True`` for a model that ships before it has a published
-        paper and a reference-implementation parity check (topica's bar for a
-        *validated* model). Experimental models are gated at construction (see
+    experimental : ``True`` for a model that has not earned a place on the
+        validated roster, on either of two grounds: it is **unpublished** (a
+        topica original with no paper, so it can only ever be validated by
+        planted recovery, not by an independent yardstick), or it is a published
+        method topica ships whose **benefit has not held up** against a simpler
+        baseline. A published method with faithful inference stays validated even
+        when its accuracy basis is planted-recovery (no maintained reference
+        implementation exists); planted-recovery is a validation *basis*, not an
+        experimental marker. Experimental models are gated at construction (see
         :func:`topica.enable_experimental`) and listed apart from the validated
         roster; they may change or be removed without a deprecation cycle.
+        Graduation is the triple gate (accuracy, adversarial, user); see
+        ``docs/contributing/validation.md``.
     common_start : ``True`` for a *common starting point*: one of the handful of
         models most social scientists reach for first, chosen by contemporary
         popularity and applied usefulness. This is an editorial suggestion about
@@ -242,9 +250,9 @@ REGISTRY: dict[str, ModelInfo] = {
         _m("FASTopic", "embedding", ("text", "embeddings"), "optimal-transport", "seed-reproducible", (),
            "Topics from optimal-transport plans between document, topic, and word embeddings.",
            "guides/embedding.md"),
-        _m("EmbeddingLDA", "embedding", ("text", "embeddings", "seeds"), "gibbs", "seed-reproducible", (),
-           "Seeded LDA whose seed sets are expanded with nearest neighbors in an embedding space.",
-           "guides/embedding.md"),
+        _m("EmbeddingLDA", "embedding", ("text", "embeddings"), "gibbs", "seed-reproducible", (),
+           "LDA anchored by pre-trained embeddings: k-means clusters the vocabulary embeddings, seeds each topic with the words nearest a cluster centroid, and (optionally) biases each document's mixture toward its own embedding. A topica original; validated by planted-recovery only.",
+           "guides/embedding.md", experimental=True),
         _m("CombinedTM", "embedding", ("text", "embeddings"), "vae", "seed-reproducible", (),
            "Contextualized ProdLDA: encoder reads the bag of words plus a document embedding.",
            "guides/embedding.md#combinedtm"),
@@ -354,7 +362,7 @@ IMPL: dict[str, ImplInfo] = {
     "TBIP": _i("src/tbip.rs", "src/python/tbip.rs", "Poisson-factorization mean-field SVI", "", "parity/tbip_parity.py, tests/test_tbip.py"),
     "PartyEmbeddings": _i("src/party_embeddings.rs", "src/python/party_embeddings.rs", "PV-DM paragraph vectors (negative sampling)", "", "parity/party_embeddings_compare.py, tests/test_party_embeddings.py"),
     "FASTopic": _i("src/fastopic.rs", "src/python/mod.rs", "reverse-mode Sinkhorn optimal transport", "", "parity/fastopic_gold.py, parity/fastopic_compare.py"),
-    "EmbeddingLDA": _i("python/topica/embedding.py", "", "seeded Gibbs + embedding NN expansion (Python)", "", "parity/embeddinglda_gold.py, tests/test_embedding_lda.py"),
+    "EmbeddingLDA": _i("python/topica/embedding.py", "", "k-means embedding seeding over a SeededLDA Gibbs core (Python); planted-recovery gold only, no external reference", "", "parity/embeddinglda_gold.py, tests/test_embedding_lda.py"),
     "CombinedTM": _i("src/prodlda.rs", "src/python/neural.rs", "contextualized ProdLDA VAE (prodlda.rs)", "", "parity/combinedtm_gold.py, parity/combinedtm_compare.py"),
     "ZeroShotTM": _i("src/prodlda.rs", "src/python/neural.rs", "contextualized ProdLDA VAE (prodlda.rs)", "", "parity/zeroshot_gold.py, parity/zeroshot_compare.py"),
     "InfoCTM": _i("src/infoctm.rs", "src/python/neural.rs", "two ProdLDA VAEs + TAMI alignment (prodlda.rs)", "", "parity/infoctm_gold.py, parity/infoctm_compare.py"),
@@ -654,10 +662,18 @@ def markdown_table(by_group: bool = True) -> str:
         if experimental:
             lines.append("### Experimental\n")
             lines.append(
-                "Shipped before a published paper and reference-implementation parity "
-                "(topica's bar for a validated model). Gated: call "
+                "Not (yet) on the validated roster, on one of two grounds: the model "
+                "is unpublished (a topica original with no paper), or it is a "
+                "published method whose benefit has not held up against a simpler "
+                "baseline. A published method with faithful inference stays validated "
+                "even when its basis is planted-recovery, so planted validation alone "
+                "does not land a model here. Gated: call "
                 "`topica.enable_experimental()` (or set `TOPICA_EXPERIMENTAL=1`) before "
-                "use. These may change or be removed without a deprecation cycle.\n"
+                "use. These may change or be removed without a deprecation cycle. For "
+                "the triple gate a model clears to graduate to the validated roster, "
+                "and where every model stands on validation evidence, see "
+                "[Validation & graduation]"
+                "(https://nealcaren.github.io/topica/contributing/validation/).\n"
             )
             lines += _rows(experimental)
             lines.append("")

--- a/tests/test_embedding_lda.py
+++ b/tests/test_embedding_lda.py
@@ -9,6 +9,27 @@ import topica
 from topica.embedding import embedding_seeds
 
 
+@pytest.fixture(autouse=True)
+def _experimental():
+    """EmbeddingLDA is experimental-gated (#660); enable it for every test here."""
+    was = topica.experimental_enabled()
+    topica.enable_experimental(True)
+    yield
+    topica.enable_experimental(was)
+
+
+def test_requires_experimental():
+    """Construction is refused unless experimental models are enabled (#660)."""
+    vocab, emb, _ = _blocks()
+    was = topica.experimental_enabled()
+    topica.enable_experimental(False)
+    try:
+        with pytest.raises(RuntimeError, match="experimental"):
+            topica.EmbeddingLDA(num_topics=3, embeddings=emb, vocabulary=vocab)
+    finally:
+        topica.enable_experimental(was)
+
+
 def _blocks(n_blocks=3, per_block=8, e_dim=16, seed=0):
     """Vocabulary of disjoint blocks; each block's embeddings cluster around a
     distinct random center. Returns (vocab, embeddings, blocks)."""

--- a/tests/test_embedding_save_load.py
+++ b/tests/test_embedding_save_load.py
@@ -9,6 +9,15 @@ import pytest
 import topica
 
 
+@pytest.fixture(autouse=True)
+def _experimental():
+    """EmbeddingLDA is experimental-gated (#660); enable it for every test here."""
+    was = topica.experimental_enabled()
+    topica.enable_experimental(True)
+    yield
+    topica.enable_experimental(was)
+
+
 def _planted(seed=0, per=60, k=3, dim=12):
     rng = np.random.default_rng(seed)
     themes = {

--- a/tests/test_model_invariants.py
+++ b/tests/test_model_invariants.py
@@ -631,6 +631,7 @@ def _fit_fastopic(iters=200):
 def _fit_embeddinglda(iters=300):
     docs, vocab = _planted_blocks(k=K, block=8, n=300, seed=0)
     _, word_emb = _planted_embeddings(k=K, block=8, seed=0)
+    topica.enable_experimental()  # EmbeddingLDA is experimental and gated (#660)
     m = topica.EmbeddingLDA(num_topics=K, embeddings=word_emb, vocabulary=vocab,
                             top_m=5, seed=1)
     m.fit(docs, iters=iters)


### PR DESCRIPTION
Addresses the first three action items of #660.

## Part 1 — EmbeddingLDA → experimental (your decision)
EmbeddingLDA is a topica original: no published paper, no external reference, and a planted-recovery gold that cannot distinguish it from plain LDA (on the planted corpus, plain LDA and shuffled/random embeddings score the same block purity). On real labeled text (20 Newsgroups) its recovery sits *below* plain LDA. Gated behind `enable_experimental()`.

Also fixes the inaccurate registry metadata the audit surfaced:
- `brings` drops the false `"seeds"` (the constructor takes no seeds).
- Summary rewritten — seeds are k-means-derived, not user-supplied and "expanded with nearest neighbors."
- Drops the unsupported "best recovery" superlative in the embedding guide.

Caveats added to the class + module docstrings and the embedding / guided / choosing-k guides; the `SeededLDA` core it delegates to stays validated (what's unproven is the embedding-seeding *benefit*).

## Part 3 — triple-gate graduation policy + flag definition
New `docs/contributing/validation.md` documents the accuracy / adversarial / user triple gate as the experimental→validated graduation criterion, and reconciles the `experimental`-flag definition to the actual rule: **experimental = unpublished (topica original) research, or a published method whose benefit hasn't held up against a simpler baseline.** A published method with faithful inference stays validated even on a planted-recovery basis (no maintained reference exists) — planted validation alone does not gate a model.

## Part 2 — full per-model validation-basis audit
The same page records every model (topica 0.55.0) by paper / validation basis (cross-impl reference · paper-oracle · planted-recovery · behavioral) / experimental status. The planted-only bucket (SAGE, HDP, HLDA, PA, PT, GSDMM, SupervisedLDA, ETM, DETM, TopicsOverTime, Scholar) is recorded honestly as the two-evidence-levels gap #660 opened, and kept validated per the policy above.

## Not in this PR (follow-up on #660)
Running the four experimental models through the full triple gate. `TensorLDA` is the nearest graduation candidate — it's the only experimental model with both a paper and a cross-implementation reference (opt-in TensorLy compare) already in the tree.

## Checks
- `pytest tests/` — 4838 passed, 38 skipped
- `mkdocs build --strict` — clean
- `scripts/preflight.sh` — fmt/clippy + generated tables + stub all in sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)