### PR TITLE
refactor(757): compat scaffold + latent-import fixes ahead of the namespace split

### DIFF
--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -830,6 +830,16 @@ def _as_topic_word(obj):
     return np.asarray(obj, dtype=np.float64)
 
 
+def _ref_corpus(texts):
+    """Normalize a coherence reference to ``list[list[str]]``: a Corpus, raw
+    strings (split on whitespace), or token lists all work."""
+    if hasattr(texts, "documents"):
+        return texts.documents()
+    if len(texts) and isinstance(texts[0], str):
+        return [t.split() for t in texts]
+    return [list(t) for t in texts]
+
+
 def _as_doc_topic(obj):
     """A fitted model (use its ``doc_topic``) or a ``(D, K)`` array."""
     if hasattr(obj, "doc_topic") and not isinstance(obj, np.ndarray):

--- a/python/topica/crossval.py
+++ b/python/topica/crossval.py
@@ -666,7 +666,7 @@ def _heldout_completion(model, test_docs, cov_slice, seed):
     docs are co-dropped with their covariate rows). Returns a dict with per-fold
     perplexity, scored-token count, and OOV info.
     """
-    from .validation import _as_topic_word
+    from .coherence import _as_topic_word
 
     phi = _as_topic_word(model)
     if phi.shape[0] == 0:

--- a/python/topica/validation.py
+++ b/python/topica/validation.py
@@ -28,19 +28,9 @@ from dataclasses import dataclass, field
 import numpy as np
 
 from .coherence import (
-    _as_topic_word, _as_doc_topic, _vocabulary_of, _rbo,
+    _as_topic_word, _as_doc_topic, _vocabulary_of, _rbo, _ref_corpus,
     coherence as _coherence, exclusivity as _exclusivity,
 )
-
-
-def _ref_corpus(texts):
-    """Normalize a coherence reference to ``list[list[str]]``: a Corpus, raw
-    strings (split on whitespace), or token lists all work."""
-    if hasattr(texts, "documents"):
-        return texts.documents()
-    if len(texts) and isinstance(texts[0], str):
-        return [t.split() for t in texts]
-    return [list(t) for t in texts]
 
 
 def diagnostics(model, texts=None, *, n=10, coherence_type=None, stability=False,


### PR DESCRIPTION
First of the #757 workflow-namespace migration PRs (see the approved plan). **Structural only — no behavior change.** This lands the two fixes that are easy to get wrong and independently testable *before* the big `validation.py` split, so PR 2's review can focus purely on the concern-partitioning.

## Changes
- **crossval `_as_topic_word` source.** `crossval.py` imported `_as_topic_word` from `.validation`, but that helper lives in `coherence.py` and is only re-exported by validation. Repointed to `.coherence`. (Latent bug: the upcoming validation.py split would have broken this import.)
- **`_ref_corpus` rehomed.** Moved the one genuinely cross-concern private helper (used by both `diagnostics` and `search_k`) from `validation.py` to `coherence.py`, next to `_as_topic_word`. `validation.py` re-exports it, so `diagnostics`, `search_k`, and any `from .validation import _ref_corpus` are unaffected — and both the future `select` and `evaluate` modules can import it without a cycle.
- **Cycle check.** Verified `analysis` ↔ `validation` is already cycle-safe: `analysis` binds the `validation` module object and defers attribute access to call time, and `validation` imports `analysis` only inside functions. The split forms no import cycle.

## Verification
Full suite: **4959 passed, 38 skipped**. Python-only; no rebuild required.

Part of the #757 arc: this (scaffold) → split `validation.py` into `select`/`inspect`/`evaluate` → add the nine namespaces + curated root → truly-lazy + docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)