### PR TITLE
fix(guardrails): stop silent misconfigurations in LDA and bootstrap_stability (#740, #741)

### DIFF
--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -3089,10 +3089,14 @@ def bootstrap_stability(
             UserWarning,
             stacklevel=2,
         )
-    if k is None:
-        if reference is None:
-            raise ValueError("pass k (number of topics) or a fitted reference model")
+    if k is None and reference is not None:
         k = int(reference.num_topics)
+    # k is only needed to build the *default* factory; a supplied model_factory
+    # owns the topic count itself (the reference K is read back off the fit), so
+    # factory-only usage without k= is allowed — matching the docstring (#742).
+    if model_factory is None and k is None:
+        raise ValueError(
+            "pass k (number of topics), a model_factory, or a fitted reference model")
     factory = model_factory or (lambda s: LDA(num_topics=k, seed=s))
 
     def top_word_sets(model):

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -3022,7 +3022,8 @@ def bootstrap_stability(
     seed=0,
     model_factory=None,
     reference=None,
-    **fit_kwargs,
+    fit_kwargs=None,
+    **extra_fit_kwargs,
 ):
     """Flag fragile topics by refitting on bootstrap resamples of the corpus.
 
@@ -3047,8 +3048,15 @@ def bootstrap_stability(
     reference : an already-fitted model to measure the stability *of*. When given,
         the resample topics are matched back to it (rather than to a fresh
         full-corpus fit), so the per-topic stability lines up with that model's
-        topic indices. ``model_factory`` should rebuild the same model type.
-    fit_kwargs : forwarded to each model's ``fit`` (e.g. ``iters=500``).
+        topic indices. ``model_factory`` should rebuild the same model type. The
+        factory's single argument is the **seed** (not ``k``), e.g.
+        ``model_factory=lambda seed: topica.LDA(8, seed=seed)``; the factory sets
+        the topic count, so ``k=`` is ignored when a factory is given.
+    fit_kwargs : dict of keyword arguments forwarded to each model's ``fit`` (e.g.
+        ``fit_kwargs={"iters": 500}``), matching :func:`cross_validate`. For
+        convenience the same arguments may also be passed inline as keywords
+        (``bootstrap_stability(docs, k=5, iters=500)``); the two are merged, with
+        inline keywords taking precedence on a clash.
 
     Returns
     -------
@@ -3056,6 +3064,11 @@ def bootstrap_stability(
     ``[0, 1]``), ``mean`` (overall), and ``reference`` (the reference model).
     """
     from . import LDA  # local import to avoid a cycle at module load
+
+    # fit_kwargs= (a dict, like cross_validate) and inline **extra_fit_kwargs both
+    # forward to fit; merge them so the documented dict form works and no longer
+    # collides with the old **kwargs (issue #740). Inline keywords win on a clash.
+    fit_kwargs = {**(fit_kwargs or {}), **extra_fit_kwargs}
 
     # Accept a Corpus, matching the docstring and the sibling functions
     # (perplexity, prepare_pyldavis): pull its token lists before resampling.
@@ -3065,6 +3078,17 @@ def bootstrap_stability(
     D = len(docs)
     if D < 2:
         raise ValueError("need at least two documents to resample")
+    if model_factory is not None and k is not None:
+        # The factory owns the topic count and its argument is the seed, so a
+        # stray k= here is silently ignored — warn rather than build the wrong K
+        # (issue #740: `lambda k: LDA(k)` reads like k but receives the seed).
+        warnings.warn(
+            "bootstrap_stability: k= is ignored when model_factory= is given (the "
+            "factory sets the topic count). Note the factory's argument is the SEED, "
+            "not k — write model_factory=lambda seed: LDA(k, seed=seed).",
+            UserWarning,
+            stacklevel=2,
+        )
     if k is None:
         if reference is None:
             raise ValueError("pass k (number of topics) or a fitted reference model")

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1386,6 +1386,18 @@ impl LDA {
         let num_topics = slf.num_topics;
         let num_types = corpus.num_types();
         let num_docs = corpus.num_docs();
+        // K larger than the vocabulary can never yield K distinct word
+        // distributions, so the extra topics collapse to empty/degenerate rows
+        // with no warning. Guard it the way NMF/CTM already do rather than fit
+        // silently meaningless topics (issue #741).
+        if num_topics > num_types {
+            return Err(PyValueError::new_err(format!(
+                "num_topics ({num_topics}) exceeds the vocabulary size ({num_types}): \
+                 there are not enough distinct word types to form that many topics, so \
+                 the surplus topics would be empty. Lower num_topics to at most {num_types}, \
+                 or supply a corpus with a larger vocabulary."
+            )));
+        }
         let alpha_sum = slf.alpha_sum.unwrap_or(num_topics as f64);
         let total_tokens = corpus.total_tokens().max(1) as f64;
 

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -795,6 +795,18 @@ def test_bootstrap_stability_fit_kwargs_dict_and_inline_merge():
     assert r_dict["mean"] == r_inline["mean"]  # same effective fit args -> same result
 
 
+def test_bootstrap_stability_factory_only_without_k():
+    # #742/#745: a supplied model_factory owns the topic count, so factory-only
+    # usage (no k=, no reference=) must work rather than raising "pass k ...".
+    c = _two_topic_corpus()
+    r = topica.bootstrap_stability(
+        c, n_boot=1, model_factory=lambda seed: topica.LDA(2, seed=seed), iters=30)
+    assert r["stability"].shape == (2,)  # K read back off the fitted reference
+    # still errors when there is genuinely no way to know K
+    with pytest.raises(ValueError, match="pass k"):
+        topica.bootstrap_stability(c, n_boot=1, iters=30)
+
+
 def test_bootstrap_stability_warns_on_k_with_model_factory():
     # #740: k= is silently ignored when model_factory= is given (the factory owns
     # the topic count and its argument is the seed). Warn instead of building the

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -765,3 +765,42 @@ def test_predicted_prevalence_scalar_helpers():
                                 ci_low=np.array([0.0, 0.1]), ci_high=np.array([0.2, 0.3]))
     with pytest.raises(ValueError, match="single grid point"):
         multi.value
+
+
+def test_lda_rejects_num_topics_over_vocab():
+    # #741: K larger than the vocabulary produces only degenerate topics, so LDA
+    # now guards it the way NMF/CTM do instead of fitting silently. K == vocab is
+    # still allowed.
+    tiny = [["a", "b"], ["b", "c"], ["a", "c"]]  # 3 distinct word types
+    with pytest.raises(ValueError, match="exceeds the vocabulary size"):
+        topica.LDA(num_topics=100, seed=13).fit(tiny, iters=10)
+    m = topica.LDA(num_topics=3, seed=13).fit(tiny, iters=10)  # K == vocab: fine
+    assert np.asarray(m.topic_word).shape == (3, 3)
+
+
+def _two_topic_corpus():
+    a = [["cat", "dog", "pet", "vet", "paw"]] * 30
+    b = [["star", "moon", "sky", "sun", "orbit"]] * 30
+    return topica.Corpus.from_documents(a + b)
+
+
+def test_bootstrap_stability_fit_kwargs_dict_and_inline_merge():
+    # #740: fit_kwargs= (a dict, like cross_validate) is documented but used to be
+    # **kwargs, so passing it crashed. Both the dict form and inline keywords now
+    # work and merge.
+    c = _two_topic_corpus()
+    r_dict = topica.bootstrap_stability(c, k=2, n_boot=2, fit_kwargs={"iters": 40})
+    r_inline = topica.bootstrap_stability(c, k=2, n_boot=2, iters=40)
+    assert 0.0 <= r_dict["mean"] <= 1.0
+    assert r_dict["mean"] == r_inline["mean"]  # same effective fit args -> same result
+
+
+def test_bootstrap_stability_warns_on_k_with_model_factory():
+    # #740: k= is silently ignored when model_factory= is given (the factory owns
+    # the topic count and its argument is the seed). Warn instead of building the
+    # wrong K.
+    c = _two_topic_corpus()
+    with pytest.warns(UserWarning, match="k= is ignored when model_factory"):
+        topica.bootstrap_stability(
+            c, k=8, n_boot=1,
+            model_factory=lambda seed: topica.LDA(2, seed=seed), iters=30)

--- a/tests/test_lda.py
+++ b/tests/test_lda.py
@@ -315,12 +315,14 @@ class TestSpectralInit:
         assert covered == set(range(k)), f"only recovered {covered}"
 
     def test_spectral_falls_back_on_tiny_corpus(self):
-        # Fewer word types than topics: spectral_init returns None and the fit
-        # falls back to the random draw rather than erroring.
-        docs = [["a", "b"], ["a", "b"], ["b", "a"]]
-        m = LDA(5, seed=1, init="spectral")
+        # A degenerate corpus (identical docs) offers no K independent anchors, so
+        # spectral_init returns None and the fit falls back to the random draw
+        # rather than erroring. num_topics == vocab here, so it is a valid K (K >
+        # vocab is now rejected up front, see #741).
+        docs = [["a", "b", "c"], ["a", "b", "c"], ["a", "b", "c"]]
+        m = LDA(3, seed=1, init="spectral")
         m.fit(docs, iters=20)
-        assert m.num_topics == 5
+        assert m.num_topics == 3
         assert m.topic_word.shape[1] == len(m.vocabulary)
 
     def test_spectral_survives_save_load(self, tmp_path):


### PR DESCRIPTION
Closes #741. Closes #740.

Three footguns from the power-user stress test on `load_congress()`, all of which produced wrong or degenerate results **with no error**. Silent-wrong-result footguns are worse than crashes, so these get guarded. All verified to reproduce on 0.55.0.

## Fixes

**1. `LDA` silently accepted `num_topics > vocabulary` (#741).** A K larger than the vocabulary can never form K distinct word distributions, so the surplus topics collapse to empty/degenerate rows — but LDA fit them anyway with no warning, while `NMF` and `CTM` already raise on the same case. LDA now raises up front:

```python
topica.LDA(num_topics=100, seed=13).fit([["a","b"],["b","c"],["a","c"]], iters=20)
# ValueError: num_topics (100) exceeds the vocabulary size (3): there are not
# enough distinct word types to form that many topics ...
```
`num_topics == vocab` is still allowed. The spectral-init fallback test is retargeted to a valid `K == vocab` degenerate corpus (identical docs → no K independent anchors → `spectral_init` returns `None` → random-init fallback), since `K > vocab` is now rejected before init.

**2. `bootstrap_stability(fit_kwargs=...)` crashed (#740).** The docstring documented a `fit_kwargs` parameter, but the signature was `**fit_kwargs`, so the documented dict form raised `TypeError: LDA.fit() got an unexpected keyword argument 'fit_kwargs'`. There is now a real `fit_kwargs=` dict param (matching `cross_validate`), merged with any inline keywords (inline wins on a clash) — so both `fit_kwargs={"iters": 500}` and inline `iters=500` work.

**3. `bootstrap_stability` silently ignored `k=` when `model_factory=` was given (#740).** The factory owns the topic count and its single argument is the **seed**, not `k`, so `model_factory=lambda k: LDA(k)` built `LDA(num_topics=seed)` — the wrong K, no warning. It now warns when both `k=` and `model_factory=` are passed, and the docstring states the factory argument is the seed.

## Tests
- `test_lda_rejects_num_topics_over_vocab` — K>vocab raises; K==vocab fits.
- `test_bootstrap_stability_fit_kwargs_dict_and_inline_merge` — dict and inline forms both work and agree.
- `test_bootstrap_stability_warns_on_k_with_model_factory` — the silent-k warning fires.
- `test_spectral_falls_back_on_tiny_corpus` retargeted to a valid corpus.

## Gates
- Full `pytest`: **4933 passed, 38 skipped, 0 failed**.
- `cargo test --lib`: **340 passed**.
- `scripts/preflight.sh` (fmt, clippy, stub-sync, model tables): green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)