### PR TITLE
fix(consistency): resolve power-user API papercuts (#742)

### DIFF
--- a/docs/contributing/conventions.md
+++ b/docs/contributing/conventions.md
@@ -51,6 +51,12 @@ by construction rather than by memory.
    keys from each constructor signature, so a new parameter that is not surfaced in
    `settings` fails the suite — there is no second inventory to maintain. The
    analysis manifest (`record_fit`) reads this surface directly.
+5. **`top_words(n, topic=None)` returns `(word, prob)` pairs**, not bare words:
+   `list[list[tuple[str, float]]]` for all topics, or `list[tuple[str, float]]`
+   for one `topic=`. So `", ".join(model.top_words(n, topic=t))` raises — unpack
+   the pairs first (`", ".join(w for w, _ in model.top_words(n, topic=t))`). The
+   probabilities are the topic-word weights, descending. This is uniform across
+   every model (issue #742).
 
 ## Threads and stopping rules
 

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -406,6 +406,15 @@ def coherence(topics, texts, *, coherence_type="c_v", n=10, topn=None, window_si
     equals ``coherence(model, training_texts, coherence_type=ct)``. ``c_v`` lies in
     ``[0, 1]``.
 
+    **Default note (issue #742):** this function defaults to ``c_v`` while the
+    model method ``model.coherence()`` defaults to ``u_mass``. The difference is
+    deliberate: ``u_mass`` is intrinsic (it needs only the model's own corpus), so
+    it is the one measure the method can compute without an external reference,
+    whereas this function always receives ``texts`` and so can default to the
+    stronger sliding-window ``c_v``. Pass ``coherence_type=`` explicitly on both
+    sides if you need to compare scores across the two entry points — the measures
+    are on different scales.
+
     ``u_mass`` is the **sum** of the pairwise log-ratios, the original Mimno et al.
     (2011) definition, matching the model method. gensim's ``u_mass`` reports the
     *mean* of the same per-pair scores, so topica's values differ from gensim's by the

--- a/python/topica/registry.py
+++ b/python/topica/registry.py
@@ -70,6 +70,14 @@ class ModelInfo:
     experimental: bool = False
     common_start: bool = False
 
+    def __lt__(self, other: "ModelInfo") -> bool:
+        # Order by name so ``sorted(list_models())`` just works (issue #742). A
+        # frozen dataclass without ``order=True`` is unorderable by default, and
+        # comparing every field would be meaningless here — name is the identity.
+        if not isinstance(other, ModelInfo):
+            return NotImplemented
+        return self.name < other.name
+
 
 # Purpose groups, in display order. Organized by what the user brings and wants,
 # not by inference family.

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -1301,7 +1301,12 @@ def _build_reference_rows(
             setting_a, setting_b = contrast
             col = None  # no named column in the sequence form
         else:
-            raise ValueError("contrast= must be a 2-item dict or a 2-element sequence.")
+            raise ValueError(
+                "contrast= must be either a one-key dict mapping a covariate to its "
+                'two levels, {"party": ["D", "R"]} (reports level_b - level_a), or a '
+                "2-element sequence of covariate settings, (setting_a, setting_b). "
+                f"Got {contrast!r} (length {len(contrast)})."
+            )
 
         def _single_row(setting):
             """Build one design row for a covariate setting (dict or scalar)."""
@@ -1481,8 +1486,12 @@ def predicted_prevalence(
         when using the raw ``X`` path.
     at : dict or DataFrame, optional
         Reference covariate settings for point predictions.
-    contrast : dict or 2-tuple, optional
-        Two covariate settings; the result is their difference.
+    contrast : dict or 2-element sequence, optional
+        Two covariate settings; the result is their difference (second minus
+        first). Two accepted forms: a one-key dict mapping a covariate to its two
+        levels, ``{"party": ["D", "R"]}`` (reports ``R - D``); or a 2-element
+        sequence of full settings, ``(setting_a, setting_b)``. A 3-tuple such as
+        ``("party", "D", "R")`` is *not* accepted — use the dict form.
     continuous : str, optional
         Column name to sweep over its observed range.
     npoints : int

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -17,6 +17,23 @@ use super::build_corpus_from_docs_ext;
 use super::error::io_err;
 use crate::corpus::{self, InputFormat, LoadOptions};
 
+/// Collect an optional stopword argument into a set, accepting any iterable of
+/// strings (list, tuple, set, frozenset) so the bundled `ENGLISH_STOPWORDS`
+/// frozenset composes directly with the corpus builders (issue #742), the same
+/// way `tokenize` already accepts it.
+fn stopwords_set(stopwords: Option<&Bound<'_, PyAny>>) -> PyResult<HashSet<String>> {
+    match stopwords {
+        Some(obj) => {
+            let mut s = HashSet::new();
+            for item in obj.iter()? {
+                s.insert(item?.extract::<String>()?);
+            }
+            Ok(s)
+        }
+        None => Ok(HashSet::new()),
+    }
+}
+
 /// The vocabulary-filtering parameters Topica applied when building a corpus.
 /// Recorded so a fitted corpus can report how it was preprocessed (issue #399).
 /// `None` on a corpus loaded from disk, where the parameters were not persisted.
@@ -233,7 +250,7 @@ impl Corpus {
         documents: Vec<Vec<String>>,
         doc_names: Option<Vec<String>>,
         doc_labels: Option<Vec<String>>,
-        stopwords: Option<Vec<String>>,
+        stopwords: Option<&Bound<'_, PyAny>>,
         min_doc_freq: u32,
         max_doc_fraction: f64,
         min_cf: u32,
@@ -263,7 +280,7 @@ impl Corpus {
             ));
         }
         let used_fixed_vocab = vocabulary.is_some();
-        let stop: HashSet<String> = stopwords.unwrap_or_default().into_iter().collect();
+        let stop: HashSet<String> = stopwords_set(stopwords)?;
         let (inner, kept_indices) = build_corpus_from_docs_ext(
             documents,
             doc_names,
@@ -360,7 +377,7 @@ impl Corpus {
         label_column: Option<usize>,
         text_column: usize,
         token_regex: Option<String>,
-        stopwords: Option<Vec<String>>,
+        stopwords: Option<&Bound<'_, PyAny>>,
         min_doc_freq: u32,
         max_doc_fraction: f64,
     ) -> PyResult<Self> {
@@ -378,7 +395,7 @@ impl Corpus {
                 )))
             }
         };
-        let stop: HashSet<String> = stopwords.unwrap_or_default().into_iter().collect();
+        let stop: HashSet<String> = stopwords_set(stopwords)?;
         let opts = LoadOptions {
             format: fmt,
             token_regex: token_regex.unwrap_or_else(|| corpus::DEFAULT_TOKEN_REGEX.to_string()),

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -765,3 +765,39 @@ def test_predicted_prevalence_scalar_helpers():
                                 ci_low=np.array([0.0, 0.1]), ci_high=np.array([0.2, 0.3]))
     with pytest.raises(ValueError, match="single grid point"):
         multi.value
+
+
+def test_list_models_is_sortable():
+    # #742: ModelInfo had no __lt__, so sorted(list_models()) raised TypeError.
+    models = topica.list_models()
+    ordered = sorted(models)
+    assert [m.name for m in ordered] == sorted(m.name for m in models)
+
+
+def test_stopwords_frozenset_composes_with_corpus_builder():
+    # #742: topica.stopwords()/ENGLISH_STOPWORDS is a frozenset, but the corpus
+    # builders demanded a Sequence, so the library's own accessor did not compose
+    # with its own builder. Any iterable (set/frozenset/tuple/list) is now accepted.
+    sw = topica.stopwords("english")
+    assert isinstance(sw, frozenset)
+    c = topica.Corpus.from_documents([["the", "cat", "runs"], ["a", "dog", "barks"]],
+                                     stopwords=sw)
+    assert "the" not in c.vocabulary and "cat" in c.vocabulary
+    # a bare set and a tuple work too
+    topica.Corpus.from_documents([["x", "y"]], stopwords={"x"})
+    topica.Corpus.from_documents([["x", "y"]], stopwords=("x",))
+
+
+def test_predicted_prevalence_contrast_bad_shape_is_actionable():
+    # #742: a 3-tuple contrast raised a terse "must be a 2-item dict or 2-element
+    # sequence"; the message now names both accepted forms.
+    docs = [["cat", "dog", "pet", "vet", "paw"]] * 20 + \
+           [["star", "moon", "sky", "sun", "orbit"]] * 20
+    import pandas as pd
+    df = pd.DataFrame({"text": [" ".join(d) for d in docs],
+                       "party": (["D"] * 20) + (["R"] * 20)})
+    m = topica.LDA(3, seed=13).fit(
+        topica.from_dataframe(df, text_col="text", metadata_cols=["party"]), iters=40)
+    with pytest.raises(ValueError, match="one-key dict.*or a 2-element sequence"):
+        topica.predicted_prevalence(m, formula="party", data=df,
+                                    contrast=("R", 1.0, 0.0))


### PR DESCRIPTION
Addresses #742. Small cross-cutting friction points from the power-user stress test on `load_congress()` — each a place a user had to guess or read source. All verified on 0.55.0.

## Behavioral fixes (with regression tests)

- **`sorted(topica.list_models())` raised `TypeError`.** `ModelInfo` is a frozen dataclass with no `__lt__`. It now orders by `name`.
- **`topica.stopwords()` / `ENGLISH_STOPWORDS` (a `frozenset`) would not compose with the corpus builders**, which demanded a `Sequence` (`'frozenset' object cannot be converted to 'Sequence'`). `Corpus.from_documents` and `from_text_file` now accept any iterable of strings — the same way `tokenize` already does (shared `stopwords_set` helper in `corpus.rs`).
- **`predicted_prevalence(contrast=("R", 1.0, 0.0))` gave a terse error.** The message now names both accepted forms (one-key dict `{"party": ["D","R"]}` or a 2-element sequence) and echoes what it received; the `contrast=` docstring documents them, including that the 3-tuple form is not accepted.

## Documentation

- Documented **why `.coherence()` defaults to `u_mass` while `topica.coherence()` defaults to `c_v`** — the method is intrinsic (only the model's own corpus), the function always has `texts`, so the split is deliberate, not a bug. Users are steered to pass `coherence_type=` explicitly when comparing across the two.
- Documented the **`top_words(n, topic=) -> (word, prob)` contract** in the cross-model conventions (`docs/contributing/conventions.md`), with the correct unpack idiom.

## Scoped out (deliberately)
- `refine_keywords` `(refined, dropped)` return — already documented in its docstring; the original finding was inaccurate.
- A library-wide `as_frame=` / return-type unification — a real design change, better done deliberately than folded into a papercut batch.

## Gates
- Full `pytest`: **4935 passed, 38 skipped, 0 failed**.
- `cargo test --lib`: **340 passed**.
- `scripts/preflight.sh` (fmt, clippy, stub-sync, model tables) and `mkdocs build --strict`: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)