### PR TITLE
fix(sample-user): resolve #732 API-consistency + diagnostic follow-ups

### DIFF
--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -27,6 +27,15 @@ print(topica.summary(model))                  # top words per topic
 For your own data, swap the first line for `df = pandas.read_csv("yours.csv")`
 and set `text_col` to your text column.
 
+!!! tip "Add a few corpus-specific stopwords"
+    `ENGLISH_STOPWORDS` is a compact list (115 words), so a term that is
+    everywhere in *your* corpus but not in general English can still lead a topic
+    — a publication's own name, a boilerplate header word, a survey prompt term.
+    If a topic's top words are dominated by one such word, add it to the
+    stoplist: `stopwords=topica.ENGLISH_STOPWORDS | {"crisis", "magazine"}`
+    (or start from a larger base list). The [preprocessing
+    guide](../guides/preprocessing.md) covers stoplist choices in full.
+
 !!! tip "Just `fit(corpus)` is enough"
     `LDA(num_topics=k).fit(corpus)` uses well-chosen defaults. The Gibbs samplers
     expose tuning knobs (`iters`, `num_samples`, `optimize_interval`, …), but you

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -373,7 +373,7 @@ def _warn_if_non_distributional(topics):
         pass  # exotic topic_word; skip the check rather than fail coherence
 
 
-def coherence(topics, texts, *, coherence_type="c_v", n=10, topn=None, window_size=None, epsilon=1e-12):
+def coherence(topics, texts, *, coherence_type="c_v", metric=None, n=10, topn=None, window_size=None, epsilon=1e-12):
     """Per-topic coherence against a reference corpus.
 
     Parameters
@@ -386,7 +386,7 @@ def coherence(topics, texts, *, coherence_type="c_v", n=10, topn=None, window_si
         (Raw strings are tokenized for you — passing them is not silently scored
         character-by-character; see issue #648.)
     coherence_type : one of ``"u_mass"``, ``"c_uci"``, ``"c_npmi"``, ``"c_v"``
-        (default ``"c_v"``).
+        (default ``"c_v"``). ``metric=`` is accepted as an alias (issue #732).
     n : number of top words per topic to score (default 10). ``n`` is topica's
         canonical top-words name, shared with ``model.coherence(n=...)`` and
         ``top_words(n)``; ``topn`` is accepted as an alias.
@@ -421,9 +421,18 @@ def coherence(topics, texts, *, coherence_type="c_v", n=10, topn=None, window_si
     pairwise-count factor ``n·(n-1)/2`` at a fixed ``n`` — but because that is a
     constant divisor, the two rank topics identically; only the absolute scale differs.
     """
+    if metric is not None:
+        # `metric=` is an intuitive alias two independent users reached for (#732).
+        if coherence_type != "c_v" and metric != coherence_type:
+            raise ValueError(
+                f"pass either coherence_type= or metric=, not both with different "
+                f"values (coherence_type={coherence_type!r}, metric={metric!r}); "
+                "they are aliases"
+            )
+        coherence_type = metric
     ct = coherence_type.lower()
     if ct not in _VALID:
-        raise ValueError(f"coherence_type must be one of {_VALID}, got {coherence_type!r}")
+        raise ValueError(f"coherence_type/metric must be one of {_VALID}, got {coherence_type!r}")
     topn = n if topn is None else topn  # `topn` is the back-compatible alias for `n`
     if not isinstance(topn, (int, np.integer)) or topn < 1:
         raise ValueError(f"n must be a positive integer, got {topn!r}")

--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -213,15 +213,35 @@ def from_dataframe(
                 stacklevel=2,
             )
 
