### PR TITLE
fix(nmf): sample-user usability follow-ups (#726)

### DIFF
--- a/docs/api/models.md
+++ b/docs/api/models.md
@@ -71,4 +71,8 @@ for the full grouped table.
 
 ::: topica.HLDA
 
+::: topica.NMF
+
+::: topica.LSA
+
 ::: topica.Corpus

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -323,8 +323,8 @@ not the minimum, and cross it against coherence.
 ```python
 import topica
 
-b = topica.datasets.load_poliblog()
-corpus = topica.Corpus.from_documents([t.split() for t in b.texts])
+df = topica.datasets.load_poliblog()      # a DataFrame; the text is already stemmed
+corpus = topica.Corpus.from_documents([t.split() for t in df["text"]])
 
 for k in [10, 15, 20, 30, 40]:
     m = topica.NMF(num_topics=k, seed=1).fit(corpus)

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -311,6 +311,38 @@ Pick the knee, not the maximum. Note the sign convention differs from the c_v sw
 above: `EmbeddingLDA.coherence` is per-topic UMass (more-negative is worse), so
 average it and compare on that scale.
 
+## Matrix-factorization models (NMF, LSA)
+
+`NMF` and `LSA` factor the document-term matrix at a fixed rank K, so K is a model
+setting you sweep the ordinary way, by **refitting per K**. `search_k` raises for
+them (it only fits LDA/STM), so run the sweep by hand. NMF gives you a second
+signal LDA does not: the `reconstruction_error` (the fit's residual). Read it like
+a scree plot — the reconstruction error falls monotonically in K, so take the knee,
+not the minimum, and cross it against coherence.
+
+```python
+import topica
+
+b = topica.datasets.load_poliblog()
+corpus = topica.Corpus.from_documents([t.split() for t in b.texts])
+
+for k in [10, 15, 20, 30, 40]:
+    m = topica.NMF(num_topics=k, seed=1).fit(corpus)
+    coh = float(m.coherence(10).mean())        # per-topic UMass -> mean (higher is better)
+    div = topica.topic_diversity(m, topn=25)
+    print(f"K={k:>2}  coherence={coh:.1f}  diversity={div:.2f}  "
+          f"reconstruction_error={m.reconstruction_error:.1f}")
+```
+
+Pick the K where coherence and diversity plateau and the reconstruction error has
+passed its knee. Note the sign convention: `NMF.coherence` is per-topic UMass
+(more-negative is worse), so average it and compare on that scale.
+
+For a **stability** check across seeds, refit with `init="random"` — the default
+`init="nndsvd"` is deterministic and ignores `seed`, so `topic_stability` over
+nndsvd fits would report a meaningless 1.0. Vary the seed under random init, or
+resample the documents, to get an honest robustness read.
+
 ## Report sensitivity
 
 Pick the `K` that balances metrics, interpretability, and theory, then **show

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -4764,8 +4764,16 @@ class NMF:
     is each row of H normalized to sum 1; the document-topic matrix weights each
     topic by its H-row mass before row-normalizing (W_{d,k} * rowsum(H_k), then
     rows to sum 1), so the reported proportion tracks each topic's share of the
-    reconstructed term mass. weighting builds X from topica's TF-IDF (default) or
-    raw counts (weighting="count")."""
+    reconstructed term mass. weighting builds X from topica's TF-IDF (default, the
+    classic NMF recipe) or raw counts (weighting="count").
+
+    Constructor: NMF(num_topics, *, beta_loss="frobenius", init="nndsvd",
+    weighting="tfidf", convergence_tol=1e-4, seed=13). convergence_tol stops early
+    on the relative reconstruction-error decrease; 0.0 disables the early-stop
+    check, so the fit runs the full iters and reports converged=False by design.
+    seed affects only init="random" -- the default init="nndsvd" is deterministic
+    and ignores it, so a stability check that varies only the seed under nndsvd
+    compares identical fits; use init="random" to vary across seeds."""
     @property
     def settings(self) -> dict:
         """The constructor configuration as a JSON-serialisable dict,
@@ -4790,9 +4798,12 @@ class NMF:
     ) -> None:
         """beta_loss is 'frobenius' or 'kullback-leibler' (alias 'kl'); init is
         'nndsvd' or 'random'; weighting is 'tfidf' (default) or 'count'. seed affects only
-        init='random'. The 'nndsvd' init is scikit-learn's NNDSVDa variant (exact
-        zeros filled with the data mean) and requires num_topics <=
-        min(num_documents, num_words); use 'random' above that rank."""
+        init='random' (the default 'nndsvd' init is deterministic and ignores it).
+        convergence_tol=0.0 disables the early-stop check, so the fit runs the full
+        iters and reports converged=False by design. The 'nndsvd' init is
+        scikit-learn's NNDSVDa variant (exact zeros filled with the data mean) and
+        requires num_topics <= min(num_documents, num_words); use 'random' above
+        that rank."""
         ...
     def fit(
         self,

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1448,11 +1448,14 @@ def search_k(
             f"search_k fits an LDA or STM per K; model must be 'lda' or 'stm' "
             f"(got {model!r}). Other models are not scanned here: embedding-guided "
             f"models (EmbeddingLDA) need embeddings/vocabulary search_k cannot "
-            f"infer, and embedding+cluster models (BERTopic, Top2Vec) set K by the "
-            f"clusterer, not by refitting. Sweep K for those by hand: fit each K "
-            f"and compare the mean coherence; see the 'Fixed-K embedding models' "
-            f"(EmbeddingLDA) and 'Embedding + cluster models' (BERTopic/Top2Vec) "
-            f"sections of docs/publishing/choosing-k.md.")
+            f"infer, embedding+cluster models (BERTopic, Top2Vec) set K by the "
+            f"clusterer, not by refitting, and matrix-factorization models (NMF, "
+            f"LSA) are swept the ordinary way by refitting per K. Sweep K for those "
+            f"by hand: fit each K and compare the mean coherence (for NMF also the "
+            f"reconstruction_error); see the 'Matrix-factorization models "
+            f"(NMF, LSA)', 'Fixed-K embedding models' (EmbeddingLDA) and "
+            f"'Embedding + cluster models' (BERTopic/Top2Vec) sections of "
+            f"docs/publishing/choosing-k.md.")
     if int(num_seeds) < 1:
         raise ValueError(f"num_seeds must be >= 1, got {num_seeds!r}")
     if content is not None and model != "stm":
@@ -2664,11 +2667,31 @@ def topic_stability(runs, *, topn=10, metric="cosine"):
     later run's topics are matched to the first run's, and stability is the mean
     Jaccard overlap of their top-`topn` words. Returns a float in ``[0, 1]``;
     higher means more reproducible topics.
+
+    If every run is bit-identical to the first, a stability of 1.0 is
+    meaningless — the runs never varied. This most often bites when the runs are
+    the *same* deterministic fit repeated: models with a deterministic
+    initialization (e.g. ``NMF``/``LSA`` with the default ``init="nndsvd"``)
+    ignore ``seed``, so ``[NMF(seed=s).fit(docs) for s in range(5)]`` is five
+    copies of one fit. A ``UserWarning`` is emitted in that case; refit with
+    ``init="random"`` (which does respond to ``seed``) or measure stability on
+    bootstrap resamples of the documents instead.
     """
     mats = [_as_topic_word(r) for r in runs]
     if len(mats) < 2:
         raise ValueError("need at least two runs to measure stability")
     ref = mats[0]
+    if all(m.shape == ref.shape and np.array_equal(m, ref) for m in mats[1:]):
+        warnings.warn(
+            f"topic_stability: all {len(mats)} runs are identical, so the score "
+            "is a trivial 1.0 that says nothing about robustness. Deterministic "
+            "initializations ignore the seed (e.g. NMF/LSA with init='nndsvd'), "
+            "so repeating the same fit at different seeds gives identical runs. "
+            "Refit with init='random' (which responds to seed) or measure "
+            "stability on bootstrap resamples of the documents.",
+            UserWarning,
+            stacklevel=2,
+        )
     k = ref.shape[0]
     ref_top = [set(np.argsort(ref[t])[::-1][:topn]) for t in range(k)]
     scores = []

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -20,7 +20,16 @@ use pyo3::types::PyDict;
 /// ``H``-row mass before row-normalizing (``W_{d,k} * rowsum(H_k)``, then rows to
 /// sum 1), so the reported proportion tracks each topic's share of the
 /// reconstructed term mass. ``weighting`` builds ``X`` from topica's TF-IDF
-/// (default) or raw counts (``weighting="count"``).
+/// (default, the classic NMF recipe) or raw counts (``weighting="count"``).
+///
+/// Constructor: ``NMF(num_topics, *, beta_loss="frobenius", init="nndsvd",
+/// weighting="tfidf", convergence_tol=1e-4, seed=13)``. ``convergence_tol`` stops
+/// early on the relative reconstruction-error decrease; ``0.0`` disables the
+/// early-stop check, so the fit runs the full ``iters`` and reports
+/// ``converged=False`` by design. ``seed`` affects only ``init="random"`` -- the
+/// default ``init="nndsvd"`` is deterministic and ignores it, so a stability check
+/// that varies only the seed under nndsvd compares identical fits; use
+/// ``init="random"`` to vary across seeds.
 #[pyclass(module = "topica")]
 pub struct NMF {
     num_topics: usize,
@@ -140,7 +149,10 @@ impl NMF {
     /// the initial factors are dense; it requires `num_topics <= min(num_documents,
     /// num_words)` (use `"random"` above that rank). `weighting` is `"tfidf"` (default)
     /// or `"count"`. `convergence_tol` stops early on the relative
-    /// reconstruction-error decrease. `seed` affects only `init="random"`.
+    /// reconstruction-error decrease; `0.0` disables the early-stop check, so the
+    /// fit runs the full `iters` and reports `converged=False` by design. `seed`
+    /// affects only `init="random"` (the default `"nndsvd"` init is deterministic
+    /// and ignores it).
     #[new]
     #[pyo3(signature = (num_topics, *, beta_loss="frobenius", init="nndsvd",
                         weighting="tfidf", convergence_tol=1e-4, seed=13))]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,6 +1,8 @@
 """LDAvis relevance + pyLDAvis export, Taddy residual check, and topic
 alignment / stability utilities (topica.stm)."""
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -165,3 +167,23 @@ class TestStability:
         m, _ = two_topic
         with pytest.raises(ValueError):
             stm.topic_stability([m])
