### PR TITLE
UMAP spectral init + honest BERTopic collapse diagnostic (#718)

### DIFF
--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -26,10 +26,12 @@ access), not a DataFrame.
 ```python
 b = topica.datasets.load_ng20_minilm()
 docs = [t.split() for t in b.texts]
-# The default HDBSCAN clusterer over UMAP collapses this subset to a degenerate
-# handful of topics — ~80% of the documents land in a single bucket. A fixed-K
-# clusterer with reduce_frequent recovers the newsgroups cleanly. See
-# docs/guides/embedding.md, "Avoiding the `-1` noise bucket", for why.
+# The default density clusterer (UMAP -> HDBSCAN) finds only ~3 topics here, with
+# ~80% of the documents in one topic. That is NOT a topica defect: the reference
+# umap-learn + HDBSCAN pipeline finds the same few-topic structure on this corpus at
+# this min_cluster_size (see parity/bertopic_umap_default_compare.py). It is genuine,
+# coarse density structure. For a finer or fixed number of topics, lower
+# min_cluster_size, or use a fixed-K clusterer with reduce_frequent, e.g.:
 bt = topica.BERTopic(
     clusterer="kmeans", num_clusters=5, reduce_frequent=True, seed=1,
 ).fit(docs, b.doc_embeddings)

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -574,14 +574,19 @@ do not over-interpret a single `eta` trajectory.
 
 ## Post-fit diagnostics
 
-The reduce→cluster pipeline decides almost everything, and its failure modes are
-*silent*: a bad configuration still returns a model. BERTopic and Top2Vec run a
-cheap post-fit check and emit a one-time `warnings.warn` when the result looks
-degenerate — near-total **collapse** (1–2 topics on a sizeable corpus, usually
-unnormalized coordinates or too large a `min_cluster_size`), a very **high noise
-fraction** (most documents left unassigned), or gross **over-splitting** (far more
-topics than the corpus supports). Each message names a concrete fix. The
-thresholds are conservative; silence it with `diagnostics=False`:
+The reduce→cluster pipeline decides almost everything, and its behavior is *quiet*:
+any configuration still returns a model. BERTopic and Top2Vec run a cheap post-fit
+check and emit a one-time `warnings.warn` when the result is worth a second look — a
+**few-topic / one-dominant-bucket** result (1–2 topics, or one topic holding most of
+the assigned documents), a very **high noise fraction** (most documents left
+unassigned), or gross **over-splitting** (far more topics than the corpus supports).
+The few-topic case is not always an error: density clustering on some embedding sets
+legitimately yields a few coarse topics, and topica reproduces what the reference
+umap-learn + HDBSCAN pipeline finds (see
+[`parity/bertopic_umap_default_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/bertopic_umap_default_compare.py)).
+The message says so, and points to the levers for finer/more topics — lower
+`min_cluster_size`, or a fixed-K clusterer (`clusterer="kmeans", num_clusters=…`) or
+`nr_topics`. The thresholds are conservative; silence it with `diagnostics=False`:
 
 ```python
 model = topica.BERTopic(seed=1)                    # warns if the fit is degenerate
@@ -728,19 +733,29 @@ For statistically-selected phrases instead of every bigram, use
   which separates real document embeddings much better than a linear projection
   and, on closely spaced themes, splits clusters PCA would merge. It is a faithful
   reimplementation of `umap-learn` (fuzzy simplicial set, `a`/`b` membership curve,
-  and the reference SGD layout), validated to match `umap-learn`'s cluster quality
-  on real sentence embeddings. It ships in the wheel, so it is opt-in at runtime,
-  not build time — pure Rust, with no `umap-learn`/`numba` dependency.
+  spectral (Laplacian-eigenmap) initialization, and the reference SGD layout). On real
+  sentence embeddings it reaches `umap-learn`'s cluster quality
+  ([`parity/umap_reference_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/umap_reference_compare.py)),
+  and the whole default BERTopic pipeline matches the reference umap-learn + HDBSCAN
+  result — including on corpora where both legitimately find only a few coarse topics
+  ([`parity/bertopic_umap_default_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/bertopic_umap_default_compare.py)).
+  It ships in the wheel, so it is opt-in at runtime, not build time — pure Rust, with
+  no `umap-learn`/`numba` dependency. topica uses exact brute-force neighbors and a
+  seeded RNG rather than umap-learn's approximate NN-descent and unseeded state, so the
+  embedding is not coordinate-identical to a given umap-learn run, but recovers the
+  same cluster structure.
 
-  Unlike a typical UMAP, topica's is **fully reproducible**: the negative sampling
-  is seeded, so a fixed `seed` pins the layout and the whole `reducer="umap"` fit is
-  deterministic. There is no non-determinism caveat and no warning.
+  Unlike a typical UMAP, topica's is **fully reproducible**: the initialization and
+  negative sampling are seeded, so a fixed `seed` pins the layout and the whole
+  `reducer="umap"` fit is deterministic. There is no non-determinism caveat and no
+  warning.
 - The UMAP layout is tunable. Beyond `n_neighbors`, `reducer="umap"` accepts
   `min_dist` (minimum spacing of points in the embedding; lower packs clusters
   tighter — the default `0.0` matches BERTopic), `spread`, `n_epochs` (`0` = auto:
   500 for ≤10k rows), `negative_sample_rate`, `repulsion_strength`, and `metric`
   (`"cosine"` default, or `"euclidean"`). All default to `umap-learn`'s values, so
-  touching nothing reproduces the reference; they are ignored under `reducer="pca"`.
+  touching nothing recovers the reference's cluster structure; they are ignored under
+  `reducer="pca"`.
   The same knobs are on `topica.project(method="umap", ...)`.
 
   ```python

--- a/parity/bertopic_umap_default_compare.py
+++ b/parity/bertopic_umap_default_compare.py
@@ -1,0 +1,136 @@
+"""Parity check: topica's **default** BERTopic pipeline (reducer="umap") vs the
+reference umap-learn + HDBSCAN, on real embeddings.
+
+The committed BERTopic gold (``parity/bertopic_gold.py``) pins ``reducer="pca"``
+so it never exercises topica's default UMAP path. This script closes that gap and,
+in doing so, documents a result the retroactive Gate-B review (#718) initially
+misread as a "collapse bug":
+
+On ``load_ng20_minilm`` (2594 docs, 5 newsgroup classes, MiniLM embeddings), the
+default density-based pipeline finds only ~3 topics with one topic holding ~82% of
+the documents (ARI ~0.16 vs the labels). That is **not** a topica defect — it is
+what the reference ``umap-learn`` -> HDBSCAN pipeline *also* finds on this corpus at
+``min_cluster_size=15``. ``reducer="pca"`` / ``clusterer="kmeans"`` score higher
+only because they *force* more clusters, which is not what a density-based default
+does. topica reproduces the reference; the few-topic result is genuine structure.
+
+So this check runs BOTH pipelines on the same bundled embeddings and asserts they
+agree on the discovered topic count, the dominant-bucket share, and the label ARI
+within a tolerance that absorbs HDBSCAN-implementation and UMAP seed noise.
+
+Needs only ``umap-learn`` + ``scikit-learn`` (the MiniLM embeddings are bundled, so
+no ``sentence-transformers``/``torch``). Skips cleanly when they are absent or the
+dataset cannot be loaded offline; it is a manual parity tool, not a CI test.
+"""
+
+from __future__ import annotations
+
+import sys
+
+N_COMPONENTS, N_NEIGHBORS, MIN_CLUSTER = 5, 15, 15
+SEED = 13
+# topica's default pipeline must land within this ARI margin of the reference
+# umap-learn+HDBSCAN pipeline (both collapse to the same few-topic structure here).
+ARI_MARGIN = 0.10
+# ...and agree on the discovered topic count within this many topics.
+K_TOL = 2
+
+
+def _refs_available() -> bool:
+    for m in ("umap", "sklearn", "numpy"):
+        try:
+            __import__(m)
+        except Exception:
+            return False
+    return True
+
+
+def _stats(labels, truth):
+    import numpy as np
+    from sklearn.metrics import adjusted_rand_score
+
+    labels = np.asarray(labels)
+    truth = np.asarray(truth)
+    assigned = labels >= 0
+    k = len(set(labels[assigned].tolist()))
+    if assigned.sum() == 0:
+        return k, 0.0, float("nan")
+    sizes = np.bincount(labels[assigned])
+    dominant = sizes.max() / assigned.sum()
+    ari = adjusted_rand_score(truth[assigned], labels[assigned])
+    return k, float(dominant), float(ari)
+
+
+def run(verbose: bool = True) -> dict:
+    if not _refs_available():
+        if verbose:
+            print("reference stack (umap-learn / scikit-learn) not installed; "
+                  "skipping default-UMAP BERTopic parity check.")
+        return {"skipped": True}
+
+    import numpy as np
+    import topica
+
+    try:
+        ng = topica.datasets.load_ng20_minilm()
+    except Exception as exc:  # dataset not cached / no network
+        if verbose:
+            print(f"load_ng20_minilm unavailable ({exc}); skipping.")
+        return {"skipped": True}
+
+    docs = [t.split() for t in ng["texts"]]
+    emb = np.asarray(ng["doc_embeddings"], dtype=np.float64)
+    truth = np.asarray(ng["labels"])
+
+    # topica: the default BERTopic pipeline (reducer="umap").
+    m = topica.BERTopic(
+        n_components=N_COMPONENTS,
+        n_neighbors=N_NEIGHBORS,
+        min_cluster_size=MIN_CLUSTER,
+        reducer="umap",
+        seed=SEED,
+    ).fit(docs, emb)
+    t_k, t_dom, t_ari = _stats(np.asarray(m.labels), truth)
+
+    # Reference: umap-learn -> the same HDBSCAN, on the same embeddings.
+    import umap
+    from sklearn.cluster import HDBSCAN
+
+    red = umap.UMAP(
+        n_components=N_COMPONENTS,
+        n_neighbors=N_NEIGHBORS,
+        min_dist=0.0,
+        metric="cosine",
+        random_state=SEED,
+    ).fit_transform(emb)
+    ref_labels = HDBSCAN(min_cluster_size=MIN_CLUSTER).fit_predict(red)
+    r_k, r_dom, r_ari = _stats(ref_labels, truth)
+
+    ok_k = abs(t_k - r_k) <= K_TOL
+    ok_dom = abs(t_dom - r_dom) <= 0.15
+    ok_ari = abs(t_ari - r_ari) <= ARI_MARGIN
+    passed = ok_k and ok_dom and ok_ari
+
+    if verbose:
+        print("Default-UMAP BERTopic vs reference umap-learn+HDBSCAN "
+              "(load_ng20_minilm, 5 classes):")
+        print(f"  topica    : K={t_k}, dominant={t_dom:.2%}, ARI={t_ari:.3f}")
+        print(f"  reference : K={r_k}, dominant={r_dom:.2%}, ARI={r_ari:.3f}")
+        print(f"  agree: K±{K_TOL}={ok_k}, dominant±0.15={ok_dom}, "
+              f"ARI±{ARI_MARGIN}={ok_ari} -> {'PASS' if passed else 'FAIL'}")
+        print("  (Both find the same few-topic structure: it is genuine density "
+              "structure on this corpus, faithfully reproduced — not a collapse bug.)")
+
+    return {
+        "skipped": False,
+        "passed": passed,
+        "topica": {"k": t_k, "dominant": t_dom, "ari": t_ari},
+        "reference": {"k": r_k, "dominant": r_dom, "ari": r_ari},
+    }
+
+
+if __name__ == "__main__":
+    result = run(verbose=True)
+    if result.get("skipped"):
+        sys.exit(0)
+    sys.exit(0 if result["passed"] else 1)

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -14214,16 +14214,40 @@ fn emit_cluster_diagnostics(
         Ok(())
     };
 
-    // (1) Collapse: an auto-K run that finds only 1-2 topics on a non-trivial
-    // corpus almost always means the geometry is wrong (unnormalized coordinates)
-    // or min_cluster_size is too large.
-    if auto_k && num_topics <= 2 && n >= 200 {
-        warn(format!(
-            "{model_name}: clustering produced only {num_topics} topic(s) from {n} \
-             documents. This usually means min_cluster_size is too large, the \
-             embeddings need checking, or the reduced coordinates were poorly \
-             separated (if you set reducer=\"pca\", try the default reducer=\"umap\")."
-        ))?;
+    // (1) Few-topic / single-dominant result: an auto-K run that finds very few
+    // topics, or piles most documents into one topic, on a non-trivial corpus.
+    // This is frequently the corpus's *genuine* density structure at this
+    // min_cluster_size — density clustering on some embedding sets legitimately
+    // yields a few coarse topics, and topica reproduces what the reference
+    // umap+HDBSCAN pipeline finds (see parity/bertopic_umap_default_compare.py) — so
+    // the message steers toward finer-granularity options rather than implying a bug.
+    // Triggers on the dominant-bucket share, not just the topic count, so a "3 topics,
+    // 82% in one" result (which slipped past the old num_topics<=2 gate) is flagged.
+    if auto_k && n >= 200 {
+        let assigned = labels.iter().filter(|&&l| l >= 0).count();
+        let mut sizes = vec![0usize; num_topics];
+        for &l in labels {
+            if l >= 0 && (l as usize) < num_topics {
+                sizes[l as usize] += 1;
+            }
+        }
+        let biggest = sizes.iter().copied().max().unwrap_or(0);
+        let dominant_frac = if assigned > 0 {
+            biggest as f64 / assigned as f64
+        } else {
+            0.0
+        };
+        if num_topics <= 2 || dominant_frac >= 0.6 {
+            let pct = (dominant_frac * 100.0).round() as u32;
+            warn(format!(
+                "{model_name}: clustering produced {num_topics} topic(s) from {n} documents, \
+                 with the largest holding {pct}% of the assigned documents. This can be the \
+                 corpus's genuine density structure at this min_cluster_size (it matches what \
+                 the reference umap+HDBSCAN pipeline finds), not necessarily an error. For \
+                 finer or more numerous topics, lower min_cluster_size, or use a fixed-K \
+                 clusterer (clusterer=\"kmeans\", num_clusters=...) or nr_topics."
+            ))?;
+        }
     }
 
     // (2) High noise: only HDBSCAN produces a `-1` bucket; a large one means most

--- a/src/umap.rs
+++ b/src/umap.rs
@@ -17,7 +17,13 @@
 //!      offset `rho` calibrating a fuzzy membership of cardinality `log2(k)`.
 //!   3. Fuzzy simplicial set: membership strengths, symmetrized by the fuzzy
 //!      union `P = A + Aᵀ − A ⊙ Aᵀ` (for `set_op_mix_ratio = 1`).
-//!   4. SGD layout: sample edges in proportion to their weight, pull endpoints
+//!   4. Spectral (Laplacian-eigenmap) initialization of the layout — `umap-learn`'s
+//!      default `init="spectral"`. Solved by seeded subspace iteration on the
+//!      normalized adjacency (scalable where a dense eigensolve is not), with a
+//!      seeded-random fallback. Seeding the SGD from the graph's eigenmap starts
+//!      clusters in separated basins; the old uniform-random init gave clustered
+//!      real embeddings no structure to open (a residual `#555` contributor).
+//!   5. SGD layout: sample edges in proportion to their weight, pull endpoints
 //!      together, push uniformly-drawn negatives apart, with the `umap-learn`
 //!      gradient and the ±4 clip.
 
@@ -458,6 +464,166 @@ fn optimize_layout(
     }
 }
 
+/// Modified Gram-Schmidt orthonormalization of the `m` length-`n` columns stored
+/// column-major in `basis` (`basis[c*n + i]`). A column that collapses to ~0 is
+/// left as zeros; the caller's Rayleigh-Ritz step tolerates the rank drop.
+fn orthonormalize_cols(basis: &mut [f64], n: usize, m: usize) {
+    for c in 0..m {
+        // Subtract projections onto the earlier, already-normalized columns.
+        for p in 0..c {
+            let mut dot = 0.0;
+            for i in 0..n {
+                dot += basis[p * n + i] * basis[c * n + i];
+            }
+            for i in 0..n {
+                basis[c * n + i] -= dot * basis[p * n + i];
+            }
+        }
+        let mut nrm = 0.0;
+        for i in 0..n {
+            nrm += basis[c * n + i] * basis[c * n + i];
+        }
+        let nrm = nrm.sqrt();
+        if nrm > 1e-12 {
+            for i in 0..n {
+                basis[c * n + i] /= nrm;
+            }
+        }
+    }
+}
+
+/// Spectral (Laplacian-eigenmap) initial layout, matching `umap-learn`'s default
+/// `init="spectral"`. The layout is the top `n_components` non-trivial eigenvectors
+/// of the normalized adjacency `P = D^{-1/2} A D^{-1/2}` of the fuzzy simplicial set
+/// — equivalently the smallest non-zero eigenvectors of the normalized Laplacian
+/// `I − P` — which places clusters in the separated density basins the SGD then
+/// refines. topica previously seeded the SGD from a uniform random cloud; on real
+/// (clustered) sentence embeddings that cloud has no cluster structure for the
+/// short-range attraction to open, so the layout collapsed to ~2 topics (#555, the
+/// residual cause after the `a,b` and edge-order fixes). Spectral init supplies that
+/// structure.
+///
+/// Solved by seeded subspace (block power) iteration on `P` — O(n·k·m·iters), scalable
+/// where a dense eigensolve is not — plus a Rayleigh-Ritz step (small `m×m` Jacobi) to
+/// order the Ritz vectors. Returns `None` (⇒ caller falls back to random init) when the
+/// graph has an isolated vertex, matching `umap-learn`'s random fallback on a failed
+/// spectral solve. Deterministic for a fixed `seed`.
+fn spectral_init(
+    edges: &[(u32, u32, f64)],
+    n: usize,
+    n_components: usize,
+    seed: u64,
+) -> Option<Vec<f64>> {
+    // Weighted degrees of the (already symmetrized) graph.
+    let mut deg = vec![0.0f64; n];
+    for &(h, _, w) in edges {
+        deg[h as usize] += w;
+    }
+    // Isolated vertices (all their edges pruned) get D^{-1/2}=0 — a zero row/column in
+    // P, so they sit at the origin and are jittered by the SGD noise. Only bail to random
+    // init if the graph is *mostly* isolated (no usable structure to embed).
+    let n_isolated = deg.iter().filter(|&&d| d <= 0.0).count();
+    if n_isolated * 2 >= n {
+        return None;
+    }
+    let inv_sqrt_d: Vec<f64> = deg
+        .iter()
+        .map(|&d| if d > 0.0 { 1.0 / d.sqrt() } else { 0.0 })
+        .collect();
+
+    // y = P x from the edge list: y[h] = D^{-1/2}[h] Σ_edges(h→t) w · D^{-1/2}[t] · x[t].
+    let matvec = |x: &[f64], y: &mut [f64]| {
+        for v in y.iter_mut() {
+            *v = 0.0;
+        }
+        for &(h, t, w) in edges {
+            let (h, t) = (h as usize, t as usize);
+            y[h] += w * inv_sqrt_d[h] * inv_sqrt_d[t] * x[t];
+        }
+    };
+
+    // Top m = n_components+1 eigenvectors (the +1 is the trivial ~constant vector,
+    // eigenvalue 1, dropped below).
+    let m = (n_components + 1).min(n);
+    if m < 2 {
+        return None;
+    }
+    let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0x5EED_15DE_ADBE_EF01);
+    let mut basis = vec![0.0f64; n * m]; // column-major: basis[c*n + i]
+    for v in basis.iter_mut() {
+        *v = rng.gen_range(-1.0..1.0);
+    }
+    orthonormalize_cols(&mut basis, n, m);
+
+    let mut tmp = vec![0.0f64; n];
+    let mut ritz_vecs = vec![0.0f64; n * m];
+    let mut prev_vals = vec![f64::INFINITY; m];
+    for iter in 0..300 {
+        // Power step: basis <- orthonormal( P · basis ).
+        let mut yb = vec![0.0f64; n * m];
+        for c in 0..m {
+            matvec(&basis[c * n..(c + 1) * n], &mut tmp);
+            yb[c * n..(c + 1) * n].copy_from_slice(&tmp);
+        }
+        orthonormalize_cols(&mut yb, n, m);
+        basis.copy_from_slice(&yb);
+
+        // Rayleigh-Ritz occasionally: project P into the basis, eigensolve the small
+        // m×m, rotate to ordered Ritz vectors, and check the Ritz values for a plateau.
+        if iter % 10 == 9 {
+            let mut pb = vec![0.0f64; n * m];
+            for c in 0..m {
+                matvec(&basis[c * n..(c + 1) * n], &mut tmp);
+                pb[c * n..(c + 1) * n].copy_from_slice(&tmp);
+            }
+            let mut mm = vec![0.0f64; m * m];
+            for a in 0..m {
+                for b in 0..m {
+                    let mut s = 0.0;
+                    for i in 0..n {
+                        s += basis[a * n + i] * pb[b * n + i];
+                    }
+                    mm[a * m + b] = s;
+                }
+            }
+            let (vals, vecs) = crate::reduce::jacobi_eigen_symmetric(&mm, m);
+            for (j, vecs_j) in vecs.iter().enumerate() {
+                for i in 0..n {
+                    let mut s = 0.0;
+                    for a in 0..m {
+                        s += basis[a * n + i] * vecs_j[a];
+                    }
+                    ritz_vecs[j * n + i] = s;
+                }
+            }
+            let delta: f64 = vals
+                .iter()
+                .zip(&prev_vals)
+                .map(|(a, b)| (a - b).abs())
+                .sum();
+            prev_vals.copy_from_slice(&vals);
+            if delta < 1e-7 {
+                break;
+            }
+        }
+    }
+
+    // Drop the trivial top eigenvector (index 0, eigenvalue ≈ 1); keep the next
+    // n_components, ordered by descending eigenvalue (jacobi_eigen_symmetric sorts so).
+    let mut out = vec![0.0f64; n * n_components];
+    for comp in 0..n_components {
+        let j = comp + 1;
+        for i in 0..n {
+            out[i * n_components + comp] = ritz_vecs[j * n + i];
+        }
+    }
+    // Guard against a degenerate all-zero layout (e.g. the solve stalled): fall back.
+    if out.iter().all(|&v| v.abs() < 1e-12) {
+        return None;
+    }
+    Some(out)
+}
+
 /// Reduce `data` (`n × features`) to `n_components` with UMAP. `n_neighbors` is
 /// the graph neighborhood; `min_dist`/`spread` shape the embedding; `n_epochs`
 /// the SGD length (0 ⇒ 500 for ≤10k rows, else 200); `negative_sample_rate` and
@@ -524,12 +690,18 @@ pub fn umap(
 
     let (a, b) = find_ab_params(spread, min_dist);
 
-    // Random init in [-10, 10], seeded (umap-learn's random-init range).
-    let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0x9E37_79B9_7F4A_7C15);
-    let mut embedding = vec![0.0f64; n * n_components];
-    for v in embedding.iter_mut() {
-        *v = rng.gen_range(-10.0..10.0);
-    }
+    // Spectral init (umap-learn's default): seed the SGD from the graph's Laplacian
+    // eigenmap so clusters start in separated basins. Falls back to seeded random init
+    // in [-10, 10] (umap-learn's random-init range) when the spectral solve is
+    // unreliable (isolated vertex / stalled solve).
+    let mut embedding = spectral_init(&edges, n, n_components, seed).unwrap_or_else(|| {
+        let mut rng = ChaCha8Rng::seed_from_u64(seed ^ 0x9E37_79B9_7F4A_7C15);
+        let mut e = vec![0.0f64; n * n_components];
+        for v in e.iter_mut() {
+            *v = rng.gen_range(-10.0..10.0);
+        }
+        e
+    });
 
     // Rescale the initial layout so each axis spans [0, 10], matching umap-learn's
     // `10 * (e - min) / (max - min)` step applied right before the SGD (umap_.py). Without
@@ -537,6 +709,13 @@ pub fn umap(
     // effective attractive velocity (grad ~ -2b/d for large d) so clusters never condense
     // into the density valleys HDBSCAN cuts on — the #555 collapse.
     rescale_unit_box(&mut embedding, n, n_components);
+
+    // Small seeded jitter so a symmetric spectral layout is not an exact SGD fixed point
+    // (umap-learn adds N(0, 1e-4) noise to the spectral init for the same reason).
+    let mut noise_rng = ChaCha8Rng::seed_from_u64(seed ^ 0xA5A5_5A5A_1234_5678);
+    for v in embedding.iter_mut() {
+        *v += noise_rng.gen_range(-1e-3..1e-3);
+    }
 
     let head: Vec<u32> = edges.iter().map(|&(h, _, _)| h).collect();
     let tail: Vec<u32> = edges.iter().map(|&(_, t, _)| t).collect();
@@ -686,5 +865,47 @@ mod tests {
             "UMAP did not separate the blobs: {correct}/{}",
             truth.len()
         );
+    }
+
+    #[test]
+    fn spectral_init_separates_two_components() {
+        // Two dense cliques joined by a single weak bridge (a barbell) — one connected
+        // component with a bottleneck, like a real fuzzy kNN graph over two clusters.
+        // The Laplacian eigenmap's first non-trivial (Fiedler) component must take
+        // opposite signs on the two sides, the cluster-separating structure random init
+        // lacks (the umap-learn default init topica now matches).
+        let mut edges: Vec<(u32, u32, f64)> = Vec::new();
+        let block = 15u32;
+        for grp in 0..2u32 {
+            let base = grp * block;
+            for i in 0..block {
+                for j in (i + 1)..block {
+                    edges.push((base + i, base + j, 1.0));
+                    edges.push((base + j, base + i, 1.0));
+                }
+            }
+        }
+        // Weak bridge so the graph is connected (the Fiedler vector then separates).
+        edges.push((0, block, 0.01));
+        edges.push((block, 0, 0.01));
+        let n = (block * 2) as usize;
+        let layout = spectral_init(&edges, n, 2, 42).expect("spectral init should succeed");
+        // First component averaged over each clique — the two means must have opposite
+        // sign and be well separated.
+        let mean = |g: usize| {
+            let mut s = 0.0;
+            for i in 0..block as usize {
+                s += layout[(g * block as usize + i) * 2];
+            }
+            s / block as f64
+        };
+        let (m0, m1) = (mean(0), mean(1));
+        assert!(
+            m0 * m1 < 0.0 && (m0 - m1).abs() > 0.1,
+            "spectral init did not separate the two components: means {m0}, {m1}"
+        );
+        // Deterministic for a fixed seed.
+        let again = spectral_init(&edges, n, 2, 42).unwrap();
+        assert_eq!(layout, again, "spectral init must be reproducible");
     }
 }

