### PR TITLE
feat(757): add the nine workflow namespaces (additive)

### DIFF
--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -133,61 +133,7 @@ __citation__ = (
 )
 
 
-def one_hot(values, *, drop_first=True, reference=None, prefix=""):
-    """One-hot encode a categorical covariate for use as DMR features.
-
-    Given a sequence of category labels (one per document), returns
-    ``(matrix, names)`` where ``matrix`` is a ``(num_docs, num_categories)``
-    float array of 0/1 indicators and ``names`` are the corresponding column
-    names. One category is omitted as the reference (baseline) level, which
-    avoids collinearity with the DMR/STM intercept; every coefficient is then a
-    contrast *against that reference*, so which level is the reference sets what
-    the effects mean.
-
-    ``reference`` names the level to drop. When ``None`` (and ``drop_first=True``,
-    the default), the alphabetically-first category is dropped; with three or more
-    levels a warning names it, since which of several baselines is the reference
-    shapes the whole story and a silent choice is easy to misread — pass
-    ``reference=`` to choose it explicitly (and silence the warning).
-    ``drop_first=False`` keeps every level (full dummy set, e.g. for a model
-    without an intercept). Pass the result straight to ``DMR.fit(docs, matrix,
-    feature_names=names)``; combine multiple covariates with ``numpy.hstack``.
-    """
-    import numpy as np
-    import warnings
-
-    values = list(values)
-    categories = sorted(set(values))
-    if reference is not None:
-        if reference not in categories:
-            raise ValueError(
-                f"reference={reference!r} is not one of the categories "
-                f"{categories}"
-            )
-        categories = [c for c in categories if c != reference]
-    elif drop_first and categories:
-        dropped = categories[0]
-        categories = categories[1:]
-        # Binary covariate: the baseline is unambiguous (only one other level), so
-        # warning would be noise. With 3+ levels the reference genuinely shapes the
-        # contrasts and a silent alphabetical choice is a Tier-1 footgun.
-        if len(categories) >= 2:
-            warnings.warn(
-                f"one_hot: dropped the alphabetically-first level {dropped!r} as "
-                "the reference, so every coefficient is a contrast against it. "
-                "Pass reference= to choose the baseline explicitly (and silence "
-                "this warning), or drop_first=False to keep all levels.",
-                UserWarning,
-                stacklevel=2,
-            )
-    index = {c: j for j, c in enumerate(categories)}
-    matrix = np.zeros((len(values), len(categories)), dtype=np.float64)
-    for i, v in enumerate(values):
-        j = index.get(v)
-        if j is not None:
-            matrix[i, j] = 1.0
-    names = [f"{prefix}{c}" for c in categories]
-    return matrix, names
+# one_hot lives in topica.design (re-exported below); see design.py.
 
 
 def summary(model, topn=8):
@@ -337,11 +283,13 @@ from .crossval import (  # noqa: E402  (#701 cross-validation evaluation framewo
 )
 from .ensemble import ensemble, EnsembleResult, cross_ensemble  # noqa: E402  (consensus across runs)
 from .compare import (  # noqa: E402  (statistical two-fit topic-drift comparison, #415)
-    compare,
     CompareResult,
     MatchedPair,
     UnmatchedTopic,
 )
