### PR TITLE
STM: R-default Global uncertainty + honest parity docs (#715, part 1)

### DIFF
--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -38,8 +38,9 @@ model = topica.STM(num_topics=scan.best_k(), seed=1)
 model.fit(corpus, prevalence=X, prevalence_names=names)
 
 # Effects with method-of-composition uncertainty, as a tidy long table.
-draws = topica.posterior_theta_samples(model, nsims=50, seed=0)
-effects = topica.estimate_effect(draws, X, feature_names=names)
+# Passing the model + nsims draws the theta posterior for you, with R
+# estimateEffect's default Global uncertainty.
+effects = topica.estimate_effect(model, X=X, feature_names=names, nsims=50, seed=0)
 table = pd.concat([e.to_frame() for e in effects], ignore_index=True)
 ```
 
@@ -111,12 +112,12 @@ GLM links:
 import pandas as pd
 import topica
 
-draws = topica.posterior_theta_samples(model, nsims=50, seed=0)
 effects = topica.estimate_effect(
-    draws, X, feature_names=names,
+    model, X=X, feature_names=names, nsims=50, seed=0,
     cluster=source_id,     # cluster-robust SEs for nested data
     weights=survey_weight,  # weighted least squares (e.g. survey weights)
     # link="logit",        # keep predictions in [0, 1]
+    # uncertainty="local", # per-document covariance instead of R's Global default
 )
 
 # One tidy row per (topic, feature): coef, se, z, ci_low, ci_high, r_squared

--- a/docs/publishing/effects.md
+++ b/docs/publishing/effects.md
@@ -24,17 +24,20 @@ A naive regression of point topic proportions on covariates treats θ as if it
 were observed exactly. It isn't. R's `stm` uses the **method of composition**
 (Treier & Jackman 2008): draw θ from the model's posterior, regress each draw,
 and pool by Rubin's rules so the standard errors include topic-estimation
-uncertainty. topica does the same, drawing θ from each document's variational
-posterior. (It propagates that per-document θ uncertainty; it does not also
-simulate the global parameters β, Σ, and γ, so its pooled standard errors run a
-touch smaller than `stm`'s. The inflation over naive point-θ OLS is the part that
-matters, and it is there.)
+uncertainty. topica does the same, and by default uses R `estimateEffect`'s
+**Global** uncertainty — one shared topic covariance across documents (`stm`'s
+`thetaPosterior(type="Global")`), which is what `estimateEffect` draws from. Pass
+`uncertainty="local"` to `estimate_effect` for each document's own variational
+covariance instead, or `"none"` for OLS on the point θ. The inflation over naive
+point-θ OLS is the part that matters, and it is there.
 
 ```python
 from topica import stm
 
-draws = stm.posterior_theta_samples(model, nsims=50, seed=0)   # (50, D, K)
-effects = stm.estimate_effect(draws, X, feature_names=names)
+# Pass the model + nsims and the θ posterior is drawn for you, with R
+# estimateEffect's default Global uncertainty. (Equivalent to drawing explicitly:
+# stm.posterior_theta_samples(model, nsims=50, seed=0, uncertainty="global").)
+effects = stm.estimate_effect(model, X=X, feature_names=names, nsims=50, seed=0)
 for e in effects:
     d = e.as_dict()
     print(f"Topic {d['topic']}: {names[0]} coef={d[names[0]]['coef']:+.4f} "

--- a/docs/replications/stm.md
+++ b/docs/replications/stm.md
@@ -30,22 +30,31 @@ for the content model, and
 [`stm_r_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_r_compare.py)
 for the small Gadarian stress case.
 
-## Content model: exact agreement
+## Content model: close agreement, with a different default prior
 
 The content (SAGE) covariate is the deterministic part of STM: given the topic
-assignments, the per-group word distributions follow in closed form. Here topica
-and R agree exactly. On a bilingual corpus fit with `content = ~group`, K = 2,
-the best-aligned cosine between R's and topica's per-group word distributions is
-1.000 in both groups, and both engines separate the two topics rather than
-collapsing them (topic-separation near 0 in each):
+assignments, the per-group word distributions follow in closed form. One default
+differs, so "exact agreement" would overstate it. topica's content prior defaults
+to Gaussian **L2** (`content_prior="l2"`, `content_prior_var=0.5`); R `stm`
+defaults to `kappa.prior="L1"` (a glmnet word-wise lasso). The two regularizers
+pull the per-group deviations differently, so the fits are close but not
+identical. On a bilingual corpus fit with `content = ~group`, K = 2
+([`stm_content_r_compare.py`](https://github.com/nealcaren/topica/blob/main/parity/stm_content_r_compare.py)),
+R's L1 fit and topica's L2 fit align to a per-group cosine of ~0.999, but the
+topic-separation the two produce differs (R ~0.03 per topic, topica ~0.11) — the
+expected signature of L1 (sparser deviations) versus L2:
 
-| Content group | topica–R cosine | both separated |
-|---|---:|:--|
-| `de` | 1.000 | yes |
-| `en` | 1.000 | yes |
+| Content group | topica(L2)–R(L1) cosine |
+|---|---:|
+| `de` | ~0.999 |
+| `en` | ~0.999 |
 
 This is the path where a symmetric-initialization bug once collapsed all topics
-to the background; the exact match against R is how we know it is fixed.
+to the background; the high matched cosine against R is how we know it is fixed.
+If you need R-comparable content regularization, this is the knob to match — pass
+`content_prior="l1"`; topica keeps L2 as its default because that is the path its
+committed gold validates. (A matched-prior parity fixture is tracked as a
+follow-up.)
 
 ## Prevalence model: same neighborhood as R, and the same conclusions
 
@@ -83,12 +92,22 @@ computed base β (for example R `stm`'s exact spectral β), so a fit can start f
 R's initialization and reproduce that run.
 
 What replicates stably across optima is the substantive conclusion. Regressing
-topic prevalence on ideology, topica recovers R's effect coefficients with a
-Pearson correlation of 0.84, and the same sign and significance on 13 of 15
-topics. The [Poliblog](../examples/poliblog.md) and
-[Gadarian](../examples/gadarian.md) worked examples refit the canonical `stm`
-vignettes end to end and recover the prevalence effects the package documents,
-with well-calibrated standard errors from the method of composition.
+topic prevalence on ideology, topica recovers the same effect directions R does:
+in the worked examples the per-topic effect coefficients correlate strongly with
+R's and agree on the sign and significance of most topics (the few that differ are
+the bistable topics the two optimizers split, not a systematic offset). The
+[Poliblog](../examples/poliblog.md) and [Gadarian](../examples/gadarian.md)
+worked examples refit the canonical `stm` vignettes end to end and recover the
+prevalence effects the package documents. `estimate_effect` computes its
+method-of-composition standard errors with R `estimateEffect`'s default
+**Global** uncertainty (one shared topic covariance across documents); pass
+`uncertainty="local"` for the per-document variational covariance, or `"none"`
+for OLS on the point estimate.
+
+The committed gold gates the topic-word matrix (β cosine and top-word overlap);
+the prevalence-effect, θ, and content-κ agreement above is demonstrated in the
+worked-example replications, with committed effect/θ parity fixtures tracked as a
+follow-up.
 
 The smaller Gadarian survey corpus (339 documents, K = 3) is a deliberately
 harder, more multimodal case: with so few short open-ended responses, R itself

--- a/python/topica/effects.py
+++ b/python/topica/effects.py
@@ -199,7 +199,7 @@ def _resample_draws(draws, nsims, seed):
     return draws[rng.integers(0, s, size=nsims)]
 
 
-def composition_theta(model, corpus=None, *, nsims=25, seed=0):
+def composition_theta(model, corpus=None, *, nsims=25, seed=0, uncertainty="local"):
     """Draw ``nsims`` theta matrices for method-of-composition, auto-selecting the
     sampler from the model family. Returns ``(nsims, num_docs, num_topics)``.
 
@@ -207,10 +207,17 @@ def composition_theta(model, corpus=None, *, nsims=25, seed=0):
     cross-sweep posterior samples; issue #31) when present, which also means no
     ``corpus`` is needed. It falls back to :func:`dirichlet_theta_samples` (the
     within-document Dirichlet approximation, which does need ``corpus`` for the
-    document lengths) when the model was fit with ``keep_theta_draws=False``."""
+    document lengths) when the model was fit with ``keep_theta_draws=False``.
+
+    ``uncertainty`` applies only to the logistic-normal (STM/CTM) family and is
+    forwarded to :func:`posterior_theta_samples` (``"local"`` / ``"global"`` /
+    ``"none"``, R ``stm``'s ``thetaPosterior`` types); it is ignored for the
+    Dirichlet family, whose draws come from the retained MCMC state."""
     fam = model_family(model)
     if fam == "logistic_normal":
-        return posterior_theta_samples(model, nsims=nsims, seed=seed)
+        return posterior_theta_samples(
+            model, nsims=nsims, seed=seed, uncertainty=uncertainty
+        )
     if fam == "dirichlet":
         draws = getattr(model, "theta_draws", None)
         if draws is not None and len(draws):

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -20,10 +20,10 @@ or — given posterior draws from :func:`posterior_theta_samples` (an STM/CTM
 variational posterior) — the **method of composition**, pooling per-draw
 regressions by Rubin's rules so the standard errors propagate topic-estimation
 uncertainty, following the same method-of-composition procedure as R ``stm``'s
-``estimateEffect``. topica propagates the per-document theta posterior
-uncertainty; it does not additionally simulate global-parameter (beta, Sigma,
-gamma) uncertainty, so its pooled standard errors are generally a touch smaller.
-Nonlinear and interaction terms are built with :func:`spline` and
+``estimateEffect``. The θ draws use R ``estimateEffect``'s default **Global**
+uncertainty (one shared topic covariance across documents) unless you pass
+``uncertainty="local"`` (each document's own variational covariance) or
+``"none"``. Nonlinear and interaction terms are built with :func:`spline` and
 :func:`interaction`.
 """
 
@@ -589,6 +589,7 @@ def estimate_effect(
     corpus=None,
     nsims=None,
     seed=0,
+    uncertainty="global",
 ):
     """Regress each topic's proportion on document covariates.
 
@@ -605,6 +606,16 @@ def estimate_effect(
     posterior (e.g. BERTopic), method-of-composition is unavailable; pass the model
     (not just its ``doc_topic`` array) so this is flagged, and use
     ``standard_errors(..., method="bootstrap")`` to quantify uncertainty.
+
+    ``uncertainty`` (STM/CTM only, when the θ posterior is drawn here via a model
+    + ``nsims``) selects the draw covariance, matching R ``stm``'s
+    ``thetaPosterior`` ``type=``. It defaults to ``"global"`` — R
+    ``estimateEffect``'s default — which draws every document from one shared
+    covariance (the global topic-model uncertainty) and so widens the intervals
+    relative to ``"local"`` (each document's own variational covariance, topica's
+    former behavior). ``"none"`` propagates no topic uncertainty (OLS on the point
+    θ). It has no effect when you pass a precomputed draw array or a Dirichlet
+    (Gibbs) model.
 
     For paper-grade inference two extras matter:
 
@@ -675,6 +686,12 @@ def estimate_effect(
         Restrict to these topics. Defaults to all.
     ci : float
         Confidence level for the (normal-approximation) intervals.
+    uncertainty : {"global", "local", "none"}
+        Draw covariance for the STM/CTM θ posterior when it is sampled here
+        (model + ``nsims``); R ``stm``'s ``thetaPosterior`` ``type=``. Defaults
+        to ``"global"`` (R ``estimateEffect``'s default; shared covariance,
+        wider CIs). See the discussion above. Ignored for precomputed draws or
+        Dirichlet models.
 
     Returns
     -------
@@ -720,12 +737,18 @@ def estimate_effect(
     # nsims, the family-appropriate posterior is sampled for method-of-composition
     # standard errors (no hand-wiring a sampler); without it, the point theta is
     # used for plain OLS.
+    if uncertainty not in ("global", "local", "none"):
+        raise ValueError(
+            f"uncertainty must be 'global', 'local', or 'none' (got {uncertainty!r})"
+        )
     if hasattr(doc_topic, "doc_topic") and not isinstance(doc_topic, np.ndarray):
         from .effects import composition_theta, model_family
 
         _model = doc_topic
         if nsims:
-            doc_topic = composition_theta(_model, corpus, nsims=nsims, seed=seed)
+            doc_topic = composition_theta(
+                _model, corpus, nsims=nsims, seed=seed, uncertainty=uncertainty
+            )
         else:
             # A model with no posterior over theta (a cluster/embedding model such as
             # BERTopic) has no method-of-composition path, so this is plain OLS on a
@@ -1580,17 +1603,38 @@ def predicted_prevalence(
     return out
 
 
-def posterior_theta_samples(model, nsims=25, seed=0):
+def posterior_theta_samples(model, nsims=25, seed=0, *, uncertainty="local"):
     """Draw `nsims` samples of the document-topic matrix θ from a fitted
     :class:`STM`/:class:`CTM`'s variational posterior.
 
-    Each document's logistic-normal posterior is ``η_d ~ N(λ_d, ν_d)`` (from
-    ``model.eta_mean`` / ``model.eta_cov``); a draw of η is mapped through the
-    softmax (with the reference category fixed at 0) to a θ row. Feed the result
-    to :func:`estimate_effect` for method-of-composition uncertainty.
+    Each document's logistic-normal posterior is centered at ``λ_d``
+    (``model.eta_mean``); a draw of η is mapped through the softmax (with the
+    reference category fixed at 0) to a θ row. Feed the result to
+    :func:`estimate_effect` for method-of-composition uncertainty.
+
+    ``uncertainty`` chooses the draw covariance, matching R ``stm``'s
+    ``thetaPosterior`` ``type=``:
+
+    - ``"local"`` (default here) — each document draws from its own variational
+      covariance ``ν_d`` (``model.eta_cov``). This is R's ``type="Local"``.
+    - ``"global"`` — every document draws from one *shared* covariance, R's
+      ``type="Global"`` (``Σ − crossprod(λ − μ)/N``). For STM/CTM's M-step that
+      shared covariance is identically the mean per-document variational
+      covariance ``mean_d(ν_d)`` (the between-document spread of the point λ is
+      exactly what the ``Σ`` update adds to ``mean(ν)``), so this propagates the
+      global topic-model uncertainty rather than each document's local Hessian.
+      It is R ``estimateEffect``'s default; :func:`estimate_effect` uses it.
+    - ``"none"`` — no topic-model uncertainty: every draw is the point θ
+      (``model.doc_topic``). Method-of-composition then reduces to OLS on the
+      point estimate and *understates* uncertainty; provided for parity with R's
+      ``type="None"`` and for a fast point-estimate pass.
 
     Returns an array of shape ``(nsims, num_docs, num_topics)``.
     """
+    if uncertainty not in ("local", "global", "none"):
+        raise ValueError(
+            f"uncertainty must be 'local', 'global', or 'none' (got {uncertainty!r})"
+        )
     # This is the logistic-normal (STM/CTM) sampler. Refuse other families cleanly
     # rather than failing with an AttributeError on the missing ``eta_mean`` getter
     # (issue #651): point at the right path for each family.
@@ -1610,34 +1654,56 @@ def posterior_theta_samples(model, nsims=25, seed=0):
             "of='effect', method='bootstrap') for uncertainty on this model."
         )
     lam = np.asarray(model.eta_mean, dtype=np.float64)  # (D, K-1)
+    d, km1 = lam.shape
+
+    # "none": no topic-model uncertainty — every draw is the point θ.
+    if uncertainty == "none":
+        full = np.concatenate([lam, np.zeros((d, 1))], axis=1)  # ref cat = 0
+        full -= full.max(axis=1, keepdims=True)
+        e = np.exp(full)
+        theta = e / e.sum(axis=1, keepdims=True)                # (D, K)
+        return np.broadcast_to(theta, (nsims, d, theta.shape[1])).copy()
+
     try:
         cov = np.asarray(model.eta_cov, dtype=np.float64)   # (D, K-1, K-1)
     except RuntimeError:
         cov = np.asarray(model._recompute_eta_cov(), dtype=np.float64)
-    d, km1 = lam.shape
-    k = km1 + 1
     rng = np.random.default_rng(seed)
     eye = np.eye(km1)
 
-    # Cholesky factors for every document at once. Cholesky is all-or-nothing on
-    # a batch, so only fall back to per-doc eigh for the docs that aren't PD —
-    # the common (all-PD) case stays a single batched LAPACK call.
-    csym = 0.5 * (cov + cov.transpose(0, 2, 1)) + 1e-10 * eye
-    try:
-        chol = np.linalg.cholesky(csym)                  # (D, K-1, K-1)
-    except np.linalg.LinAlgError:
-        chol = np.empty_like(csym)
-        for di in range(d):
-            try:
-                chol[di] = np.linalg.cholesky(csym[di])
-            except np.linalg.LinAlgError:
-                w, v = np.linalg.eigh(csym[di])
-                chol[di] = v @ np.diag(np.sqrt(np.clip(w, 1e-12, None)))
+    if uncertainty == "global":
+        # One shared covariance for all documents: the mean per-doc variational
+        # covariance, which equals R's Global Σ − crossprod(λ − μ)/N (the STM/CTM
+        # M-step sets Σ = crossprod(λ − μ)/N + mean(ν) at sigma.prior=0). Averaging
+        # PSD covariances keeps it PSD, so the Cholesky is robust.
+        shared = 0.5 * (cov.mean(axis=0) + cov.mean(axis=0).T) + 1e-10 * eye
+        try:
+            l_shared = np.linalg.cholesky(shared)
+        except np.linalg.LinAlgError:
+            w, v = np.linalg.eigh(shared)
+            l_shared = v @ np.diag(np.sqrt(np.clip(w, 1e-12, None)))
+        z = rng.standard_normal((d, nsims, km1))
+        eta = lam[:, None, :] + z @ l_shared.T               # (D, nsims, K-1)
+    else:
+        # Local: per-document covariance ν_d. Cholesky is all-or-nothing on a
+        # batch, so only fall back to per-doc eigh for the docs that aren't PD —
+        # the common (all-PD) case stays a single batched LAPACK call.
+        csym = 0.5 * (cov + cov.transpose(0, 2, 1)) + 1e-10 * eye
+        try:
+            chol = np.linalg.cholesky(csym)                  # (D, K-1, K-1)
+        except np.linalg.LinAlgError:
+            chol = np.empty_like(csym)
+            for di in range(d):
+                try:
+                    chol[di] = np.linalg.cholesky(csym[di])
+                except np.linalg.LinAlgError:
+                    w, v = np.linalg.eigh(csym[di])
+                    chol[di] = v @ np.diag(np.sqrt(np.clip(w, 1e-12, None)))
+        # Draw in document order (matches the old per-doc loop's RNG stream), then
+        # η = λ + Z·Lᵀ for all docs/sims via one batched matmul.
+        z = rng.standard_normal((d, nsims, km1))
+        eta = lam[:, None, :] + z @ chol.transpose(0, 2, 1)  # (D, nsims, K-1)
 
-    # Draw in document order (matches the old per-doc loop's RNG stream), then
-    # η = λ + Z·Lᵀ for all docs/sims via one batched matmul.
-    z = rng.standard_normal((d, nsims, km1))
-    eta = lam[:, None, :] + z @ chol.transpose(0, 2, 1)  # (D, nsims, K-1)
     full = np.concatenate([eta, np.zeros((d, nsims, 1))], axis=2)  # ref cat = 0
     full -= full.max(axis=2, keepdims=True)
     e = np.exp(full)

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7870,9 +7870,12 @@ impl STM {
     /// β init) or ``"random"`` (seeded). Spectral init applies to the base
     /// topic-word β with or without a content covariate: the content (SAGE)
     /// deviations κ are then derived deterministically from that base β, so a
-    /// content fit under spectral init is seed-independent too. Spectral can fall
-    /// back to a seeded random init for a degenerate corpus; ``initialization``
-    /// records which route ran.
+    /// content fit under spectral init is seed-independent too. Because the whole
+    /// spectral fit is deterministic, refitting across `seed` values is a no-op —
+    /// it does not test topic stability. For a stability check use
+    /// ``init="random"`` with varied seeds, or ``topica.topic_stability``.
+    /// Spectral can fall back to a seeded random init for a degenerate corpus;
+    /// ``initialization`` records which route ran.
     /// `variational` selects the per-document variational-covariance mode:
     /// ``"laplace"`` (default; full posterior covariance ν = H⁻¹) or
     /// ``"diagonal"`` (mean-field ν = diag(1/H_ii), which skips the per-document
@@ -7980,10 +7983,13 @@ impl STM {
     /// random walk, the temporal generalization of `content`. `content_smooth`
     /// controls that random-walk penalty strength (``1/tau^2``); larger values tie
     /// adjacent periods more tightly. `content_prior` selects the prior on the
-    /// content (SAGE κ) deviation blocks: ``"l2"`` (default) is a Gaussian ridge on
-    /// the deviations, while ``"l1"`` puts a *pure* sparse Laplace prior (FISTA, exact
-    /// zeros) on them — recovering sparse content contrasts, matching R `stm`'s sparse
-    /// content model. Under ``"l1"`` the deviation blocks carry the Laplace prior only
+    /// content (SAGE κ) deviation blocks: ``"l2"`` (topica's default) is a Gaussian
+    /// ridge on the deviations, while ``"l1"`` puts a *pure* sparse Laplace prior
+    /// (FISTA, exact zeros) on them — recovering sparse content contrasts and matching
+    /// R `stm`'s default (`kappa.prior="L1"`, a glmnet word-wise lasso). topica keeps
+    /// L2 as its default because that is the path its committed gold validates; pass
+    /// ``"l1"`` for R-comparable sparse content. Under ``"l1"`` the deviation blocks
+    /// carry the Laplace prior only
     /// (not an additional ridge); the topic baseline `kappa_topic` keeps its L2 either
     /// way. `content_prior_var` (default ``0.5``) sets the deviation-prior scale: under
     /// ``"l2"`` it is the Gaussian prior variance, under ``"l1"`` the Laplace scale (the

--- a/tests/test_estimate_effect_moc.py
+++ b/tests/test_estimate_effect_moc.py
@@ -104,6 +104,58 @@ class TestMethodOfComposition:
             stm.estimate_effect(np.zeros((2, 2, 2, 2)), X)
 
 
+class TestUncertaintySelector:
+    """#715-#2: R stm's thetaPosterior Global/Local/None, defaulting to Global
+    (R estimateEffect's default) for estimate_effect's method-of-composition."""
+
+    def test_none_draws_are_the_point_theta(self, treated_model):
+        m, _ = treated_model
+        draws = stm.posterior_theta_samples(m, nsims=5, seed=0, uncertainty="none")
+        assert draws.shape == (5, m.doc_topic.shape[0], m.num_topics)
+        # No topic-model uncertainty: every draw is the point theta.
+        for s in range(5):
+            np.testing.assert_allclose(draws[s], np.asarray(m.doc_topic), atol=1e-12)
+
+    def test_global_covariance_is_mean_eta_cov(self, treated_model):
+        # R's Global shared covariance (Sigma - crossprod(lambda-mu)/N) equals the
+        # mean per-doc variational covariance at sigma.prior=0. Verify the draws'
+        # empirical within-doc covariance matches mean(eta_cov), shared across docs.
+        m, _ = treated_model
+        shared = np.asarray(m.eta_cov, dtype=np.float64).mean(axis=0)  # (K-1,K-1)
+        draws = stm.posterior_theta_samples(m, nsims=4000, seed=0, uncertainty="global")
+        # Map theta back to eta (ref cat 0): eta_k = log(theta_k) - log(theta_ref).
+        logit = np.log(draws[..., :-1]) - np.log(draws[..., -1:])  # (S, D, K-1)
+        emp = np.cov(logit[:, 0, :], rowvar=False)  # doc 0's draw covariance
+        np.testing.assert_allclose(np.atleast_2d(emp), shared, rtol=0.15, atol=0.02)
+
+    def test_se_ordering_none_local_global(self, treated_model):
+        m, X = treated_model
+        ses = {}
+        for unc in ("none", "local", "global"):
+            eff = stm.estimate_effect(
+                m, X=X, feature_names=["treatment"], nsims=80, seed=0, uncertainty=unc
+            )
+            ti = eff[0].feature_names.index("treatment")
+            ses[unc] = eff[0].se[ti]
+        # Global propagates the most uncertainty, none the least.
+        assert ses["none"] <= ses["local"] <= ses["global"]
+
+    def test_global_is_the_default(self, treated_model):
+        m, X = treated_model
+        default = stm.estimate_effect(m, X=X, feature_names=["treatment"], nsims=80, seed=0)
+        explicit = stm.estimate_effect(
+            m, X=X, feature_names=["treatment"], nsims=80, seed=0, uncertainty="global"
+        )
+        np.testing.assert_allclose(default[0].se, explicit[0].se)
+
+    def test_invalid_uncertainty_rejected(self, treated_model):
+        m, X = treated_model
+        with pytest.raises(ValueError, match="uncertainty must be"):
+            stm.estimate_effect(m, X=X, nsims=5, uncertainty="bogus")
+        with pytest.raises(ValueError, match="uncertainty must be"):
+            stm.posterior_theta_samples(m, nsims=5, uncertainty="bogus")
+
+
 class TestSpline:
     def test_basis_shape_and_names(self):
         x = np.linspace(0, 10, 100)


### PR DESCRIPTION
Part 1 of the Gate B STM findings (#715). Per Neal's split decision: the Global-uncertainty fix + doc honesty land here; the committed effect/θ/topic-correlation golds and the matched-prior content test are a follow-up (PR-B).

## Decisions applied
- **#715-#2 (Global vs Local)** → add an `uncertainty=` selector, **default Global** (R `estimateEffect`'s default).
- **#715-#3 (content L1/L2)** → keep L2 default, document the deviation from R's L1.
- **#715-#1 (parity overclaim)** → narrow the docs to what's actually gated; committed effect/θ golds tracked as follow-up.

## Global uncertainty (the headline)
`estimate_effect` now draws its method-of-composition θ with R `estimateEffect`'s default **Global** uncertainty — one shared topic covariance across documents — instead of the narrower per-document (Local) covariance. This widens the effect CIs to match R's drop-in behavior.

The implementation rests on an exact identity rather than new plumbing: R stm's `thetaPosterior(type="Global")` shared covariance is `Σ − crossprod(λ − μ)/N`, and the STM/CTM M-step (`sigma.prior=0`, both engines' default) sets `Σ = crossprod(λ − μ)/N + mean(ν)`. So the Global covariance is **identically `mean(eta_cov)`** — already exposed, guaranteed PSD (a mean of PSD matrices), and needs no per-doc μ or Σ getter. Verified numerically (`Σ − mean(ν)` is PSD) and with a test asserting the empirical draw covariance equals `mean(eta_cov)`.

- `uncertainty="global"` (default) — shared covariance, R's default, widest CIs.
- `uncertainty="local"` — each document's own variational covariance (topica's former behavior).
- `uncertainty="none"` — OLS on the point θ (no topic-model uncertainty).

Threaded `posterior_theta_samples → composition_theta → estimate_effect`. `posterior_theta_samples` keeps its own `"local"` default so `topic_correlation_ci` / `prevalence_ci` (deliberately per-document) are unchanged; only `estimate_effect` defaults to Global.

**Behavior change:** existing STM/CTM `estimate_effect(model, nsims=...)` CIs widen (Global > Local). SE ordering `none ≤ local ≤ global` is asserted in tests.

## Content L1/L2 (#715-#3)
Documented that topica defaults to Gaussian **L2** while R defaults to `kappa.prior="L1"`; `content_prior="l1"` is the R-match knob. L2 stays the default (the path the committed gold validates).

## Doc honesty (#715-#1)
- `docs/replications/stm.md`: content "exact agreement" → close agreement with a different default prior (~0.999 cosine, differing topic-separation, the L1-vs-L2 signature); the "0.84 / 13-of-15" effect claim → qualitative agreement demonstrated in the worked examples, with committed effect/θ golds called out as a follow-up.
- Effects/covariates guides updated to the Global default and the simpler `estimate_effect(model, nsims=)` idiom.
- Spectral-init seed-inertness footgun note (deterministic fit → refitting across seeds is a no-op; use `init="random"` or `topic_stability`).

## Tests / verification
- `TestUncertaintySelector` in `test_estimate_effect_moc.py`: Global-is-default, SE ordering, `none`==point θ, empirical covariance == `mean(eta_cov)`, invalid rejected.
- Full suite: **4871 passed**, 38 skipped.
- `scripts/preflight.sh` clean; `mkdocs build --strict` clean.

## Follow-up (PR-B, #715-#1 golds + #715-#3 test)
Extend `stm_gold.py` with θ / composition-effect / topic-correlation R golds (β-aligned; γ/Σ validated via their interpretable K-space forms), recompute the real effect-correlation numbers, and add the matched-prior content parity test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)