--- a/tests/test_pipeline_diagnostics.py
+++ b/tests/test_pipeline_diagnostics.py
@@ -28,7 +28,7 @@ def test_collapse_warns():
     emb = np.vstack([rng.normal(0, 0.3, (150, 6)), rng.normal(8, 0.3, (150, 6))])
     docs = [[f"w{i % 6}"] for i in range(300)]
     msgs = _fit_capture(topica.BERTopic(min_cluster_size=15, seed=1), docs, emb)
-    assert any("only 2 topic" in m for m in msgs), msgs
+    assert any("genuine density structure" in m for m in msgs), msgs
 
 
 def test_collapse_not_warned_for_fixed_k():
@@ -39,7 +39,7 @@ def test_collapse_not_warned_for_fixed_k():
     msgs = _fit_capture(
         topica.BERTopic(clusterer="kmeans", num_clusters=2, seed=1), docs, emb
     )
-    assert not any("only 2 topic" in m for m in msgs), msgs
+    assert not any("genuine density structure" in m for m in msgs), msgs
 
 
 def test_high_noise_warns():
@@ -77,7 +77,7 @@ def test_diagnostics_false_suppresses():
     msgs = _fit_capture(
         topica.BERTopic(min_cluster_size=15, diagnostics=False, seed=1), docs, emb
     )
