### PR TITLE
fix(usability): resolve the #755 sample-user follow-ups

### DIFF
--- a/docs/contributing/conventions.md
+++ b/docs/contributing/conventions.md
@@ -64,12 +64,19 @@ by construction rather than by memory.
    attribute, so `model.converged()` raises `TypeError: 'bool' object is not
    callable`. In contrast `model.coherence()` and `model.bound()` are called.
    (`Corpus` documents the same property-vs-method split for its own accessors.)
+   `converged` reports **early stopping**, not "the fit is good": it is `True`
+   only when a positive `convergence_tol` was actually hit, so with the default
+   (`convergence_tol=0`, full `iters`) it is always `False`. Read
+   `model.early_stopped` — the same value under the name that says what it means —
+   when the ambiguity would mislead; `converged` is kept as an alias (issue #755).
 7. **`coherence(...)`'s first positional argument is `n`, the top-word count — not
    the corpus.** It defaults to the training corpus, so bare `model.coherence()`
    works; pass a reference corpus with the keyword `texts=` for the windowed
    measures. This flips the convention of the module-level `topica.coherence(
    topics, texts, ...)`, whose first argument is the topics — so
-   `model.coherence(corpus.documents())` misfires (issue #752).
+   `model.coherence(corpus.documents())` misfires. Passing texts positionally now
+   raises a directive `TypeError` naming the `texts=` keyword rather than an
+   opaque "cannot be interpreted as an integer" (issues #752, #755).
 
 ## Threads and stopping rules
 

--- a/docs/contributing/conventions.md
+++ b/docs/contributing/conventions.md
@@ -68,7 +68,9 @@ by construction rather than by memory.
    only when a positive `convergence_tol` was actually hit, so with the default
    (`convergence_tol=0`, full `iters`) it is always `False`. Read
    `model.early_stopped` — the same value under the name that says what it means —
-   when the ambiguity would mislead; `converged` is kept as an alias (issue #755).
+   when the ambiguity would mislead; `converged` is kept as an alias. For a
+   plain-English summary of why a fit stopped, call `topica.stop_reason(model)`
+   (issue #755).
 7. **`coherence(...)`'s first positional argument is `n`, the top-word count — not
    the corpus.** It defaults to the training corpus, so bare `model.coherence()`
    works; pass a reference corpus with the keyword `texts=` for the windowed

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -46,11 +46,17 @@ and set `text_col` to your text column.
 
 `num_topics` (K) is a research decision, not a tuning parameter. As a starting
 point, K=10 gives broad themes, K=30 finer ones. `search_k` scores a range of K
-on coherence, exclusivity, and held-out likelihood:
+on coherence and exclusivity by default; pass `held_out=make_heldout(corpus)` to
+add a held-out likelihood column too:
 
 ```python
 result = topica.search_k(corpus, ks=[5, 10, 20, 30], seed=13)
-print(result.best_k())
+print(result.best_k())                 # the coherence/exclusivity frontier knee
+print(result.best_k(explain=True))     # ...and the per-K scores behind the pick
+
+# add held-out likelihood as a selection criterion
+ho = topica.search_k(corpus, ks=[5, 10, 20, 30], seed=13,
+                     held_out=topica.make_heldout(corpus))
 ```
 
 The [choosing K guide](../publishing/choosing-k.md) walks through how to justify

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -476,6 +476,12 @@ class DMR:
         ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if fit early-stopped because the relative change in the objective
         fell below ``convergence_tol``; False when the full ``iters`` ran (the
@@ -577,6 +583,12 @@ class CTM:
     @property
     def bound_history(self) -> list[float]:
         """Variational bound after each EM iteration (length = iterations run)."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool:
@@ -756,6 +768,12 @@ class STM:
     @property
     def bound_history(self) -> list[float]:
         """Variational bound after each EM iteration (length = iterations run)."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool:
@@ -1038,6 +1056,12 @@ class STS:
     @property
     def bound_history(self) -> list[float]: ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
@@ -1148,6 +1172,12 @@ class HDP:
     @property
     def fit_history(self) -> list[tuple[int, float]]:
         """Uniform convergence trace aliasing log_likelihood_history."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool:
@@ -1332,6 +1362,12 @@ class DTM:
         """Per-iteration trace: list of (iteration, objective) pairs. Empty for DTM."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """Always False; DTM has no early-stop criterion."""
         ...
@@ -1476,6 +1512,12 @@ class DETM:
     @property
     def bound(self) -> float:
         """The final ELBO reached during fitting."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool: ...
@@ -1672,6 +1714,12 @@ class SupervisedLDA:
         ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if fit early-stopped because the relative change in the objective
         fell below ``convergence_tol``; False when the full ``iters`` ran (the
@@ -1847,6 +1895,12 @@ class SAGE:
         ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if fit early-stopped because the relative change in the objective
         fell below ``convergence_tol``; False when the full ``iters`` ran (the
@@ -2009,6 +2063,12 @@ class LabeledLDA:
         ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if fit early-stopped because the relative change in the objective
         fell below ``convergence_tol``; False when the full ``iters`` ran (the
@@ -2142,6 +2202,12 @@ class OnlineLDA:
         draws. Present for the Dirichlet-family contract."""
         ...
 
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool:
         """Whether fit stopped early on the per-pass bound tolerance."""
@@ -2420,6 +2486,12 @@ class LDA:
         ...
 
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if early stopping fired (``convergence_tol > 0`` and the relative
         change in log-likelihood fell below the tolerance). False by default."""
@@ -2641,6 +2713,12 @@ class PT:
         ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if fit early-stopped because the relative change in the objective
         fell below ``convergence_tol``; False when the full ``iters`` ran (the
@@ -2713,6 +2791,12 @@ class GSDMM:
     @property
     def fit_history(self) -> list[tuple[int, float]]:
         """Uniform convergence trace aliasing log_likelihood_history."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool:
@@ -2974,6 +3058,12 @@ class FactorialLDA:
         ending with the final-iteration value."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool: ...
     @property
     def vocabulary(self) -> list[str]: ...
@@ -3181,6 +3271,12 @@ class DiscLDA:
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
     @property
+    def early_stopped(self) -> bool | None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool | None: ...
     @property
     def vocabulary(self) -> list[str]: ...
@@ -3299,6 +3395,12 @@ class RTM:
     def link(self) -> str: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool: ...
     @property
@@ -3434,6 +3536,12 @@ class PA:
         ``check_every`` sweeps during :meth:`fit` (empty when ``check_every=0``)."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if fit early-stopped because the relative change in the objective
         fell below ``convergence_tol``; False when the full ``iters`` ran (the
@@ -3527,6 +3635,12 @@ class HLDA:
     @property
     def fit_history(self) -> list[tuple[int, float]]:
         """Per-iteration trace. Empty; HLDA has no flat K-topic objective."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool:
@@ -3701,6 +3815,12 @@ class SeededLDA:
         """Uniform convergence trace aliasing :attr:`log_likelihood_history`."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if fit early-stopped because the relative change in the objective
         fell below ``convergence_tol``; False when the full ``iters`` ran (the
@@ -3834,6 +3954,12 @@ class Top2Vec:
         """Always []; Top2Vec is not an iterative sampler."""
         ...
     @property
+    def early_stopped(self) -> None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> None:  # type: ignore[override]
         """Always None; Top2Vec is a cluster model with no iterative objective."""
         ...
@@ -3951,6 +4077,12 @@ class BERTopic:
         """Always []; BERTopic is not an iterative sampler."""
         ...
     @property
+    def early_stopped(self) -> None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> None:  # type: ignore[override]
         """Always None; BERTopic is a cluster model with no iterative objective."""
         ...
@@ -4025,6 +4157,12 @@ class SemanticSignalSeparation:
     @property
     def source_scores(self) -> numpy.typing.NDArray[numpy.float64]:
         """Signed document loadings on each axis, the raw ICA sources (D x K)."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool:
@@ -4127,6 +4265,12 @@ class ETM:
     def topic_embeddings(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
     def bound(self) -> float: ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool: ...
     @property
@@ -4241,6 +4385,12 @@ class InfoCTM:
     @property
     def fit_history(self) -> list[float]: ...
     @property
+    def early_stopped(self) -> bool | None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool | None: ...
     def save(self, path: str) -> None:
         """Persist the fitted model (both languages) to path. Reload with InfoCTM.load."""
@@ -4320,6 +4470,12 @@ class ProdLDA:
     def bound(self) -> float: ...
     @property
     def bound_history(self) -> list[float]: ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool: ...
     @property
@@ -4439,6 +4595,12 @@ class Scholar:
     def bound(self) -> float: ...
     @property
     def bound_history(self) -> list[float]: ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool: ...
     @property
@@ -4560,6 +4722,12 @@ class CombinedTM:
     @property
     def bound_history(self) -> list[float]: ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
@@ -4670,6 +4838,12 @@ class ZeroShotTM:
     @property
     def bound_history(self) -> list[float]: ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
@@ -4770,6 +4944,12 @@ class KeyNMF:
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool: ...
     @property
     def reconstruction_error(self) -> float: ...
@@ -4861,6 +5041,12 @@ class NMF:
     def reconstruction_error(self) -> float: ...
     @property
     def error_history(self) -> list[float]: ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool: ...
     @property
@@ -4995,6 +5181,12 @@ class GuidedNMF:
         """Per-iteration value of the FULL objective
         ``||X - A S||_F^2 + guidance * ||Y - B S||_F^2`` (reconstruction plus
         guidance), with the initial value (before any update) first."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool:
@@ -5143,6 +5335,12 @@ class CorEx:
         """Per-iteration (iter, total_tc) pairs."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True only if the total-correlation early stop fired before the iter budget."""
         ...
@@ -5256,6 +5454,12 @@ class AuthorTopic:
         diagnostic, not an early-stop criterion. Collapsed Gibbs runs the full
         ``iters`` budget, so ``converged`` is always False (there is no tolerance
         test) -- watch this trace flatten to judge mixing."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool:
@@ -5389,6 +5593,12 @@ class MGLDA:
         False (collapsed Gibbs runs the full iters budget)."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool: ...
     def top_words(
         self, n: int = 10, *, topic: int | None = None, weights: bool = False
@@ -5499,6 +5709,12 @@ class TopicsOverTime:
         """List of (iteration, held-in log-likelihood) pairs — column 0 is the sweep
         number, column 1 the log-likelihood — logged roughly every iters/25 sweeps
         (length ~25, not iters). converged is always False (Gibbs runs the full budget)."""
+        ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
         ...
     @property
     def converged(self) -> bool: ...
@@ -5624,6 +5840,12 @@ class GaussianLDA:
         """Per-sweep ``(iteration, avgLL)`` trace (see ``log_likelihood_history``)."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool: ...
     @property
     def vocabulary(self) -> list[str]: ...
@@ -5723,6 +5945,12 @@ class LSA:
         """Empty: the SVD is a direct solve with no iterative trace."""
         ...
     @property
+    def early_stopped(self) -> bool | None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool | None:
         """None: convergence is not meaningful for a one-shot SVD."""
         ...
@@ -5800,6 +6028,12 @@ class TensorLDA:
     def unwhitened_raw(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool: ...
     @property
@@ -5886,6 +6120,12 @@ class FASTopic:
     def word_embeddings(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
     def loss_history(self) -> list[float]: ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool: ...
     @property
@@ -6203,6 +6443,12 @@ class KeyATM:
         """Per-iteration log-likelihood trace: list of (iteration, log_likelihood) pairs."""
         ...
     @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool:
         """True if the Gibbs run early-stopped because the relative change in the
         recorded model_fit log-likelihood fell below `convergence_tol`; False when
@@ -6350,6 +6596,12 @@ class IdealPointTM:
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
     @property
+    def early_stopped(self) -> Optional[bool]:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> Optional[bool]: ...
     @property
     def bound(self) -> float: ...
@@ -6430,6 +6682,12 @@ class TopicalNGrams:
     def doc_names(self) -> list[str]: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
+    @property
+    def early_stopped(self) -> bool:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool: ...
     @property
@@ -6525,6 +6783,12 @@ class Wordfish:
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
     @property
+    def early_stopped(self) -> bool | None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool | None: ...
     @property
     def iters_run(self) -> int: ...
@@ -6612,6 +6876,12 @@ class Wordshoal:
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
     @property
+    def early_stopped(self) -> bool | None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
+    @property
     def converged(self) -> bool | None: ...
     @property
     def iters_run(self) -> int: ...
@@ -6695,6 +6965,12 @@ class IdealPointSentenceTM:
     def log_likelihood(self) -> float: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
+    @property
+    def early_stopped(self) -> bool | None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool | None: ...
     @property
@@ -6883,6 +7159,12 @@ class PartyEmbeddings:
     def vocabulary(self) -> list[str]: ...
     @property
     def fit_history(self) -> list[tuple[int, float]]: ...
+    @property
+    def early_stopped(self) -> bool | None:
+        """Alias of :attr:`converged` under the name that says what it
+        means: True only if the fit early-stopped on ``convergence_tol``;
+        False when the full ``iters`` ran (issue #755)."""
+        ...
     @property
     def converged(self) -> bool | None: ...
     def nearest_words(self, group: str, n: int = 10) -> list[tuple[str, float]]:

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -686,14 +686,34 @@ def label_topics(topic_word, vocabulary=None, *, n=10, word_counts=None, corpus=
     return out
 
 
-def topic_table(model, vocabulary=None, *, doc_topic=None, n=7):
+class TopicTable(list):
+    """The :func:`topic_table` result: a ``list`` of per-topic dict rows, with a
+    ``.to_frame()`` for the one-line jump to a pandas DataFrame.
+
+    It is a ``list`` subclass, so it iterates, indexes, and hands to
+    ``pandas.DataFrame(...)`` exactly like the plain list it always returned.
+    ``.to_frame()`` is the same tidy shape :func:`search_k` and the effect /
+    robustness results expose, so you do not have to remember which helpers wrap
+    their output and which do not.
+    """
+
+    def to_frame(self):
+        """The per-topic rows as a pandas DataFrame, one row per topic (raises if
+        pandas is absent)."""
+        import pandas as pd
+
+        return pd.DataFrame(list(self))
+
+
+def topic_table(model, vocabulary=None, *, doc_topic=None, n=7, weights=False):
     """A publication-ready topic table: one row per topic with its prevalence and
     its top probability and FREX words.
 
-    Returns a list of dicts with ``topic``, ``prevalence`` (mean θ), ``prob`` (the
-    top-`n` highest-probability words), and ``frex`` (the top-`n` FREX words —
-    usually the better label). Hand it to ``pandas.DataFrame`` for the table that
-    goes in a results section.
+    Returns a :class:`TopicTable` (a ``list`` subclass) of dicts with ``topic``,
+    ``prevalence`` (mean θ), ``prob`` (the top-`n` highest-probability words), and
+    ``frex`` (the top-`n` FREX words — usually the better label). Call
+    ``.to_frame()`` for the pandas DataFrame that goes in a results section, or
+    hand the object straight to ``pandas.DataFrame`` (either works).
 
     Note the word shape differs from :func:`label_topics`: here ``prob`` and
     ``frex`` are **bare word strings** (ready to drop straight into a DataFrame
@@ -701,6 +721,12 @@ def topic_table(model, vocabulary=None, *, doc_topic=None, n=7):
     ``", ".join(row["frex"])`` is correct on a ``topic_table`` row, while the
     ``", ".join(w for w, _ in ...)`` idiom you would use on ``label_topics`` output
     raises here.
+
+    Pass ``weights=True`` to also carry the numbers behind the words — two extra
+    columns ``prob_weights`` and ``frex_weights`` (``list[float]``, aligned with
+    ``prob`` / ``frex``) so you can print ``"war (0.03)"``-style cells without a
+    separate call. This is the same information :meth:`top_words(n, weights=True)
+    <>` returns on the model; ``topic_table`` just lays it out per topic.
 
     Accepts either a **fitted model** (uses its ``topic_word``, ``doc_topic``, and
     ``vocabulary``) or a bare ``(K, V)`` **topic-word array**, matching the sibling
@@ -722,15 +748,19 @@ def topic_table(model, vocabulary=None, *, doc_topic=None, n=7):
     else:
         prevalence = None  # a bare topic-word array carries no prevalence
     labels = label_topics(phi, vocab, n=n)
-    return [
-        {
+    rows = []
+    for t in range(len(labels)):
+        row = {
             "topic": t,
             "prevalence": float(prevalence[t]) if prevalence is not None else None,
             "prob": [w for w, _ in labels[t]["prob"]],
             "frex": [w for w, _ in labels[t]["frex"]],
         }
-        for t in range(len(labels))
-    ]
+        if weights:
+            row["prob_weights"] = [float(s) for _, s in labels[t]["prob"]]
+            row["frex_weights"] = [float(s) for _, s in labels[t]["frex"]]
+        rows.append(row)
+    return TopicTable(rows)
 
 
 def topics_for_term(topic_word, terms, vocabulary=None, *, top_n=5, per_term=False,
@@ -1062,6 +1092,57 @@ def _frontier_score(coherence, exclusivity):
     return score
 
 
+class BestKExplanation(int):
+    """The return of ``SearchKResult.best_k(explain=True)``: the chosen ``k`` as a
+    plain ``int`` (so it drops into ``LDA(num_topics=best_k)`` unchanged and
+    compares equal to the bare pick), carrying the reasoning behind it.
+
+    Attributes
+    ----------
+    metric : str
+        The metric actually optimized (``"frontier"`` or a column name), after
+        the ``metric=None`` default was resolved.
+    rule : str
+        The ``rule`` used (``"best"`` / ``"1se"`` / ``"elbow"``).
+    rule_desc : str
+        A one-line plain description of the composite/curve the pick came from,
+        e.g. ``"frontier knee (max of z(coherence) + z(exclusivity))"``.
+    scores : list[dict]
+        The per-K score table the pick was read off — one row per scanned K with
+        the value(s) compared. Hand it to ``pandas.DataFrame`` to see the curve.
+    notes : list[str]
+        Any boundary / monotonicity warnings ``best_k`` raised (e.g. the pick sat
+        at the grid edge), captured here instead of only reaching the warning
+        stream.
+    """
+
+    def __new__(cls, k, *, metric, rule, rule_desc, scores, notes):
+        obj = super().__new__(cls, int(k))
+        obj.metric = metric
+        obj.rule = rule
+        obj.rule_desc = rule_desc
+        obj.scores = scores
+        obj.notes = notes
+        return obj
+
+    def __repr__(self) -> str:
+        head = f"best_k = {int(self)}  (metric={self.metric!r}, rule={self.rule!r})"
+        why = f"  chosen by: {self.rule_desc}"
+        rows = "\n".join(
+            "    " + ", ".join(f"{k}={v}" for k, v in row.items())
+            for row in self.scores
+        )
+        note_txt = ("\n  notes:\n" + "\n".join("    - " + n for n in self.notes)) \
+            if self.notes else ""
+        return f"{head}\n{why}\n  scores:\n{rows}{note_txt}"
+
+    def to_frame(self):
+        """The per-K score table as a pandas DataFrame (raises if pandas absent)."""
+        import pandas as pd
+
+        return pd.DataFrame(self.scores)
+
+
 class SearchKResult(list):
     """The :func:`search_k` result: a list of per-K dict rows, with the
     optimization direction stamped in and a safe ``best_k`` selector.
@@ -1141,9 +1222,38 @@ class SearchKResult(list):
                 stacklevel=3,
             )
 
+    def _resolve_metric(self, metric):
+        """The metric ``best_k`` will actually optimize, applying the
+        ``metric=None`` default (held-out → frontier → coherence) and the
+        ``coherence_metric`` label alias. Shared by :meth:`best_k` and
+        :meth:`_explain_best_k` so the two never drift."""
+        if metric is None:
+            if "heldout_loglik" in self[0]:
+                metric = "heldout_loglik"
+            elif "perplexity" in self[0]:
+                metric = "perplexity"
+            elif len(self) >= 2 and "coherence" in self[0] and "exclusivity" in self[0]:
+                metric = "frontier"
+            else:
+                metric = "coherence"
+        # The results advertise which coherence flavor the "coherence" column holds
+        # via the coherence_metric label ("semcoh"/"u_mass"). Accept that label as
+        # an alias so best_k(res[0]["coherence_metric"]) works instead of raising
+        # "unknown metric" for a name the result itself displays (#733).
+        if metric is not None and metric == self[0].get("coherence_metric"):
+            metric = "coherence"
+        return metric
+
     def best_k(self, metric: str | None = None, *, rule: str = "best",
-               frontier_metrics=None, weights=None) -> int:
+               frontier_metrics=None, weights=None, explain: bool = False):
         """Return the ``k`` chosen by ``metric``.
+
+        With ``explain=True`` the return is not the bare ``int`` but a
+        :class:`BestKExplanation` — the chosen ``k`` plus the per-K score table
+        that produced it (the frontier composite ``z(coherence)+z(exclusivity)``,
+        or the scalar metric column) and any boundary/monotonicity notes — so the
+        pick is auditable rather than opaque. It still prints as, and compares
+        equal to, the integer ``k``.
 
         With ``metric=None`` (the default), selection is:
 
@@ -1195,21 +1305,9 @@ class SearchKResult(list):
             raise ValueError(f"rule must be 'best', '1se', or 'elbow', got {rule!r}")
         if not self:
             raise ValueError("search_k returned no rows")
-        if metric is None:
-            if "heldout_loglik" in self[0]:
-                metric = "heldout_loglik"
-            elif "perplexity" in self[0]:
-                metric = "perplexity"
-            elif len(self) >= 2 and "coherence" in self[0] and "exclusivity" in self[0]:
-                metric = "frontier"
-            else:
-                metric = "coherence"
-        # The results advertise which coherence flavor the "coherence" column holds
-        # via the coherence_metric label ("semcoh"/"u_mass"). Accept that label as
-        # an alias so best_k(res[0]["coherence_metric"]) works instead of raising
-        # "unknown metric" for a name the result itself displays (#733).
-        if metric is not None and metric == self[0].get("coherence_metric"):
-            metric = "coherence"
+        if explain:
+            return self._explain_best_k(metric, rule, frontier_metrics, weights)
+        metric = self._resolve_metric(metric)
         if metric != "frontier" and (frontier_metrics is not None or weights is not None):
             raise ValueError(
                 "frontier_metrics and weights only apply to metric='frontier'; "
@@ -1309,6 +1407,40 @@ class SearchKResult(list):
                     stacklevel=2,
                 )
         return pick
+
+    def _explain_best_k(self, metric, rule, frontier_metrics, weights):
+        """Build the :class:`BestKExplanation` for ``best_k(..., explain=True)``.
+
+        Runs the ordinary selection (capturing any warning it raises as a note),
+        then reconstructs the per-K score the pick was read off: the frontier
+        composite ``z(coherence)+z(exclusivity)`` for the frontier, otherwise the
+        scalar metric column in its optimization direction."""
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            pick = self.best_k(metric, rule=rule, frontier_metrics=frontier_metrics,
+                               weights=weights)
+        notes = [str(w.message) for w in caught]
+        resolved = self._resolve_metric(metric)
+        ks = [r["k"] for r in self]
+        if resolved == "frontier" and frontier_metrics is None and weights is None:
+            comp = _frontier_score([r["coherence"] for r in self],
+                                    [r["exclusivity"] for r in self])
+            scores = [{"k": k, "score": float(s)} for k, s in zip(ks, comp)]
+            basis = "z(coherence) + z(exclusivity)"
+            rule_desc = f"frontier knee (max of {basis})"
+        elif resolved == "frontier":
+            mets = list(frontier_metrics) if frontier_metrics is not None else \
+                ["coherence", "exclusivity"]
+            scores = [{"k": r["k"], **{m: r.get(m) for m in mets}} for r in self]
+            basis = " + ".join(f"z({m})" for m in mets)
+            rule_desc = f"custom frontier knee (max of {basis})"
+        else:
+            direction = SEARCH_K_DIRECTIONS.get(resolved, "maximize")
+            scores = [{"k": r["k"], resolved: r.get(resolved)} for r in self]
+            basis = f"{resolved} ({direction})"
+            rule_desc = f"rule={rule!r} on {basis}"
+        return BestKExplanation(pick, metric=resolved, rule=rule,
+                                rule_desc=rule_desc, scores=scores, notes=notes)
 
     def _one_se_k(self, present, metric, maximize):
         """One-standard-error rule on a scalar ``metric``: the smallest K whose
@@ -2850,15 +2982,26 @@ def _kl(p, q):
     return float(np.sum(p * np.log(p / q)))
 
 
-def topic_stability(runs, *, topn=10, metric="cosine"):
+def topic_stability(runs, *, num_topics=None, seeds=None, model_factory=None,
+                    topn=10, metric="cosine", fit_kwargs=None, **extra_fit_kwargs):
     """Term-centric stability of topics across multiple fits (Greene, O'Callaghan
     & Cunningham 2014): a "how robust is this K?" score.
 
-    `runs` is a list of fitted models or topic-word arrays over the *same*
-    vocabulary (e.g. fits at different seeds, or on bootstrap resamples). Each
-    later run's topics are matched to the first run's, and stability is the mean
-    Jaccard overlap of their top-`topn` words. Returns a float in ``[0, 1]``;
-    higher means more reproducible topics.
+    Two call shapes:
+
+    - **From fitted runs** (the base form): ``runs`` is a list of fitted models
+      or topic-word arrays over the *same* vocabulary (e.g. fits at different
+      seeds, or on bootstrap resamples). You control exactly what is compared.
+    - **From a corpus** (the convenience overload, matching
+      :func:`bootstrap_stability`'s ``docs`` + ``num_topics`` convention): pass
+      the corpus as ``runs`` together with ``num_topics=`` and/or ``seeds=``, and
+      it fits one model per seed for you (``LDA(num_topics=k, seed=s)`` by
+      default, or your ``model_factory``) before scoring. ``seeds`` defaults to
+      ``range(5)``; extra keywords / ``fit_kwargs=`` forward to each ``fit``.
+
+    Either way, each later run's topics are matched to the first run's, and
+    stability is the mean Jaccard overlap of their top-`topn` words. Returns a
+    float in ``[0, 1]``; higher means more reproducible topics.
 
     If every run is bit-identical to the first, a stability of 1.0 is
     meaningless — the runs never varied. This most often bites when the runs are
@@ -2869,6 +3012,46 @@ def topic_stability(runs, *, topn=10, metric="cosine"):
     ``init="random"`` (which does respond to ``seed``) or measure stability on
     bootstrap resamples of the documents instead.
     """
+    corpus_mode = (num_topics is not None or seeds is not None
+                   or model_factory is not None)
+    fit_kwargs = {**(fit_kwargs or {}), **extra_fit_kwargs}
+    if corpus_mode:
+        from . import LDA  # local import to avoid a cycle at module load
+
+        corpus = runs.documents() if hasattr(runs, "documents") else runs
+        if model_factory is None and num_topics is None:
+            raise ValueError(
+                "topic_stability(corpus, ...) needs num_topics= (the topic count) "
+                "or a model_factory=")
+        factory = model_factory or (lambda s: LDA(num_topics=num_topics, seed=s))
+        seed_list = list(range(5)) if seeds is None else list(seeds)
+        if len(seed_list) < 2:
+            raise ValueError("need at least two seeds to measure stability")
+        runs = [factory(s).fit(corpus, **fit_kwargs) for s in seed_list]
+    elif fit_kwargs:
+        raise TypeError(
+            "topic_stability got fit keyword(s) "
+            f"{sorted(fit_kwargs)} but no num_topics=/seeds=/model_factory=, so it "
+            "is in from-fitted-runs mode where the first argument must be a list of "
+            "already-fitted models, not a corpus. Either pass fitted runs "
+            "(topic_stability([m1, m2, ...])) or use the corpus overload "
+            "(topic_stability(docs, num_topics=K, seeds=[...])).")
+    else:
+        # Directive error for the intuitive-but-wrong topic_stability(docs) call:
+        # in from-fitted-runs mode each element must be a model / topic-word array,
+        # not a document (a list/tuple of tokens or a raw string).
+        first = next(iter(runs), None)
+        if isinstance(first, str) or (
+            isinstance(first, (list, tuple))
+            and (len(first) == 0 or isinstance(first[0], str))
+        ):
+            raise TypeError(
+                "topic_stability's first argument is a list of already-fitted "
+                "models (or topic-word arrays), but you passed what looks like a "
+                "corpus (documents of tokens). To measure stability from a corpus, "
+                "use the overload topic_stability(docs, num_topics=K, seeds=[...]), "
+                "or fit the models yourself and pass them: "
+                "topic_stability([LDA(K, seed=s).fit(docs) for s in range(5)]).")
     mats = [_as_topic_word(r) for r in runs]
     if len(mats) < 2:
         raise ValueError("need at least two runs to measure stability")

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -725,8 +725,12 @@ def topic_table(model, vocabulary=None, *, doc_topic=None, n=7, weights=False):
     Pass ``weights=True`` to also carry the numbers behind the words — two extra
     columns ``prob_weights`` and ``frex_weights`` (``list[float]``, aligned with
     ``prob`` / ``frex``) so you can print ``"war (0.03)"``-style cells without a
-    separate call. This is the same information :meth:`top_words(n, weights=True)
-    <>` returns on the model; ``topic_table`` just lays it out per topic.
+    separate call. ``prob_weights`` are the topic-word probabilities φ (the same
+    numbers :meth:`top_words(n, weights=True) <>` returns). ``frex_weights`` are
+    the FREX **scores** from :func:`frex`, not probabilities: a bounded quantile
+    score in ``[0, 1]`` (stm's ECDF FREX), so the top word sits near ``1.0`` and
+    the values fall off by rank — they rank a topic's words, they are not a
+    distribution and do not sum to one.
 
     Accepts either a **fitted model** (uses its ``topic_word``, ``doc_topic``, and
     ``vocabulary``) or a bare ``(K, V)`` **topic-word array**, matching the sibling
@@ -2982,7 +2986,7 @@ def _kl(p, q):
     return float(np.sum(p * np.log(p / q)))
 
 
-def topic_stability(runs, *, num_topics=None, seeds=None, model_factory=None,
+def topic_stability(runs, *, num_topics=None, k=None, seeds=None, model_factory=None,
                     topn=10, metric="cosine", fit_kwargs=None, **extra_fit_kwargs):
     """Term-centric stability of topics across multiple fits (Greene, O'Callaghan
     & Cunningham 2014): a "how robust is this K?" score.
@@ -2994,10 +2998,11 @@ def topic_stability(runs, *, num_topics=None, seeds=None, model_factory=None,
       seeds, or on bootstrap resamples). You control exactly what is compared.
     - **From a corpus** (the convenience overload, matching
       :func:`bootstrap_stability`'s ``docs`` + ``num_topics`` convention): pass
-      the corpus as ``runs`` together with ``num_topics=`` and/or ``seeds=``, and
-      it fits one model per seed for you (``LDA(num_topics=k, seed=s)`` by
-      default, or your ``model_factory``) before scoring. ``seeds`` defaults to
-      ``range(5)``; extra keywords / ``fit_kwargs=`` forward to each ``fit``.
+      the corpus as ``runs`` together with ``num_topics=`` (``k=`` is accepted as
+      an alias, matching :func:`bootstrap_stability`) and/or ``seeds=``, and it
+      fits one model per seed for you (``LDA(num_topics=k, seed=s)`` by default, or
+      your ``model_factory``) before scoring. ``seeds`` defaults to ``range(5)``;
+      extra keywords / ``fit_kwargs=`` forward to each ``fit``.
 
     Either way, each later run's topics are matched to the first run's, and
     stability is the mean Jaccard overlap of their top-`topn` words. Returns a
@@ -3012,6 +3017,14 @@ def topic_stability(runs, *, num_topics=None, seeds=None, model_factory=None,
     ``init="random"`` (which does respond to ``seed``) or measure stability on
     bootstrap resamples of the documents instead.
     """
+    # k= is bootstrap_stability's name for the topic count; accept it here too so
+    # the two robustness siblings share one convention (issue #755 follow-up).
+    if k is not None:
+        if num_topics is not None and int(k) != int(num_topics):
+            raise ValueError(
+                f"pass either k= or num_topics=, not both with different values "
+                f"(k={k}, num_topics={num_topics}); they are aliases for the topic count")
+        num_topics = k
     corpus_mode = (num_topics is not None or seeds is not None
                    or model_factory is not None)
     fit_kwargs = {**(fit_kwargs or {}), **extra_fit_kwargs}
@@ -3037,21 +3050,34 @@ def topic_stability(runs, *, num_topics=None, seeds=None, model_factory=None,
             "(topic_stability([m1, m2, ...])) or use the corpus overload "
             "(topic_stability(docs, num_topics=K, seeds=[...])).")
     else:
+        corpus_hint = (
+            "To measure stability from a corpus, use the overload "
+            "topic_stability(docs, num_topics=K, seeds=[...]), or fit the models "
+            "yourself and pass them: "
+            "topic_stability([LDA(K, seed=s).fit(docs) for s in range(5)]).")
+        # A Corpus passed without num_topics=/seeds= isn't corpus-mode; catch it
+        # before the peek (a Corpus is not iterable) and steer to the overload.
+        if hasattr(runs, "documents"):
+            raise TypeError(
+                "topic_stability got a Corpus but no num_topics=/seeds=, so it is "
+                "in from-fitted-runs mode (the first argument must be a list of "
+                f"already-fitted models). {corpus_hint}")
+        # Materialize before the peek so a generator of runs isn't partly consumed
+        # (next(iter(...)) would drop run 0 and silently score the rest).
+        runs = list(runs)
         # Directive error for the intuitive-but-wrong topic_stability(docs) call:
         # in from-fitted-runs mode each element must be a model / topic-word array,
-        # not a document (a list/tuple of tokens or a raw string).
-        first = next(iter(runs), None)
+        # not a document (a list/tuple of tokens or ids, or a raw string).
+        first = runs[0] if runs else None
         if isinstance(first, str) or (
             isinstance(first, (list, tuple))
-            and (len(first) == 0 or isinstance(first[0], str))
+            and (len(first) == 0
+                 or isinstance(first[0], (str, int, np.integer)))
         ):
             raise TypeError(
                 "topic_stability's first argument is a list of already-fitted "
                 "models (or topic-word arrays), but you passed what looks like a "
-                "corpus (documents of tokens). To measure stability from a corpus, "
-                "use the overload topic_stability(docs, num_topics=K, seeds=[...]), "
-                "or fit the models yourself and pass them: "
-                "topic_stability([LDA(K, seed=s).fit(docs) for s in range(5)]).")
+                f"corpus (documents of tokens). {corpus_hint}")
     mats = [_as_topic_word(r) for r in runs]
     if len(mats) < 2:
         raise ValueError("need at least two runs to measure stability")

--- a/src/python/author_topic.rs
+++ b/src/python/author_topic.rs
@@ -317,6 +317,13 @@ impl AuthorTopic {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     /// Top `n` words per topic (bare word strings). Pass ``weights=True`` for
     /// ``(word, φ)`` pairs.
@@ -368,14 +375,15 @@ impl AuthorTopic {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -370,14 +370,15 @@ impl BTM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/cor_ex.rs
+++ b/src/python/cor_ex.rs
@@ -381,6 +381,13 @@ impl CorEx {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
     #[getter]
     fn iters_run(&self) -> PyResult<usize> {
         Ok(self.fitted_model()?.iters_run)
@@ -439,14 +446,15 @@ impl CorEx {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -483,6 +483,11 @@ impl Corpus {
         self.inner.docs.iter().map(|d| d.len()).collect()
     }
 
+    /// The pruned vocabulary as a list of word strings, indexed by word id
+    /// (length ``num_words``). This is a **property**, so read it bare —
+    /// ``corpus.vocabulary``, no parentheses. (Its sibling :meth:`documents` *is* a
+    /// method — ``corpus.documents()`` — because it does work each call; calling
+    /// ``corpus.vocabulary()`` by analogy raises ``'list' object is not callable``.)
     #[getter]
     fn vocabulary(&self) -> Vec<String> {
         self.inner.id_to_word.clone()
@@ -503,6 +508,9 @@ impl Corpus {
     /// ``from_documents``: use it to recover tokens for ``prepare_pyldavis``,
     /// ``coherence``, or any function that wants ``list[list[str]]`` after you have
     /// committed to a ``Corpus``.
+    ///
+    /// This is a **method** — call it with parentheses, ``corpus.documents()`` —
+    /// unlike the bare :attr:`vocabulary` property next to it.
     fn documents(&self) -> Vec<Vec<String>> {
         self.inner
             .docs

--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -576,6 +576,13 @@ impl DiscLDA {
     fn converged(&self) -> Option<bool> {
         None
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> Option<bool> {
+        None
+    }
 
     #[getter]
     fn vocabulary(&self) -> PyResult<Vec<String>> {
@@ -636,14 +643,15 @@ impl DiscLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let m = self.fitted_model()?;
         let phi = vecs_to_arr2(&m.topic_word);
         let tops = top_word_ids_phi(&phi, m.num_topics, n);

--- a/src/python/embedding_cluster.rs
+++ b/src/python/embedding_cluster.rs
@@ -727,14 +727,15 @@ impl Top2Vec {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let m = self.fitted_model()?;
         let phi = vecs_to_arr2(&m.topic_word);
         let tops = top_word_ids_phi(&phi, m.num_topics, n);
@@ -942,6 +943,13 @@ impl Top2Vec {
     /// Top2Vec is not an iterative sampler (UMAP + clustering); converged is always ``None``.
     #[getter]
     fn converged(&self) -> Option<bool> {
+        None
+    }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> Option<bool> {
         None
     }
 
@@ -1410,14 +1418,15 @@ impl BERTopic {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let m = self.fitted_model()?;
         let phi = vecs_to_arr2(&m.topic_word);
         let tops = top_word_ids_phi(&phi, m.num_topics, n);
@@ -1664,6 +1673,13 @@ impl BERTopic {
     /// BERTopic is not an iterative sampler (UMAP + clustering); converged is always ``None``.
     #[getter]
     fn converged(&self) -> Option<bool> {
+        None
+    }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> Option<bool> {
         None
     }
 

--- a/src/python/factorial_lda.rs
+++ b/src/python/factorial_lda.rs
@@ -493,6 +493,13 @@ impl FactorialLDA {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     // --- fLDA-specific factorial surface ---
     /// Number of components per factor.
@@ -598,14 +605,15 @@ impl FactorialLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/gaussian_lda.rs
+++ b/src/python/gaussian_lda.rs
@@ -413,6 +413,13 @@ impl GaussianLDA {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     // --- Conventional extras ---
     #[pyo3(signature = (n=10, *, topic=None, weights=false))]
@@ -440,14 +447,15 @@ impl GaussianLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/guided_nmf.rs
+++ b/src/python/guided_nmf.rs
@@ -452,6 +452,13 @@ impl GuidedNMF {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
     /// Uniform convergence trace: `(iter, objective)` pairs (iter 1 = initial).
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
@@ -522,14 +529,15 @@ impl GuidedNMF {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -386,6 +386,14 @@ impl PA {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
     #[getter]
     fn topic_names(&self) -> PyResult<Vec<String>> {
         self.require_fitted()?;
@@ -443,14 +451,15 @@ impl PA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_sub, n);
         coherence_dispatch(
@@ -922,6 +931,14 @@ impl HLDA {
     /// HLDA does not implement an early-stop criterion; always ``False``.
     #[getter]
     fn converged(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(false)
+    }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
         Ok(false)
     }

--- a/src/python/idealpoint.rs
+++ b/src/python/idealpoint.rs
@@ -634,6 +634,13 @@ impl IdealPointTM {
     fn converged(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged()))
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<Option<bool>> {
+        Ok(Some(self.fitted_model()?.converged()))
+    }
     #[getter]
     fn bound(&self) -> PyResult<f64> {
         Ok(self.fitted_model()?.bound())
@@ -694,14 +701,15 @@ impl IdealPointTM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(self.fitted_model()?.beta0());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/keynmf.rs
+++ b/src/python/keynmf.rs
@@ -336,6 +336,13 @@ impl KeyNMF {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.nmf.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.nmf.converged)
+    }
     /// The NMF reconstruction error (Frobenius) at convergence.
     #[getter]
     fn reconstruction_error(&self) -> PyResult<f64> {
@@ -381,14 +388,15 @@ impl KeyNMF {
         )
     }
 
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.nmf.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/mg_lda.rs
+++ b/src/python/mg_lda.rs
@@ -417,6 +417,13 @@ impl MGLDA {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     /// Top `n` words per combined topic (global topics first, then local), as
     /// bare word strings. Pass ``weights=True`` for ``(word, prob)`` pairs.
@@ -445,14 +452,15 @@ impl MGLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let k = self.num_global_topics + self.num_local_topics;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, k, n);

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -3416,13 +3416,34 @@ pub(crate) struct TopN(pub usize);
 
 impl<'py> FromPyObject<'py> for TopN {
     fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
-        match ob.extract::<usize>() {
-            Ok(n) => Ok(TopN(n)),
-            Err(_) => Err(pyo3::exceptions::PyTypeError::new_err(
+        // A bool is a Python int subclass, so `True`/`False` would extract to 1/0
+        // — reject it as an obvious not-a-count before the usize path.
+        if ob.is_instance_of::<pyo3::types::PyBool>() {
+            return Err(pyo3::exceptions::PyTypeError::new_err(
+                "coherence()'s `n` (number of top words per topic) must be a \
+                 non-negative int, got a bool.",
+            ));
+        }
+        if let Ok(n) = ob.extract::<usize>() {
+            return Ok(TopN(n));
+        }
+        // A number that isn't a usize (a float, or a negative int) is plainly an
+        // intended `n`, not the reference texts — say what `n` must be rather than
+        // sending the caller toward `texts=`. Only a genuinely wrong *type*
+        // (list/str/array, i.e. reference texts passed first) gets the texts hint.
+        let is_number = ob.is_instance_of::<pyo3::types::PyInt>()
+            || ob.is_instance_of::<pyo3::types::PyFloat>();
+        if is_number {
+            Err(pyo3::exceptions::PyTypeError::new_err(
+                "coherence()'s `n` (number of top words per topic) must be a \
+                 non-negative int.",
+            ))
+        } else {
+            Err(pyo3::exceptions::PyTypeError::new_err(
                 "coherence()'s first positional argument is `n`, the number of top \
                  words per topic (an int) — not the reference texts. Pass reference \
                  texts as the keyword `texts=`, e.g. model.coherence(10, texts=docs).",
-            )),
+            ))
         }
     }
 }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1928,6 +1928,14 @@ impl LDA {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     /// MALLET-formula model log-likelihood of the final sampler state.
     fn log_likelihood(&self) -> PyResult<f64> {
@@ -2267,14 +2275,15 @@ impl LDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = self.top_word_ids(n);
         coherence_dispatch(
@@ -3395,6 +3404,27 @@ fn umass_coherence(corpus: &corpus::Corpus, tops: &[Vec<usize>]) -> Vec<f64> {
             score
         })
         .collect()
+}
+
+/// The first positional argument of every model's ``coherence(n, ...)`` — the
+/// number of top words per topic. It exists only to replace PyO3's opaque
+/// ``"argument 'n': 'list' object cannot be interpreted as an integer"`` with a
+/// directive message when a caller passes reference texts first out of gensim
+/// muscle memory (``coherence(texts, ...)``), which is the single most common
+/// misuse (issue #755).
+pub(crate) struct TopN(pub usize);
+
+impl<'py> FromPyObject<'py> for TopN {
+    fn extract_bound(ob: &Bound<'py, PyAny>) -> PyResult<Self> {
+        match ob.extract::<usize>() {
+            Ok(n) => Ok(TopN(n)),
+            Err(_) => Err(pyo3::exceptions::PyTypeError::new_err(
+                "coherence()'s first positional argument is `n`, the number of top \
+                 words per topic (an int) — not the reference texts. Pass reference \
+                 texts as the keyword `texts=`, e.g. model.coherence(10, texts=docs).",
+            )),
+        }
+    }
 }
 
 /// Shared dispatch behind every model's ``coherence(n, coherence_type=, texts=)``.
@@ -4957,6 +4987,14 @@ impl DMR {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     #[getter]
     fn vocabulary(&self) -> PyResult<Vec<String>> {
@@ -5044,14 +5082,15 @@ impl DMR {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(
@@ -5806,6 +5845,14 @@ impl LabeledLDA {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     #[getter]
     fn vocabulary(&self) -> PyResult<Vec<String>> {
@@ -5894,14 +5941,15 @@ impl LabeledLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(
@@ -6606,6 +6654,14 @@ impl SAGE {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     #[getter]
     fn vocabulary(&self) -> PyResult<Vec<String>> {
@@ -6757,14 +6813,15 @@ impl SAGE {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(&self.topic_marginal(), self.num_topics, n);
         coherence_dispatch(
@@ -7459,6 +7516,14 @@ impl CTM {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     /// Variational-covariance mode: ``"laplace"`` (full ν = H⁻¹) or
     /// ``"diagonal"`` (mean-field ν = diag(1/H_ii)).
@@ -7693,14 +7758,15 @@ impl CTM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.beta.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(
@@ -8569,6 +8635,14 @@ impl STM {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     /// Variational-covariance mode: ``"laplace"`` (full ν = H⁻¹) or
     /// ``"diagonal"`` (mean-field ν = diag(1/H_ii)).
@@ -8980,14 +9054,15 @@ impl STM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.beta.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(
@@ -10186,6 +10261,14 @@ impl STS {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     /// Uniform convergence trace: ``(iteration, bound)`` pairs.
     #[getter]
@@ -10369,14 +10452,15 @@ impl STS {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.beta.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(
@@ -10794,6 +10878,14 @@ impl HDP {
         self.require_fitted()?;
         Ok(false)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(false)
+    }
 
     /// The learned-concentration trace: ``(iteration, alpha, gamma)`` triples
     /// sampled during fit (only informative when ``resample_conc=True``). Empty
@@ -10901,14 +10993,15 @@ impl HDP {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.beta.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(
@@ -11494,6 +11587,14 @@ impl DTM {
         self.require_fitted()?;
         Ok(false)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(false)
+    }
 
     /// One label per topic, in topic order. Defaults to ``["topic_0", ...]``
     /// after fit; assign a list of the same length to override.
@@ -12057,6 +12158,14 @@ impl SupervisedLDA {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     #[getter]
     fn vocabulary(&self) -> PyResult<Vec<String>> {
@@ -12115,14 +12224,15 @@ impl SupervisedLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.beta.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(
@@ -12548,6 +12658,14 @@ impl PT {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
     /// One label per topic, in topic order. Defaults to ``["topic_0", ...]``
     /// after fit; assign a list of the same length to override.
     #[getter]
@@ -12607,14 +12725,15 @@ impl PT {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(
@@ -13040,6 +13159,14 @@ impl GSDMM {
         self.require_fitted()?;
         Ok(false)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(false)
+    }
     /// Document-topic matrix θ, shape ``(num_docs, num_topics)``; rows sum to 1.
     ///
     /// Each row is the Movie-Group-Process soft conditional (Yin & Wang Eq. 4) of
@@ -13193,14 +13320,15 @@ impl GSDMM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_used, n);
         coherence_dispatch(
@@ -13951,6 +14079,14 @@ impl SeededLDA {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
     /// MALLET-formula collapsed marginal log-likelihood of the fitted model: the
     /// final recorded trace value (the log-likelihood at the last checkpoint, which
     /// is the final sweep when ``check_every`` divides ``iters``). Raises if no
@@ -14073,14 +14209,15 @@ impl SeededLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_topics_val(), n);
         coherence_dispatch(
@@ -14710,6 +14847,13 @@ impl FASTopic {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
     /// Uniform convergence trace: ``(epoch, negative_loss)`` pairs. The
     /// objective is the negated OT loss (so higher = better), indexed from 1.
     #[getter]
@@ -14780,14 +14924,15 @@ impl FASTopic {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let m = self.fitted_model()?;
         let phi = vecs_to_arr2(&m.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
@@ -15947,6 +16092,14 @@ impl KeyATM {
         self.require_fitted()?;
         Ok(self.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.require_fitted()?;
+        Ok(self.converged)
+    }
 
     /// Trace of the estimated document-topic prior α as ``(iteration, alpha)``
     /// pairs, where ``alpha`` is the length-K asymmetric prior at that sweep —
@@ -16030,14 +16183,15 @@ impl KeyATM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.require_fitted()?;
         let tops = top_word_ids_phi(self.phi.as_ref().unwrap(), self.num_topics, n);
         coherence_dispatch(

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -503,6 +503,13 @@ impl ETM {
     fn converged(&self) -> PyResult<bool> {
         self.surf_converged()
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        self.surf_converged()
+    }
     /// Uniform convergence trace: ``(iteration, bound)`` pairs, one per EM or
     /// VAE epoch. The objective is the variational ELBO. Empty after
     /// :meth:`load` (bound_history is not persisted in the saved state).
@@ -572,14 +579,15 @@ impl ETM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(self.surf_beta()?);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(
@@ -1287,6 +1295,13 @@ impl DETM {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     /// Uniform convergence trace: ``(epoch, ELBO)`` pairs, one per training epoch.
     #[getter]
@@ -1387,14 +1402,15 @@ impl DETM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word_mean());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(
@@ -1903,6 +1919,13 @@ impl InfoCTM {
     fn converged(&self) -> Option<bool> {
         self.model.as_ref().map(|m| m.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> Option<bool> {
+        self.model.as_ref().map(|m| m.converged)
+    }
 
     /// Save the fitted model to `path`. Reload with :meth:`InfoCTM.load`.
     fn save(&self, path: &str) -> PyResult<()> {
@@ -2359,6 +2382,13 @@ impl ProdLDA {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
     /// Uniform convergence trace: ``(epoch, elbo)`` pairs, one per training
     /// epoch (same as :attr:`bound_history` but indexed).
     #[getter]
@@ -2431,14 +2461,15 @@ impl ProdLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(
@@ -3008,6 +3039,13 @@ macro_rules! ctm_embedding_model {
             fn converged(&self) -> PyResult<bool> {
                 Ok(self.fitted_model()?.converged)
             }
+            /// Alias of :attr:`converged` under the name that says what the flag means:
+            /// True only if the fit early-stopped on `convergence_tol`; False when the
+            /// full `iters` ran. `converged` is kept as an alias (issue #755).
+            #[getter]
+            fn early_stopped(&self) -> PyResult<bool> {
+                Ok(self.fitted_model()?.converged)
+            }
             /// Uniform convergence trace: ``(epoch, elbo)`` pairs, one per epoch.
             #[getter]
             fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
@@ -3079,14 +3117,15 @@ macro_rules! ctm_embedding_model {
             /// supplies the reference corpus for the windowed measures (defaults to the
             /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
             /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-            #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+            #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
             fn coherence<'py>(
                 &self,
                 py: Python<'py>,
-                n: usize,
+                n: TopN,
                 coherence_type: String,
                 texts: Option<&Bound<'py, PyAny>>,
             ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+                let n = n.0;
                 let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
                 let tops = top_word_ids_phi(&phi, self.num_topics, n);
                 coherence_dispatch(py, self.corpus.as_ref().unwrap(), &tops, n, &coherence_type, texts)

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -298,6 +298,13 @@ impl NMF {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
     /// Uniform convergence trace: `(iter, reconstruction_error)` pairs. The first
     /// entry (`iter = 1`) is the initial error before any update.
     #[getter]
@@ -366,14 +373,15 @@ impl NMF {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(
@@ -673,6 +681,14 @@ impl LSA {
         self.fitted_model()?;
         Ok(None)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<Option<bool>> {
+        self.fitted_model()?;
+        Ok(None)
+    }
     #[getter]
     fn topic_names(&self) -> PyResult<Vec<String>> {
         self.fitted_model()?;
@@ -745,14 +761,15 @@ impl LSA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
         let absphi = phi.mapv(f64::abs);
         let tops = top_word_ids_phi(&absphi, self.num_topics, n);

--- a/src/python/online_lda.rs
+++ b/src/python/online_lda.rs
@@ -422,6 +422,13 @@ impl OnlineLDA {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
     /// Per-pass evidence-lower-bound trace as `(pass, elbo)` pairs (from `fit`).
     #[getter]
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
@@ -479,14 +486,15 @@ impl OnlineLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -546,6 +546,14 @@ impl PartyEmbeddings {
         self.fitted_model()?;
         Ok(None)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<Option<bool>> {
+        self.fitted_model()?;
+        Ok(None)
+    }
 
     fn save(&self, path: &str) -> PyResult<()> {
         let m = self.model.as_ref();

--- a/src/python/pltm.rs
+++ b/src/python/pltm.rs
@@ -505,15 +505,16 @@ impl PolylingualLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, lang=None, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, lang=None, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         lang: Option<&str>,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let m = self.fitted_model()?;
         let li = self.lang_index(lang)?;
         let phi = vecs_to_arr2(&m.topic_word[li]);

--- a/src/python/rtm.rs
+++ b/src/python/rtm.rs
@@ -359,6 +359,13 @@ impl RTM {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     /// Plug-in link probability between two training documents,
     /// ``psi(phi_bar_i o phi_bar_j)``.
@@ -438,14 +445,15 @@ impl RTM {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -609,6 +609,13 @@ impl Scholar {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.base.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.base.converged)
+    }
 
     /// Fit history: ``(epoch, elbo)`` pairs, one per training epoch.
     #[getter]
@@ -692,14 +699,15 @@ impl Scholar {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/semantic_signal_separation.rs
+++ b/src/python/semantic_signal_separation.rs
@@ -351,6 +351,13 @@ impl SemanticSignalSeparation {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
     /// `(iteration, convergence measure)` for the FastICA fixed-point, one entry
     /// per iteration until convergence.
     #[getter]
@@ -415,14 +422,15 @@ impl SemanticSignalSeparation {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         let corpus = self.coherence_corpus();

--- a/src/python/sentence_ideal.rs
+++ b/src/python/sentence_ideal.rs
@@ -331,6 +331,13 @@ impl IdealPointSentenceTM {
     fn converged(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<Option<bool>> {
+        Ok(Some(self.fitted_model()?.converged))
+    }
     #[getter]
     fn iters_run(&self) -> PyResult<usize> {
         Ok(self.fitted_model()?.iters_run)

--- a/src/python/tbip.rs
+++ b/src/python/tbip.rs
@@ -408,14 +408,15 @@ impl TBIP {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word());
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/tlda.rs
+++ b/src/python/tlda.rs
@@ -577,6 +577,13 @@ impl TensorLDA {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     #[getter]
     fn topic_names(&self) -> PyResult<Vec<String>> {
@@ -642,14 +649,15 @@ impl TensorLDA {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         self.fitted_model()?;
         // UMass coherence reads document co-occurrences; a streamed model does not
         // retain the documents, so it would silently return all-zeros. Refuse it.

--- a/src/python/topical_ngrams.rs
+++ b/src/python/topical_ngrams.rs
@@ -359,6 +359,13 @@ impl TopicalNGrams {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     /// Top unigram words per topic (the standard topic-word view). Phrases are
     /// separate — see `top_phrases`.
@@ -442,14 +449,15 @@ impl TopicalNGrams {
     /// Per-topic coherence of the unigram topics (aligned to topic index). Higher is
     /// more coherent. `texts` supplies the reference corpus for windowed measures
     /// (defaults to the training corpus).
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/topics_over_time.rs
+++ b/src/python/topics_over_time.rs
@@ -370,6 +370,13 @@ impl TopicsOverTime {
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<bool> {
+        Ok(self.fitted_model()?.converged)
+    }
 
     /// Top `n` words per topic (bare word strings). Pass ``weights=True`` for
     /// ``(word, φ)`` pairs.
@@ -399,14 +406,15 @@ impl TopicsOverTime {
     /// supplies the reference corpus for the windowed measures (defaults to the
     /// training corpus). Higher is more coherent (``u_mass`` is <= 0, nearer 0 is
     /// better; ``c_v`` in [0, 1]). Compare topics within one fit, not across corpora.
-    #[pyo3(signature = (n=10, *, coherence_type="u_mass".to_string(), texts=None))]
+    #[pyo3(signature = (n=TopN(10), *, coherence_type="u_mass".to_string(), texts=None))]
     fn coherence<'py>(
         &self,
         py: Python<'py>,
-        n: usize,
+        n: TopN,
         coherence_type: String,
         texts: Option<&Bound<'py, PyAny>>,
     ) -> PyResult<Bound<'py, PyArray1<f64>>> {
+        let n = n.0;
         let phi = vecs_to_arr2(&self.fitted_model()?.topic_word);
         let tops = top_word_ids_phi(&phi, self.num_topics, n);
         coherence_dispatch(

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -427,6 +427,13 @@ impl Wordfish {
     fn converged(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<Option<bool>> {
+        Ok(Some(self.fitted_model()?.converged))
+    }
     #[getter]
     fn iters_run(&self) -> PyResult<usize> {
         Ok(self.fitted_model()?.iters_run)

--- a/src/python/wordshoal.rs
+++ b/src/python/wordshoal.rs
@@ -481,6 +481,13 @@ impl Wordshoal {
     fn converged(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))
     }
+    /// Alias of :attr:`converged` under the name that says what the flag means:
+    /// True only if the fit early-stopped on `convergence_tol`; False when the
+    /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    #[getter]
+    fn early_stopped(&self) -> PyResult<Option<bool>> {
+        Ok(Some(self.fitted_model()?.converged))
+    }
     #[getter]
     fn iters_run(&self) -> PyResult<usize> {
         Ok(self.fitted_model()?.iters_run)


### PR DESCRIPTION
Closes #755. Addresses all nine friction items surfaced by the pre-merge sample-user trial for #752, across the four tiers.

## Tier 1 — wrong-signal trap
- **`early_stopped`**: every model gains an `early_stopped` getter that mirrors `converged`; `converged` stays as an alias. The flag reports early stopping (a positive `convergence_tol` was hit), not "the fit is good" — with the default (`convergence_tol=0`, full `iters`) it is always `False`, so the clearer name no longer reads as "did not converge". Added uniformly across ~46 getters + the `.pyi` stub.

## Tier 2 — intuitive call fails
- **`coherence(texts)`**: the first positional `n` is now a `TopN` extractor that raises a directive `TypeError` naming the `texts=` keyword when a caller passes the reference corpus first (gensim muscle memory), replacing the opaque `"'list' object cannot be interpreted as an integer"`. Applied to all 42 coherence methods.
- **`topic_stability` overload**: `topic_stability(docs, num_topics=K, seeds=[...])` now fits the runs for you, matching `bootstrap_stability`'s corpus+K convention. Both misuse shapes (`topic_stability(docs)` and stray fit kwargs) raise a directive error.

## Tier 3 — return-shape inconsistency
- **`topic_table.to_frame()`**: returns a `TopicTable` (list subclass) with `.to_frame()` for parity with `search_k`; still hands to `pandas.DataFrame` unchanged. `weights=True` adds aligned `prob_weights` / `frex_weights` columns.
- **`Corpus`** property-vs-method docstrings: `vocabulary` (bare attribute) vs `documents()` (method).

## Tier 4 — discoverability / docs
- **Quickstart** no longer over-promises held-out likelihood; it shows the `held_out=make_heldout(...)` opt-in and `best_k(explain=True)`.
- **`best_k(explain=True)`**: returns a `BestKExplanation` (int subclass — drops into `LDA(num_topics=...)` unchanged) carrying the per-K score table, the composite rule, and any boundary notes.
- **`topic_table`** docstring links to `top_words(weights=True)` and the new `weights=` arg.

`docs/contributing/conventions.md` documents the `early_stopped` alias and the directive coherence error.

## Verification
- Full suite: **4959 passed, 38 skipped** (matches the #752 baseline; no regressions).
- `scripts/preflight.sh` (fmt + clippy + NaN guards + model tables + stub-sync): all pass. `mkdocs build --strict`: passes.
- Live smoke tests of `early_stopped` (both fit paths), the coherence directive error, `topic_table.to_frame()`/`weights=`, `best_k(explain=True)`, and the `topic_stability` corpus overload all behave as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)