+
+    def test_warns_on_identical_runs(self, two_topic):
+        # Deterministic-init models (NMF init='nndsvd') ignore the seed, so a
+        # seed-varying stability loop silently compares identical fits and would
+        # report a meaningless 1.0. topic_stability must warn (issue #726).
+        import topica
+        _, docs = two_topic
+        runs = [topica.NMF(num_topics=2, seed=s).fit(docs) for s in (1, 2, 3)]
+        with pytest.warns(UserWarning, match="identical"):
+            s = stm.topic_stability(runs, topn=3)
+        assert s == 1.0
+
+    def test_no_warning_when_runs_differ(self, two_topic):
+        import topica
+        _, docs = two_topic
+        runs = [topica.NMF(num_topics=2, init="random", seed=s).fit(docs)
+                for s in (1, 2, 3)]
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # any UserWarning would fail here
+            stm.topic_stability(runs, topn=3)


### PR DESCRIPTION
Docs + guards for the first-time-NMF-user friction surfaced by the sample-user audit in #726. All of it is pre-existing (none introduced by #725). Scope is deliberately **docs + guards**; the cross-model API ergonomics items in #726 are left deferred.

## Changes

**Tier 1 — seed-inert trap.** `topic_stability` now emits a `UserWarning` when every run is bit-identical to the first (a trivial 1.0 that says nothing about robustness). This is the only change that reaches the actual trap: NMF/LSA `init="nndsvd"` is deterministic and ignores `seed`, so `[NMF(seed=s).fit(docs) for s in range(5)]` is one fit repeated, and the built-in bootstrap/permutation helpers already vary the *data* so they were never fooled. Message points the user at `init="random"` or bootstrap resamples.