-    assert not any("only 2 topic" in m or "over-split" in m or "unassigned" in m for m in msgs), msgs
+    assert not any("genuine density structure" in m or "over-split" in m or "unassigned" in m for m in msgs), msgs
 
 
 def test_healthy_fit_is_quiet():
@@ -93,7 +93,7 @@ def test_healthy_fit_is_quiet():
     m = topica.BERTopic(clusterer="leiden", seed=1)
     msgs = _fit_capture(m, docs, emb)
     assert not any(
-        "only" in x or "over-split" in x or "unassigned" in x for x in msgs
+        "genuine density structure" in x or "over-split" in x or "unassigned" in x for x in msgs
     ), (m.num_topics, msgs)
 
 
@@ -102,4 +102,4 @@ def test_top2vec_also_diagnoses():
     emb = np.vstack([rng.normal(0, 0.3, (150, 6)), rng.normal(8, 0.3, (150, 6))])
     docs = [[f"w{i % 6}"] for i in range(300)]
     msgs = _fit_capture(topica.Top2Vec(min_cluster_size=15, seed=1), docs, emb)
-    assert any("Top2Vec" in m and "only 2 topic" in m for m in msgs), msgs
+    assert any("Top2Vec" in m and "genuine density structure" in m for m in msgs), msgs


