### PR TITLE
fix(helpers): accept the covariate arrays you fit with (#739)

### DIFF
--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -286,7 +286,7 @@ class SearchKResult(list):
     def best_k(self, metric: str | None = ..., *, rule: str = ..., frontier_metrics: Sequence[str] | None = ..., weights: Sequence[float] | None = ...) -> int: ...
 
 
-def search_k(docs: Any, ks: Sequence[int], *, model: str = ..., prevalence: Any | None = ..., content: Any | None = ..., held_out: Any = ..., iters: int = ..., num_samples: int = ..., sample_interval: int = ..., seed: int = ..., coherence_n: int = ..., coherence_type: str = ..., n_jobs: int = ..., num_seeds: int = ..., criteria: Sequence[str] = ...) -> SearchKResult:
+def search_k(docs: Any, ks: Sequence[int], *, model: str = ..., prevalence: Any | None = ..., prevalence_names: Any | None = ..., content: Any | None = ..., held_out: Any = ..., iters: int = ..., num_samples: int = ..., sample_interval: int = ..., seed: int = ..., coherence_n: int = ..., coherence_type: str = ..., n_jobs: int = ..., num_seeds: int = ..., criteria: Sequence[str] = ...) -> SearchKResult:
     """Fit an LDA/STM per K; report coherence, exclusivity, residual dispersion, and (optional) held-out metric."""
     ...
 

--- a/python/topica/effects.py
+++ b/python/topica/effects.py
@@ -305,11 +305,21 @@ def prevalence_ci(model, groups, *, ci=0.95, normalize=True, corpus=None,
             "groups must be one label per document"
         )
 
-    group_str = np.asarray([str(v) for v in groups])
+    def _canon(v):
+        # Match groups to labels by string form, but render an integer-valued
+        # float as the plain integer ("2013.0" -> "2013"). A dynamic keyATM
+        # stores time_labels as int-like strings while the fit-time timestamps
+        # are often a float year array; without this, str(2013.0) != "2013"
+        # would spuriously report every period as missing (issue #739).
+        if isinstance(v, (float, np.floating)) and np.isfinite(v) and float(v).is_integer():
+            return str(int(v))
+        return str(v)
+
+    group_str = np.asarray([_canon(v) for v in groups])
     if labels is None:
-        uniq = sorted(np.unique(groups), key=lambda v: str(v))
+        uniq = sorted(np.unique(groups), key=_canon)
         labels = [u.item() if hasattr(u, "item") else u for u in uniq]
-    label_to_idx = {str(lbl): i for i, lbl in enumerate(labels)}
+    label_to_idx = {_canon(lbl): i for i, lbl in enumerate(labels)}
     missing = set(group_str) - set(label_to_idx)
     if missing:
         raise ValueError(f"groups contains values not in labels: {sorted(missing)}")

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1453,6 +1453,7 @@ def search_k(
     model="lda",
     fit=None,
     prevalence=None,
+    prevalence_names=None,
     content=None,
     held_out=None,
     iters=500,
@@ -1525,6 +1526,10 @@ def search_k(
         precedence over ``model`` and lets ``search_k`` scan any model type; the
         callable owns the fit (it closes over ``docs`` and any covariates).
     prevalence : covariate design matrix for ``model="stm"``; ignored otherwise.
+    prevalence_names : accepted for signature-parity with ``STM.fit`` (so the same
+        kwargs drop straight in) and ignored — ``search_k`` scans K on the design
+        matrix and never labels the covariates, so their names do not affect any
+        metric it reports.
     content : optional content group labels (sequence of str/int) for ``model="stm"``.
     held_out : optional held-out set. Pass a :class:`Heldout` (from
         :func:`make_heldout`) or a separate corpus / token lists.

--- a/tests/test_keyatm_dynamic.py
+++ b/tests/test_keyatm_dynamic.py
@@ -216,6 +216,20 @@ def test_time_prevalence_ci_bounds(dyn_model_ci):
     assert np.all(result["sd"] >= 0.0)
 
 
+def test_time_prevalence_ci_accepts_float_timestamps(dyn_model_ci):
+    """#739: passing the fit-time timestamps as a float array (e.g. a pandas
+    float `year` column) must match int-like string time_labels, not report every
+    period missing because str(2013.0) != '2013'."""
+    m, _, years = dyn_model_ci
+    ref = topica.time_prevalence_ci(m, years)
+    float_years = np.asarray(years, dtype=np.float64)  # 2000.0, 2001.0, ...
+    out = topica.time_prevalence_ci(m, float_years)
+    assert out["labels"] == ref["labels"]
+    np.testing.assert_allclose(out["mean"], ref["mean"])
+    np.testing.assert_allclose(out["ci_low"], ref["ci_low"])
+    np.testing.assert_allclose(out["ci_high"], ref["ci_high"])
+
+
 def test_time_prevalence_ci_requires_draws():
     """Raises a clear error when theta_draws were not retained."""
     docs, years = _corpus(seed=8, n_years=4, change_at=2, per_year=20)

--- a/tests/test_search_k_models.py
+++ b/tests/test_search_k_models.py
@@ -136,6 +136,21 @@ def test_fit_hook_with_covariate_model():
     assert [r["k"] for r in rows] == [2, 3]
 
 
+def test_stm_accepts_prevalence_names_for_fit_parity():
+    """#739: STM.fit takes prevalence_names=; the same kwargs must drop straight
+    into search_k(model='stm', ...). It is accepted and ignored (search_k scans K
+    on the design matrix and never labels the covariates)."""
+    c, docs = _corpus()
+    x = np.array([[1.0, float(i < len(docs) // 2)] for i in range(len(docs))])
+    names = ["(Intercept)", "group"]
+    ref = topica.search_k(c, [2, 3], model="stm", prevalence=x, iters=40)
+    rows = topica.search_k(c, [2, 3], model="stm", prevalence=x,
+                           prevalence_names=names, iters=40)
+    assert [r["k"] for r in rows] == [2, 3]
+    # passing the names changes nothing about the scan
+    assert [r["k"] for r in rows] == [r["k"] for r in ref]
+
+
 def test_fit_hook_takes_precedence_and_rejects_covariate_args():
     c, _ = _corpus()
     x = np.ones((60, 1))


### PR DESCRIPTION
Closes #739.

Two post-fit helpers rejected the exact arguments a user had just fit the model with, forcing a detour through the source. Found in the power-user stress test on `load_congress()` and verified to reproduce on 0.55.0.

## Fixes

**1. `search_k(model="stm", ...)` had no `prevalence_names=`.** `STM.fit` takes `prevalence_names=`, so copy-pasting the same kwargs into `search_k` raised `TypeError: unexpected keyword argument 'prevalence_names'`. It is now accepted for signature parity and ignored — `search_k` scans K on the design matrix and never labels the covariates, so their names cannot affect any metric it reports (documented as such).

**2. `time_prevalence_ci` rejected the fit-time float `year` array.** The docstring says pass "the same array passed to `fit`", but a dynamic keyATM stores `time_labels` as int-like strings (`'2013'`) while a pandas float `year` column stringifies to `'2013.0'`, so `prevalence_ci` reported every period missing:

```
ValueError: groups contains values not in labels: ['2013.0', ...]
```

`prevalence_ci` now canonicalizes integer-valued floats to their plain integer form (`2013.0 -> "2013"`) before matching. Genuine non-integer floats (`1.5`) and string groups are unaffected.

## Tests
- `test_stm_accepts_prevalence_names_for_fit_parity` — the `STM.fit` kwargs drop straight into `search_k`, and passing the names changes nothing about the scan.
- `test_time_prevalence_ci_accepts_float_timestamps` — a float year array matches the int-based result element-for-element.

Full `pytest` on the affected modules (104 passed) and `scripts/preflight.sh` (fmt, clippy, stub-sync, model tables) are green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)