**Tier 2 — K-selection gap.** Added a "Matrix-factorization models (NMF, LSA)" section to `docs/publishing/choosing-k.md` (by-hand K sweep on mean coherence + `reconstruction_error`, pick the knee; stability under `init="random"`). The `search_k` "not scanned here" error now names matrix-factorization models and points at that section instead of only listing embedding models.

**Tier 3 — API reference.** `NMF` and `LSA` were missing from `docs/api/models.md` (no autodoc entry); added both.

**Tier 4 — `convergence_tol=0.0` + T4-a root cause.** Moved the constructor parameter docs (`weighting`, `convergence_tol=0.0` → `converged=False` by design, `seed` only under `init="random"`) into the **class** docstring. PyO3 does not surface the `#[new]` doc comment via `help()`, which is exactly why the audit's Dr. Ruiz could see `weighting='tfidf'` in the signature but no explanation of it (T4-a).

## Verification
- `topic_stability` warns on identical nndsvd fits, silent on `init="random"` fits (new tests in `tests/test_diagnostics.py`).
- `search_k(model="nmf")` error names matrix-factorization + the new section.
- 261 related tests pass; preflight (fmt/clippy/stub-sync/tables) green; `mkdocs build --strict` clean with the new NMF/LSA reference entries.

Addresses #726 (Tier 1/2/4 + Tier 3 api-reference item).

🤖 Generated with [Claude Code](https://claude.com/claude-code)