-    corpus = Corpus.from_documents(
-        docs,
-        min_doc_freq=min_doc_freq,
-        max_doc_fraction=max_doc_fraction,
-        min_cf=min_cf,
-        rm_top=rm_top,
-        max_features=max_features,
-        vocabulary=vocabulary,
-    )
+    try:
+        corpus = Corpus.from_documents(
+            docs,
+            min_doc_freq=min_doc_freq,
+            max_doc_fraction=max_doc_fraction,
+            min_cf=min_cf,
+            rm_top=rm_top,
+            max_features=max_features,
+            vocabulary=vocabulary,
+        )
+    except ValueError as e:
+        # A frequent first-timer mistake is pointing text_col= at a covariate
+        # (e.g. a blog-name column), which tokenizes to almost nothing and empties
+        # the vocabulary. The core's "no words after frequency filtering" is
+        # column-blind; re-raise naming the column, how little it produced, and the
+        # other columns to pick from (issue #732).
+        if "no words after frequency filtering" in str(e):
+            n_tok = sum(len(d) for d in docs)
+            n_nonempty = sum(1 for d in docs if d)
+            others = [str(c) for c in df.columns if c != text_col]
+            raise ValueError(
+                f"text_col={text_col!r} produced an empty corpus: it tokenized to "
+                f"{n_tok} token(s) across {n_nonempty} non-empty document(s), then "
+                f"pruning removed them all. If that count is small, {text_col!r} may "
+                f"be a covariate rather than the text column — other columns are "
+                f"{others}. Otherwise relax the pruning (min_doc_freq / "
+                f"max_doc_fraction / rm_top)."
+            ) from e
+        raise
 
     # Web-scraped text often leaves markup tokens (href/http/aspx) in the vocab,
     # where they form a spurious boilerplate topic. If the user did not strip and

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -1149,7 +1149,11 @@ class SearchKResult(list):
 
         - the held-out metric when a held-out set was supplied
           (``"heldout_loglik"`` for a :class:`Heldout`, ``"perplexity"`` for a
-          legacy corpus) — the principled, non-monotone criterion;
+          legacy corpus) — the held-out criterion, which unlike bare coherence
+          reflects generalization; note that on many real corpora it improves
+          only slowly and near-monotonically in K, so ``rule="best"`` can land on
+          the largest K scanned (a boundary warning fires and cites the
+          ``elbow``/``frontier`` picks when it does);
         - otherwise the ``"frontier"`` (see below), since bare ``"coherence"``
           is roughly monotone in K and would just return the grid floor.
 
@@ -1271,12 +1275,36 @@ class SearchKResult(list):
                 and len(present) >= 2:
             k_max = max(r["k"] for r in present)
             if pick == k_max:
+                # Cite the alternative picks we can already compute, so the user
+                # sees the actual less-fragmented K rather than just a rule name
+                # (issue #732). Guard each: elbow needs a bend, frontier needs the
+                # coherence/exclusivity columns — skip whichever isn't available.
+                hints = []
+                with warnings.catch_warnings():
+                    # The hint computation is exploratory; silence any warning the
+                    # elbow/frontier helpers raise (e.g. "elbow not well defined")
+                    # so only this boundary warning reaches the user.
+                    warnings.simplefilter("ignore")
+                    try:
+                        e = self._elbow_k(present, metric, maximize)
+                        if e != pick:
+                            hints.append(f"rule='elbow' gives K={e}")
+                    except Exception:
+                        pass
+                    try:
+                        f = self._frontier_k()
+                        if f != pick:
+                            hints.append(f"metric='frontier' gives K={f}")
+                    except Exception:
+                        pass
+                hint_txt = (" " + "; ".join(hints) + ".") if hints else ""
                 warnings.warn(
                     f"best_k(metric={metric!r}) selected K={pick}, the largest K "
                     "scanned: this metric tends to keep improving with K, so the "
                     "optimum is at the grid boundary and the real best K may lie "
-                    "beyond it. Widen ks=, or use rule='elbow' (diminishing-returns "
-                    "knee) or metric='frontier' (coherence/exclusivity knee).",
+                    f"beyond it.{hint_txt} Widen ks=, or use rule='elbow' "
+                    "(diminishing-returns knee) or metric='frontier' "
+                    "(coherence/exclusivity knee).",
                     UserWarning,
                     stacklevel=2,
                 )
