### PR TITLE
chore(datasets): bump _DATA_REF so load_congress() resolves on main

### DIFF
--- a/python/topica/datasets/__init__.py
+++ b/python/topica/datasets/__init__.py
@@ -90,7 +90,7 @@ class Bunch(dict):
 # Immutable commit that holds the dataset files. Pinned (not ``main``) so a
 # given topica version always fetches the same bytes; override with the
 # TOPICA_DATA_REF environment variable for local development against a branch.
-_DATA_REF = "6bd06bd9bd8477952a5405251626271563b51216"
+_DATA_REF = "548b09228e8641422557d79c0b84aace1cdd97b3"
 _RAW_BASE = "https://raw.githubusercontent.com/nealcaren/topica"
 
 # name -> dataset record. ``vendored`` files ship in the wheel; the rest carry a


### PR DESCRIPTION
Post-merge follow-up to #736. Points `_DATA_REF` at the squash commit `548b092` that ships `examples/congress_press.csv`, so a real `load_congress()` call fetches and checksum-verifies on `main` (it 404'd against the old ref, which predates the file). poliblog/dubois/ng20_minilm are unchanged at that commit and still resolve — verified live for all three, plus the hermetic dataset tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)