### PR TITLE
feat(results): give the dict-returning diagnostics a .to_frame() (#742)

### DIFF
--- a/python/topica/_results.py
+++ b/python/topica/_results.py
@@ -1,0 +1,101 @@
+"""Small result containers shared across the diagnostic helper families.
+
+Several diagnostics (:func:`~topica.quality_frontier`,
+:func:`~topica.bootstrap_stability`, :func:`~topica.visualize_keywords`,
+:func:`~topica.time_prevalence_ci`) historically returned a plain ``dict``. They
+still *are* dicts — every ``result[key]`` access, ``.get``, ``**`` unpacking, and
+JSON round-trip is unchanged, and ``FrameDict({...}) == {...}`` — but they now
+carry the same ``.to_frame()`` a pandas user already reaches for on the other
+result types (:class:`~topica.SearchKResult`, the effect/robustness results).
+That converges the "return-type zoo" (#742) onto one idiom without breaking the
+dict contract.
+
+Each subclass defines its own natural *tidy* shape in :meth:`FrameDict.to_frame`;
+the base frames every value as a column, which is correct when the values are
+equal-length arrays.
+"""
+
+from __future__ import annotations
+
+
+class FrameDict(dict):
+    """A ``dict`` result that also renders as a tidy ``pandas.DataFrame``.
+
+    Behaves exactly like the ``dict`` it subclasses; adds :meth:`to_frame`.
+    """
+
+    def to_frame(self):
+        """Render as a ``pandas.DataFrame`` (raises if pandas is absent)."""
+        import pandas as pd
+
+        return pd.DataFrame(dict(self))
+
+
+class QualityFrontier(FrameDict):
+    """:func:`~topica.quality_frontier` result: one row per topic with
+    ``topic``, ``coherence``, ``exclusivity``, ``prevalence``. The base
+    :meth:`~FrameDict.to_frame` (every column an equal-length array) is exactly
+    right here."""
+
+
+class BootstrapStability(FrameDict):
+    """:func:`~topica.bootstrap_stability` result. ``topic`` and ``stability``
+    are per-topic arrays; ``mean`` (overall) and ``reference`` (the fitted model)
+    are scalars, so :meth:`to_frame` frames only the per-topic columns."""
+
+    def to_frame(self):
+        """Per-topic stability as a DataFrame (``topic``, ``stability``); the
+        scalar ``mean`` and the ``reference`` model stay on the dict."""
+        import pandas as pd
+
+        return pd.DataFrame({"topic": self["topic"], "stability": self["stability"]})
+
+
+class KeywordDiagnostics(FrameDict):
+    """:func:`~topica.visualize_keywords` result: ``{set_name: [row, ...]}``.
+    :meth:`to_frame` stacks every set's rows into one long frame with a leading
+    ``set`` column."""
+
+    _COLUMNS = ["set", "keyword", "count", "proportion", "doc_freq", "in_vocab"]
+
+    def to_frame(self):
+        """The per-keyword rows across all sets as one long DataFrame, with a
+        ``set`` column naming the keyword set each row came from."""
+        import pandas as pd
+
+        rows = [{"set": name, **row} for name, items in self.items() for row in items]
+        return pd.DataFrame(rows, columns=self._COLUMNS)
+
+
+class TimePrevalenceCI(FrameDict):
+    """:func:`~topica.time_prevalence_ci` result: ``labels`` plus ``(T, K)``
+    arrays ``mean``/``ci_low``/``ci_high``/``sd``. :meth:`to_frame` melts them to
+    one row per (period, topic)."""
+
+    _COLUMNS = ["period", "topic", "mean", "ci_low", "ci_high", "sd"]
+
+    def to_frame(self):
+        """Long tidy frame, one row per (period, topic), with columns
+        ``period``, ``topic``, ``mean``, ``ci_low``, ``ci_high``, ``sd``."""
+        import numpy as np
+        import pandas as pd
+
+        labels = list(self["labels"])
+        mean = np.asarray(self["mean"])
+        lo = np.asarray(self["ci_low"])
+        hi = np.asarray(self["ci_high"])
+        sd = np.asarray(self["sd"])
+        T, K = mean.shape
+        rows = [
+            {
+                "period": labels[t],
+                "topic": k,
+                "mean": float(mean[t, k]),
+                "ci_low": float(lo[t, k]),
+                "ci_high": float(hi[t, k]),
+                "sd": float(sd[t, k]),
+            }
+            for t in range(T)
+            for k in range(K)
+        ]
+        return pd.DataFrame(rows, columns=self._COLUMNS)

--- a/python/topica/keyatm.py
+++ b/python/topica/keyatm.py
@@ -216,17 +216,22 @@ def visualize_keywords(docs, keywords):
     a pruned seed shows ``count == 0`` and is flagged; scoring against raw docs
     reports the pre-pruning counts and can disagree with the fit (issue #743).
 
-    Returns a dict mapping each keyword-set name to a list of dicts
+    Returns a :class:`~topica._results.KeywordDiagnostics` (a ``dict``) mapping
+    each keyword-set name to a list of dicts
     ``{"keyword", "count", "proportion", "doc_freq", "in_vocab"}`` sorted by
     descending proportion, where ``proportion`` is the keyword's share of all
     corpus tokens, ``doc_freq`` is the number of documents containing it, and
-    ``in_vocab`` is ``False`` for a keyword ``fit`` will not see (count 0). When a
-    Corpus is passed, keywords absent from its vocabulary raise a warning.
+    ``in_vocab`` is ``False`` for a keyword ``fit`` will not see (count 0). Call
+    ``.to_frame()`` for one long DataFrame across all sets (a leading ``set``
+    column names each row's keyword set). When a Corpus is passed, keywords absent
+    from its vocabulary raise a warning.
     """
+    from ._results import KeywordDiagnostics
+
     counts, doc_freq, total = _corpus_counts(docs)
     _, vocab = _docs_and_vocab(docs)
     total = max(total, 1)
-    out = {}
+    out = KeywordDiagnostics()
     missing = {}
     for name, words in keywords.items():
         rows = [
@@ -296,12 +301,14 @@ def time_prevalence_ci(model, timestamps, *, ci=0.95, normalize=True):
 
     Returns
     -------
-    dict with keys:
+    :class:`~topica._results.TimePrevalenceCI` (a ``dict``) with keys:
         - ``labels``: list of period labels (equals ``model.time_labels``)
         - ``mean``: ndarray shape (T, K), posterior mean prevalence per period
         - ``ci_low``: ndarray shape (T, K), lower credible bound
         - ``ci_high``: ndarray shape (T, K), upper credible bound
         - ``sd``: ndarray shape (T, K), posterior standard deviation
+
+    Call ``.to_frame()`` for a long tidy DataFrame, one row per (period, topic).
     """
     time_labels = list(getattr(model, "time_labels", []))
     if not time_labels:
@@ -327,9 +334,12 @@ def time_prevalence_ci(model, timestamps, *, ci=0.95, normalize=True):
     # requiring the HMM's own draws (above) and pinning the period order to
     # time_labels, so this is a thin wrapper over the general primitive.
     from .effects import prevalence_ci
+    from ._results import TimePrevalenceCI
 
-    return prevalence_ci(
-        model, timestamps, ci=ci, normalize=normalize, labels=time_labels
+    return TimePrevalenceCI(
+        prevalence_ci(
+            model, timestamps, ci=ci, normalize=normalize, labels=time_labels
+        )
     )
 
 

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -2968,12 +2968,13 @@ def quality_frontier(model, *, n=10, texts=None, coherence_type="u_mass", plot=F
     """Per-topic coherence, exclusivity, and prevalence — the data behind stm's
     classic coherence-vs-exclusivity quality plot.
 
-    Returns a dict of equal-length arrays: ``topic``, ``coherence``,
-    ``exclusivity``, ``prevalence`` (mean θ). By default coherence is the fast
-    per-topic UMass score; pass ``texts`` and a windowed ``coherence_type`` (e.g.
-    ``"c_v"``) for the human-aligned measure. Feed the dict straight to pandas /
-    matplotlib; with ``plot=True`` (and matplotlib installed) a labeled scatter
-    ``Figure`` is returned alongside the dict as ``(data, fig)``.
+    Returns a :class:`~topica._results.QualityFrontier` (a ``dict`` of
+    equal-length arrays — ``topic``, ``coherence``, ``exclusivity``,
+    ``prevalence`` (mean θ) — that also offers ``.to_frame()`` for a tidy
+    one-row-per-topic DataFrame). By default coherence is the fast per-topic
+    UMass score; pass ``texts`` and a windowed ``coherence_type`` (e.g. ``"c_v"``)
+    for the human-aligned measure. With ``plot=True`` (and matplotlib installed) a
+    labeled scatter ``Figure`` is returned alongside the data as ``(data, fig)``.
     """
     from .coherence import coherence as _coherence, exclusivity as _exclusivity
 
@@ -2995,12 +2996,14 @@ def quality_frontier(model, *, n=10, texts=None, coherence_type="u_mass", plot=F
                 stacklevel=2,
             )
         coh = np.asarray(model.coherence(n))
-    data = {
+    from ._results import QualityFrontier
+
+    data = QualityFrontier({
         "topic": np.arange(K),
         "coherence": coh,
         "exclusivity": _exclusivity(phi, n=n),
         "prevalence": theta.mean(axis=0),
-    }
+    })
     if not plot:
         return data
     try:
@@ -3065,8 +3068,10 @@ def bootstrap_stability(
 
     Returns
     -------
-    dict with ``topic`` (indices), ``stability`` (per-topic mean Jaccard in
-    ``[0, 1]``), ``mean`` (overall), and ``reference`` (the reference model).
+    :class:`~topica._results.BootstrapStability` (a ``dict``) with ``topic``
+    (indices), ``stability`` (per-topic mean Jaccard in ``[0, 1]``), ``mean``
+    (overall), and ``reference`` (the reference model). Call ``.to_frame()`` for a
+    per-topic ``(topic, stability)`` DataFrame.
     """
     from . import LDA  # local import to avoid a cycle at module load
 
@@ -3138,12 +3143,14 @@ def bootstrap_stability(
             per_topic[i].append(len(ref_sets[i] & boot_sets[j]) / len(union) if union else 0.0)
 
     stability = np.array([float(np.mean(s)) if s else float("nan") for s in per_topic])
-    return {
+    from ._results import BootstrapStability
+
+    return BootstrapStability({
         "topic": np.arange(K),
         "stability": stability,
         "mean": float(np.nanmean(stability)),
         "reference": ref,
-    }
+    })
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_results_to_frame.py
+++ b/tests/test_results_to_frame.py
@@ -1,0 +1,102 @@
+"""#742: the dict-returning diagnostics converge on the library's ``.to_frame()``
+idiom without breaking the dict contract.
+
+``quality_frontier``, ``bootstrap_stability``, ``visualize_keywords``, and
+``time_prevalence_ci`` return ``FrameDict`` subclasses — still dicts (indexing,
+``.get``, ``==`` with a plain dict, ``**`` unpacking all unchanged) that also
+offer ``.to_frame()`` like ``SearchKResult`` and the effect/robustness results.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+from topica import keyatm
+from topica._results import (
+    BootstrapStability,
+    KeywordDiagnostics,
+    QualityFrontier,
+    TimePrevalenceCI,
+)
+
+pd = pytest.importorskip("pandas")
+
+A = ["tax", "market", "trade"]
+B = ["war", "troop", "militari"]
+
+
+def _corpus(seed=0, n=120):
+    rng = np.random.default_rng(seed)
+    docs = []
+    for i in range(n):
+        heavy, light = (A, B) if i % 2 else (B, A)
+        docs.append(rng.choice(heavy, 6).tolist() + rng.choice(light, 2).tolist())
+    return docs
+
+
+def test_framedict_is_still_a_dict():
+    # Non-breaking: a FrameDict compares equal to the plain dict and unpacks.
+    fd = BootstrapStability({"mean": 0.7, "topic": [0, 1], "stability": [0.6, 0.8]})
+    assert fd == {"mean": 0.7, "topic": [0, 1], "stability": [0.6, 0.8]}
+    assert isinstance(fd, dict)
+    assert fd["mean"] == 0.7
+    assert fd.get("missing") is None
+    assert dict(**fd).keys() == fd.keys()
+
+
+def test_quality_frontier_to_frame():
+    docs = _corpus()
+    model = topica.LDA(num_topics=3, seed=13).fit(docs)
+    qf = topica.quality_frontier(model)
+    assert isinstance(qf, QualityFrontier)
+    # dict access unchanged
+    assert set(qf) == {"topic", "coherence", "exclusivity", "prevalence"}
+    df = qf.to_frame()
+    assert list(df.columns) == ["topic", "coherence", "exclusivity", "prevalence"]
+    assert len(df) == 3  # one row per topic
+
+
+def test_bootstrap_stability_to_frame():
+    docs = _corpus()
+    bs = topica.bootstrap_stability(docs, k=3, n_boot=3, seed=13)
+    assert isinstance(bs, BootstrapStability)
+    assert "mean" in bs and "reference" in bs  # dict access unchanged
+    df = bs.to_frame()
+    # scalar `mean` and the `reference` model do not leak into the per-topic frame
+    assert list(df.columns) == ["topic", "stability"]
+    assert len(df) == 3
+
+
+def test_visualize_keywords_to_frame_stacks_sets():
+    docs = _corpus()
+    kw = {"econ": ["tax", "market", "absent"], "war": ["war"]}
+    vis = keyatm.visualize_keywords(docs, kw)
+    assert isinstance(vis, KeywordDiagnostics)
+    assert set(vis) == {"econ", "war"}  # dict access unchanged
+    df = vis.to_frame()
+    assert list(df.columns) == ["set", "keyword", "count", "proportion", "doc_freq", "in_vocab"]
+    # one row per keyword across both sets, tagged by set name
+    assert len(df) == 4
+    assert set(df["set"]) == {"econ", "war"}
+    assert df[df["keyword"] == "absent"]["count"].iloc[0] == 0
+
+
+def test_time_prevalence_ci_to_frame_melts():
+    # The wrapping is exercised by the dynamic-keyATM tests; here we check the
+    # melt directly so the (period, topic) tidy shape is covered cheaply.
+    T, K = 3, 2
+    tpc = TimePrevalenceCI({
+        "labels": ["2013", "2014", "2015"],
+        "mean": np.arange(T * K, dtype=float).reshape(T, K),
+        "ci_low": np.zeros((T, K)),
+        "ci_high": np.ones((T, K)),
+        "sd": np.full((T, K), 0.1),
+    })
+    assert isinstance(tpc, TimePrevalenceCI)
+    assert list(tpc["labels"]) == ["2013", "2014", "2015"]  # dict access unchanged
+    df = tpc.to_frame()
+    assert list(df.columns) == ["period", "topic", "mean", "ci_low", "ci_high", "sd"]
+    assert len(df) == T * K
+    # period 2014 (index 1), topic 1 -> mean value 3.0
+    row = df[(df["period"] == "2014") & (df["topic"] == 1)].iloc[0]
+    assert row["mean"] == 3.0 and row["ci_high"] == 1.0


### PR DESCRIPTION
The last open item from the power-user API-consistency audit, **#742** — the "return-type zoo". The other items landed in #746; this closes it out.

## The problem
`search_k` returns a `SearchKResult` with `.to_frame()`, and the effect/robustness results have it too — but four diagnostics returned bare dicts with no frame path: `quality_frontier`, `bootstrap_stability`, `visualize_keywords`, `time_prevalence_ci`. A user with a DataFrame in hand had to hand-roll the reshape each time.

## The fix
Converge them onto the library's existing `.to_frame()` idiom rather than introduce an `as_frame=` kwarg (a second idiom the rest of the library doesn't use). Each now returns a small `FrameDict` subclass (`python/topica/_results.py`) that **is still a dict** — indexing, `.get`, `== ` with a plain dict, `**` unpacking, and JSON are all unchanged — and adds `.to_frame()` rendering its natural tidy shape:

| helper | `.to_frame()` shape |
|---|---|
| `quality_frontier` → `QualityFrontier` | one row per topic (`topic, coherence, exclusivity, prevalence`) |
| `bootstrap_stability` → `BootstrapStability` | per-topic (`topic, stability`); scalar `mean` + `reference` model stay on the dict, off the frame |
| `visualize_keywords` → `KeywordDiagnostics` | one long frame across all sets, leading `set` column |
| `time_prevalence_ci` → `TimePrevalenceCI` | melted long, one row per `(period, topic)` |

Fully **non-breaking** — dict subclasses, no signature changes. `refine_keywords`' `(refined, dropped)` tuple is left as-is: it was already documented, so that part of the original finding was inaccurate (same conclusion #746 reached).

## Gates
- New `tests/test_results_to_frame.py` covers each `.to_frame()` shape and the dict-compatibility.
- Full `pytest`: **4946 passed, 38 skipped, 0 failed**.
- `scripts/preflight.sh` and `mkdocs build --strict`: green.

Closes #742.

🤖 Generated with [Claude Code](https://claude.com/claude-code)