### PR TITLE
fix(evaluate): diagnostics warning + perplexity(Heldout) crash + topic_stability footgun (#761)

### DIFF
--- a/python/topica/evaluate.py
+++ b/python/topica/evaluate.py
@@ -114,7 +114,9 @@ def diagnostics(model, texts=None, *, n=10, coherence_type=None, stability=False
     def words_for(t):
         if callable(top_method):
             try:
-                return [w for w, _ in top_method(n, topic=t)]
+                # top_words returns bare word strings by default (#752); take them
+                # as-is so the model's own ordering/weighting is preserved.
+                return list(top_method(n, topic=t))
             except Exception as exc:
                 warnings.warn(
                     f"{type(model).__name__}.top_words failed ({type(exc).__name__}: "
@@ -431,8 +433,13 @@ def perplexity(model, held_out, *, seed=0):
             "held-out perplexity. Compare clustering models with coherence or "
             "topic_diversity instead."
         )
-    if hasattr(held_out, "documents"):
-        held_out = held_out.documents()
+    # Corpus.documents is a method; Heldout.documents is a plain list attribute.
+    # Accept both (and raw token lists) rather than assuming a callable (#761).
+    docs_attr = getattr(held_out, "documents", None)
+    if callable(docs_attr):
+        held_out = docs_attr()
+    elif docs_attr is not None:
+        held_out = docs_attr
     phi = _as_topic_word(model)
     if phi.shape[0] == 0:
         raise ValueError("the model has no topics (empty topic_word)")
@@ -1105,6 +1112,19 @@ def topic_stability(runs, *, num_topics=None, k=None, seeds=None, model_factory=
     if corpus_mode:
         from . import LDA  # local import to avoid a cycle at module load
 
+        # Guard the footgun of passing fitted runs *and* num_topics=/seeds= (which
+        # trips corpus mode and then tries to .fit() the model list). A fitted
+        # model exposes topic_word/num_topics; a corpus is a Corpus or token lists.
+        if not hasattr(runs, "documents"):
+            first = next(iter(runs), None)
+            if first is not None and (hasattr(first, "topic_word")
+                                      or hasattr(first, "num_topics")):
+                raise TypeError(
+                    "topic_stability got a list of fitted models together with "
+                    "num_topics=/seeds=/model_factory=, which only apply to the "
+                    "corpus overload. For already-fitted runs, drop those keywords: "
+                    "topic_stability([m1, m2, ...]). To fit from a corpus, pass the "
+                    "corpus as the first argument instead of models.")
         corpus = runs.documents() if hasattr(runs, "documents") else runs
         if model_factory is None and num_topics is None:
             raise ValueError(

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -852,3 +852,46 @@ def test_predicted_prevalence_contrast_bad_shape_is_actionable():
     with pytest.raises(ValueError, match="one-key dict.*or a 2-element sequence"):
         topica.predicted_prevalence(m, formula="party", data=df,
                                     contrast=("R", 1.0, 0.0))
+
+
+def test_diagnostics_no_spurious_warning_after_top_words_bare_strings():
+    # #761: diagnostics() unpacked top_words as (word, weight) pairs, but since
+    # #752 top_words returns bare strings, so it warned and fell back on every call.
+    import warnings
+    docs = [["housing", "rent", "tenant", "landlord", "evict"] * 3,
+            ["health", "clinic", "doctor", "patient", "care"] * 3,
+            ["school", "teacher", "student", "class", "grade"] * 3] * 20
+    m = topica.LDA(3, seed=13).fit(topica.Corpus.from_documents(docs), iters=80)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        rows = topica.diagnostics(m, texts=docs)
+    assert len(rows) == 3
+
+
+def test_perplexity_accepts_heldout_object():
+    # #761: perplexity called held_out.documents() unconditionally, but
+    # Heldout.documents is a list attribute (only Corpus.documents is a method),
+    # so perplexity(model, make_heldout(corpus)) crashed with 'list' not callable.
+    docs = [["housing", "rent", "tenant", "landlord", "evict"] * 3,
+            ["health", "clinic", "doctor", "patient", "care"] * 3,
+            ["school", "teacher", "student", "class", "grade"] * 3] * 20
+    c = topica.Corpus.from_documents(docs)
+    m = topica.LDA(3, seed=13).fit(c, iters=80)
+    ho = topica.make_heldout(c)
+    pp_heldout = float(topica.perplexity(m, ho))
+    pp_corpus = float(topica.perplexity(m, c))
+    assert pp_heldout > 0 and pp_corpus > 0
+
+
+def test_topic_stability_fitted_runs_with_num_topics_is_directive():
+    # #761: passing fitted runs AND num_topics= tripped the corpus overload, which
+    # then tried to .fit() the model list. It should raise a directive TypeError.
+    docs = [["housing", "rent", "tenant", "landlord", "evict"] * 3,
+            ["health", "clinic", "doctor", "patient", "care"] * 3,
+            ["school", "teacher", "student", "class", "grade"] * 3] * 20
+    c = topica.Corpus.from_documents(docs)
+    runs = [topica.LDA(3, seed=s).fit(c, iters=40) for s in (1, 2)]
+    with pytest.raises(TypeError, match="list of fitted models"):
+        topica.topic_stability(runs, num_topics=3)
+    # the plain fitted-runs path still works
+    assert 0.0 <= float(topica.topic_stability(runs)) <= 1.0


### PR DESCRIPTION
Closes #761. Three pre-existing correctness/UX bugs surfaced by the real-data (dwillis congress) sample-user gate on PR #760. All independent of the validation split — verified byte-identical on `main` before the move — and all traceable to the #752 `top_words` bare-strings change or a `Corpus`/`Heldout` API inconsistency.

## Fixes
1. **`diagnostics(model, texts=)` warned on every call.** It unpacked `top_words()` as `(word, weight)` pairs, but since #752 `top_words` returns bare strings, so the unpack raised `ValueError` and was caught into a `UserWarning` ("falling back to raw topic-word rows") that fired unconditionally on a core diagnostic. Now takes the bare strings directly.
2. **`perplexity(model, Heldout)` crashed.** `Corpus.documents` is a method but `Heldout.documents` is a plain list attribute, and the code called `.documents()` unconditionally → `TypeError: 'list' object is not callable`. Now guards on callability and accepts a `Corpus`, a `Heldout`, or raw token lists.
3. **`topic_stability(fitted_runs, num_topics=...)` misdispatched.** Passing already-fitted models together with `num_topics=`/`seeds=` tripped the corpus overload (added in #756), which then tried to `.fit()` the model list. Now raises a directive `TypeError` pointing at the right call; the plain fitted-runs path is unchanged.

## Verification
- Full suite: **4959 passed, 38 skipped** (one fewer spurious warning).
- Added three regression tests in `tests/test_issue_fixes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)