@@ -3025,6 +3053,7 @@ def bootstrap_stability(
     docs,
     *,
     k=None,
+    num_topics=None,
     n_boot=20,
     topn=10,
     seed=0,
@@ -3049,7 +3078,7 @@ def bootstrap_stability(
     ----------
     docs : the corpus (``list[list[str]]`` or a ``Corpus``).
     k : number of topics. Required unless ``reference`` is given (then taken from
-        it).
+        it). ``num_topics=`` is accepted as an alias (the library-wide name).
     n_boot : number of bootstrap resamples.
     model_factory : ``callable(seed) -> unfitted model``. Defaults to
         ``LDA(num_topics=k, seed=seed)``. Use it to bootstrap any model.
@@ -3074,6 +3103,17 @@ def bootstrap_stability(
     per-topic ``(topic, stability)`` DataFrame.
     """
     from . import LDA  # local import to avoid a cycle at module load
+
+    # num_topics= is the library-wide name for the topic count (every constructor
+    # is Model(num_topics=...)); accept it as an alias for this function's k= so a
+    # user need not remember the odd one out (issue #732).
+    if num_topics is not None:
+        if k is not None and int(k) != int(num_topics):
+            raise ValueError(
+                f"pass either k= or num_topics=, not both with different values "
+                f"(k={k}, num_topics={num_topics}); they are aliases for the topic count"
+            )
+        k = num_topics
 
     # fit_kwargs= (a dict, like cross_validate) and inline **extra_fit_kwargs both
     # forward to fit; merge them so the documented dict form works and no longer
@@ -3106,7 +3146,8 @@ def bootstrap_stability(
     # factory-only usage without k= is allowed — matching the docstring (#742).
     if model_factory is None and k is None:
         raise ValueError(
-            "pass k (number of topics), a model_factory, or a fitted reference model")
+            "pass k= / num_topics= (number of topics), a model_factory, or a "
+            "fitted reference model")
     factory = model_factory or (lambda s: LDA(num_topics=k, seed=s))
 
     def top_word_sets(model):

--- a/tests/test_sample_user_732.py
+++ b/tests/test_sample_user_732.py
@@ -1,0 +1,80 @@
+"""#732: sample-user audit follow-ups — API-consistency and diagnostic ergonomics.
+
+- bootstrap_stability accepts the library-wide num_topics= alias for k=
+- coherence accepts metric= as an alias for coherence_type=
+- from_dataframe raises a column-aware error when text_col= empties the corpus
+- best_k's grid-edge warning cites the elbow/frontier K it can already compute
+"""
+
+import numpy as np
+import pytest
+
+import topica
+from topica.validation import SearchKResult
+
+DOCS = [["a", "b", "c", "a"], ["b", "c", "d"], ["a", "d", "e"], ["c", "e", "f"]] * 8
+
+
+def test_bootstrap_stability_num_topics_alias():
+    r = topica.bootstrap_stability(DOCS, num_topics=3, n_boot=2, seed=1)
+    assert len(r["topic"]) == 3
+    # k= still works and matches
+    r2 = topica.bootstrap_stability(DOCS, k=3, n_boot=2, seed=1)
+    assert np.array_equal(r["topic"], r2["topic"])
+
+
+def test_bootstrap_stability_k_num_topics_conflict():
+    with pytest.raises(ValueError, match="not both with different values"):
+        topica.bootstrap_stability(DOCS, k=2, num_topics=3, n_boot=2)
+
+
+def test_coherence_metric_alias():
+    model = topica.LDA(num_topics=3, seed=13).fit(DOCS)
+    by_alias = topica.coherence(model, DOCS, metric="u_mass")
+    by_canon = topica.coherence(model, DOCS, coherence_type="u_mass")
+    assert np.allclose(by_alias, by_canon)
+
+
+def test_coherence_metric_coherence_type_conflict():
+    model = topica.LDA(num_topics=3, seed=13).fit(DOCS)
+    with pytest.raises(ValueError, match="not both with different values"):
+        topica.coherence(model, DOCS, coherence_type="u_mass", metric="c_v")
+
+
+def test_from_dataframe_wrong_text_col_names_the_column():
+    pd = pytest.importorskip("pandas")
+    # An "author"-like covariate: every value a distinct single token, so
+    # min_doc_freq prunes the whole vocabulary and the corpus empties.
+    authors = [
+        "alpha", "bravo", "charlie", "delta", "echo", "foxtrot", "golf", "hotel",
+        "india", "juliet", "kilo", "lima", "mike", "november", "oscar", "papa",
+        "quebec", "romeo", "sierra", "tango",
+    ]
+    df = pd.DataFrame({"text": ["apple banana cherry", "date elder fig"] * 10,
+                       "author": authors})
+    with pytest.raises(ValueError) as exc:
+        topica.from_dataframe(df, text_col="author", min_doc_freq=3)
+    msg = str(exc.value)
+    assert "text_col='author'" in msg
+    assert "other columns are ['text']" in msg
+
+
+def test_best_k_boundary_warning_cites_alternative_picks():
+    # heldout_loglik improves monotonically (best -> largest K), but with
+    # diminishing returns (an interior elbow) and an interior coherence/exclusivity
+    # frontier. The boundary warning should name the concrete elbow/frontier K.
+    ks = [10, 20, 30, 40]
+    res = SearchKResult([
+        {"k": 10, "heldout_loglik": -100.0, "coherence": -5.0, "exclusivity": 0.40},
+        {"k": 20, "heldout_loglik": -50.0, "coherence": -4.0, "exclusivity": 0.60},
+        {"k": 30, "heldout_loglik": -45.0, "coherence": -6.0, "exclusivity": 0.50},
+        {"k": 40, "heldout_loglik": -44.0, "coherence": -8.0, "exclusivity": 0.45},
+    ])
+    with pytest.warns(UserWarning) as rec:
+        pick = res.best_k("heldout_loglik")
+    assert pick == 40  # the grid edge
+    msg = " ".join(str(w.message) for w in rec)
+    # at least one concrete alternative K is cited, not just a rule name
+    assert "rule='elbow' gives K=" in msg or "metric='frontier' gives K=" in msg
+    # and the cited K is an interior grid value, not the boundary pick
+    assert any(f"K={k}" in msg for k in ks if k != 40)


### PR DESCRIPTION
The still-open items from the sample-user acceptance gate, **#732**.

## Already resolved by later work (ticking the boxes, no code here)
- **Tier 1 — `estimate_effect` intercept off-by-one.** `TopicEffect` already exposes `.effect_of(name)`, `.by_feature` (full name→estimate map), `.as_dict()`, and `.to_frame()`, plus a class docstring steering off `coef[0]`. Name-keyed access never requires positional indexing.
- **Tier 3 — `topic_table` vs `label_topics` shape.** Both docstrings already mirror each other with the correct unpack idioms (`[w for w, _ in labels[0]["frex"]]` vs the bare-string `topic_table` rows), landed with the `TopicLabels` work in #735.
- **Tier 3 — `bootstrap_stability` `.to_frame()`.** Shipped in #749.

## Fixed here (all Python-only, no Rust change)
- **`bootstrap_stability(num_topics=)` alias.** `k=` was the odd one out against the library-wide `Model(num_topics=...)`. `num_topics=` is now accepted; passing conflicting `k=` + `num_topics=` raises.
- **`coherence(metric=)` alias.** Two independent users reached for `metric=`; it now aliases `coherence_type=` (conflicting values raise).
- **`best_k` grid-edge warning cites concrete picks.** When `heldout_loglik` / `perplexity` / `reconstruction_error` selects the largest K scanned, the warning now names the actual less-fragmented K it can already compute — `rule='elbow' gives K=20; metric='frontier' gives K=20` — instead of only the rule names. The "principled, non-monotone" docstring framing is softened to admit that on real corpora the held-out curve is often near-monotone and lands on the boundary.
- **`from_dataframe` column-aware empty-corpus error.** Pointing `text_col=` at a covariate (a blog-name / author column) empties the vocabulary; the core's `no words after frequency filtering` is column-blind. `from_dataframe` now re-raises naming the column, how few tokens it produced, and the other columns to choose from.
- **Quickstart tip on corpus-specific stopwords** — the "magazine's own name surfaces as a topic" trap that the Du Bois worked example fixes but the quickstart didn't mention.

## Gates
- New `tests/test_sample_user_732.py` (6 tests) covers the aliases, the column-aware error, and the warning citing an interior K.
- Full `pytest`: **4952 passed, 38 skipped, 0 failed**.
- `scripts/preflight.sh` and `mkdocs build --strict`: green.

Closes #732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)