### PR TITLE
docs(audit): close #733 Tier-4 discoverability items

### DIFF
--- a/docs/guides/model-comparison.md
+++ b/docs/guides/model-comparison.md
@@ -175,6 +175,17 @@ topic is still found, and the cost is redundant topics that can be read and
 pruned. When unsure, err high. topica's [`search_k`](../publishing/validation.md)
 automates the scan.
 
+The matrix-factorization models (`NMF`, `LSA`) need extra care here. They have no
+held-out likelihood to anchor the scan, so K-selection leans on coherence and the
+reconstruction-error elbow — and both tend to keep improving as `K` grows, pointing
+higher than the substantive number of groups in the data. On a four-desk news
+corpus the coherence frontier reached `K=12` and the NMF reconstruction elbow sat
+around `K=8`, neither near the four known desks. Read those metrics as an upper
+bound, not an answer: cross-check the fitted topics against the structure you
+expect, and when the metric points past what you can interpret, err toward the
+smaller, readable `K`. The "err high" advice above is for likelihood-anchored
+parametric models; for MF models without that anchor, err toward interpretability.
+
 The nonparametric alternative is to let the model discover `K`. On this corpus
 that alternative disappoints. `HDP`, which is supposed to infer the topic count,
 collapses to a single topic under its default concentration and, as that

--- a/docs/guides/preprocessing.md
+++ b/docs/guides/preprocessing.md
@@ -58,6 +58,47 @@ corpus = topica.from_dataframe(df, text_col="text", strip_html=True)
 did not strip, so the trap is hard to miss. `strip_html` is a conservative clean
 (tags and URLs only); for heavier normalization, pass your own `tokenizer`.
 
+### Email, forum, and Usenet text: strip headers, quotes, and signatures
+
+`strip_html` handles markup, but email and newsgroup corpora (the classic
+20 Newsgroups set, mailing-list archives, forum dumps) carry a different kind of
+boilerplate: RFC headers (`From:`, `Subject:`, `NNTP-Posting-Host:`), quoted
+replies (`> ...`, `On <date> so-and-so wrote:`), and signature blocks after a
+`-- ` line. None of it is content, all of it survives `min_length=3` pruning, and
+left in it forms "topics" of mail-client vocabulary and the most-quoted posters'
+names. There is no built-in stripper for this — the shape is corpus-specific — so
+clean the raw text before you tokenize. A pragmatic pass for Usenet-style messages:
+
+```python
+import re
+import topica
+
+def strip_message_boilerplate(raw: str) -> str:
+    # 1. drop the header block: everything up to the first blank line
+    body = raw.split("\n\n", 1)[-1]
+    lines = []
+    for line in body.splitlines():
+        # 2. drop quoted reply lines and attribution ("On ... wrote:")
+        if line.lstrip().startswith(">"):
+            continue
+        if re.match(r"\s*On .+wrote:\s*$", line):
+            continue
+        # 3. stop at the signature delimiter
+        if line.rstrip() == "--":
+            break
+        lines.append(line)
+    return "\n".join(lines)
+
+df["clean"] = df["text"].map(strip_message_boilerplate)
+corpus = topica.from_dataframe(df, text_col="clean")
+```
+
+Tune the rules to your source — headers, quote markers, and signature conventions
+vary — but the principle holds: remove structural boilerplate in a preprocessing
+pass, then let `from_dataframe`/`tokenize` handle the linguistic cleaning. Inspect
+`corpus.vocabulary` afterward; if mail-client tokens or frequent poster surnames
+still lead the counts, the strip did not reach them.
+
 ### Readable topic words: lemmatize, don't stem
 
 Stemming truncates words to a root (`military` → `militari`, `economy` →

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -56,7 +56,10 @@ pub(crate) struct PrepInfo {
 /// Build one from already-tokenised documents with
 /// :meth:`Corpus.from_documents`, from a raw text file with
 /// :meth:`Corpus.from_text_file`, or load a binary corpus written by the
-/// ``preprocess`` CLI with :meth:`Corpus.load`.
+/// ``preprocess`` CLI with :meth:`Corpus.load`. Starting from a pandas
+/// ``DataFrame``? Use the module-level :func:`topica.from_dataframe` (it builds
+/// the ``Corpus`` and keeps your metadata row-aligned through pruning) — there is
+/// no ``Corpus.from_dataframe``; the DataFrame on-ramp is a module function.
 ///
 /// Accessor convention: scalar/array *facts about the corpus* are attribute
 /// **properties** — access them with no parentheses (``corpus.num_docs``,


### PR DESCRIPTION
The three remaining **Tier-4** (docs / discoverability) items from the four-sociologist raw-data audit, #733 — after Tier 1 (#734) and Tier 2/3 (#735) landed. This finishes #733.

## Items

1. **Email / Usenet boilerplate cleaning recipe.** `strip_html` handles markup, but 20NG-style corpora carry RFC headers, quoted replies, and signature blocks that survive `min_length=3` pruning and form mail-client / frequent-poster "topics". There is no built-in stripper (the shape is corpus-specific), so `preprocessing.md` gains a subsection with a pragmatic strip-before-tokenize pass and a pointer to inspect `corpus.vocabulary` afterward.
2. **`Corpus.from_dataframe` discoverability.** `dir(topica.Corpus)` doesn't reveal the pandas on-ramp because it's a module function, so the first instinct `Corpus.from_dataframe(...)` `AttributeError`s. The `Corpus` class docstring now points to `topica.from_dataframe` and states plainly there is no `Corpus.from_dataframe`.
3. **MF-model K over-split.** `model-comparison.md`'s "Choosing K" section now notes that `NMF`/`LSA` lack a held-out-likelihood anchor, so coherence and the reconstruction elbow point higher than the substantive K (the four-desk corpus scanned to K=12 / elbow ~8). Read them as an upper bound and err toward interpretability — distinct from the "err high" advice for likelihood-anchored parametric models.

The ordinal-vs-one-hot covariate item from the same tier was already handled in #734.

## Scope / gates
Docs-only plus one Rust docstring line on the `Corpus` pyclass (no signature change; the `.pyi` stub stays in sync). `scripts/preflight.sh` and `mkdocs build --strict`: green.

Closes #733.

🤖 Generated with [Claude Code](https://claude.com/claude-code)