### PR TITLE
fix(usability): resolve a bare stopwords= string as a language (#766)

### DIFF
--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -137,6 +137,12 @@ def from_dataframe(
         conservative clean (tags + URLs only); for heavier normalization pass your
         own ``tokenizer``. When left False, a vocabulary that still contains obvious
         web-boilerplate terms triggers a warning pointing here.
+    stopwords : iterable of str or str, optional
+        Words to drop during tokenizing. Pass an iterable of words (a set, or the
+        bundled :data:`topica.ENGLISH_STOPWORDS`), or a language name/code string
+        like ``"english"`` / ``"en"``, which is resolved through
+        :func:`topica.stopwords` (the larger stopwords-iso list). Ignored when a
+        custom ``tokenizer`` is given.
     tokenizer : callable, optional
         ``str -> list[str]``. Defaults to :func:`topica.tokenize` with the
         ``stopwords`` and ``min_length`` arguments below. This is also where you
@@ -166,6 +172,14 @@ def from_dataframe(
     if strip_html:
         texts = [_strip_web(t) if isinstance(t, str) else t for t in texts]
     if tokenizer is None:
+        if isinstance(stopwords, str):
+            # A bare string is a language name/code (the scikit-learn
+            # stop_words="english" habit), not an iterable of words. Resolve it
+            # once here rather than letting list("english") shatter it into
+            # single characters that remove nothing useful (#766).
+            from .stopwords import stopwords as _resolve_stopwords
+
+            stopwords = _resolve_stopwords(stopwords)
         sw = list(stopwords) if stopwords is not None else None
         docs = [
             tokenize(t if isinstance(t, str) else "", stopwords=sw, min_length=min_length)

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -11,7 +11,7 @@ use std::path::Path;
 
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
-use pyo3::types::{PyBytes, PyDict};
+use pyo3::types::{PyBytes, PyDict, PyString};
 
 use super::build_corpus_from_docs_ext;
 use super::error::io_err;
@@ -21,11 +21,27 @@ use crate::corpus::{self, InputFormat, LoadOptions};
 /// strings (list, tuple, set, frozenset) so the bundled `ENGLISH_STOPWORDS`
 /// frozenset composes directly with the corpus builders (issue #742), the same
 /// way `tokenize` already accepts it.
-fn stopwords_set(stopwords: Option<&Bound<'_, PyAny>>) -> PyResult<HashSet<String>> {
+///
+/// A bare string is read as a language name/code (the scikit-learn
+/// `stop_words="english"` habit) and resolved through `topica.stopwords(lang)`,
+/// rather than iterating the string into single characters — which silently
+/// removed a handful of letters and left the real stopwords in place (#766).
+pub(crate) fn stopwords_set(stopwords: Option<&Bound<'_, PyAny>>) -> PyResult<HashSet<String>> {
     match stopwords {
         Some(obj) => {
+            let resolved;
+            let iterable = if obj.is_instance_of::<PyString>() {
+                resolved = obj
+                    .py()
+                    .import_bound("topica")?
+                    .getattr("stopwords")?
+                    .call1((obj,))?;
+                &resolved
+            } else {
+                obj
+            };
             let mut s = HashSet::new();
-            for item in obj.iter()? {
+            for item in iterable.iter()? {
                 s.insert(item?.extract::<String>()?);
             }
             Ok(s)
@@ -225,7 +241,10 @@ impl Corpus {
     ///
     /// `documents` is a sequence of token lists. Optional `doc_names` /
     /// `doc_labels` (each the same length as `documents`) attach an id and a
-    /// label to every document. `stopwords` are dropped. Vocabulary is pruned by
+    /// label to every document. `stopwords` are dropped: pass an iterable of words
+    /// (e.g. a set, or the bundled `ENGLISH_STOPWORDS`), or a language name/code
+    /// string like `"english"` / `"en"`, which is resolved through
+    /// :func:`topica.stopwords`. Vocabulary is pruned by
     /// `min_doc_freq` (minimum document frequency) and `max_doc_fraction`
     /// (maximum fraction of documents), by `min_cf` (minimum collection/total
     /// frequency), and by `rm_top` (drop the N most frequent words) — matching

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -9543,7 +9543,9 @@ fn project<'py>(
 ///
 /// `text` is the input string. `token_regex` is the token-matching pattern
 /// (None = the default word regex). `min_length` drops tokens shorter than that
-/// many characters.
+/// many characters. `stopwords` is an iterable of words (e.g. a set or the bundled
+/// `ENGLISH_STOPWORDS`), or a language name/code string like `"english"` / `"en"`,
+/// which is resolved through :func:`topica.stopwords`.
 #[pyfunction]
 #[pyo3(signature = (text, *, lowercase=true, stopwords=None, token_regex=None, min_length=1))]
 fn tokenize(
@@ -9556,17 +9558,9 @@ fn tokenize(
     let pattern = token_regex.unwrap_or_else(|| corpus::DEFAULT_TOKEN_REGEX.to_string());
     let re = Regex::new(&pattern).map_err(|e| PyValueError::new_err(e.to_string()))?;
     // Accept any iterable of strings (list, tuple, set, frozenset) so a
-    // `ENGLISH_STOPWORDS` frozenset can be passed directly.
-    let stop: HashSet<String> = match stopwords {
-        Some(obj) => {
-            let mut s = HashSet::new();
-            for item in obj.iter()? {
-                s.insert(item?.extract::<String>()?);
-            }
-            s
-        }
-        None => HashSet::new(),
-    };
+    // `ENGLISH_STOPWORDS` frozenset can be passed directly; a bare language
+    // string (e.g. "english") is resolved via `topica.stopwords` (#766).
+    let stop: HashSet<String> = py_corpus::stopwords_set(stopwords)?;
 
     let mut out = Vec::new();
     for m in re.find_iter(text) {

--- a/tests/test_frames.py
+++ b/tests/test_frames.py
@@ -225,3 +225,42 @@ def test_clean_text_does_not_warn_boilerplate():
     with warnings.catch_warnings():
         warnings.simplefilter("error")  # clean corpus: no boilerplate warning
         topica.from_dataframe(df, text_col="text")
+
+
+# ---------------------------------------------------------------------------
+# #766: a bare stopwords= string is a language, not an iterable of characters
+# ---------------------------------------------------------------------------
+
+
+def test_from_dataframe_stopwords_string_resolves_as_language():
+    # The scikit-learn stop_words="english" habit used to be list()'d into single
+    # characters and silently removed nothing. It now resolves via topica.stopwords.
+    df = pd.DataFrame(
+        {"text": ["the government passed a new law and the senate agreed today"]}
+    )
+    c = topica.from_dataframe(df, text_col="text", stopwords="english")
+    assert not ({"the", "and", "a"} & set(c.vocabulary))  # real stopwords gone
+    assert "government" in c.vocabulary
+    # a language code works too
+    c2 = topica.from_dataframe(df, text_col="text", stopwords="en")
+    assert set(c2.vocabulary) == set(c.vocabulary)
+
+
+def test_from_documents_and_tokenize_stopwords_string_resolves_as_language():
+    toks = [["the", "senate", "and", "the", "house", "agreed"]]
+    c = topica.Corpus.from_documents(toks, stopwords="english", min_doc_freq=1)
+    assert not ({"the", "and"} & set(c.vocabulary))
+    assert topica.tokenize("the senate and the house", stopwords="english") == [
+        "senate",
+        "house",
+    ]
+
+
+def test_stopwords_set_still_accepted_and_unknown_language_raises():
+    df = pd.DataFrame({"text": ["the cat and the dog"]})
+    # an explicit set is unchanged (only those words dropped)
+    c = topica.from_dataframe(df, text_col="text", stopwords={"the"})
+    assert "the" not in c.vocabulary and "and" in c.vocabulary
+    # an unknown language surfaces topica.stopwords' own directive error
+    with pytest.raises(ValueError, match="no bundled stopword list"):
+        topica.tokenize("hello world", stopwords="klingon")


### PR DESCRIPTION
Addresses the top (silent-broken-model) item of #766, surfaced by the #765 sample-user run on the dwillis congress corpus.

## The bug
`from_dataframe(df, text_col=..., stopwords="english")` — the scikit-learn `stop_words="english"` habit — was silently accepted and did nothing useful. Every `stopwords=` path ran the value through `list(...)` (Python) or iterated it (Rust `obj.iter()`), so a **string shattered into single characters**: `"english"` → `['e','n','g','l','i','s','h']`. It "removed" seven letters and left every real stopword (`the`, `they`, `and`, ...) in the vocabulary, with no error. A newcomer ships a broken model and never knows.

## The fix
A bare string is now read as a **language name/code** and resolved through `topica.stopwords(lang)` (the stopwords-iso lists), matching sklearn's `stop_words="english"`. Per the design call, resolve rather than raise.

Fixed at the shared choke point so all three entry points are covered with no duplicated logic:
- **`stopwords_set`** (`corpus.rs`, now `pub(crate)`) gains the str→language branch — used by `Corpus.from_documents`.
- **`tokenize`** (`mod.rs`) dropped its own inline copy of the loop and reuses `stopwords_set`.
- **`from_dataframe`** (`frames.py`) resolves a string once up front (not per document) before tokenizing.

The Rust→Python callback (`import_bound("topica").getattr("stopwords")`) follows existing precedent (`mod.rs` already calls `topica.coherence` the same way).

Behavior:
```python
from_dataframe(df, text_col="text", stopwords="english")   # 1298-word ISO list
tokenize("the senate and the house", stopwords="english")  # -> ['senate','house']
Corpus.from_documents(toks, stopwords="en")                # language code works
from_dataframe(df, text_col="text", stopwords={"the"})     # explicit set unchanged
tokenize("hi", stopwords="klingon")                        # ValueError: no bundled stopword list for 'klingon'
```

## Testing
- New regression tests in `tests/test_frames.py` (3 tests across all entry points: language name, language code, explicit set still works, unknown language raises).
- Full suite: **4984 passed, 38 skipped**.
- `scripts/preflight.sh` clean; `mkdocs build --strict` clean.

Remaining #766 items (opaque `**kwargs` signatures, two stopword lists, `doc_topic()` message) stay open for separate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)