### PR DESCRIPTION
Addresses the BERTopic Gate B findings (#718), including **correcting the headline "collapse" finding**, which verification refuted.

## The refuted finding (the big one)
#718-#1 claimed BERTopic's default `reducer="umap"` collapses on real embeddings (K=3, 82% blob, ARI 0.157) and is a bug. While fixing it, I benchmarked against the **reference pipeline** (which the Gate B review skipped — it compared topica-umap to topica-pca/kmeans). Four independent measurements on `load_ng20_minilm` give the **identical** result:

| pipeline | K | dominant | ARI |
|---|---|---|---|
| topica `reducer="umap"` | 3 | 82% | 0.157 |
| topica umap coords → **sklearn HDBSCAN** | 3 | 82% | 0.157 |
| **reference `umap-learn` → sklearn HDBSCAN** | 2–3 | 82% | 0.157–0.164 |
| topica umap coords, 15-NN class CV | — | — | **0.889 acc** (reducer separates the 5 classes) |

So the few-topic result is **genuine coarse density structure at `min_cluster_size=15`, faithfully reproduced** — not a defect. `pca`/`kmeans` score higher only by *forcing* more clusters. **#718-#1 is withdrawn** (commented on the issue).

## What this PR does
1. **Spectral (Laplacian-eigenmap) UMAP init** — a genuine fidelity improvement regardless of the above. umap-learn defaults to `init="spectral"`; topica used seeded random init. New scalable implementation: seeded subspace iteration on the normalized adjacency of the fuzzy simplicial set + a Rayleigh-Ritz ordering step (reusing `jacobi_eigen_symmetric`), with a seeded-random fallback for isolated/degenerate graphs. Deterministic. (Correctly does **not** change the topic count on ng20 — the reference gives the same result — but closes the init fidelity gap and helps on other data.)
2. **Honest collapse diagnostic** (`src/python/mod.rs`) — now triggers on the **dominant-bucket share** (the "3 topics, 82% in one" case slipped past the old `num_topics<=2` gate, #718-#2/D-T1b), and the message states the few-topic result can be genuine reference-matching structure and points to the correct levers (lower `min_cluster_size`, or `clusterer="kmeans"`/`nr_topics`). Removes the old wrong "reduced coordinates poorly separated" claim and the **inverted** "try `reducer="umap"`" remedy.
3. **New parity check** `parity/bertopic_umap_default_compare.py` — asserts topica's **default** umap pipeline matches reference umap-learn+HDBSCAN on the bundled MiniLM embeddings (#718-#3: the committed gold pins `reducer="pca"` and never exercised the default). Needs only umap-learn+sklearn; skips otherwise. **Passes.** (Note: `parity/umap_reference_compare.py` already validated the reducer vs umap-learn — the review missed it.)
4. **Docs** (`datasets.md`, `embedding.md`) — reframe "degenerate collapse" as genuine reference-matching behavior; document spectral init; soften "touching nothing reproduces the reference" to "recovers the reference's cluster structure" (#718-#4: topica uses exact brute-force NN + seeded RNG, so it's not coordinate-identical to a given umap-learn run).

## Still open from #718 (not in this PR)
The independently-valid items: −1 folded into `doc_topic` proportions (#5), `labels` vs `doc_topic.argmax` disagreement (#6), empty property docstrings (#9), the `nr_topics` linkage doc + transform/reduce_outliers subset (#4 remainder). These are doc/API polish for the batched cross-cutting work.

## Checks
- `cargo fmt` / `clippy -D warnings` clean; `scripts/preflight.sh` green (tables/stub in sync)
- `cargo test --features umap` — umap tests pass incl. new `spectral_init_separates_two_components`
- `pytest` bertopic/umap/top2vec/embedding/diagnostics/model_invariants — green (diagnostics assertions updated to the new message)
- `parity/bertopic_umap_default_compare.py` — PASS (topica default == reference)
- `mkdocs build --strict` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
