### PR TITLE
fix(usability): #758 sample-user API-consistency follow-ups

### DIFF
--- a/docs/guides/preprocessing.md
+++ b/docs/guides/preprocessing.md
@@ -156,6 +156,33 @@ Ties are broken deterministically (by frequency, then by first appearance). Note
 that scikit-learn ranks by collection (total) frequency, while gensim's `keep_n`
 ranks by document frequency; topica follows scikit-learn.
 
+### Domain boilerplate and proper nouns survive frequency pruning
+
+Frequency filters (`max_doc_fraction`, `rm_top`) remove words that are common
+*across the corpus*, so they miss two kinds of noise that are common *within a
+genre* but not corpus-wide. The first is template or interface text that rides
+along with the content: on a corpus of congressional press releases, even with
+`strip_html=True`, `rm_top=20`, and `max_doc_fraction=0.5`, the share-button
+labels `print` and `tweet` survive and cluster into their own topic. The second
+is proper nouns, especially names of the actors the corpus is about: in the same
+corpus, legislator surnames (`durbin`, `tester`, ...) collect into a topic that
+tells you who spoke, not what they said.
+
+Neither is a bug in the pruning; it is doing what you asked. When a run surfaces a
+boilerplate-or-names topic, add the offending terms to a custom stopword list and
+rebuild:
+
+```python
+stop = topica.stopwords("en") | {"print", "tweet", "share", "email"}
+stop |= {"durbin", "tester", "schumer"}   # actor names, if they are not the object of study
+corpus = topica.from_dataframe(df, text_col="text", stopwords=stop)
+```
+
+Inspect `corpus.word_counts` (or a first fit's `top_words`) before committing to a
+list: the terms worth cutting are usually obvious once ranked, and whether a name
+is noise depends on the question. If *who spoke* is part of the analysis, keep the
+names and model authorship directly (`AuthorTopic`, or a speaker covariate).
+
 ## Apply a fixed vocabulary, or vectorize held-out documents
 
 Two related tasks need the vocabulary held fixed rather than learned from the data.

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -191,6 +191,7 @@ from . import manifest  # noqa: E402  (analysis manifest / provenance record)
 from .manifest import AnalysisManifest, record_fit  # noqa: E402
 from .effects import (  # noqa: E402  general, work on any model's theta
     estimate_effect,
+    EffectList,
     by_strata,
     prevalence_ci,
     top_topics,
@@ -341,6 +342,12 @@ from .embedding import (  # noqa: E402
     save_embeddings,
     load_embeddings,
 )
+from .inspect import _bind_topic_table_method  # noqa: E402  (issue #758)
+# Give every topic-word model a `.topic_table()` method so `m.topic_table()` works
+# by analogy with `m.top_words()`, not just the top-level `topica.topic_table(m)`
+# function. Runs after every model class is imported above (including the Python-side
+# TopicGPT / AnchorLDA), binding each by its registry name.
+_bind_topic_table_method(globals().get(_name) for _name in REGISTRY)
 from .preprocess import split_documents  # noqa: E402
 from .stopwords import (  # noqa: E402
     ENGLISH_STOPWORDS,
@@ -350,6 +357,19 @@ from .stopwords import (  # noqa: E402
 )
 from .phrases import learn_phrases, apply_phrases, add_ngrams, Phrases  # noqa: E402
 from .frames import from_dataframe, align, prep_documents, plot_removed  # noqa: E402
+
+
+def _corpus_from_dataframe(cls, df, **kwargs):
+    """Build a :class:`Corpus` from a DataFrame; a classmethod alias for the
+    module-level :func:`topica.from_dataframe` (the pandas-native
+    ``Corpus.from_dataframe(df, text_col=...)`` first guess, issue #758). See
+    :func:`topica.from_dataframe` for every keyword argument."""
+    return from_dataframe(df, **kwargs)
+
+
+# A DataFrame on-ramp under the name a pandas user reaches for first; both this
+# and the top-level topica.from_dataframe build the same Corpus (issue #758).
+Corpus.from_dataframe = classmethod(_corpus_from_dataframe)
 from .formulas import design_matrix  # noqa: E402
 from .scaling import bimodality, polarization, polarization_ci, split_half_reliability, position_intervals  # noqa: E402  (intrinsic ideal-point diagnostics)
 from . import datasets  # noqa: E402  (bundled + fetch-on-demand example datasets)

--- a/python/topica/_compat.py
+++ b/python/topica/_compat.py
@@ -17,6 +17,7 @@ LAZY = {
     'CompareResult': 'compare',
     'CrossValResult': 'select',
     'ENGLISH_STOPWORDS': 'data',
+    'EffectList': 'effects',
     'EmbeddingLDA': 'embeddings',
     'EmbeddingRegression': 'embeddings',
     'Folds': 'select',

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -221,6 +221,10 @@ class Corpus:
         """Number of documents in the corpus."""
         ...
 
+    def __len__(self) -> int:
+        """Number of documents, the same value as :attr:`num_docs`."""
+        ...
+
     @property
     def num_words(self) -> int:
         """Vocabulary size (number of unique word types)."""

--- a/python/topica/anchor.py
+++ b/python/topica/anchor.py
@@ -450,7 +450,10 @@ class AnchorLDA:
     def converged(self):
         """For ``recover="kl"``, whether the recovery stopped early on
         ``convergence_tol``;
-        ``None`` for the non-iterative ``"l2"`` recovery."""
+        ``None`` for the non-iterative ``"l2"`` recovery.
+
+        :func:`topica.stop_reason` turns this flag into a plain-language summary of
+        why the fit stopped."""
         return self._converged
 
     def _word_count_vector(self):

--- a/python/topica/effects.py
+++ b/python/topica/effects.py
@@ -22,6 +22,7 @@ import numpy as np
 
 from .stm import (
     estimate_effect,
+    EffectList,
     posterior_theta_samples,
     predicted_prevalence,
     PredictedPrevalence,
@@ -34,6 +35,7 @@ from .keyatm import by_strata, top_topics
 
 __all__ = [
     "estimate_effect",
+    "EffectList",
     "posterior_theta_samples",
     "predicted_prevalence",
     "PredictedPrevalence",

--- a/python/topica/evaluate.py
+++ b/python/topica/evaluate.py
@@ -202,6 +202,18 @@ class Heldout:
     missing: list
     doc_indices: np.ndarray
 
+    @property
+    def corpus(self):
+        """Directive hint: a common mis-reach is ``heldout.corpus``. The reduced
+        training corpus lives on ``.documents``, and the pair is scored with
+        :func:`eval_heldout` (not :func:`perplexity`)."""
+        raise AttributeError(
+            "Heldout has no `.corpus`; the reduced training corpus is "
+            "`heldout.documents`. Fit on it and score the withheld words with "
+            "eval_heldout: `model.fit(heldout.documents); "
+            "eval_heldout(model, heldout)`."
+        )
+
 
 
 @dataclass

--- a/python/topica/gdmr.py
+++ b/python/topica/gdmr.py
@@ -844,7 +844,10 @@ class GDMR:
 
     @property
     def converged(self) -> bool:
-        """True if fit early-stopped due to convergence."""
+        """True if fit early-stopped due to convergence.
+
+        :func:`topica.stop_reason` turns this flag into a plain-language summary of
+        why the fit stopped."""
         self._require_fitted()
         return self._dmr.converged
 

--- a/python/topica/inspect.py
+++ b/python/topica/inspect.py
@@ -356,6 +356,40 @@ def topic_table(model, vocabulary=None, *, doc_topic=None, n=7, weights=False):
     return TopicTable(rows)
 
 
+def _model_topic_table(self, vocabulary=None, *, doc_topic=None, n=7, weights=False):
+    """A publication-ready topic table for this fitted model.
+
+    Method form of :func:`topica.topic_table`, so ``m.topic_table()`` works by
+    analogy with ``m.top_words()`` / ``m.coherence()``. Equivalent to
+    ``topica.topic_table(m, ...)``; see that function for the full argument and
+    return description.
+    """
+    return topic_table(self, vocabulary, doc_topic=doc_topic, n=n, weights=weights)
+
+
+def _bind_topic_table_method(classes):
+    """Attach a ``.topic_table(...)`` method to each model class that exposes
+    ``top_words`` (issue #758).
+
+    The method/function split is a coin-flip a newcomer loses: they reach for
+    ``m.topic_table()`` by analogy with ``m.top_words()``. Bind the method form
+    onto every topic-word model so both spellings work. Classes without a
+    ``top_words`` accessor (scaling / embedding models with no topic-word matrix)
+    are skipped, matching what the top-level :func:`topic_table` already accepts.
+    """
+    _model_topic_table.__name__ = "topic_table"
+    _model_topic_table.__qualname__ = "topic_table"
+    for cls in classes:
+        if cls is None or not hasattr(cls, "top_words"):
+            continue
+        if "topic_table" in vars(cls):  # already a real (Rust) method; leave it
+            continue
+        try:
+            cls.topic_table = _model_topic_table
+        except (TypeError, AttributeError):
+            pass  # a class that refuses attribute assignment keeps the function form
+
+
 
 def topics_for_term(topic_word, terms, vocabulary=None, *, top_n=5, per_term=False,
                     normalize=False, with_labels=False, label_n=5):

--- a/python/topica/inspect.py
+++ b/python/topica/inspect.py
@@ -382,6 +382,13 @@ def _bind_topic_table_method(classes):
     for cls in classes:
         if cls is None or not hasattr(cls, "top_words"):
             continue
+        # Time-sliced models (e.g. DTM) expose ``topic_word`` as a method that
+        # takes a time index rather than a plain ``(K, V)`` property, so a single
+        # flat topic table is ill-defined; skip them rather than binding a method
+        # that could only ever raise. ``topica.topic_table(m.topic_word(t), vocab)``
+        # remains the per-slice route.
+        if callable(getattr(cls, "topic_word", None)):
+            continue
         if "topic_table" in vars(cls):  # already a real (Rust) method; leave it
             continue
         try:

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -176,6 +176,13 @@ class EffectList(list):
     :func:`bootstrap_stability` also give: a container-level :meth:`to_frame`, so
     ``estimate_effect(...).to_frame()`` works without the
     ``pd.concat([e.to_frame() for e in effects])`` boilerplate.
+
+    Use :meth:`to_frame`, not ``pandas.DataFrame(effects)``: the two differ here.
+    :meth:`to_frame` gives the tidy long table (one row per topic-feature, named
+    columns); ``pandas.DataFrame(effects)`` would build a wide frame of raw
+    :class:`TopicEffect` fields (array-valued cells, internal attributes). Unlike
+    :func:`topic_table`, whose result hands straight to ``pandas.DataFrame``, an
+    ``EffectList`` does not.
     """
 
     def to_frame(self):
@@ -731,7 +738,8 @@ def estimate_effect(
 
             table = topica.estimate_effect(model, X, feature_names=names).to_frame()
 
-        (equivalent to ``pd.concat([e.to_frame() for e in result])``).
+        (equivalent to
+        ``pd.concat([e.to_frame() for e in result], ignore_index=True)``).
     """
     # Formula path: build X and feature_names from an R-style formula + a
     # DataFrame. A string `cluster` is read as a column of that frame.

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -167,6 +167,33 @@ class TopicEffect:
         )
 
 
+class EffectList(list):
+    """The result of :func:`estimate_effect`: a ``list`` of per-topic
+    :class:`TopicEffect` objects, one per topic.
+
+    It *is* a plain ``list`` (index it, iterate it, ``len()`` it), with one
+    convenience the siblings :func:`search_k` / :func:`topic_table` /
+    :func:`bootstrap_stability` also give: a container-level :meth:`to_frame`, so
+    ``estimate_effect(...).to_frame()`` works without the
+    ``pd.concat([e.to_frame() for e in effects])`` boilerplate.
+    """
+
+    def to_frame(self):
+        """One tidy pandas DataFrame for the whole call, one row per
+        (topic, feature).
+
+        Concatenates every :meth:`TopicEffect.to_frame`, so the columns are
+        ``topic``, ``feature``, ``coef``, ``se``, ``z``, ``pvalue``, ``ci_low``,
+        ``ci_high``, ``r_squared`` (see :meth:`TopicEffect.to_frame`). Returns an
+        empty DataFrame when there are no effects.
+        """
+        import pandas as pd
+
+        if not self:
+            return pd.DataFrame()
+        return pd.concat([e.to_frame() for e in self], ignore_index=True)
+
+
 def _coerce_design(X, feature_names):
     """Coerce a design-matrix argument to a float64 ``(n, p)`` array.
 
@@ -697,12 +724,14 @@ def estimate_effect(
 
     Returns
     -------
-    list[TopicEffect]
-        One regression per topic. For a tidy long table with one row per
-        (topic, feature), concatenate the per-topic frames::
+    EffectList
+        A ``list`` of one :class:`TopicEffect` per topic (index and iterate it
+        like any list). For a tidy long table with one row per (topic, feature),
+        call the container's :meth:`~EffectList.to_frame`::
 
-            import pandas as pd
-            table = pd.concat([e.to_frame() for e in result], ignore_index=True)
+            table = topica.estimate_effect(model, X, feature_names=names).to_frame()
+
+        (equivalent to ``pd.concat([e.to_frame() for e in result])``).
     """
     # Formula path: build X and feature_names from an R-style formula + a
     # DataFrame. A string `cluster` is read as a column of that frame.
@@ -888,7 +917,7 @@ def estimate_effect(
             topic_list=topic_list, weights=weights,
         )
 
-    out: list[TopicEffect] = []
+    out = EffectList()
     for (beta, Sigma, r2), t in zip(pooled_results, topic_list):
         se = np.sqrt(np.clip(np.diag(Sigma), 0.0, None))
         with np.errstate(divide="ignore", invalid="ignore"):

--- a/src/python/author_topic.rs
+++ b/src/python/author_topic.rs
@@ -313,6 +313,9 @@ impl AuthorTopic {
         Ok(self.fitted_model()?.fit_history.clone())
     }
 
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -320,6 +323,9 @@ impl AuthorTopic {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/cor_ex.rs
+++ b/src/python/cor_ex.rs
@@ -377,6 +377,9 @@ impl CorEx {
             .collect())
     }
     /// True only if the total-correlation early stop fired before the iter budget.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -384,6 +387,9 @@ impl CorEx {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -57,9 +57,10 @@ pub(crate) struct PrepInfo {
 /// :meth:`Corpus.from_documents`, from a raw text file with
 /// :meth:`Corpus.from_text_file`, or load a binary corpus written by the
 /// ``preprocess`` CLI with :meth:`Corpus.load`. Starting from a pandas
-/// ``DataFrame``? Use the module-level :func:`topica.from_dataframe` (it builds
-/// the ``Corpus`` and keeps your metadata row-aligned through pruning) — there is
-/// no ``Corpus.from_dataframe``; the DataFrame on-ramp is a module function.
+/// ``DataFrame``? Use :func:`topica.from_dataframe` (it builds the ``Corpus`` and
+/// keeps your metadata row-aligned through pruning); ``Corpus.from_dataframe(df,
+/// text_col=...)`` is a classmethod alias for the same function, for the
+/// pandas-native spelling.
 ///
 /// Accessor convention: scalar/array *facts about the corpus* are attribute
 /// **properties** — access them with no parentheses (``corpus.num_docs``,
@@ -460,6 +461,13 @@ impl Corpus {
 
     #[getter]
     fn num_docs(&self) -> usize {
+        self.inner.num_docs()
+    }
+
+    /// ``len(corpus)`` is the number of documents, the same value as the
+    /// :attr:`num_docs` property, so a ``Corpus`` counts like the list of
+    /// documents it stands in for.
+    fn __len__(&self) -> usize {
         self.inner.num_docs()
     }
 

--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -572,6 +572,9 @@ impl DiscLDA {
     }
 
     /// Convergence flag; `None` -- DiscLDA runs a fixed number of Gibbs sweeps.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> Option<bool> {
         None
@@ -579,6 +582,9 @@ impl DiscLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> Option<bool> {
         None

--- a/src/python/embedding_cluster.rs
+++ b/src/python/embedding_cluster.rs
@@ -941,6 +941,9 @@ impl Top2Vec {
     }
 
     /// Top2Vec is not an iterative sampler (UMAP + clustering); converged is always ``None``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> Option<bool> {
         None
@@ -948,6 +951,9 @@ impl Top2Vec {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> Option<bool> {
         None
@@ -1671,6 +1677,9 @@ impl BERTopic {
     }
 
     /// BERTopic is not an iterative sampler (UMAP + clustering); converged is always ``None``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> Option<bool> {
         None
@@ -1678,6 +1687,9 @@ impl BERTopic {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> Option<bool> {
         None

--- a/src/python/factorial_lda.rs
+++ b/src/python/factorial_lda.rs
@@ -489,6 +489,9 @@ impl FactorialLDA {
         self.fitted_model()?;
         Ok(self.corpus.as_ref().unwrap().id_to_word.clone())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -496,6 +499,9 @@ impl FactorialLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/gaussian_lda.rs
+++ b/src/python/gaussian_lda.rs
@@ -409,6 +409,9 @@ impl GaussianLDA {
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         Ok(self.fitted_model()?.fit_history.clone())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -416,6 +419,9 @@ impl GaussianLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/guided_nmf.rs
+++ b/src/python/guided_nmf.rs
@@ -448,6 +448,9 @@ impl GuidedNMF {
     /// ``convergence_tol``). With the default ``convergence_tol=0.0`` there is no
     /// early stop, so a completed fit reports ``False`` — it means "ran the full
     /// iters budget", not a failure.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -455,6 +458,9 @@ impl GuidedNMF {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -381,6 +381,9 @@ impl PA {
     }
     /// ``True`` if the relative-change convergence criterion was satisfied before
     /// all iterations completed. Always ``False`` when ``convergence_tol=0``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -389,6 +392,9 @@ impl PA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -929,6 +935,9 @@ impl HLDA {
     }
 
     /// HLDA does not implement an early-stop criterion; always ``False``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -937,6 +946,9 @@ impl HLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;

--- a/src/python/idealpoint.rs
+++ b/src/python/idealpoint.rs
@@ -630,6 +630,9 @@ impl IdealPointTM {
             .map(|(i, &b)| (i + 1, b))
             .collect())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged()))
@@ -637,6 +640,9 @@ impl IdealPointTM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged()))

--- a/src/python/keynmf.rs
+++ b/src/python/keynmf.rs
@@ -332,6 +332,9 @@ impl KeyNMF {
             .map(|(i, &e)| (i + 1, e))
             .collect())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.nmf.converged)
@@ -339,6 +342,9 @@ impl KeyNMF {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.nmf.converged)

--- a/src/python/mg_lda.rs
+++ b/src/python/mg_lda.rs
@@ -413,6 +413,9 @@ impl MGLDA {
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         Ok(self.fitted_model()?.fit_history.clone())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -420,6 +423,9 @@ impl MGLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1923,6 +1923,9 @@ impl LDA {
     /// ``True`` if fit stopped early because the convergence tolerance criterion
     /// was met (``convergence_tol > 0``); ``False`` if the full ``iters``
     /// sweeps ran (the default).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -1931,6 +1934,9 @@ impl LDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -5003,6 +5009,9 @@ impl DMR {
 
     /// ``True`` if the relative-change convergence criterion was satisfied before
     /// all iterations completed. Always ``False`` when ``convergence_tol=0``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -5011,6 +5020,9 @@ impl DMR {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -5861,6 +5873,9 @@ impl LabeledLDA {
     }
 
     /// ``True`` if the convergence criterion was met; ``False`` otherwise.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -5869,6 +5884,9 @@ impl LabeledLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -6670,6 +6688,9 @@ impl SAGE {
 
     /// ``True`` if the relative-change convergence criterion was satisfied before
     /// all iterations completed. Always ``False`` when ``convergence_tol=0``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -6678,6 +6699,9 @@ impl SAGE {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -7532,6 +7556,9 @@ impl CTM {
 
     /// ``True`` if EM stopped on the `em_tol` criterion; ``False`` if it hit the
     /// `iters` cap first (the fit may not have converged).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -7540,6 +7567,9 @@ impl CTM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -8651,6 +8681,9 @@ impl STM {
 
     /// ``True`` if EM stopped on the `em_tol` criterion; ``False`` if it hit the
     /// `iters` cap first (the fit may not have converged).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -8659,6 +8692,9 @@ impl STM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -10277,6 +10313,9 @@ impl STS {
 
     /// ``True`` if EM stopped on the `em_tol` criterion, ``False`` if it hit the
     /// `iters` cap.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -10285,6 +10324,9 @@ impl STS {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -10894,6 +10936,9 @@ impl HDP {
     }
 
     /// HDP does not implement an early-stop criterion; always ``False``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -10902,6 +10947,9 @@ impl HDP {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -11603,6 +11651,9 @@ impl DTM {
     }
 
     /// DTM does not implement an early-stop criterion; always ``False``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -11611,6 +11662,9 @@ impl DTM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -12174,6 +12228,9 @@ impl SupervisedLDA {
 
     /// ``True`` if the relative-change convergence criterion was satisfied before
     /// all EM iterations completed. Always ``False`` when ``convergence_tol=0``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -12182,6 +12239,9 @@ impl SupervisedLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -12674,6 +12734,9 @@ impl PT {
     }
     /// ``True`` if the relative-change convergence criterion was satisfied before
     /// all iterations completed. Always ``False`` when ``convergence_tol=0``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -12682,6 +12745,9 @@ impl PT {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -13175,6 +13241,9 @@ impl GSDMM {
         Ok(self.trace.iter().map(|&(it, _, ll)| (it, ll)).collect())
     }
     /// GSDMM does not implement an early-stop criterion; always ``False``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -13183,6 +13252,9 @@ impl GSDMM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -14095,6 +14167,9 @@ impl SeededLDA {
     }
     /// ``True`` if the convergence criterion was met (``convergence_tol > 0``);
     /// ``False`` if the full ``iters`` ran.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -14103,6 +14178,9 @@ impl SeededLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -14864,6 +14942,9 @@ impl FASTopic {
     fn loss_history(&self) -> PyResult<Vec<f64>> {
         Ok(self.fitted_model()?.loss_history.clone())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -14871,6 +14952,9 @@ impl FASTopic {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -16108,6 +16192,9 @@ impl KeyATM {
     /// recorded ``model_fit`` log-likelihood fell below ``convergence_tol``;
     /// ``False`` when the full ``iters`` sweeps ran (the default, and always for
     /// the CVB0 backend, which keeps no trace).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.require_fitted()?;
@@ -16116,6 +16203,9 @@ impl KeyATM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.require_fitted()?;

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -499,6 +499,9 @@ impl ETM {
     fn bound(&self) -> PyResult<f64> {
         self.surf_bound()
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         self.surf_converged()
@@ -506,6 +509,9 @@ impl ETM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         self.surf_converged()
@@ -1291,6 +1297,9 @@ impl DETM {
         Ok(self.fitted_model()?.bound)
     }
 
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -1298,6 +1307,9 @@ impl DETM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -1915,6 +1927,9 @@ impl InfoCTM {
             .unwrap_or_default()
     }
 
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> Option<bool> {
         self.model.as_ref().map(|m| m.converged)
@@ -1922,6 +1937,9 @@ impl InfoCTM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> Option<bool> {
         self.model.as_ref().map(|m| m.converged)
@@ -2378,6 +2396,9 @@ impl ProdLDA {
     fn bound_history(&self) -> PyResult<Vec<f64>> {
         Ok(self.fitted_model()?.bound_history.clone())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -2385,6 +2406,9 @@ impl ProdLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -3035,6 +3059,9 @@ macro_rules! ctm_embedding_model {
             fn bound_history(&self) -> PyResult<Vec<f64>> {
                 Ok(self.fitted_model()?.bound_history.clone())
             }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
             #[getter]
             fn converged(&self) -> PyResult<bool> {
                 Ok(self.fitted_model()?.converged)
@@ -3042,6 +3069,9 @@ macro_rules! ctm_embedding_model {
             /// Alias of :attr:`converged` under the name that says what the flag means:
             /// True only if the fit early-stopped on `convergence_tol`; False when the
             /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
             #[getter]
             fn early_stopped(&self) -> PyResult<bool> {
                 Ok(self.fitted_model()?.converged)

--- a/src/python/nmf_lsa.rs
+++ b/src/python/nmf_lsa.rs
@@ -294,6 +294,9 @@ impl NMF {
     fn error_history(&self) -> PyResult<Vec<f64>> {
         Ok(self.fitted_model()?.error_history.clone())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -301,6 +304,9 @@ impl NMF {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -676,6 +682,9 @@ impl LSA {
         Ok(Vec::new())
     }
     /// `None`: "converged" is not meaningful for a one-shot SVD.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<Option<bool>> {
         self.fitted_model()?;
@@ -684,6 +693,9 @@ impl LSA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<Option<bool>> {
         self.fitted_model()?;

--- a/src/python/online_lda.rs
+++ b/src/python/online_lda.rs
@@ -418,6 +418,9 @@ impl OnlineLDA {
     fn theta_draws(&self, _py: Python<'_>) -> Option<PyObject> {
         None
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -425,6 +428,9 @@ impl OnlineLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/party_embeddings.rs
+++ b/src/python/party_embeddings.rs
@@ -541,6 +541,9 @@ impl PartyEmbeddings {
     }
 
     /// `None`: the fit runs a fixed number of epochs and does not early-stop.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<Option<bool>> {
         self.fitted_model()?;
@@ -549,6 +552,9 @@ impl PartyEmbeddings {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<Option<bool>> {
         self.fitted_model()?;

--- a/src/python/rtm.rs
+++ b/src/python/rtm.rs
@@ -355,6 +355,9 @@ impl RTM {
         Ok(self.fitted_model()?.fit_history.clone())
     }
     /// Whether the objective met the convergence tolerance before ``iters``.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -362,6 +365,9 @@ impl RTM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -605,6 +605,9 @@ impl Scholar {
         Ok(self.fitted_model()?.base.bound_history.clone())
     }
 
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.base.converged)
@@ -612,6 +615,9 @@ impl Scholar {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.base.converged)

--- a/src/python/semantic_signal_separation.rs
+++ b/src/python/semantic_signal_separation.rs
@@ -347,6 +347,9 @@ impl SemanticSignalSeparation {
         Ok(vecs_to_arr2(&self.fitted_model()?.source_scores).to_pyarray_bound(py))
     }
     /// Whether FastICA reached `convergence_tol` before `iters`.
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -354,6 +357,9 @@ impl SemanticSignalSeparation {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/sentence_ideal.rs
+++ b/src/python/sentence_ideal.rs
@@ -327,6 +327,9 @@ impl IdealPointSentenceTM {
             .map(|(i, &b)| (i + 1, b))
             .collect())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))
@@ -334,6 +337,9 @@ impl IdealPointSentenceTM {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))

--- a/src/python/tlda.rs
+++ b/src/python/tlda.rs
@@ -573,6 +573,9 @@ impl TensorLDA {
         Ok(self.fitted_model()?.fit_history.clone())
     }
 
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -580,6 +583,9 @@ impl TensorLDA {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/topical_ngrams.rs
+++ b/src/python/topical_ngrams.rs
@@ -355,6 +355,9 @@ impl TopicalNGrams {
     fn fit_history(&self) -> PyResult<Vec<(usize, f64)>> {
         Ok(self.fitted_model()?.fit_history.clone())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -362,6 +365,9 @@ impl TopicalNGrams {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/topics_over_time.rs
+++ b/src/python/topics_over_time.rs
@@ -366,6 +366,9 @@ impl TopicsOverTime {
         Ok(self.fitted_model()?.fit_history.clone())
     }
 
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)
@@ -373,6 +376,9 @@ impl TopicsOverTime {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<bool> {
         Ok(self.fitted_model()?.converged)

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -423,6 +423,9 @@ impl Wordfish {
             .map(|(i, &b)| (i + 1, b))
             .collect())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))
@@ -430,6 +433,9 @@ impl Wordfish {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))

--- a/src/python/wordshoal.rs
+++ b/src/python/wordshoal.rs
@@ -477,6 +477,9 @@ impl Wordshoal {
             .map(|(i, &b)| (i, b))
             .collect())
     }
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn converged(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))
@@ -484,6 +487,9 @@ impl Wordshoal {
     /// Alias of :attr:`converged` under the name that says what the flag means:
     /// True only if the fit early-stopped on `convergence_tol`; False when the
     /// full `iters` ran. `converged` is kept as an alias (issue #755).
+    /// :func:`topica.stop_reason` turns this flag into a plain-language summary of
+    /// why the fit stopped (tolerance met, ``iters`` cap hit, or no early-stop
+    /// criterion for this model).
     #[getter]
     fn early_stopped(&self) -> PyResult<Option<bool>> {
         Ok(Some(self.fitted_model()?.converged))

--- a/tests/test_results_to_frame.py
+++ b/tests/test_results_to_frame.py
@@ -191,3 +191,12 @@ def test_converged_flags_point_at_stop_reason():
     # stop_reason() pointer without hunting through conventions.md.
     assert "stop_reason" in (topica.LDA.converged.__doc__ or "")
     assert "stop_reason" in (topica.LDA.early_stopped.__doc__ or "")
+
+
+def test_topic_table_not_bound_to_time_sliced_models():
+    # #758 review: DTM's topic_word is time-sliced (a method, not a (K,V)
+    # property), so a flat topic_table is ill-defined; the method is not bound
+    # rather than bound-and-always-raising.
+    assert not hasattr(topica.DTM, "topic_table")
+    # a dynamic model that DOES expose a plain (K,V) topic_word still gets it
+    assert hasattr(topica.TopicsOverTime, "topic_table")

--- a/tests/test_results_to_frame.py
+++ b/tests/test_results_to_frame.py
@@ -112,3 +112,82 @@ def test_time_prevalence_ci_to_frame_melts():
     # period 2014 (index 1), topic 1 -> mean value 3.0
     row = df[(df["period"] == "2014") & (df["topic"] == 1)].iloc[0]
     assert row["mean"] == 3.0 and row["ci_high"] == 1.0
+
+
+# ---------------------------------------------------------------------------
+# #758: sample-user API-consistency follow-ups
+# ---------------------------------------------------------------------------
+
+
+def _fit_lda(seed=13, k=2):
+    corpus = topica.Corpus.from_documents(_corpus(seed=seed), min_doc_freq=1)
+    return corpus, topica.LDA(num_topics=k, seed=seed).fit(corpus, iters=60)
+
+
+def test_corpus_len_matches_num_docs():
+    # #758: len(corpus) works and equals num_docs.
+    corpus = topica.Corpus.from_documents(_corpus(n=37), min_doc_freq=1)
+    assert len(corpus) == corpus.num_docs == 37
+
+
+def test_corpus_from_dataframe_classmethod_alias():
+    # #758: Corpus.from_dataframe(df, ...) is the pandas-native alias for the
+    # module-level topica.from_dataframe and builds the same corpus.
+    df = pd.DataFrame({"text": [" ".join(d) for d in _corpus(n=20)],
+                       "party": (["D", "R"] * 10)})
+    via_method = topica.Corpus.from_dataframe(df, text_col="text")
+    via_func = topica.from_dataframe(df, text_col="text")
+    assert isinstance(via_method, topica.Corpus)
+    assert len(via_method) == len(via_func) == 20
+    assert via_method.vocabulary == via_func.vocabulary
+
+
+def test_model_topic_table_method_matches_function():
+    # #758: m.topic_table() mirrors the top-level topica.topic_table(m).
+    _, m = _fit_lda()
+    from_method = m.topic_table()
+    from_func = topica.topic_table(m)
+    assert [r["topic"] for r in from_method] == [r["topic"] for r in from_func]
+    assert [r["frex"] for r in from_method] == [r["frex"] for r in from_func]
+    # and it carries the same .to_frame() the function's result does
+    assert from_method.to_frame().equals(from_func.to_frame())
+
+
+def test_topic_table_method_absent_on_scaling_models():
+    # #758: models with no topic-word matrix (scaling / embedding) do not get it.
+    assert not hasattr(topica.Wordfish, "topic_table")
+
+
+def test_estimate_effect_returns_effectlist_with_to_frame():
+    # #758: the estimate_effect container has .to_frame() like its siblings, and
+    # is still a plain list.
+    corpus, m = _fit_lda()
+    X = np.array([[1.0, 0.0] if i % 2 else [0.0, 1.0] for i in range(len(corpus))])
+    eff = topica.estimate_effect(m, X=X, feature_names=["D", "R"], add_intercept=False)
+    assert isinstance(eff, topica.EffectList)
+    assert isinstance(eff, list)  # non-breaking: still indexes / iterates
+    df = eff.to_frame()
+    # one row per (topic, feature); matches the manual concat it replaces.
+    manual = pd.concat([e.to_frame() for e in eff], ignore_index=True)
+    assert df.equals(manual)
+    assert set(["topic", "feature", "coef", "se"]).issubset(df.columns)
+
+
+def test_effectlist_to_frame_empty():
+    empty = topica.EffectList()
+    assert empty.to_frame().empty
+
+
+def test_heldout_corpus_attribute_gives_directive_hint():
+    # #758: heldout.corpus (a common mis-reach) points at .documents / eval_heldout.
+    corpus = topica.Corpus.from_documents(_corpus(n=20), min_doc_freq=1)
+    ho = topica.make_heldout(corpus, seed=13)
+    with pytest.raises(AttributeError, match=r"\.documents"):
+        _ = ho.corpus
+
+
+def test_converged_flags_point_at_stop_reason():
+    # #758: a tab-completion user landing on the getter docstring finds the
+    # stop_reason() pointer without hunting through conventions.md.
+    assert "stop_reason" in (topica.LDA.converged.__doc__ or "")
+    assert "stop_reason" in (topica.LDA.early_stopped.__doc__ or "")

--- a/tests/test_stub_sync.py
+++ b/tests/test_stub_sync.py
@@ -18,14 +18,20 @@ import pytest
 import topica._topica as _ext
 
 
-# Members attached to the compiled model classes by the ``topica`` package layer
-# (not by the extension), so they are intentionally absent from ``_topica.pyi``.
-# ``topic_table`` is bound onto every topic-word model in ``topica/__init__.py`` so
-# ``m.topic_table()`` mirrors ``m.top_words()``; ``from_dataframe`` is bound onto
-# ``Corpus`` as a classmethod alias for ``topica.from_dataframe`` (both issue #758).
-# They live on the same class objects the extension exports, but are not compiled
-# bindings, so they are intentionally absent from the stub.
-_PACKAGE_ATTACHED = {"topic_table", "from_dataframe"}
+# Members attached to the compiled classes by the ``topica`` package layer (not by
+# the extension), so they are intentionally absent from ``_topica.pyi``. Scoped per
+# class so the guard still catches a real Rust binding of the same name drifting on
+# any other class:
+#   - ``topic_table`` is bound onto every topic-word model in ``topica/__init__.py``
+#     so ``m.topic_table()`` mirrors ``m.top_words()`` (issue #758);
+#   - ``from_dataframe`` is bound onto ``Corpus`` as a classmethod alias for
+#     ``topica.from_dataframe`` (issue #758).
+_PACKAGE_ATTACHED_BY_CLASS = {"Corpus": {"from_dataframe"}}
+_PACKAGE_ATTACHED_DEFAULT = {"topic_table"}
+
+
+def _package_attached(class_name: str) -> set:
+    return _PACKAGE_ATTACHED_BY_CLASS.get(class_name, _PACKAGE_ATTACHED_DEFAULT)
 
 
 def _is_dunder(name: str) -> bool:
@@ -77,7 +83,7 @@ def test_no_members_missing_from_stub(class_name: str) -> None:
     """Every public member on the compiled class must appear in the stub."""
     compiled = _compiled_public_members(_COMPILED_CLASSES[class_name])
     stub = _STUB_MEMBERS.get(class_name, set())
-    missing = compiled - stub - _PACKAGE_ATTACHED
+    missing = compiled - stub - _package_attached(class_name)
     assert not missing, (
         f"{class_name}: compiled members missing from stub: {sorted(missing)}"
     )

--- a/tests/test_stub_sync.py
+++ b/tests/test_stub_sync.py
@@ -18,6 +18,16 @@ import pytest
 import topica._topica as _ext
 
 
+# Members attached to the compiled model classes by the ``topica`` package layer
+# (not by the extension), so they are intentionally absent from ``_topica.pyi``.
+# ``topic_table`` is bound onto every topic-word model in ``topica/__init__.py`` so
+# ``m.topic_table()`` mirrors ``m.top_words()``; ``from_dataframe`` is bound onto
+# ``Corpus`` as a classmethod alias for ``topica.from_dataframe`` (both issue #758).
+# They live on the same class objects the extension exports, but are not compiled
+# bindings, so they are intentionally absent from the stub.
+_PACKAGE_ATTACHED = {"topic_table", "from_dataframe"}
+
+
 def _is_dunder(name: str) -> bool:
     return name.startswith("__") and name.endswith("__")
 
@@ -67,7 +77,7 @@ def test_no_members_missing_from_stub(class_name: str) -> None:
     """Every public member on the compiled class must appear in the stub."""
     compiled = _compiled_public_members(_COMPILED_CLASSES[class_name])
     stub = _STUB_MEMBERS.get(class_name, set())
-    missing = compiled - stub
+    missing = compiled - stub - _PACKAGE_ATTACHED
     assert not missing, (
         f"{class_name}: compiled members missing from stub: {sorted(missing)}"
     )


### PR DESCRIPTION
Closes #758. Resolves the pre-existing API-learning friction the two #755 sample-user runs surfaced (split out of #755 so that PR stayed scoped). None of these change model behavior; they smooth the path from a repr or a sibling helper to the accessor a newcomer reaches for first.

## Changes

**Return-shape / API consistency**
- **`Corpus.__len__`** — `len(corpus)` now returns `num_docs`, matching the repr and every list/pandas habit. *(Rust: `src/python/corpus.rs`; added to the `.pyi` stub.)*
- **`estimate_effect` → `EffectList`** — a `list` subclass with a container-level `.to_frame()`, like `search_k` / `topic_table` / `bootstrap_stability`. Still a plain `list`, so indexing and iteration are unchanged; `eff.to_frame()` now works without the `pd.concat([e.to_frame() for e in eff])` boilerplate.
- **`model.topic_table()`** — every topic-word model gains a thin method mirroring the top-level `topica.topic_table(m)`, bound by registry name at import (all 50 topic-word models; scaling/embedding models with no topic-word matrix are skipped).
- **`Corpus.from_dataframe(df, text_col=...)`** — classmethod alias for the module-level `topica.from_dataframe` (the pandas-native first guess).
- **`Heldout.corpus`** — raises a directive `AttributeError` pointing at `.documents` and `eval_heldout`, closing the mis-wiring loop.

**Docs**
- `converged` / `early_stopped` getter docstrings now point at `stop_reason()`.
- Preprocessing guide: a note that domain boilerplate (`print`/`tweet`) and proper nouns (legislator names) survive frequency pruning and may warrant a custom stopword list.

## Notes
- `topic_table` and `from_dataframe` are attached at the package layer to the same class objects the extension exports, so they are correctly absent from `_topica.pyi`; the stub-sync guard carves them out with a comment.
- Regenerated `_compat.py` (adds `EffectList`).
- Items already handled earlier are noted in the issue: `perplexity(Heldout)` crash (#762) and the `converged=False` naming (#756).

## Testing
- New regression tests in `tests/test_results_to_frame.py` (8 tests: `__len__`, `from_dataframe` alias, `topic_table` method + parity + scaling-model exclusion, `EffectList.to_frame` + empty, `Heldout.corpus` hint, docstring pointers).
- Full suite: **4980 passed, 38 skipped**.
- `scripts/preflight.sh` clean; `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)