### PR TITLE
fix(audit): resolve Tier-1 findings from the four-sociologist raw-data audit (#733)

### DIFF
--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -48,6 +48,19 @@ If you would rather not add the `formulaic` dependency, replace `design_matrix`
 with hand-built blocks: `X, names = topica.one_hot(df["party"])` combined with
 `topica.spline` / `topica.interaction` via `numpy.hstack`.
 
+`one_hot` drops one level as the reference (baseline), so every coefficient is a
+contrast against it. With three or more levels, name the baseline yourself with
+`one_hot(values, reference="technical")` rather than accepting the silent
+alphabetical default; each `coef` is then the difference from `technical`. For an
+*ordered* covariate (a 1-to-5 rating, a year), a single centered numeric column
+often reads better than a set of dummies: it gives one interpretable per-step
+slope, which is what a "how does prevalence move along the scale" question wants.
+
+For a sentiment or rating study, build the corpus with
+`stopwords=topica.SENTIMENT_STOPWORDS`, not the default `ENGLISH_STOPWORDS`: the
+default strips `not`/`no`/`very`/`too`, which would collapse "not clean" into
+"clean" in exactly the study whose outcome is valence.
+
 ## Prevalence covariates
 
 ```python

--- a/docs/guides/preprocessing.md
+++ b/docs/guides/preprocessing.md
@@ -38,6 +38,26 @@ Unknown languages raise with the list of available codes. For the cross-lingual
 models ([`InfoCTM`](models.md#infoctm), [`ZeroShotTM`](embedding.md#zeroshottm)),
 pass the matching list per language. Anything not covered: supply your own list.
 
+For a sentiment or rating study, use `topica.SENTIMENT_STOPWORDS` instead of the
+default: `ENGLISH_STOPWORDS` strips `not`/`no`/`very`/`too`, which would collapse
+"not clean" into "clean" in exactly the analysis whose outcome is valence.
+
+### Web-scraped text: strip HTML and URLs
+
+Text scraped from the web (news blurbs, press releases, forum posts) often carries
+markup — `<a href=...>` tags, `www.example.com/page.aspx` URLs — whose fragments
+(`href`, `http`, `aspx`) survive tokenization and form a spurious "boilerplate"
+topic. Pass `strip_html=True` to remove tags and `http`/`www` URLs before
+tokenizing:
+
+```python
+corpus = topica.from_dataframe(df, text_col="text", strip_html=True)
+```
+
+`from_dataframe` also warns if such tokens survive into the vocabulary when you
+did not strip, so the trap is hard to miss. `strip_html` is a conservative clean
+(tags and URLs only); for heavier normalization, pass your own `tokenizer`.
+
 ### Readable topic words: lemmatize, don't stem
 
 Stemming truncates words to a root (`military` → `militari`, `economy` →

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -133,24 +133,53 @@ __citation__ = (
 )
 
 
-def one_hot(values, *, drop_first=True, prefix=""):
+def one_hot(values, *, drop_first=True, reference=None, prefix=""):
     """One-hot encode a categorical covariate for use as DMR features.
 
     Given a sequence of category labels (one per document), returns
     ``(matrix, names)`` where ``matrix`` is a ``(num_docs, num_categories)``
     float array of 0/1 indicators and ``names`` are the corresponding column
-    names. With ``drop_first=True`` (default) the first category (sorted) is
-    omitted as the reference level, which avoids collinearity with the DMR
-    intercept. Pass the result straight to ``DMR.fit(docs, matrix,
-    feature_names=names)``; combine multiple covariates with
-    ``numpy.hstack``.
+    names. One category is omitted as the reference (baseline) level, which
+    avoids collinearity with the DMR/STM intercept; every coefficient is then a
+    contrast *against that reference*, so which level is the reference sets what
+    the effects mean.
+
+    ``reference`` names the level to drop. When ``None`` (and ``drop_first=True``,
+    the default), the alphabetically-first category is dropped; with three or more
+    levels a warning names it, since which of several baselines is the reference
+    shapes the whole story and a silent choice is easy to misread — pass
+    ``reference=`` to choose it explicitly (and silence the warning).
+    ``drop_first=False`` keeps every level (full dummy set, e.g. for a model
+    without an intercept). Pass the result straight to ``DMR.fit(docs, matrix,
+    feature_names=names)``; combine multiple covariates with ``numpy.hstack``.
     """
     import numpy as np
+    import warnings
 
     values = list(values)
     categories = sorted(set(values))
-    if drop_first and categories:
+    if reference is not None:
+        if reference not in categories:
+            raise ValueError(
+                f"reference={reference!r} is not one of the categories "
+                f"{categories}"
+            )
+        categories = [c for c in categories if c != reference]
+    elif drop_first and categories:
+        dropped = categories[0]
         categories = categories[1:]
+        # Binary covariate: the baseline is unambiguous (only one other level), so
+        # warning would be noise. With 3+ levels the reference genuinely shapes the
+        # contrasts and a silent alphabetical choice is a Tier-1 footgun.
+        if len(categories) >= 2:
+            warnings.warn(
+                f"one_hot: dropped the alphabetically-first level {dropped!r} as "
+                "the reference, so every coefficient is a contrast against it. "
+                "Pass reference= to choose the baseline explicitly (and silence "
+                "this warning), or drop_first=False to keep all levels.",
+                UserWarning,
+                stacklevel=2,
+            )
     index = {c: j for j, c in enumerate(categories)}
     matrix = np.zeros((len(values), len(categories)), dtype=np.float64)
     for i, v in enumerate(values):
@@ -358,7 +387,12 @@ from .embedding import (  # noqa: E402
     load_embeddings,
 )
 from .preprocess import split_documents  # noqa: E402
-from .stopwords import ENGLISH_STOPWORDS, stopwords, stopword_languages  # noqa: E402
+from .stopwords import (  # noqa: E402
+    ENGLISH_STOPWORDS,
+    SENTIMENT_STOPWORDS,
+    stopwords,
+    stopword_languages,
+)
 from .phrases import learn_phrases, apply_phrases, add_ngrams, Phrases  # noqa: E402
 from .frames import from_dataframe, align, prep_documents, plot_removed  # noqa: E402
 from .formulas import design_matrix  # noqa: E402
@@ -535,6 +569,7 @@ __all__ = [
     "load_embeddings",
     "split_documents",
     "ENGLISH_STOPWORDS",
+    "SENTIMENT_STOPWORDS",
     "stopwords",
     "stopword_languages",
     "from_dataframe",

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -346,6 +346,33 @@ def _as_reference(texts):
     return [list(t) for t in texts]
 
 
+def _warn_if_non_distributional(topics):
+    """Warn when ``topics`` is a model whose ``topic_word`` rows are not a word
+    distribution (LSA's signed SVD loadings; any matrix with negative entries).
+
+    Coherence still scores that model's top words, but the number is not on the
+    same footing as a probabilistic model's, so ranking model *families* by
+    coherence (e.g. NMF vs a signed factorization) is misleading. Coherence
+    compares topics *within* a model; this flags the cross-family trap."""
+    tw = getattr(topics, "topic_word", None)
+    if tw is None:
+        return
+    try:
+        if float(np.asarray(tw).min()) < -1e-9:
+            warnings.warn(
+                "coherence: this model's topic_word has negative entries, so its "
+                "rows are not a word distribution (e.g. LSA's signed SVD loadings). "
+                "Coherence still ranks topics within this model, but the value is "
+                "not comparable across model families — do not use it to choose "
+                "between, say, NMF and a signed factorization. Compare recovery "
+                "against known labels or held-out likelihood instead.",
+                UserWarning,
+                stacklevel=3,
+            )
+    except (TypeError, ValueError):
+        pass  # exotic topic_word; skip the check rather than fail coherence
+
+
 def coherence(topics, texts, *, coherence_type="c_v", n=10, topn=None, window_size=None, epsilon=1e-12):
     """Per-topic coherence against a reference corpus.
 
@@ -394,6 +421,7 @@ def coherence(topics, texts, *, coherence_type="c_v", n=10, topn=None, window_si
     texts = _as_reference(texts)
     if len(texts) == 0:
         raise ValueError("texts is empty; pass the reference corpus as list[list[str]]")
+    _warn_if_non_distributional(topics)
     tops = _extract_topics(topics, topn)
     relevant = sorted({w for t in tops for w in t})
     vocab = {w: i for i, w in enumerate(relevant)}

--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -8,10 +8,29 @@ prevalence regression. These helpers keep text and metadata bound together.
 
 from __future__ import annotations
 
+import re
 import warnings
 from typing import Sequence
 
 from . import Corpus, tokenize
+
+# HTML tags/entities and http/www URLs, removed by from_dataframe(strip_html=True).
+_HTML_TAG = re.compile(r"<[^>]+>")
+_HTML_ENTITY = re.compile(r"&(?:[a-zA-Z]+|#\d+);")
+# URL: stop at whitespace or the quote/bracket chars that delimit HTML attributes,
+# so a URL inside <a href="..."> does not swallow the closing tag.
+_URL = re.compile(r"(?:https?://|www\.)[^\s\"'<>]+", re.IGNORECASE)
+# Tokens that betray un-stripped web boilerplate if they survive into the vocab.
+_WEB_BOILERPLATE = frozenset({"http", "https", "www", "href", "aspx", "html", "nbsp"})
+
+
+def _strip_web(text: str) -> str:
+    """Remove HTML tags/entities and http/www URLs from a raw string, leaving a
+    space so adjacent words do not fuse."""
+    text = _HTML_TAG.sub(" ", text)     # tags first, before URLs touch the '>'
+    text = _URL.sub(" ", text)
+    text = _HTML_ENTITY.sub(" ", text)
+    return text
 
 
 def _is_polars(obj) -> bool:
@@ -72,6 +91,7 @@ def from_dataframe(
     metadata_cols=None,
     tokenizer=None,
     stopwords=None,
+    strip_html=False,
     min_length=1,
     min_doc_freq=1,
     max_doc_fraction=1.0,
@@ -108,6 +128,15 @@ def from_dataframe(
     metadata_cols : sequence[str], optional
         Columns to carry as aligned metadata. Defaults to all columns except
         ``text_col``.
+    strip_html : bool, default False
+        When True, remove HTML tags, entities, and ``http``/``www`` URLs from each
+        document before tokenizing. Web-scraped corpora (news blurbs, press
+        releases, forum posts) often carry markup such as ``<a href=...>`` or
+        ``www.example.com/page.aspx``; left in, tokens like ``href``, ``http``,
+        ``aspx`` survive pruning and form a spurious "boilerplate" topic. This is a
+        conservative clean (tags + URLs only); for heavier normalization pass your
+        own ``tokenizer``. When left False, a vocabulary that still contains obvious
+        web-boilerplate terms triggers a warning pointing here.
     tokenizer : callable, optional
         ``str -> list[str]``. Defaults to :func:`topica.tokenize` with the
         ``stopwords`` and ``min_length`` arguments below. This is also where you
@@ -134,6 +163,8 @@ def from_dataframe(
         ``max_doc_fraction`` — not both.
     """
     texts = list(df[text_col])  # pandas Series and Polars Series both iterate to values
+    if strip_html:
+        texts = [_strip_web(t) if isinstance(t, str) else t for t in texts]
     if tokenizer is None:
         sw = list(stopwords) if stopwords is not None else None
         docs = [
@@ -191,6 +222,21 @@ def from_dataframe(
         max_features=max_features,
         vocabulary=vocabulary,
     )
+
+    # Web-scraped text often leaves markup tokens (href/http/aspx) in the vocab,
+    # where they form a spurious boilerplate topic. If the user did not strip and
+    # such tokens survived, point them at strip_html=.
+    if not strip_html and vocabulary is None:
+        leaked = sorted(_WEB_BOILERPLATE.intersection(corpus.vocabulary))
+        if leaked:
+            warnings.warn(
+                f"vocabulary contains web-boilerplate token(s) {leaked}, which "
+                "suggests HTML/URLs in the raw text. Pass strip_html=True to "
+                "from_dataframe to remove tags and http/www URLs before "
+                "tokenizing, or they may form a spurious topic.",
+                UserWarning,
+                stacklevel=2,
+            )
 
     cols = (
         list(metadata_cols)

--- a/python/topica/stopwords.py
+++ b/python/topica/stopwords.py
@@ -97,3 +97,24 @@ ENGLISH_STOPWORDS = frozenset({
     "very", "was", "we", "were", "what", "when", "where", "which", "while",
     "who", "will", "with", "would", "you", "your",
 })
+
+# Words in ENGLISH_STOPWORDS that carry sentiment and must NOT be stripped for a
+# sentiment / rating study: negation flips polarity ("not clean" != "clean") and
+# degree/contrast words modulate it. SENTIMENT_STOPWORDS is ENGLISH_STOPWORDS with
+# these retained in the text.
+_SENTIMENT_BEARING = frozenset({
+    "no", "not",                                             # negation
+    "very", "too", "more", "most", "much", "only", "just",   # degree / intensity
+    "so", "even", "few",
+    "but", "however", "although", "against",                 # contrast / opposition
+})
+
+#: :data:`ENGLISH_STOPWORDS` minus negation, intensifier, and contrast words, for
+#: sentiment or rating-covariate studies where those tokens carry the signal.
+#: The default :data:`ENGLISH_STOPWORDS` strips ``not``/``no``/``very``/``too``,
+#: which would collapse "not clean" into "clean"; pass this list instead when the
+#: outcome is valence::
+#:
+#:     corpus = topica.from_dataframe(df, text_col="review",
+#:                                    stopwords=topica.SENTIMENT_STOPWORDS)
+SENTIMENT_STOPWORDS = ENGLISH_STOPWORDS - _SENTIMENT_BEARING

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1347,6 +1347,7 @@ def _aggregate_over_seeds(ks, seeds, tasks, fitted):
     keep_scalar = {"k", "coherence_metric"}
     no_se = {"dispersion_pvalue"}  # an SE on a p-value is not meaningful
     rows, coh_by_k, exc_by_k = [], [], []
+    max_spread = 0.0  # largest across-seed range of any metric, over all K
     for k in ks:
         seed_rows = by_k[k]
         agg = {"k": k}
@@ -1359,9 +1360,28 @@ def _aggregate_over_seeds(ks, seeds, tasks, fitted):
             agg[key] = float(np.mean(vals))
             if key not in no_se:
                 agg[key + "_se"] = float(np.std(vals, ddof=1) / np.sqrt(n))
+            if np.all(np.isfinite(vals)):
+                max_spread = max(max_spread, float(np.ptp(vals)))
         rows.append(agg)
         coh_by_k.append([r["coherence"] for r in seed_rows])
         exc_by_k.append([r["exclusivity"] for r in seed_rows])
+
+    # If every seed produced identical metrics, the model's initialization ignores
+    # the seed (STM's spectral init, NMF/LSA init='nndsvd'), so the *_se columns
+    # are all 0 and best_k(rule='1se') is meaningless — a user could read SE=0 as
+    # "robust across seeds" when the seeds never varied. Warn, mirroring
+    # topic_stability's identical-runs guard.
+    if n > 1 and max_spread <= 1e-12:
+        warnings.warn(
+            f"search_k(num_seeds={n}): every seed produced an identical fit at each "
+            "K, so all *_se columns are 0 and best_k(rule='1se') says nothing about "
+            "robustness. Deterministic initializations ignore the seed (STM's "
+            "spectral init; NMF/LSA with init='nndsvd'). To assess robustness, refit "
+            "with init='random' (which responds to seed) or use bootstrap resampling "
+            "(bootstrap_stability); num_seeds>1 adds no information for this model.",
+            UserWarning,
+            stacklevel=3,
+        )
 
     result = SearchKResult(rows)
     # Per-seed frontier: z-score within each seed across K (via the shared helper),

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -6,6 +6,7 @@ normalized measures must respect their ranges, and the gensim-style API should
 accept both explicit word lists and fitted models.
 """
 
+import warnings
 import numpy as np
 import pytest
 
@@ -507,3 +508,34 @@ class TestModelCoherenceMethodConsistency:
         m, docs = self._fit()
         assert np.allclose(topica.coherence(m, docs, n=5, coherence_type="u_mass"),
                            topica.coherence(m, docs, topn=5, coherence_type="u_mass"))
+
+
+class TestNonDistributionalWarning:
+    """coherence() warns when a model's topic_word is not a distribution (LSA's
+    signed loadings), so a user does not rank model families by it (issue #733)."""
+
+    def _corpus(self):
+        rng = np.random.default_rng(0)
+        a = [["cat", "dog", "pet", "vet", "paw"]] * 40
+        b = [["star", "moon", "sky", "sun", "orbit"]] * 40
+        return topica.Corpus.from_documents(a + b)
+
+    def test_lsa_warns_non_distributional(self):
+        c = self._corpus()
+        lsa = topica.LSA(num_topics=4).fit(c)
+        with pytest.warns(UserWarning, match="not comparable across model families"):
+            topica.coherence(lsa, c, coherence_type="u_mass")
+
+    def test_lda_does_not_warn(self):
+        c = self._corpus()
+        lda = LDA(num_topics=4, seed=13).fit(c)
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # a distribution -> no comparability warning
+            topica.coherence(lda, c, coherence_type="u_mass")
+
+    def test_word_lists_do_not_warn(self):
+        # passing bare word lists (no model) never triggers the model-only check
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            topica.coherence([["cat", "dog"], ["star", "moon"]],
+                             [["cat", "dog"], ["star", "moon"]], topn=2)

--- a/tests/test_dmr.py
+++ b/tests/test_dmr.py
@@ -1,5 +1,7 @@
 """Tests for the DMR class and one_hot helper."""
 
+import warnings
+
 import numpy as np
 import numpy.testing as npt
 import pytest
@@ -445,6 +447,32 @@ class TestOneHot:
         matrix, names = one_hot(values, drop_first=True)
         # sorted categories: bird, cat, dog -> drop bird -> 2 columns
         assert matrix.shape == (5, 2)
+
+    def test_reference_chooses_baseline(self):
+        # issue #733: pick the reference level explicitly instead of the silent
+        # alphabetical default.
+        values = ["cat", "dog", "bird"]
+        matrix, names = one_hot(values, reference="dog")
+        assert "dog" not in names and set(names) == {"cat", "bird"}
+        # the dog row is all zeros (it is the baseline)
+        assert matrix[1].sum() == 0.0
+
+    def test_reference_unknown_raises(self):
+        with pytest.raises(ValueError, match="not one of the categories"):
+            one_hot(["a", "b"], reference="z")
+
+    def test_multilevel_default_warns_binary_does_not(self):
+        # 3+ levels with a silent alphabetical baseline is a Tier-1 footgun -> warn;
+        # a binary covariate has an unambiguous baseline -> stay quiet.
+        with pytest.warns(UserWarning, match="alphabetically-first"):
+            one_hot(["cat", "dog", "bird"])
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")  # binary: must NOT warn
+            one_hot(["cat", "dog"])
+        # passing reference= silences the multilevel warning
+        with warnings.catch_warnings():
+            warnings.simplefilter("error")
+            one_hot(["cat", "dog", "bird"], reference="bird")
 
     def test_drop_first_false_shape(self):
         values = ["cat", "dog", "cat", "bird", "dog"]

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -195,3 +195,33 @@ class TestDfAliases:
         df = _alias_frame()
         with pytest.raises(ValueError, match="min_df must be an int or a float"):
             topica.from_dataframe(df, text_col="text", min_df=True)
+
+
+# -- strip_html + web-boilerplate diagnostic (issue #733 Tier 1) -----------------
+
+
+def test_strip_html_removes_tags_and_urls():
+    rows = [f'See <a href="http://ex.com/p{i}.aspx">link</a> and www.foo.org policy reform vote budget'
+            for i in range(20)]
+    df = pd.DataFrame({"text": rows})
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        c = topica.from_dataframe(df, text_col="text", strip_html=True)
+    for junk in ("http", "https", "href", "aspx", "www", "html"):
+        assert junk not in c.vocabulary
+    for real in ("policy", "reform", "vote", "budget"):
+        assert real in c.vocabulary
+
+
+def test_web_boilerplate_warns_when_not_stripped():
+    rows = [f'<a href="http://ex.com">x</a> policy reform vote budget item {i}' for i in range(20)]
+    df = pd.DataFrame({"text": rows})
+    with pytest.warns(UserWarning, match="web-boilerplate"):
+        topica.from_dataframe(df, text_col="text")  # strip_html defaults False
+
+
+def test_clean_text_does_not_warn_boilerplate():
+    df = pd.DataFrame({"text": [f"policy reform vote budget item {i}" for i in range(20)]})
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")  # clean corpus: no boilerplate warning
+        topica.from_dataframe(df, text_col="text")

--- a/tests/test_search_k_models.py
+++ b/tests/test_search_k_models.py
@@ -140,6 +140,12 @@ def test_unknown_model_names_the_fit_hook():
 
 def test_nmf_multi_seed_reconstruction_error_has_se():
     c, _ = _corpus()
-    rows = topica.search_k(c, [2, 3], model="nmf", iters=80, num_seeds=2)
-    # multi-seed adds an SE column for numeric metrics
+    # NMF's default init='nndsvd' is deterministic, so every seed is identical:
+    # the SE column is still added (mechanics), but it is 0 and search_k warns
+    # that num_seeds adds no robustness information here (issue #733 Tier 1).
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        rows = topica.search_k(c, [2, 3], model="nmf", iters=80, num_seeds=2)
     assert any("reconstruction_error_se" in r for r in rows)
+    assert all(r["reconstruction_error_se"] == 0.0 for r in rows)
+    assert any("identical fit" in str(x.message) for x in w)

--- a/tests/test_stopwords.py
+++ b/tests/test_stopwords.py
@@ -59,3 +59,17 @@ def test_plugs_into_corpus_builder():
     # French function words dropped; content words kept.
     assert "le" not in flat and "et" not in flat and "la" not in flat
     assert "chat" in flat and "planete" in flat
+
+
+def test_sentiment_stopwords_keep_negation_and_intensifiers():
+    # issue #733 Tier 1: the default list strips negation, which silently inverts
+    # a sentiment study. SENTIMENT_STOPWORDS retains it.
+    ss = topica.SENTIMENT_STOPWORDS
+    for w in ["not", "no", "very", "too", "but", "however"]:
+        assert w in topica.ENGLISH_STOPWORDS  # default strips it
+        assert w not in ss                     # sentiment-safe keeps it
+    # but ordinary function words are still dropped
+    for w in ["the", "and", "of", "is", "with"]:
+        assert w in ss
+    # it is a strict subset of the default
+    assert ss < topica.ENGLISH_STOPWORDS


### PR DESCRIPTION
Fixes the five **Tier 1** items (analytical traps — the ones that could put a wrong number in a paper) from the four-sociologist from-raw-data audit, #733. Each was reproduced on 0.55.0 before the fix and re-verified after.

### 1. `search_k(num_seeds>1)` reports `SE=0` with no warning on deterministic-init models
STM's spectral init and NMF/LSA `init="nndsvd"` ignore the seed, so every seed is a bit-identical fit; `search_k` ran the multi-seed machinery, returned every `*_se=0`, and still offered `best_k(rule="1se")`. Three of the four sociologists could have published "robust across seeds (SE=0)" as a *strength*. Now it warns when across-seed variance is zero — mirroring the guard `topic_stability` already has.

### 2. `SENTIMENT_STOPWORDS` — a negation-safe default
`ENGLISH_STOPWORDS` strips `not`/`no`/`very`/`too`, which collapses "not clean" into "clean" in exactly a study whose outcome is valence. Added `topica.SENTIMENT_STOPWORDS` (the default minus negation/intensifier/contrast words) for sentiment/rating work.

### 3. `one_hot(reference=)` + a multi-level baseline warning
The reference level defines every contrast, and `one_hot` silently dropped the alphabetically-first one. Added `reference=` to choose it explicitly; with 3+ levels the silent default now warns (binary covariates stay quiet — their baseline is unambiguous).

### 4. `coherence()` guards cross-family comparison
LSA/ProdLDA `topic_word` rows are not distributions (LSA row min −0.31, verified). Coherence still ranks topics *within* such a model, but comparing the number across families ranked NMF above ProdLDA while label-recovery ranked the reverse. `coherence()` now warns when the model's `topic_word` has negative entries.

### 5. `from_dataframe(strip_html=True)` + a boilerplate diagnostic
Scraped markup (`<a href=...>`, `www.x.com/p.aspx`) left `href`/`http`/`aspx` in the vocab as a spurious topic. `strip_html=True` removes tags/entities/URLs before tokenizing; left off, a vocabulary that still contains web-boilerplate tokens warns and points to it.

## Design notes
- Warnings are **scoped to avoid noise**: `one_hot` warns only at 3+ levels; the boilerplate warning fires only when such tokens actually survive; the coherence warning only for negative-entry matrices; the SE warning only when variance is genuinely zero. None fire on the common clean paths.
- `SENTIMENT_STOPWORDS` and `strip_html` are **opt-in and non-breaking**; `one_hot`/`from_dataframe` signatures gain keyword-only args with backward-compatible defaults.

## Tests / docs
New tests for all five (reference/warning scope, sentiment list, coherence non-distributional, strip_html + boilerplate, deterministic-NMF SE=0). Docs: covariates guide (`reference=`, ordinal design, `SENTIMENT_STOPWORDS`) and preprocessing guide (`SENTIMENT_STOPWORDS`, `strip_html`).

Green: `scripts/preflight.sh`, `mkdocs build --strict`, full pytest **4920 passed, 38 skipped**.

Remaining #733 items (Tier 2–4: LSA scree column, `label_topics` nested-dict shape, `SearchKResult.to_frame`, array-wrapped effect scalars, `best_k("semcoh")` alias, docs) are left open for a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)