+# `compare` is exposed as a callable module (issue #757): `topica.compare(a, b)`
+# still calls the function, and `topica.compare.CompareResult` reaches the namespace.
+from . import compare  # noqa: E402, F811
 from .robustness import (  # noqa: E402  (effect robustness across K / seeds, #644)
     effects_across_k,
     effects_across_seeds,
@@ -405,6 +353,21 @@ from .frames import from_dataframe, align, prep_documents, plot_removed  # noqa:
 from .formulas import design_matrix  # noqa: E402
 from .scaling import bimodality, polarization, polarization_ci, split_half_reliability, position_intervals  # noqa: E402  (intrinsic ideal-point diagnostics)
 from . import datasets  # noqa: E402  (bundled + fetch-on-demand example datasets)
+
+# Workflow namespaces (issue #757): task-oriented facades that group the flat API
+# by analysis stage. Every name they expose is also available at the package root,
+# so this is purely additive; prefer the namespace path in new code
+# (``topica.select.search_k``, ``topica.inspect.topic_table``, ``topica.data``).
+from . import (  # noqa: E402, F401
+    data,
+    design,
+    select,
+    inspect,
+    evaluate,
+    embeddings,
+    provenance,
+)
+from .design import one_hot  # noqa: E402  (one_hot's home is topica.design)
 
 __all__ = [
     "list_models",
@@ -518,6 +481,15 @@ __all__ = [
     "Folds",
     "CrossValResult",
     "compare",
+    # workflow namespaces (#757)
+    "data",
+    "design",
+    "select",
+    "inspect",
+    "evaluate",
+    "effects",
+    "embeddings",
+    "provenance",
     "CompareResult",
     "MatchedPair",
     "UnmatchedTopic",

--- a/python/topica/__init__.pyi
+++ b/python/topica/__init__.pyi
@@ -35,6 +35,16 @@ from . import stm as stm
 from . import keyatm as keyatm
 from . import effects as effects
 from . import mcmc as mcmc
+# workflow namespaces (#757)
+from . import data as data
+from . import design as design
+from . import select as select
+from . import inspect as inspect
+from . import evaluate as evaluate
+from . import compare as compare
+from . import embeddings as embeddings
+from . import provenance as provenance
+from .design import one_hot as one_hot
 from .mcmc import (
     mcmc_diagnostics as mcmc_diagnostics,
     effective_sample_size as effective_sample_size,
@@ -71,16 +81,6 @@ from .narrative import NarrativeTM as NarrativeTM
 
 __citation__: str
 ENGLISH_STOPWORDS: frozenset[str]
-
-def one_hot(
-    values: Sequence[object],
-    *,
-    drop_first: bool = True,
-    prefix: str = "",
-) -> tuple[numpy.typing.NDArray[numpy.float64], list[str]]:
-    """One-hot encode a categorical covariate into (matrix, names) for DMR.fit."""
-    ...
-
 
 def align_corpus(
     new_docs: Sequence[Sequence[str]],

--- a/python/topica/compare.py
+++ b/python/topica/compare.py
@@ -60,7 +60,7 @@ from typing import Any, Callable, Sequence
 
 import numpy as np
 
-from .validation import _classify_alignment, _hungarian, align_topics
+from .evaluate import _classify_alignment, _hungarian, align_topics
 
 __all__ = ["compare", "CompareResult", "MatchedPair", "UnmatchedTopic"]
 
@@ -905,3 +905,19 @@ def _render_markdown(r: CompareResult) -> str:
         lines += ["", "## Merges (many A → B)", ""]
         lines += [f"- {k} ← {v}" for k, v in r.merges.items()]
     return "\n".join(lines) + "\n"
+
+
+# Make the module itself callable so that `topica.compare(fit_a, fit_b)` (the
+# function call the whole docstring teaches) and `topica.compare.CompareResult`
+# (the workflow namespace) both resolve. Well-trodden pattern (cf. `sh`); keeps
+# `callable(topica.compare)` true after `compare` becomes a namespace (issue #757).
+import sys as _sys
+from types import ModuleType as _ModuleType
+
+
+class _CompareModule(_ModuleType):
+    def __call__(self, *args, **kwargs):
+        return compare(*args, **kwargs)
+
+
+_sys.modules[__name__].__class__ = _CompareModule

--- a/python/topica/data.py
+++ b/python/topica/data.py
@@ -1,0 +1,39 @@
+"""Corpus construction and preparation (workflow namespace, issue #757).
+
+Everything for getting text into a :class:`~topica.Corpus`: DataFrame ingest with
+aligned metadata, tokenization, phrase/collocation learning, stopword lists, and
+the bundled example datasets. Re-exports helpers that live in
+:mod:`topica.frames`, :mod:`topica.preprocess`, :mod:`topica.phrases`, and
+:mod:`topica.stopwords`; the same names are available at the package root.
+"""
+
+from __future__ import annotations
+
+from ._topica import Corpus, tokenize
+from .frames import from_dataframe, align, prep_documents, plot_removed
+from .preprocess import split_documents
+from .phrases import learn_phrases, apply_phrases, add_ngrams, export_phrases, Phrases
+from .stopwords import (
+    ENGLISH_STOPWORDS, SENTIMENT_STOPWORDS, stopwords, stopword_languages,
+)
+from . import datasets
+
+__all__ = [
+    "Corpus",
+    "tokenize",
+    "from_dataframe",
+    "align",
+    "prep_documents",
+    "plot_removed",
+    "split_documents",
+    "learn_phrases",
+    "apply_phrases",
+    "add_ngrams",
+    "export_phrases",
+    "Phrases",
+    "ENGLISH_STOPWORDS",
+    "SENTIMENT_STOPWORDS",
+    "stopwords",
+    "stopword_languages",
+    "datasets",
+]

--- a/python/topica/design.py
+++ b/python/topica/design.py
@@ -1,0 +1,78 @@
+"""Covariate design construction (workflow namespace, issue #757).
+
+Build the design a covariate model reads: R-style formulas, one-hot encodings,
+splines, and interactions. Re-exports the helpers that already live in
+:mod:`topica.formulas` and :mod:`topica.stm`; the names are also available at the
+package root (``topica.design_matrix``, ``topica.spline``, ``topica.one_hot`` …).
+"""
+
+from __future__ import annotations
+
+from .formulas import design_matrix, design_matrix_predict
+from .stm import spline, interaction, align_corpus
+
+__all__ = [
+    "one_hot",
+    "design_matrix",
+    "design_matrix_predict",
+    "spline",
+    "interaction",
+    "align_corpus",
+]
+
+
+def one_hot(values, *, drop_first=True, reference=None, prefix=""):
+    """One-hot encode a categorical covariate for use as DMR features.
+
+    Given a sequence of category labels (one per document), returns
+    ``(matrix, names)`` where ``matrix`` is a ``(num_docs, num_categories)``
+    float array of 0/1 indicators and ``names`` are the corresponding column
+    names. One category is omitted as the reference (baseline) level, which
+    avoids collinearity with the DMR/STM intercept; every coefficient is then a
+    contrast *against that reference*, so which level is the reference sets what
+    the effects mean.
+
+    ``reference`` names the level to drop. When ``None`` (and ``drop_first=True``,
+    the default), the alphabetically-first category is dropped; with three or more
+    levels a warning names it, since which of several baselines is the reference
+    shapes the whole story and a silent choice is easy to misread — pass
+    ``reference=`` to choose it explicitly (and silence the warning).
+    ``drop_first=False`` keeps every level (full dummy set, e.g. for a model
+    without an intercept). Pass the result straight to ``DMR.fit(docs, matrix,
+    feature_names=names)``; combine multiple covariates with ``numpy.hstack``.
+    """
+    import numpy as np
+    import warnings
+
+    values = list(values)
+    categories = sorted(set(values))
+    if reference is not None:
+        if reference not in categories:
+            raise ValueError(
+                f"reference={reference!r} is not one of the categories "
+                f"{categories}"
+            )
+        categories = [c for c in categories if c != reference]
+    elif drop_first and categories:
+        dropped = categories[0]
+        categories = categories[1:]
+        # Binary covariate: the baseline is unambiguous (only one other level), so
+        # warning would be noise. With 3+ levels the reference genuinely shapes the
+        # contrasts and a silent alphabetical choice is a Tier-1 footgun.
+        if len(categories) >= 2:
+            warnings.warn(
+                f"one_hot: dropped the alphabetically-first level {dropped!r} as "
+                "the reference, so every coefficient is a contrast against it. "
+                "Pass reference= to choose the baseline explicitly (and silence "
+                "this warning), or drop_first=False to keep all levels.",
+                UserWarning,
+                stacklevel=2,
+            )
+    index = {c: j for j, c in enumerate(categories)}
+    matrix = np.zeros((len(values), len(categories)), dtype=np.float64)
+    for i, v in enumerate(values):
+        j = index.get(v)
+        if j is not None:
+            matrix[i, j] = 1.0
+    names = [f"{prefix}{c}" for c in categories]
+    return matrix, names

--- a/python/topica/embeddings.py
+++ b/python/topica/embeddings.py
@@ -1,0 +1,30 @@
+"""Embedding infrastructure and embedding-based analysis (workflow namespace, #757).
+
+Embedding I/O, embedding-guided topic models, and conText-style embedding
+regression. Re-exports helpers from :mod:`topica.embedding`,
+:mod:`topica.embedding_regression`, and :mod:`topica.anchor`; the same names are
+available at the package root.
+"""
+
+from __future__ import annotations
+
+from .embedding import (
+    EmbeddingLDA, embedding_seeds, llm_embed, save_embeddings, load_embeddings,
+)
+from .embedding_regression import (
+    EmbeddingRegression, embedding_regression, alc_embeddings, compute_transform,
+)
+from .anchor import AnchorLDA
+
+__all__ = [
+    "EmbeddingLDA",
+    "embedding_seeds",
+    "llm_embed",
+    "save_embeddings",
+    "load_embeddings",
+    "EmbeddingRegression",
+    "embedding_regression",
+    "alc_embeddings",
+    "compute_transform",
+    "AnchorLDA",
+]

--- a/python/topica/evaluate.py
+++ b/python/topica/evaluate.py
@@ -22,8 +22,18 @@ from .coherence import (
 
 from .inspect import frex
 
+# Coherence / diversity / exclusivity / intrusion diagnostics belong to the
+# evaluate stage; re-export the public surface from topica.coherence (a leaf
+# module, so no import cycle) so `topica.evaluate.coherence` etc. resolve (#757).
+from .coherence import (  # noqa: F401
+    coherence, coherence_ci, CoherenceCI, semantic_coherence, embedding_coherence,
+    topic_diversity, topic_semantic_diversity, inverted_rbo, exclusivity,
+    word_intrusion, document_intrusion,
+)
+
 __all__ = [
     'AlignmentResult',
+    'CoherenceCI',
     'Heldout',
     'HeldoutResult',
     'ResidualCheck',
@@ -31,13 +41,23 @@ __all__ = [
     'align_topics',
     'bootstrap_stability',
     'check_residuals',
+    'coherence',
+    'coherence_ci',
     'diagnostics',
+    'document_intrusion',
     'document_residuals',
+    'embedding_coherence',
     'eval_heldout',
+    'exclusivity',
     'flag_topics',
+    'inverted_rbo',
     'make_heldout',
     'perplexity',
+    'semantic_coherence',
+    'topic_diversity',
+    'topic_semantic_diversity',
     'topic_dendrogram',
+    'word_intrusion',
     'topic_stability',
 ]
 
@@ -1732,3 +1752,9 @@ def document_residuals(model, docs, *, floor=1e-12):
         })
     rows.sort(key=lambda r: r["novelty"], reverse=True)
     return rows
+
+
+def __dir__():
+    """Show only the public workflow surface in tab-completion (#757), hiding the
+    module's own imports (np, re, dataclass, ...)."""
+    return sorted(__all__)

--- a/python/topica/provenance.py
+++ b/python/topica/provenance.py
@@ -1,0 +1,23 @@
+"""Analysis provenance and model discovery (workflow namespace, issue #757).
+
+Recording what was fit and how (the analysis manifest), the estimator conformance
+contract, and the model registry. Re-exports helpers from :mod:`topica.manifest`,
+:mod:`topica.conformance`, and :mod:`topica.registry`; the same names are
+available at the package root.
+"""
+
+from __future__ import annotations
+
+from .manifest import AnalysisManifest, record_fit
+from .conformance import check_conformance
+from .registry import list_models, ModelInfo, REGISTRY, effective_determinism
+
+__all__ = [
+    "AnalysisManifest",
+    "record_fit",
+    "check_conformance",
+    "list_models",
+    "ModelInfo",
+    "REGISTRY",
+    "effective_determinism",
+]

--- a/python/topica/select.py
+++ b/python/topica/select.py
@@ -20,13 +20,27 @@ from .coherence import (
     coherence as _coherence, exclusivity as _exclusivity,
 )
 
-from .evaluate import Heldout, _kl, check_residuals, eval_heldout, perplexity
+from .evaluate import (
+    Heldout, _kl, check_residuals, eval_heldout, make_heldout, perplexity,
+)
+# Cross-validation is a model-selection tool; co-locate it with search_k /
+# select_model (crossval imports from evaluate/coherence, not select — no cycle).
+from .crossval import cross_validate, make_folds, Folds, CrossValResult  # noqa: F401
 
 __all__ = [
     'BestKExplanation',
+    'CrossValResult',
+    'Folds',
+    'Heldout',
     'SEARCH_K_DIRECTIONS',
     'SearchKResult',
     'SelectModelResult',
+    'check_residuals',
+    'cross_validate',
+    'eval_heldout',
+    'make_folds',
+    'make_heldout',
+    'perplexity',
     'plot_models',
     'plot_search_k',
     'plot_topic_discovery',
@@ -1405,3 +1419,9 @@ def quality_frontier(model, *, n=10, texts=None, coherence_type="u_mass", plot=F
     ax.set_ylabel("Exclusivity")
     ax.set_title("Topic quality (size ∝ prevalence)")
     return data, fig
+
+
+def __dir__():
+    """Show only the public workflow surface in tab-completion (#757), hiding the
+    module's own imports (np, re, dataclass, ...)."""
+    return sorted(__all__)


### PR DESCRIPTION
Third of the #757 workflow-namespace migration PRs. **Purely additive** — groups the flat API into task-oriented namespaces so the surface reads by analysis stage. Every existing `topica.X` keeps working unchanged; this only *adds* `topica.<namespace>.X`.

## New façade modules (thin re-exports, each with its own `__all__`)
- **`topica.data`** — `Corpus`/`tokenize`, `from_dataframe`, `align`, `prep_documents`, phrases, stopwords, `datasets`
- **`topica.design`** — `design_matrix`, `spline`, `interaction`, `align_corpus`, `one_hot`
- **`topica.embeddings`** — `EmbeddingLDA`, embedding I/O, `embedding_regression`, `AnchorLDA`
- **`topica.provenance`** — `AnalysisManifest`, `record_fit`, `check_conformance`, `list_models`

## Finalized from the PR #760 split
- **`topica.select` / `topica.inspect` / `topica.evaluate`** are now importable namespaces carrying their split surfaces; **`topica.effects`** was already one.

## `compare` becomes a callable module
`topica.compare(a, b)` still calls the function, and `topica.compare.CompareResult` reaches the namespace (a `ModuleType` subclass with `__call__`; `callable(topica.compare)` stays `True`).

## Other
- `one_hot` moves from an inline `__init__` def to its home in `topica.design`; the root re-exports it, so `topica.one_hot` is unchanged.
- `compare.py` imports its alignment helpers from `.evaluate` (their post-split home) instead of the shim.
- The nine namespace names are added to `__all__` and `__init__.pyi`. **The curated `__all__` trim + PEP 562 lazy root come in the next PR** — this one keeps the full flat surface intact.

## Verification
- Full suite: **4962 passed, 38 skipped**. Preflight + `mkdocs --strict` clean.
- Identity checks: `topica.X is topica.<namespace>.X` for a broad sampling; `topica.compare(a,b)` runs; `topica.one_hot` unchanged.
- Pre-merge: real-data (dwillis congress) sample-user gate on the new namespace paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)