### PR TITLE
fix(audit): resolve Tier 2/3 findings from the four-sociologist audit (#733)

### DIFF
--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -317,11 +317,13 @@ average it and compare on that scale.
 `NMF` and `LSA` factor the document-term matrix at a fixed rank K, so K is a model
 setting you sweep by **refitting per K**. `search_k` scans them directly with
 `model="nmf"` or `model="lsa"`, giving you the same coherence/exclusivity frontier
-and `best_k` machinery as LDA. For NMF it adds a `reconstruction_error` column (the
-fit's residual) — read it like a scree plot: it falls monotonically in K, so take
-the knee, not the minimum, and cross it against coherence. Select on it directly
-with `rows.best_k("reconstruction_error", rule="elbow")` (bare `rule="best"` returns
-the grid edge and warns, because the error keeps shrinking with K).
+and `best_k` machinery as LDA. Both add a `reconstruction_error` column (NMF's fit
+residual; for LSA the rank-K Frobenius residual `sqrt(‖X‖² − Σσ_k²)`) — read it like
+a scree plot: it falls monotonically in K, so take the knee, not the minimum, and
+cross it against coherence. Select on it directly with
+`rows.best_k("reconstruction_error", rule="elbow")` (bare `rule="best"` returns the
+grid edge and warns, because the error keeps shrinking with K). `rows.to_frame()`
+gives the whole scan as a tidy DataFrame.
 
 ```python
 import topica

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -5689,6 +5689,11 @@ class LSA:
         """(num_topics,) truncated singular values Sigma_k."""
         ...
     @property
+    def reconstruction_error(self) -> float:
+        """Frobenius error of the rank-K truncation, sqrt(||X||_F^2 - sum_k Sigma_k^2);
+        the LSA scree column reported by search_k(model="lsa")."""
+        ...
+    @property
     def fit_history(self) -> list[tuple[int, float]]:
         """Empty: the SVD is a direct solve with no iterative trace."""
         ...

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -1142,6 +1142,14 @@ class PredictedPrevalence:
     covariate : str or None
         For ``continuous``, the name of the swept covariate (convenient for
         plotting); ``None`` otherwise.
+
+    Notes
+    -----
+    ``estimate``/``ci_low``/``ci_high`` are always arrays, one entry per grid
+    point, even for a ``contrast`` (which has a single point). For that single
+    -point case use the scalar helpers ``value`` and ``ci`` — ``f"{pp.value:+.3f}"``
+    formats, whereas ``f"{pp.estimate:+.3f}"`` raises because ``estimate`` is an
+    array. For every case, ``to_frame()`` gives a tidy per-point DataFrame.
     """
 
     topic: int
@@ -1152,6 +1160,32 @@ class PredictedPrevalence:
     ci_low: np.ndarray
     ci_high: np.ndarray
     covariate: str | None = None
+
+    @property
+    def value(self) -> float:
+        """The single predicted value as a float. Valid when there is exactly one
+        grid point (every ``contrast``, or a one-row ``at``); raises otherwise,
+        directing you to ``estimate`` (the array) or ``to_frame()``."""
+        est = np.atleast_1d(self.estimate)
+        if est.size != 1:
+            raise ValueError(
+                f"value is only defined for a single grid point; this result has "
+                f"{est.size}. Use estimate (the array, one per grid point) or "
+                "to_frame()."
+            )
+        return float(est[0])
+
+    @property
+    def ci(self) -> tuple:
+        """The single ``(ci_low, ci_high)`` as floats, under the same one-grid
+        -point condition as :attr:`value`."""
+        lo, hi = np.atleast_1d(self.ci_low), np.atleast_1d(self.ci_high)
+        if lo.size != 1:
+            raise ValueError(
+                f"ci is only defined for a single grid point; this result has "
+                f"{lo.size}. Use ci_low/ci_high (arrays) or to_frame()."
+            )
+        return float(lo[0]), float(hi[0])
 
     def to_frame(self):
         """Return a tidy pandas DataFrame with one row per grid point.

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -590,11 +590,49 @@ def mmr(topic_word, word_embeddings, vocabulary=None, *, n=10, diversity=0.3, n_
     return out
 
 
+class TopicLabels(dict):
+    """One topic's stm-style labels: a dict with keys ``prob``, ``frex``,
+    ``lift``, ``score``, each a list of ``(word, value)`` pairs.
+
+    A ``dict`` subclass, so ``labels["frex"]`` works as always. It only adds two
+    guard rails, because the nested shape is easy to misread: an ``int`` index
+    (``labels[0]``, or unpacking it as if it were a word list) raises a directive
+    error naming the real access, and the repr shows the shape instead of dumping
+    every word."""
+
+    __slots__ = ()
+
+    def __repr__(self):
+        keys = ", ".join(self.keys())
+        return f"TopicLabels({keys}); e.g. this['frex'] -> [(word, score), ...]"
+
+    def __getitem__(self, key):
+        if isinstance(key, (int, np.integer)):
+            raise TypeError(
+                "a topic's labels are a dict keyed by 'prob'/'frex'/'lift'/'score', "
+                "not a word list, so an integer index is undefined. Use "
+                "labels['frex'] for the (word, score) pairs, e.g. "
+                "[w for w, _ in labels['frex']]. label_topics returns one such "
+                "dict per topic."
+            )
+        return super().__getitem__(key)
+
+
 def label_topics(topic_word, vocabulary=None, *, n=10, word_counts=None, corpus=None):
     """stm-style topic labels: prob, FREX, lift, and score word lists per topic.
 
-    Returns a list (per topic) of dicts with keys ``prob``, ``frex``, ``lift``,
-    ``score``, each a list of ``(word, value)`` pairs. FREX, lift, and score all
+    Returns a list with one :class:`TopicLabels` per topic. Each is a dict with
+    keys ``prob``, ``frex``, ``lift``, ``score``, and each value is a list of
+    ``(word, value)`` pairs — so select a labeling before reading words::
+
+        labels = topica.label_topics(model)     # one TopicLabels per topic
+        frex_words = [w for w, _ in labels[0]["frex"]]   # top FREX words of topic 0
+        prob_score = labels[0]["prob"]                   # [(word, prob), ...]
+
+    Iterating a topic directly (``for w in labels[0]``) yields the dict *keys*
+    (``'prob'``, ``'frex'``, ...), not words — a common first-timer trap, so an
+    integer index on a topic raises a directive error. (For a table of bare word
+    strings instead of pairs, use :func:`topic_table`.) FREX, lift, and score all
     come from the single stm-faithful implementation in topica's Rust core
     (``topica-core``'s ``inspect``), so they cannot drift from faSTM / the Stata
     plugin.
@@ -639,12 +677,12 @@ def label_topics(topic_word, vocabulary=None, *, n=10, word_counts=None, corpus=
         prob_idx = np.argsort(phi[t])[::-1][:n]
         lift_idx = np.argsort(lift_mat[t])[::-1][:n]
         score_idx = np.argsort(score_mat[t])[::-1][:n]
-        out.append({
+        out.append(TopicLabels({
             "prob": [(vocabulary[i], float(phi[t, i])) for i in prob_idx],
             "frex": frex_words[t],
             "lift": [(vocabulary[i], float(lift_mat[t, i])) for i in lift_idx],
             "score": [(vocabulary[i], float(score_mat[t, i])) for i in score_idx],
-        })
+        }))
     return out
 
 
@@ -1044,6 +1082,13 @@ class SearchKResult(list):
         present = set().union(*[r.keys() for r in self]) if self else set()
         return {m: d for m, d in SEARCH_K_DIRECTIONS.items() if m in present}
 
+    def to_frame(self):
+        """The per-K rows as a pandas DataFrame, one row per K (raises if pandas
+        is absent). The same tidy shape the effect/robustness results expose."""
+        import pandas as pd
+
+        return pd.DataFrame(list(self))
+
     def _frontier_k(self) -> int:
         """K that maximizes ``z(coherence) + z(exclusivity)`` across the grid.
 
@@ -1155,6 +1200,12 @@ class SearchKResult(list):
                 metric = "frontier"
             else:
                 metric = "coherence"
+        # The results advertise which coherence flavor the "coherence" column holds
+        # via the coherence_metric label ("semcoh"/"u_mass"). Accept that label as
+        # an alias so best_k(res[0]["coherence_metric"]) works instead of raising
+        # "unknown metric" for a name the result itself displays (#733).
+        if metric is not None and metric == self[0].get("coherence_metric"):
+            metric = "coherence"
         if metric != "frontier" and (frontier_metrics is not None or weights is not None):
             raise ValueError(
                 "frontier_metrics and weights only apply to metric='frontier'; "

--- a/src/lsa.rs
+++ b/src/lsa.rs
@@ -46,6 +46,11 @@ pub struct LsaModel {
     pub doc_topic: Vec<Vec<f64>>,
     /// Truncated singular values `Sigma_k` (length K).
     pub singular_values: Vec<f64>,
+    /// Frobenius reconstruction error of the rank-K truncation,
+    /// `sqrt(||X||_F^2 - sum_k Sigma_k^2)` on the same weighted matrix the SVD
+    /// factors. Monotone-decreasing in K, so it is the LSA scree curve (the SVD
+    /// analogue of NMF's `reconstruction_error`).
+    pub reconstruction_error: f64,
 }
 
 /// Apply the scikit-learn `svd_flip` sign convention in place: for each component
@@ -118,12 +123,20 @@ pub fn fit_lsa(
         .map(|row| (0..kk).map(|c| row[c] * s[c]).collect())
         .collect();
 
+    // Frobenius residual of the rank-K truncation: ||X||_F^2 = sum of all squared
+    // singular values, and the top-K SVD captures the K largest, so the discarded
+    // energy is ||X||_F^2 - sum_k Sigma_k^2. Computed from X directly (no need for
+    // the full spectrum) so it is exact up to the randomized SVD's approximation.
+    let kept_sq: f64 = s.iter().map(|v| v * v).sum();
+    let reconstruction_error = (x.frob_sq() - kept_sq).max(0.0).sqrt();
+
     LsaModel {
         num_topics: kk,
         num_types,
         topic_word: vt_rows,
         doc_topic,
         singular_values,
+        reconstruction_error,
     }
 }
 

--- a/src/nmf.rs
+++ b/src/nmf.rs
@@ -232,7 +232,7 @@ impl SpMat {
         (&self.col_idx[s..e], &self.vals[s..e])
     }
     /// `sum_{i,j} X_ij^2`.
-    fn frob_sq(&self) -> f64 {
+    pub(crate) fn frob_sq(&self) -> f64 {
         self.vals.iter().map(|&v| v * v).sum()
     }
     /// `sum_{i,j} X_ij`.

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -508,6 +508,7 @@ struct LsaState {
     topic_word: Option<Vec<Vec<f64>>>,
     doc_topic: Option<Vec<Vec<f64>>>,
     singular_values: Option<Vec<f64>>,
+    reconstruction_error: Option<f64>,
 }
 
 impl LSA {
@@ -648,6 +649,15 @@ impl LSA {
     fn singular_values<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray1<f64>>> {
         Ok(Array1::from(self.fitted_model()?.singular_values.clone()).to_pyarray_bound(py))
     }
+    /// Frobenius reconstruction error of the rank-K truncation,
+    /// ``sqrt(||X||_F^2 - sum_k Sigma_k^2)`` on the weighted document-term matrix
+    /// the SVD factors. Falls monotonically with K, so ``search_k(model="lsa")``
+    /// reports it as a scree column just like NMF (pair with
+    /// ``best_k("reconstruction_error", rule="elbow")``).
+    #[getter]
+    fn reconstruction_error(&self) -> PyResult<f64> {
+        Ok(self.fitted_model()?.reconstruction_error)
+    }
     /// No iterative trace: the SVD is a direct solve. Returns an empty list to
     /// keep the uniform fitted surface.
     #[getter]
@@ -769,6 +779,7 @@ impl LSA {
                 topic_word: Some(m.topic_word.clone()),
                 doc_topic: Some(m.doc_topic.clone()),
                 singular_values: Some(m.singular_values.clone()),
+                reconstruction_error: Some(m.reconstruction_error),
             },
         )
     }
@@ -784,6 +795,7 @@ impl LSA {
                 topic_word: s.topic_word.unwrap_or_default(),
                 doc_topic: s.doc_topic.unwrap_or_default(),
                 singular_values: s.singular_values.unwrap_or_default(),
+                reconstruction_error: s.reconstruction_error.unwrap_or(f64::NAN),
             })
         } else {
             None

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -703,3 +703,65 @@ def test_report_is_callable():
     m.fit(docs, iters=50)
     assert topica.report(m) == topica.summary(m)
     assert "num_topics" in topica.report(m)
+
+
+def test_search_k_result_to_frame():
+    # #733 Tier 3: SearchKResult gained to_frame(), like the effect/robustness
+    # results (previously only effects_across_k had it).
+    from topica.validation import SearchKResult
+    rows = SearchKResult([{"k": 2, "coherence": -5.0, "exclusivity": 0.5},
+                          {"k": 3, "coherence": -6.0, "exclusivity": 0.6}])
+    df = rows.to_frame()
+    assert list(df["k"]) == [2, 3]
+    assert {"coherence", "exclusivity"}.issubset(df.columns)
+
+
+def test_best_k_accepts_coherence_metric_label_alias():
+    # #733 Tier 3: the result advertises coherence_metric ("semcoh"/"u_mass");
+    # best_k now accepts that label as an alias for "coherence" instead of raising.
+    from topica.validation import SearchKResult
+    for label in ("semcoh", "u_mass"):
+        rows = SearchKResult([{"k": 2, "coherence": -5.0, "exclusivity": 0.5,
+                               "coherence_metric": label},
+                              {"k": 3, "coherence": -6.0, "exclusivity": 0.6,
+                               "coherence_metric": label}])
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")  # bare-coherence monotone warning
+            assert rows.best_k(label) == rows.best_k("coherence")
+    # a label that is NOT this result's coherence_metric still errors
+    rows = SearchKResult([{"k": 2, "coherence": -5.0, "exclusivity": 0.5,
+                           "coherence_metric": "u_mass"}])
+    with pytest.raises(ValueError, match="unknown metric"):
+        rows.best_k("semcoh")
+
+
+def test_topic_labels_shape_and_guard():
+    # #733 Tier 3: label_topics rows are TopicLabels dicts; an integer index (the
+    # common "iterate for words" mistake) raises a directive error, dict access works.
+    from topica.validation import TopicLabels
+    tl = TopicLabels({"prob": [("a", 0.3)], "frex": [("b", 0.9)],
+                      "lift": [("c", 1.1)], "score": [("d", 0.2)]})
+    assert tl["frex"] == [("b", 0.9)]                  # dict access intact
+    assert [w for w, _ in tl["frex"]] == ["b"]
+    assert set(tl.keys()) == {"prob", "frex", "lift", "score"}
+    with pytest.raises(TypeError, match="dict keyed by"):
+        tl[0]                                          # int index -> directive error
+    assert "TopicLabels" in repr(tl)
+
+
+def test_predicted_prevalence_scalar_helpers():
+    # #733 Tier 3: a contrast is a single value but estimate is a 1-element array
+    # (f-string on it crashes). .value / .ci give floats; multi-point raises.
+    import numpy as np
+    from topica.stm import PredictedPrevalence
+    pp = PredictedPrevalence(topic=0, topic_name="t", mode="contrast", grid=["a", "b"],
+                             estimate=np.array([-0.096]), ci_low=np.array([-0.14]),
+                             ci_high=np.array([-0.05]))
+    assert f"{pp.value:+.3f}" == "-0.096"
+    assert pp.ci == pytest.approx((-0.14, -0.05))
+    multi = PredictedPrevalence(topic=0, topic_name="t", mode="continuous",
+                                grid=[{}, {}], estimate=np.array([0.1, 0.2]),
+                                ci_low=np.array([0.0, 0.1]), ci_high=np.array([0.2, 0.3]))
+    with pytest.raises(ValueError, match="single grid point"):
+        multi.value

--- a/tests/test_search_k_models.py
+++ b/tests/test_search_k_models.py
@@ -42,6 +42,29 @@ def test_builtin_lsa_scans():
     assert all(np.isfinite(r["coherence"]) for r in rows)
 
 
+def test_lsa_reports_reconstruction_error_scree():
+    # issue #733 Tier 2: LSA now reports a reconstruction_error scree column, like
+    # NMF (was omitted though best_k's docstring advertised it as an NMF/LSA column).
+    c, _ = _corpus()
+    rows = topica.search_k(c, [2, 3, 4, 5], model="lsa")
+    errs = [r["reconstruction_error"] for r in rows]
+    assert all(np.isfinite(e) for e in errs)
+    # rank-K Frobenius residual falls monotonically as K grows
+    assert all(a >= b for a, b in zip(errs, errs[1:]))
+    assert rows.directions["reconstruction_error"] == "minimize"
+    assert rows.best_k("reconstruction_error", rule="elbow") in (2, 3, 4, 5)
+
+
+def test_lsa_reconstruction_error_survives_save_load(tmp_path):
+    c, _ = _corpus()
+    m = topica.LSA(num_topics=4).fit(c)
+    p = tmp_path / "lsa.bin"
+    m.save(str(p))
+    assert topica.LSA.load(str(p)).reconstruction_error == pytest.approx(
+        m.reconstruction_error
+    )
+
+
 def test_lsa_omits_dispersion_signed_factors():
     # LSA's topic_word is a signed SVD factor, so the multinomial residual
     # dispersion test is meaningless (~1e9). It must be skipped, not reported.


### PR DESCRIPTION
The Tier 2 and Tier 3 items from #733 (broken/opaque + return-shape inconsistencies), following the Tier-1 batch in #734.

### Tier 2
- **LSA reports `reconstruction_error`.** It was omitted though `best_k`'s docstring advertised it as an "NMF/LSA column". Added the rank-K Frobenius residual `sqrt(‖X‖² − Σσ_k²)`, computed from the same weighted matrix the SVD factors (reusing `SpMat::frob_sq`). `search_k(model="lsa")` now reports a scree column symmetric with NMF, `best_k("reconstruction_error", rule="elbow")` works, and it round-trips through save/load.

### Tier 3
- **`SearchKResult.to_frame()`** — the scan as a tidy DataFrame, matching the effect/robustness results (only `effects_across_k` had it). Two sociologists reached for it.
- **`best_k` accepts the coherence-metric label** — the result advertises `coherence_metric` (`"semcoh"`/`"u_mass"`); `best_k("semcoh")` now maps to `"coherence"` instead of raising "unknown metric" for a name the result itself displays. A label that isn't this result's metric still errors.
- **`label_topics` rows are a `TopicLabels` dict subclass.** Iterating a row (`for w in labels[0]`) yields dict keys, not words — the trap that bit two sociologists. An integer index now raises a directive error naming the real access (`labels[0]["frex"]`), and the repr shows the shape. Dict access is unchanged; the docstring gains an explicit example.
- **`PredictedPrevalence.value` / `.ci`** — a contrast is a single number but `.estimate` is a 1-element array, so `f"{pp.estimate:+.3f}"` crashed (it crashed a sociologist's write-up live). Added scalar helpers for the single-point case; multi-point raises, directing to the arrays / `to_frame()`. The array contract is unchanged.

## Design notes
- Everything is **additive/non-breaking**: LSA gains an attribute; `best_k` widens what it accepts; `label_topics` returns a dict subclass (still a dict); `PredictedPrevalence` gains two properties. No existing signature or return type changed.
- The `label_topics` guard only fires on an **integer** index — the specific mistake — so `.keys()`, `dict(...)`, JSON, and string access are untouched.

## Tests / docs
New tests for all five (LSA scree + save/load, `to_frame`, label-alias, `TopicLabels` guard, `PredictedPrevalence` scalars). `.pyi` stub updated for the LSA getter. Docs: choosing-k notes the LSA scree column and `to_frame()`.

Green: `scripts/preflight.sh`, `mkdocs build --strict`, `cargo test --lib`, full pytest **4926 passed, 38 skipped**.

Remaining #733 items are Tier 4 (discoverability/docs): the "cleaning raw text" recipe, a `Corpus.from_dataframe` pointer, the ordinal covariate note (partly done in #734), and the K-over-split guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)