### PR TITLE
feat(results): export the FrameDict result classes at top level (#752)

### DIFF
--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -347,6 +347,13 @@ from .robustness import (  # noqa: E402  (effect robustness across K / seeds, #6
     effects_across_seeds,
     RobustnessResult,
 )
+from ._results import (  # noqa: E402  (dict results with .to_frame(); #742, #752)
+    FrameDict,
+    QualityFrontier,
+    BootstrapStability,
+    KeywordDiagnostics,
+    TimePrevalenceCI,
+)
 from .analysis import (  # noqa: E402  (model-neutral fitted-model analysis surface)
     topic_info,
     topic_sizes,
@@ -517,6 +524,11 @@ __all__ = [
     "effects_across_k",
     "effects_across_seeds",
     "RobustnessResult",
+    "FrameDict",
+    "QualityFrontier",
+    "BootstrapStability",
+    "KeywordDiagnostics",
+    "TimePrevalenceCI",
     "ensemble",
     "EnsembleResult",
     "cross_ensemble",

--- a/tests/test_results_to_frame.py
+++ b/tests/test_results_to_frame.py
@@ -34,6 +34,17 @@ def _corpus(seed=0, n=120):
     return docs
 
 
+def test_result_classes_exported_at_top_level():
+    # #752: the FrameDict result types are reachable as topica.<Name> for
+    # isinstance checks, not buried in topica._results.
+    import topica
+    for name in ("FrameDict", "QualityFrontier", "BootstrapStability",
+                 "KeywordDiagnostics", "TimePrevalenceCI"):
+        assert hasattr(topica, name), f"topica.{name} not exported"
+        assert name in topica.__all__, f"{name} missing from __all__"
+    assert topica.BootstrapStability is BootstrapStability
+
+
 def test_framedict_is_still_a_dict():
     # Non-breaking: a FrameDict compares equal to the plain dict and unpacks.
     fd = BootstrapStability({"mean": 0.7, "topic": [0, 1], "stability": [0.6, 0.8]})


### PR DESCRIPTION
One bullet from the #732 sample-user run's papercut list (#752).

A first-time user reached for `topica.BootstrapStability` to figure out what `bootstrap_stability` returns and got `AttributeError` — the result types added in #749 lived only in `topica._results`, so an `isinstance` check or object inspection had to spelunk a private module.

This exports `FrameDict`, `QualityFrontier`, `BootstrapStability`, `KeywordDiagnostics`, and `TimePrevalenceCI` at the top level and in `__all__`, alongside the other result types (`SearchKResult`, `RobustnessResult`, …). Non-breaking — the classes and their returning functions are unchanged; only their reachability improves.

```python
>>> r = topica.bootstrap_stability(docs, num_topics=10)
>>> isinstance(r, topica.BootstrapStability)   # now works
True
```

New test in `test_results_to_frame.py` asserts each name is exported and in `__all__`. `scripts/preflight.sh` and `mkdocs build --strict`: green.

Part of #752.

🤖 Generated with [Claude Code](https://claude.com/claude-code)