### PR TITLE
KeyATM: covariate dead-zone warning + α/keyword guards + honest covariate docs (#716, part 1)

### DIFF
--- a/docs/guides/guided.md
+++ b/docs/guides/guided.md
@@ -85,24 +85,46 @@ An intercept is prepended; the learned coefficients are in `feature_effects`.
 import numpy as np
 is_dem = np.array([...]).reshape(-1, 1)          # one row per document
 model = topica.KeyATM(seeds, num_topics=2, seed=1)
+# λ is optimized only on the sweeps after burn_in, so give the fit enough
+# iterations (>= burn_in + optimize_interval, 250 at the defaults) or
+# feature_effects come back all-zero — the model warns when they would.
 model.fit(docs, covariates=is_dem, feature_names=["is_dem"], iters=1000)
 
-model.feature_names       # ['intercept', 'is_dem']
-model.feature_effects     # (num_topics, 2): coefficient of each covariate per topic
-model.feature_effect_se   # same shape: standard error of each coefficient
-z = model.feature_effects / model.feature_effect_se   # |z| > ~2 ⇒ notable
+# Report predicted topic proportions at each covariate value, with CIs — the
+# interpretable, on-the-proportion-scale answer (R keyATM's predicted props).
+pp = topica.predicted_prevalence(
+    model, X=is_dem, feature_names=["is_dem"], at={"is_dem": [0, 1]}
+)
+print(pp)   # per topic (with topic_name): predicted share at is_dem=0 vs 1, 95% CI
 ```
 
-A larger `feature_effects[k, j]` means covariate `j` raises topic `k`'s
-prevalence. `feature_effect_se` gives the standard error of each λ, so you can
-tell a real effect from noise: it is the observed information of the same
-penalized Dirichlet-multinomial that `DMR` uses, computed in the standardized fit
-space (keyATM z-scores covariates internally, issue #270) and mapped back to the
-original covariate scale, so it is exact (no bootstrap) and computed once at fit
-time. An entry is `NaN` when its standardized coefficient hit keyATM's ±5 bound,
-where the constrained estimate has no valid asymptotic standard error. For
-uncertainty on the resulting topic prevalences, pair the fitted `doc_topic` with
+**Report `predicted_prevalence`, not the raw coefficient.** `feature_effects[k, j]`
+is the underlying log-α regression coefficient λ, *not* a difference in topic
+proportions: it lives on the `exp(x·λ)` prior scale, so its sign gives the
+direction but its magnitude and z-score can disagree with the actual change in
+prevalence (a λ that looks "not notable" can still move the predicted proportion
+significantly). `predicted_prevalence` pushes the effect through to the topic-share
+scale with simulation CIs, which is what keyATM users report (`plot_predicted_prop`).
+
+```python
+model.feature_names       # ['intercept', 'is_dem']
+model.feature_effects     # (num_topics, 2): the log-α coefficient λ per covariate
+model.feature_effect_se   # asymptotic SE of each λ (see the caveat below)
+```
+
+Two fidelity caveats. topica estimates λ by **L-BFGS MAP** every `optimize_interval`
+sweeps (the penalized Dirichlet-multinomial `DMR` uses), whereas R keyATM
+slice/MH-**samples** λ every iteration; the generative model, N(0,1) prior, and ±5
+bound match, but the estimator does not. So `feature_effect_se` is an **asymptotic**
+observed-information SE (a topica construct computed once at fit time in the
+standardized space and mapped back, issue #270), not keyATM's posterior SD; an entry
+is `NaN` when its standardized coefficient hit the ±5 bound, where the constrained
+estimate has no valid asymptotic SE. For uncertainty on the resulting topic
+prevalences, prefer `predicted_prevalence` above, or pair the fitted `doc_topic` with
 [`estimate_effect`](covariates.md).
+
+`visualize_keywords(model)` and `refine_keywords(...)` inspect and prune the keyword
+sets (the latter drops too-rare seeds before fitting); see their docstrings.
 
 ### Dynamic keyATM
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -6048,16 +6048,23 @@ class KeyATM:
     @property
     def feature_effects(self) -> numpy.typing.NDArray[numpy.float64]:
         """Covariate model: learned lambda, shape (num_topics, F+1); column 0 is
-        the intercept. Raises if fit without covariates."""
+        the intercept. These are the log-alpha regression coefficients
+        (alpha_dk = exp(x_d . lambda_k)), NOT differences in topic proportions:
+        the sign gives direction, but for the effect on the topic-share scale use
+        topica.predicted_prevalence. lambda is MAP-estimated (not keyATM's
+        per-sweep MCMC). Raises if fit without covariates."""
         ...
     @property
     def feature_effect_se(self) -> numpy.typing.NDArray[numpy.float64] | None:
         """Covariate model: standard errors of feature_effects (lambda), same
-        shape and column order, on the original covariate scale (observed
-        information in the standardized fit space mapped back by the
-        standardization Jacobian, issue #316). NaN where the standardized lambda
-        hit the +/-5 bound. None when lambda was never optimized to a stationary
-        point (optimize_interval past iters, burn_in>=iters, lbfgs_iters=0, or
+        shape and column order, on the original covariate scale. Asymptotic SE (a
+        topica construct), NOT keyATM's posterior SD: topica MAP-estimates lambda,
+        so the SE is the observed information of the penalized Dirichlet-multinomial
+        in the standardized fit space mapped back by the standardization Jacobian
+        (issue #316). Prefer predicted_prevalence for significance on the
+        topic-proportion scale. NaN where the standardized lambda hit the +/-5
+        bound. None when lambda was never optimized to a stationary point
+        (optimize_interval past iters, burn_in>=iters, lbfgs_iters=0, or
         non-convergence), since the observed information is only a valid covariance
         at an optimum (#418). Raises if fit without covariates."""
         ...
@@ -6078,8 +6085,10 @@ class KeyATM:
     @property
     def time_prevalence(self) -> numpy.typing.NDArray[numpy.float64]:
         """Dynamic model: smoothed topic prevalence per time segment, shape
-        (T, num_topics), aligned with `time_labels`. Raises if fit without
-        `timestamps`."""
+        (T, num_topics), aligned with `time_labels`. This is the per-state
+        normalized alpha (the learned Dirichlet prior mean per HMM state), not R
+        keyATM's period-mean of the posterior theta; they track each other but are
+        different estimators. Raises if fit without `timestamps`."""
         ...
     @property
     def time_state(self) -> list[int]:

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -568,6 +568,18 @@ impl DirichletModel for KeyAtmModel {
 /// Mirrors the `sample_index` in `gsdmm.rs`.
 fn sample_index<R: Rng>(weights: &[f64], rng: &mut R) -> usize {
     let total: f64 = weights.iter().sum();
+    // A non-finite or non-positive total means a degenerate weight vector — e.g. a
+    // NaN from an upstream numeric breakdown. Without this guard `r` is NaN, `r <=
+    // 0.0` is never true, and the loop silently falls through to the last index —
+    // a biased, wrong draw dressed up as a sample. Catch it loudly in debug/tests;
+    // in release fall back to a uniform pick rather than always the last state.
+    debug_assert!(
+        total.is_finite() && total > 0.0,
+        "sample_index: non-finite or non-positive weight total ({total})"
+    );
+    if !(total.is_finite() && total > 0.0) {
+        return rng.gen_range(0..weights.len());
+    }
     let mut r = rng.gen::<f64>() * total;
     for (i, &w) in weights.iter().enumerate() {
         r -= w;
@@ -1796,13 +1808,16 @@ fn covariate_lambda_se(
 
 /// Fit a keyATM **Covariate** model. The document-topic prior is a
 /// Dirichlet-Multinomial regression on document features,
-/// `α_{d,k} = exp(x_d · λ_k)` (Mimno & McCallum 2008), matching the keyATM R
-/// package's covariate model. Following R keyATM, the covariates are standardized
-/// and `λ` is bounded to ±5 (see [`LAMBDA_BOUND`] and [`standardize_features`])
-/// to keep `α` from blowing up; `λ` is re-estimated by L-BFGS (MAP under an
-/// N(0,1) prior) every
-/// `opt_interval` sweeps once past `burn_in`; the keyword (z, s) sampler is
-/// otherwise identical to the base model.
+/// `α_{d,k} = exp(x_d · λ_k)` (Mimno & McCallum 2008). It shares keyATM's
+/// generative model, N(0,1) prior, and ±5 bound, but **estimates `λ` by L-BFGS
+/// MAP (not keyATM's per-sweep slice/MH sampling)** — so `λ` is a MAP point
+/// estimate and its SE (issue #316) is asymptotic observed-information, not a
+/// posterior SD. Following R keyATM, the covariates are standardized and `λ` is
+/// bounded to ±5 (see [`LAMBDA_BOUND`] and [`standardize_features`]) to keep `α`
+/// from blowing up; `λ` is re-estimated every `opt_interval` sweeps once past
+/// `burn_in` (so it stays at its zero init — a null covariate effect — if
+/// `iters < burn_in + opt_interval`). The keyword (z, s) sampler is otherwise
+/// identical to the base model.
 #[allow(clippy::too_many_arguments)]
 pub fn fit_keyatm_cov<R: Rng>(
     docs: &[Vec<u32>],
@@ -3494,6 +3509,24 @@ mod tests {
     fn accepts_nonpositive_alpha_when_estimated() {
         // α is only a start when estimated, so a 0 start is not rejected.
         run_base(&two_docs(), 2, 1, &[vec![0]], 0.0, 0.1, true);
+    }
+
+    #[test]
+    fn sample_index_returns_in_range_for_valid_weights() {
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        for _ in 0..200 {
+            let i = sample_index(&[1.0, 2.0, 3.0], &mut rng);
+            assert!(i < 3);
+        }
+    }
+
+    #[test]
+    #[should_panic(expected = "non-finite or non-positive weight total")]
+    fn sample_index_rejects_nan_weights() {
+        // A NaN weight makes `r <= 0.0` never true; without the guard the loop
+        // silently falls through to the last index. The debug_assert catches it.
+        let mut rng = ChaCha8Rng::seed_from_u64(7);
+        let _ = sample_index(&[1.0, f64::NAN, 3.0], &mut rng);
     }
 
     fn run_dynamic(time_index: &[usize], num_states: usize, eta1: f64) {

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -14887,8 +14887,11 @@ impl KeyATM {
     /// Create an unfitted model. `keywords` is ``{topic_name: [words]}`` (the
     /// keyword topics, in order). `num_topics` (default = number of keyword
     /// topics) may be larger to add regular, no-keyword topics. `alpha` is the
-    /// per-topic Dirichlet; it defaults to ``1 / num_topics``, matching R keyATM's
-    /// base prior (this is the starting point when `estimate_alpha` is on).
+    /// per-topic Dirichlet prior; it defaults to ``1 / num_topics``. It is the
+    /// **fixed** symmetric α used only when ``estimate_alpha=False``. Under the
+    /// default ``estimate_alpha=True``, α is learned each sweep starting from
+    /// keyATM's own ``50 / num_topics`` (matching R keyATM's base default), and a
+    /// supplied `alpha` is **ignored** (a warning is emitted if you pass one).
     /// `beta`/`beta_keyword` are the regular and keyword topic-word smoothing, and
     /// `gamma1`/`gamma2` the Beta prior on the keyword-vs-regular switch.
     ///
@@ -14905,6 +14908,7 @@ impl KeyATM {
     #[pyo3(signature = (keywords, *, num_topics=None, alpha=None, beta=0.01, beta_keyword=0.1, gamma1=1.0, gamma2=1.0, seed=13, estimate_alpha=true, sampler="sparse", num_threads=1))]
     #[allow(clippy::too_many_arguments)]
     fn new(
+        py: Python<'_>,
         keywords: &Bound<'_, PyDict>,
         #[pyo3(from_py_with = "py_num_topics_opt")] num_topics: Option<usize>,
         alpha: Option<f64>,
@@ -14927,7 +14931,21 @@ impl KeyATM {
         if k < 2 {
             return Err(PyValueError::new_err("need at least 2 topics"));
         }
-        // Default to R keyATM's base prior 1/K.
+        // Under estimate_alpha=True (the default) α is learned from keyATM's 50/K
+        // start, so a user-supplied fixed alpha is ignored — warn rather than drop
+        // it silently. It is honored only when estimate_alpha=False.
+        if alpha.is_some() && estimate_alpha {
+            let warnings = py.import_bound("warnings")?;
+            warnings.call_method1(
+                "warn",
+                (
+                    "KeyATM(alpha=…) is ignored when estimate_alpha=True (the default): α is \
+                  learned each sweep starting from keyATM's 50/num_topics. Pass \
+                  estimate_alpha=False to use your fixed α, or drop alpha= to silence this.",
+                ),
+            )?;
+        }
+        // The fixed symmetric prior (used when estimate_alpha=False) defaults to 1/K.
         let alpha = alpha.unwrap_or(1.0 / k as f64);
         if !finite_pos(alpha)
             || !finite_pos(beta)
@@ -15195,30 +15213,59 @@ impl KeyATM {
         // causes it.
         {
             let vocab: HashSet<&str> = corpus.id_to_word.iter().map(|s| s.as_str()).collect();
-            let mut notes: Vec<String> = Vec::new();
+            // Split into mild drops (topic still meaningfully anchored) and severe
+            // drops (>= half the keywords gone), where the topic keeps its label but
+            // is effectively unseeded — its `keyword_rate` will be near zero and its
+            // top words generic. A one-shot lumped warning buried that; call the
+            // severe case out separately so it is not mistaken for a seeded topic.
+            let mut mild: Vec<String> = Vec::new();
+            let mut severe: Vec<String> = Vec::new();
             for (name, words) in slf.key_names.iter().zip(slf.keywords.iter()) {
                 let oov: Vec<&str> = words
                     .iter()
                     .map(|w| w.as_str())
                     .filter(|w| !vocab.contains(w))
                     .collect();
-                if !oov.is_empty() {
-                    notes.push(format!(
-                        "'{}' ({} of {} not in vocabulary, ignored: {})",
-                        name,
-                        oov.len(),
-                        words.len(),
-                        oov.join(", ")
-                    ));
+                if oov.is_empty() {
+                    continue;
+                }
+                let kept = words.len() - oov.len();
+                let note = format!(
+                    "'{}' ({} of {} not in vocabulary, ignored: {})",
+                    name,
+                    oov.len(),
+                    words.len(),
+                    oov.join(", ")
+                );
+                // kept == 0 is the all-dropped case handled by the hard error below.
+                if kept >= 1 && oov.len() * 2 >= words.len() {
+                    severe.push(note);
+                } else {
+                    mild.push(note);
                 }
             }
-            if !notes.is_empty() {
+            if !mild.is_empty() {
                 let warnings = py.import_bound("warnings")?;
                 warnings.call_method1(
                     "warn",
                     (format!(
                         "KeyATM: some keywords were dropped — {}",
-                        notes.join("; ")
+                        mild.join("; ")
+                    ),),
+                )?;
+            }
+            if !severe.is_empty() {
+                let warnings = py.import_bound("warnings")?;
+                warnings.call_method1(
+                    "warn",
+                    (format!(
+                        "KeyATM: these topics lost most of their keywords and are now only \
+                         weakly anchored — they keep their names but behave like unseeded \
+                         topics (keyword_rate near zero, generic top words): {}. A common \
+                         cause is unstemmed seeds against a stemmed vocabulary, or corpus \
+                         pruning (rm_top / min_doc_freq) removing them; stem your seeds to \
+                         match preprocessing, or drop these topics.",
+                        severe.join("; ")
                     ),),
                 )?;
             }
@@ -15421,6 +15468,32 @@ impl KeyATM {
                         )));
                     }
                 }
+                // The covariate coefficients λ are optimized only on the sweeps after
+                // `burn_in` that fall on an `optimize_interval` boundary. If `iters`
+                // is too small (or `optimize_interval == 0`), λ is never optimized, so
+                // it stays at its zero init and `feature_effects` come back all-zero —
+                // a silently null covariate result. The φ/θ topics are still valid, so
+                // we warn rather than refuse (mirrors the empty-keyword-topic guard).
+                let n_lambda_steps = if optimize_interval == 0 || iters <= burn_in {
+                    0
+                } else {
+                    (iters - burn_in) / optimize_interval
+                };
+                if n_lambda_steps == 0 {
+                    let need = burn_in.saturating_add(optimize_interval.max(1));
+                    let warnings = py.import_bound("warnings")?;
+                    warnings.call_method1(
+                        "warn",
+                        (format!(
+                            "KeyATM covariate fit: λ was never optimized (iters={iters}, \
+                             burn_in={burn_in}, optimize_interval={optimize_interval}), so \
+                             feature_effects will be all-zero and feature_effect_se None — \
+                             a null covariate result. The topics (φ/θ) are still valid. For \
+                             covariate effects, fit with iters >= {need} (>= burn_in + \
+                             optimize_interval), lower burn_in, or set optimize_interval > 0.",
+                        ),),
+                    )?;
+                }
                 let feats: Vec<Vec<f64>> = raw
                     .iter()
                     .map(|x| {
@@ -15560,7 +15633,12 @@ impl KeyATM {
     }
 
     /// Covariate model: learned DMR coefficients λ, shape ``(num_topics, F+1)``;
-    /// column 0 is the intercept. Raises if the model was fit without covariates.
+    /// column 0 is the intercept. These are the **log-α regression coefficients**
+    /// (``α_{d,k} = exp(x_d · λ_k)``), not differences in topic proportions: the
+    /// sign gives the direction of a covariate's effect on topic k, but for the
+    /// effect on the topic-share scale (what to report) use
+    /// ``topica.predicted_prevalence``. λ is estimated by L-BFGS MAP (not keyATM's
+    /// per-sweep MCMC sampling). Raises if the model was fit without covariates.
     #[getter]
     fn feature_effects<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
@@ -15572,13 +15650,16 @@ impl KeyATM {
 
     /// Covariate model: standard errors of `feature_effects` (λ), same shape
     /// ``(num_topics, F+1)`` and column order, on the original covariate scale.
-    /// From the observed information of the penalized Dirichlet-multinomial in the
+    /// This is an **asymptotic** SE (a topica construct), *not* keyATM's posterior
+    /// SD: because topica MAP-estimates λ rather than MCMC-sampling it, the SE comes
+    /// from the observed information of the penalized Dirichlet-multinomial in the
     /// standardized fit space, mapped back by the standardization Jacobian
     /// (issue #316). A coefficient is notable when ``|feature_effects| /
-    /// feature_effect_se`` exceeds ~2. Entries are ``NaN`` where the standardized
-    /// λ hit the ±5 bound (the constrained estimate has no valid asymptotic SE).
-    /// ``None`` when λ was never optimized to a stationary point (#418). Raises if
-    /// the model was fit without covariates.
+    /// feature_effect_se`` exceeds ~2, but prefer ``predicted_prevalence`` for
+    /// significance on the topic-proportion scale. Entries are ``NaN`` where the
+    /// standardized λ hit the ±5 bound (the constrained estimate has no valid
+    /// asymptotic SE). ``None`` when λ was never optimized to a stationary point
+    /// (#418). Raises if the model was fit without covariates.
     #[getter]
     fn feature_effect_se<'py>(
         &self,
@@ -15605,8 +15686,10 @@ impl KeyATM {
     }
 
     /// Dynamic model: smoothed topic prevalence per time segment, shape
-    /// ``(T, num_topics)``, rows sum to 1, aligned with `time_labels`. Raises if
-    /// the model was fit without `timestamps`.
+    /// ``(T, num_topics)``, rows sum to 1, aligned with `time_labels`. This is the
+    /// per-state normalized α (the learned Dirichlet prior mean per HMM state), not
+    /// R keyATM's period-mean of the posterior θ; the two track each other but are
+    /// not the same estimator. Raises if the model was fit without `timestamps`.
     #[getter]
     fn time_prevalence<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -15230,6 +15230,11 @@ impl KeyATM {
                     continue;
                 }
                 let kept = words.len() - oov.len();
+                // kept == 0 (all keywords dropped) is the authoritative hard error
+                // below; don't also emit a softer warning for it here.
+                if kept == 0 {
+                    continue;
+                }
                 let note = format!(
                     "'{}' ({} of {} not in vocabulary, ignored: {})",
                     name,
@@ -15237,8 +15242,7 @@ impl KeyATM {
                     words.len(),
                     oov.join(", ")
                 );
-                // kept == 0 is the all-dropped case handled by the hard error below.
-                if kept >= 1 && oov.len() * 2 >= words.len() {
+                if oov.len() * 2 >= words.len() {
                     severe.push(note);
                 } else {
                     mild.push(note);

--- a/tests/test_keyatm_covariate.py
+++ b/tests/test_keyatm_covariate.py
@@ -212,3 +212,46 @@ def test_feature_effect_se_is_none_without_optimization():
     m.fit(docs, covariates=party.reshape(-1, 1), feature_names=["is_D"],
           iters=150, optimize_interval=10000, burn_in=50)
     assert m.feature_effect_se is None
+
+
+# --- #716-#1: the silent covariate dead-zone -------------------------------------
+def test_covariate_deadzone_warns_and_returns_null():
+    # iters < burn_in + optimize_interval (250 at defaults) -> lambda is never
+    # optimized -> all-zero feature_effects. This must WARN, not silently null out.
+    docs, party = _corpus()
+    m = topica.KeyATM(SEEDS, num_topics=2, seed=1)
+    with pytest.warns(UserWarning, match="was never optimized"):
+        m.fit(docs, covariates=party.reshape(-1, 1), feature_names=["is_D"], iters=100)
+    assert np.all(m.feature_effects == 0.0)
+    assert m.feature_effect_se is None
+
+
+def test_covariate_no_deadzone_warn_when_iters_sufficient(recwarn):
+    # iters >= burn_in + optimize_interval -> lambda optimized -> no dead-zone warning.
+    docs, party = _corpus()
+    m = topica.KeyATM(SEEDS, num_topics=2, seed=1)
+    m.fit(docs, covariates=party.reshape(-1, 1), feature_names=["is_D"], iters=300)
+    assert not any("was never optimized" in str(w.message) for w in recwarn)
+    assert not np.all(m.feature_effects == 0.0)
+
+
+# --- #716-#6: user alpha is ignored under estimate_alpha ------------------------
+def test_alpha_ignored_warns_under_estimate_alpha():
+    with pytest.warns(UserWarning, match="ignored when estimate_alpha"):
+        topica.KeyATM(SEEDS, num_topics=2, alpha=0.5)  # estimate_alpha defaults True
+
+
+def test_alpha_honored_no_warn_when_estimate_alpha_false(recwarn):
+    topica.KeyATM(SEEDS, num_topics=2, alpha=0.5, estimate_alpha=False)
+    assert not any("ignored when estimate_alpha" in str(w.message) for w in recwarn)
+
+
+# --- #716-#5: near-total keyword drop is called out --------------------------------
+def test_severe_keyword_drop_warns():
+    # 'economic' keeps only 1 of 4 seeds (the rest are out-of-vocabulary), so it is
+    # effectively unseeded but keeps its label -> a distinct, louder warning.
+    docs, _ = _corpus()
+    seeds = {"economic": ["tax", "zzznope1", "zzznope2", "zzznope3"], "social": SOC[:4]}
+    m = topica.KeyATM(seeds, num_topics=2, seed=1)
+    with pytest.warns(UserWarning, match="weakly anchored"):
+        m.fit(docs, iters=50)


### PR DESCRIPTION
Part 1 of the Gate B KeyATM findings (#716): the safety + honesty fixes. The covariate/dynamic parity golds (decision #4, "add the missing cases") are a follow-up PR.

## #716-#1 — the silent covariate dead-zone (the sharpest finding)
A covariate fit with `iters < burn_in + optimize_interval` (< 250 at the defaults) never optimizes λ, so `feature_effects` came back **all-zero with no warning** — a silently null covariate result headed for a table:
```
iters=240 → feature_effects all-zero, 0 warnings
iters=250 → feature_effects non-zero
```
Now the covariate branch warns loudly, naming the fix (raise iters, lower `burn_in`, or set `optimize_interval > 0`). The φ/θ topics are still valid, so it **warns rather than refuses** (your decision).

## #716-#6 — user `alpha` silently ignored under `estimate_alpha`
Under the default `estimate_alpha=True`, α is learned from keyATM's `50/K` start and a user's `alpha=` was silently dropped; the docstring also wrongly said α defaults to `1/K` "the starting point when estimate_alpha is on". Fixed the docstring (`1/K` is the *fixed* prior used only when `estimate_alpha=False`; the learned start is `50/K`, matching keyATM) and now **warn** when `alpha=` is passed under `estimate_alpha=True` (your decision).

## #716-#8 — categorical sampler NaN guard
`sample_index` summed weights and tested `r <= 0.0`; a NaN weight makes that never true, so the loop silently fell through to the **last index** — a biased draw. Added a finite-positive-total guard (debug-assert + unbiased uniform fallback in release), with Rust unit tests.

## #716-#5 — near-total keyword drop
A topic that lost most (not all) of its seeds kept its label but was effectively unseeded (`keyword_rate ≈ 0`), buried in a one-shot "some dropped" warning. Topics losing ≥ half their keywords now get a distinct **"weakly anchored / behaves like an unseeded topic"** warning with the stem-your-seeds guidance.

## #716-#2/#3 — covariate honesty (docs + docstrings)
`guided.md` now **leads with `predicted_prevalence`** (topic-share scale + CIs, what keyATM users report) instead of the raw λ / z-score, which understated the effect (a λ that reads "not notable" can still move the predicted proportion significantly). `feature_effects` is reframed as the log-α coefficient (sign, not a prevalence difference); the docstrings (Rust + `.pyi`) now state λ is **MAP-estimated** (not keyATM's per-sweep MCMC), `feature_effect_se` is an **asymptotic** SE (not keyATM's posterior SD), and `time_prevalence` is **normalized state-α** (not R's period-mean θ). Surfaced `visualize_keywords`/`refine_keywords` (#716-#9).

## Verification
- Full suite: **4879 passed**, 38 skipped. keyATM Rust units 27/27. `scripts/preflight.sh` clean; `mkdocs build --strict` clean. Verified the new `predicted_prevalence` doc example runs.

## Follow-up (PR-2, decision #4)
Extend `keyatm_gold.py` with covariate λ-magnitude / token-weight / α-π / dynamic HMM state-path parity against R keyATM, then tighten the "full family validated" wording to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)