### PR TITLE
docs: teach the workflow namespaces across docs and README (stage 2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ import topica
 
 df = topica.datasets.load_gadarian()          # bundled; loads offline
 corpus = topica.from_dataframe(
-    df, text_col="open.ended.response", stopwords=topica.ENGLISH_STOPWORDS
+    df, text_col="open.ended.response", stopwords=topica.data.ENGLISH_STOPWORDS
 )
 
 model = topica.LDA(num_topics=5, seed=13)
@@ -37,8 +37,8 @@ prevalence = corpus.metadata[["treatment"]]   # a numeric DataFrame goes straigh
 stm = topica.STM(num_topics=5, seed=13)
 stm.fit(corpus, prevalence, prevalence_names=["treatment"])
 
-draws  = topica.posterior_theta_samples(stm, nsims=30, seed=0)
-effect = topica.estimate_effect(draws, prevalence, feature_names=["treatment"])
+draws  = topica.effects.posterior_theta_samples(stm, nsims=30, seed=0)
+effect = topica.effects.estimate_effect(draws, prevalence, feature_names=["treatment"])
 ```
 
 Your own data is one line away: pass `pandas.read_csv("yours.csv")` to `from_dataframe`. See the [getting-started guide](https://nealcaren.github.io/topica/getting-started/quickstart/) and the [worked examples](https://nealcaren.github.io/topica/examples/dubois/) for analyses end to end.
@@ -221,7 +221,7 @@ Model-agnostic: they work on any fitted model's `topic_word`/`doc_topic`:
 - **Validation:** `word_intrusion`, `document_intrusion`, `bootstrap_stability`, `search_k`
 - **Reliability:** `select_model` (fit many seeds) and `ensemble` (combine runs into a consensus more reliable than any single fit — cluster/align/stable methods, the last derived from gensim's `EnsembleLda`)
 - **Comparison:** `fighting_words` (weighted log-odds) for contrasting corpora
-- **Covariate effects:** `estimate_effect` (method of composition, **cluster-robust SEs**, GLM links), `topic_correlation`, and the design helpers `one_hot`, `spline`, and `interaction` (all top level; they build covariate bases for any model's design matrix); `posterior_theta_samples` draws θ for the logistic-normal models (STM/CTM)
+- **Covariate effects:** `estimate_effect` (method of composition, **cluster-robust SEs**, GLM links), `topic_correlation`, and the design helpers `one_hot`, `spline`, and `interaction` (in `topica.effects` / `topica.design`; they build covariate bases for any model's design matrix); `posterior_theta_samples` draws θ for the logistic-normal models (STM/CTM)
 - **Preprocessing:** `tokenize`, `learn_phrases` / `apply_phrases`, `split_documents`, the `Corpus` class
 
 See [diagnostics](https://nealcaren.github.io/topica/guides/diagnostics/) and [covariate effects](https://nealcaren.github.io/topica/guides/covariates/).

--- a/docs/api/content.md
+++ b/docs/api/content.md
@@ -65,13 +65,13 @@ dv = content.content_divergence(stm, groups=("Democrat", "Republican"),
 
 ## Choosing K with group-stratified coherence
 
-`topica.search_k` accepts a `"stratified_<type>"` coherence metric for
+`topica.select.search_k` accepts a `"stratified_<type>"` coherence metric for
 content models (`model="stm"` with a `content` covariate): it scores each group's
 own top words against that group's subcorpus, and reports group-adjusted
 exclusivity and mean polarization alongside.
 
 ```python
-res = topica.search_k(
+res = topica.select.search_k(
     corpus, ks=[5, 10, 15], model="stm",
     prevalence=X, content=source,
     coherence_type="stratified_c_npmi",

--- a/docs/api/datasets.md
+++ b/docs/api/datasets.md
@@ -12,7 +12,7 @@ import topica
 
 df = topica.datasets.load_gadarian()
 corpus = topica.from_dataframe(
-    df, text_col="open.ended.response", stopwords=topica.ENGLISH_STOPWORDS
+    df, text_col="open.ended.response", stopwords=topica.data.ENGLISH_STOPWORDS
 )
 ```
 

--- a/docs/api/diagnostics.md
+++ b/docs/api/diagnostics.md
@@ -2,34 +2,35 @@
 
 Model-agnostic quality, interpretation, and validation tools. They take any
 fitted model's `topic_word` / `doc_topic` (or raw arrays), so they work the same
-across every model family. All are available at the top level (`topica.<name>`)
-and in the `topica.validation` module.
+across every model family. They live in the `topica.evaluate` namespace
+(`topica.evaluate.<name>`, the documented path below); every name is also
+reachable bare at the top level (`topica.<name>`) as a compatibility alias.
 
 ## One-call table
 
-::: topica.diagnostics
+::: topica.evaluate.diagnostics
 
-::: topica.perplexity
+::: topica.evaluate.perplexity
 
 ## Quality
 
-::: topica.coherence
+::: topica.evaluate.coherence
 
-::: topica.coherence_ci
+::: topica.evaluate.coherence_ci
 
-::: topica.semantic_coherence
+::: topica.evaluate.semantic_coherence
 
-::: topica.embedding_coherence
+::: topica.evaluate.embedding_coherence
 
-::: topica.topic_diversity
+::: topica.evaluate.topic_diversity
 
-::: topica.topic_semantic_diversity
+::: topica.evaluate.topic_semantic_diversity
 
-::: topica.inverted_rbo
+::: topica.evaluate.inverted_rbo
 
-::: topica.exclusivity
+::: topica.evaluate.exclusivity
 
-::: topica.quality_frontier
+::: topica.select.quality_frontier
 
 ## External validation
 
@@ -41,9 +42,9 @@ tracks recovery, where coherence can mislead.
 
 ## Interpretation
 
-::: topica.label_topics
+::: topica.inspect.label_topics
 
-::: topica.topics_for_term
+::: topica.inspect.topics_for_term
 
 ::: topica.llm_topic_labels
 
@@ -51,25 +52,25 @@ tracks recovery, where coherence can mislead.
 
 ::: topica.topic_label_prompts
 
-::: topica.frex
+::: topica.inspect.frex
 
-::: topica.mmr
+::: topica.inspect.mmr
 
-::: topica.relevance
+::: topica.inspect.relevance
 
-::: topica.find_thoughts
+::: topica.inspect.find_thoughts
 
-::: topica.find_thoughts_html
+::: topica.inspect.find_thoughts_html
 
-::: topica.topic_correlation
+::: topica.inspect.topic_correlation
 
-::: topica.prepare_pyldavis
+::: topica.inspect.prepare_pyldavis
 
 ## Validation
 
-::: topica.word_intrusion
+::: topica.evaluate.word_intrusion
 
-::: topica.document_intrusion
+::: topica.evaluate.document_intrusion
 
 ### LLM-based evaluation (`topica.llm`)
 
@@ -89,21 +90,21 @@ tracks recovery, where coherence can mislead.
 
 ::: topica.llm.adversarial
 
-::: topica.bootstrap_stability
+::: topica.evaluate.bootstrap_stability
 
-::: topica.search_k
+::: topica.select.search_k
 
-::: topica.check_residuals
+::: topica.evaluate.check_residuals
 
-::: topica.document_residuals
+::: topica.evaluate.document_residuals
 
-::: topica.flag_topics
+::: topica.evaluate.flag_topics
 
-::: topica.topic_dendrogram
+::: topica.evaluate.topic_dendrogram
 
-::: topica.align_topics
+::: topica.evaluate.align_topics
 
-::: topica.topic_stability
+::: topica.evaluate.topic_stability
 
 ::: topica.ensemble
 
@@ -145,16 +146,16 @@ Build a within-corpus word-heldout set — the analogue of R `stm`'s
 `make.heldout` — and score it under a fitted model to get document-completion
 log-likelihood.
 
-::: topica.make_heldout
+::: topica.evaluate.make_heldout
 
-::: topica.eval_heldout
+::: topica.evaluate.eval_heldout
 
 ## Estimator conformance
 
 Check any fitted model or model class against the topica estimator contract;
 returns a list of violation strings (empty means fully conformant).
 
-::: topica.check_conformance
+::: topica.provenance.check_conformance
 
 ## Reporting
 

--- a/docs/api/keywords.md
+++ b/docs/api/keywords.md
@@ -10,21 +10,21 @@
 
 ::: topica.tokenize
 
-::: topica.split_documents
+::: topica.data.split_documents
 
-::: topica.one_hot
+::: topica.design.one_hot
 
 Prune rare (and optionally common) vocabulary from a corpus, keeping
 metadata row-aligned with the documents that survive — the analogue of R
 `stm`'s `prepDocuments`.
 
-::: topica.prep_documents
+::: topica.data.prep_documents
 
 Sweep document-frequency thresholds and visualize how many documents and
 vocabulary terms are removed at each level, to inform the choice of
 `lower_thresh`.
 
-::: topica.plot_removed
+::: topica.data.plot_removed
 
 ## DataFrames & metadata
 
@@ -33,22 +33,22 @@ lists), keeping document metadata aligned to the rows that survive pruning.
 
 ::: topica.from_dataframe
 
-::: topica.align
+::: topica.data.align
 
-::: topica.design_matrix
+::: topica.design.design_matrix
 
 ## Embeddings
 
-::: topica.llm_embed
+::: topica.embeddings.llm_embed
 
-::: topica.save_embeddings
+::: topica.embeddings.save_embeddings
 
-::: topica.load_embeddings
+::: topica.embeddings.load_embeddings
 
 ## Phrases
 
-::: topica.learn_phrases
+::: topica.data.learn_phrases
 
-::: topica.apply_phrases
+::: topica.data.apply_phrases
 
-::: topica.add_ngrams
+::: topica.data.add_ngrams

--- a/docs/api/manifest.md
+++ b/docs/api/manifest.md
@@ -17,7 +17,7 @@ corpus = topica.Corpus.from_documents(tokens)
 model = topica.STM(num_topics=20, seed=13)
 model.fit(corpus, prevalence=X, iters=1000)
 
-record = topica.record_fit(model, corpus, prevalence=X, prevalence_names=names, iters=1000)
+record = topica.provenance.record_fit(model, corpus, prevalence=X, prevalence_names=names, iters=1000)
 record.add_decision("K", "Chose 20 after inspecting 15/20/25.")
 record.save("analysis.topica.json")
 
@@ -73,7 +73,7 @@ coarse per-class registry tag: a `cvb0` sampler or an `init="random"` fit is
 recorded as `seed-reproducible` even when the model class is nominally `bit-exact`,
 and `determinism_detail` carries the machine-readable `replay_requires` (the `seed`,
 plus `num_threads` for the collapsed-Gibbs approximate parallel sampler) and any
-caveats. Compute it directly for any model with `topica.effective_determinism`.
+caveats. Compute it directly for any model with `topica.provenance.effective_determinism`.
 
 ## Recording evidence
 
@@ -92,7 +92,7 @@ cannot see them on its own. Pass them so the fit stays verifiable and reproducib
 
 ```python
 model = topica.BERTopic(num_clusters=20, seed=0).fit(tokens, embeddings)
-record = topica.record_fit(model, corpus, embeddings=embeddings)   # fingerprints them
+record = topica.provenance.record_fit(model, corpus, embeddings=embeddings)   # fingerprints them
 ```
 
 The embeddings are recorded as an order-sensitive fingerprint under
@@ -120,7 +120,7 @@ models, record each fit with its top words retained and pass the two manifests t
 [`topica.compare`](../guides/model-comparison.md#comparing-two-manifests-without-the-models):
 
 ```python
-ra = topica.record_fit(model_a, corpus_a, topic_words_n=25)   # opt-in; off by default
+ra = topica.provenance.record_fit(model_a, corpus_a, topic_words_n=25)   # opt-in; off by default
 cmp = topica.compare(ra, rb)                                  # Jaccard top-word alignment
 ```
 
@@ -171,9 +171,9 @@ record.render("analysis-card.html", verification=record.verify(corpus, model))
 
 ## Reference
 
-::: topica.record_fit
+::: topica.provenance.record_fit
 
-::: topica.effective_determinism
+::: topica.provenance.effective_determinism
 
 ::: topica.manifest.AnalysisManifest
 

--- a/docs/api/stm.md
+++ b/docs/api/stm.md
@@ -4,7 +4,7 @@ The structural / covariate operations live in `topica.stm`. The general
 post-hoc diagnostics (labeling, alignment, pyLDAvis, …) are on the
 [Diagnostics](diagnostics.md) page.
 
-::: topica.standard_errors
+::: topica.effects.standard_errors
 
 ::: topica.stm.estimate_effect
 
@@ -36,18 +36,18 @@ Compute predicted topic prevalence at chosen covariate values, with
 simulation-based credible intervals — the model-agnostic counterpart of
 R `stm`'s `plot.estimateEffect`.
 
-::: topica.predicted_prevalence
+::: topica.effects.predicted_prevalence
 
-::: topica.PredictedPrevalence
+::: topica.effects.PredictedPrevalence
 
 ## Permutation test
 
 Distribution-free test of whether a binary prevalence covariate genuinely
 shifts topic prevalence, or whether the association could arise by chance.
 
-::: topica.permutation_test
+::: topica.effects.permutation_test
 
-::: topica.PermutationResult
+::: topica.effects.PermutationResult
 
 ## Per-group prevalence with credible bands
 
@@ -67,17 +67,17 @@ model, setting the per-document prior from `mu_d = X_d gamma`.
 Map new token lists onto the fitted vocabulary before calling `transform`,
 dropping any out-of-vocabulary tokens.
 
-::: topica.align_corpus
+::: topica.design.align_corpus
 
 ## Model selection at fixed K
 
 Run multiple initializations at a fixed K and compare candidates on the
 coherence-exclusivity frontier — the analogue of R `stm`'s `selectModel`.
 
-::: topica.select_model
+::: topica.select.select_model
 
-::: topica.SelectModelResult
+::: topica.select.SelectModelResult
 
 Visualize the coherence-versus-exclusivity scatter across candidate runs.
 
-::: topica.plot_models
+::: topica.select.plot_models

--- a/docs/contributing/conventions.md
+++ b/docs/contributing/conventions.md
@@ -74,7 +74,7 @@ by construction rather than by memory.
 7. **`coherence(...)`'s first positional argument is `n`, the top-word count — not
    the corpus.** It defaults to the training corpus, so bare `model.coherence()`
    works; pass a reference corpus with the keyword `texts=` for the windowed
-   measures. This flips the convention of the module-level `topica.coherence(
+   measures. This flips the convention of the module-level `topica.evaluate.coherence(
    topics, texts, ...)`, whose first argument is the topics — so
    `model.coherence(corpus.documents())` misfires. Passing texts positionally now
    raises a directive `TypeError` naming the `texts=` keyword rather than an

--- a/docs/contributing/estimator-contract.md
+++ b/docs/contributing/estimator-contract.md
@@ -205,7 +205,7 @@ Or call the helper directly from Python:
 ```python
 import topica
 
-violations = topica.check_conformance(MyNewModel(num_topics=5))
+violations = topica.provenance.check_conformance(MyNewModel(num_topics=5))
 for v in violations:
     print(v)
 ```
@@ -223,7 +223,7 @@ open a pull request.
 3. Add it to `REGISTRY` in `python/topica/conformance.py` with a zero-arg
    factory lambda and the correct `model_family` string.
 4. Add the class to `_topica.pyi` to keep the stub in sync.
-5. Run `topica.check_conformance(MyModel())` to find any missing attributes.
+5. Run `topica.provenance.check_conformance(MyModel())` to find any missing attributes.
 6. For each missing attribute:
    - If it is a structural impossibility for this model, add it to `EXEMPT`
      with a clear reason.

--- a/docs/examples/congress.md
+++ b/docs/examples/congress.md
@@ -34,7 +34,7 @@ import topica
 df = topica.datasets.load_congress()          # bundled clean sample (or build from raw)
 corpus = topica.from_dataframe(
     df, text_col="text", strip_html=True,
-    stopwords=topica.ENGLISH_STOPWORDS,
+    stopwords=topica.data.ENGLISH_STOPWORDS,
     min_doc_freq=10, max_doc_fraction=0.4,
 )
 ```
@@ -44,12 +44,12 @@ corpus = topica.from_dataframe(
 We pick `K` at the coherence/exclusivity frontier, then fit with a hand-built
 design: the party contrast (reference = Democrat) plus a centered linear year, so
 the year coefficient reads directly as a per-year trend. For curvature, swap in
-`topica.spline(year, df=4)`, which returns a `(basis, names)` pair you `hstack`
+`topica.design.spline(year, df=4)`, which returns a `(basis, names)` pair you `hstack`
 the same way.
 
 ```python
-X_party, party_names = topica.one_hot(corpus.metadata["party"], reference="Democrat")
-scan = topica.search_k(corpus, [10, 15, 20, 25], model="stm",
+X_party, party_names = topica.design.one_hot(corpus.metadata["party"], reference="Democrat")
+scan = topica.select.search_k(corpus, [10, 15, 20, 25], model="stm",
                        prevalence=X_party, iters=60, seed=13)
 k = scan.best_k()                              # frontier knee; warns on a grid edge
 
@@ -78,7 +78,7 @@ A representative `K = 15` FREX table (`label_topics(model, n=8)`):
 Read every effect by **name** — never `coef[0]`, which is the intercept.
 
 ```python
-effects = topica.estimate_effect(model, X=X, feature_names=names, nsims=50, seed=0)
+effects = topica.effects.estimate_effect(model, X=X, feature_names=names, nsims=50, seed=0)
 
 for eff in effects:
     party = eff.effect_of("Republican")   # positive = more Republican (baseline Democrat)

--- a/docs/examples/content_time.md
+++ b/docs/examples/content_time.md
@@ -62,9 +62,9 @@ is the *attention* half — how often each topic is discussed — and is optiona
 here; the content design is where the wording lives.
 
 ```python
-party_col, pn = topica.one_hot(party)                 # indicator(Republican)
-yr_basis, sn = topica.spline(np.asarray(year, float), df=4)
-inter, _ = topica.interaction(party_col, yr_basis, name="party_year")
+party_col, pn = topica.design.one_hot(party)                 # indicator(Republican)
+yr_basis, sn = topica.design.spline(np.asarray(year, float), df=4)
+inter, _ = topica.design.interaction(party_col, yr_basis, name="party_year")
 X = np.column_stack([party_col, yr_basis, inter])
 names = list(pn) + list(sn) + [f"party_year_{i}" for i in range(inter.shape[1])]
 

--- a/docs/examples/dmr-sentiment.md
+++ b/docs/examples/dmr-sentiment.md
@@ -30,7 +30,7 @@ import topica
 df = topica.datasets.load_reviews()
 corpus = topica.from_dataframe(
     df, text_col="text",
-    stopwords=topica.SENTIMENT_STOPWORDS,   # keeps not / no / very / too
+    stopwords=topica.data.SENTIMENT_STOPWORDS,   # keeps not / no / very / too
     min_doc_freq=5, max_doc_fraction=0.5,
 )
 X = (corpus.metadata["stars"].to_numpy(float) - 3.0).reshape(-1, 1)  # centered 1..5
@@ -46,7 +46,7 @@ negative slope is a **complaint** topic (more prevalent in low-star reviews); a
 positive slope is **praise**.
 
 ```python
-effects = topica.estimate_effect(model.doc_topic, X, feature_names=["stars"],
+effects = topica.effects.estimate_effect(model.doc_topic, X, feature_names=["stars"],
                                  nsims=60, seed=0)
 for eff in effects:
     star = eff.effect_of("stars")     # dict: coef, se, z, ci_low, ci_high, pvalue

--- a/docs/examples/dubois.md
+++ b/docs/examples/dubois.md
@@ -46,8 +46,8 @@ print(len(rows), "articles;", {d: by_decade[d] for d in sorted(by_decade)})
 ## 2. Phrases, then a pruned corpus
 
 ```python
-phrases = topica.learn_phrases(docs, min_count=8, threshold=12.0)
-docs = topica.apply_phrases(docs, phrases)            # "jim crow" -> "jim_crow"
+phrases = topica.data.learn_phrases(docs, min_count=8, threshold=12.0)
+docs = topica.data.apply_phrases(docs, phrases)            # "jim crow" -> "jim_crow"
 corpus = Corpus.from_documents(docs, min_doc_freq=10, rm_top=20)
 print("vocab", corpus.num_words)                  # 3423
 ```
@@ -60,8 +60,8 @@ lda.fit(corpus, iters=400, num_samples=4, sample_interval=25)
 for t in range(15):
     print(f"T{t:>2}: " + ", ".join(w.replace("_", " ") for w in lda.top_words(8, topic=t)))
 
-print("c_v:", round(float(np.mean(topica.coherence(lda, docs, coherence_type="c_v"))), 3),
-      "diversity:", round(topica.topic_diversity(lda, topn=15), 3))
+print("c_v:", round(float(np.mean(topica.evaluate.coherence(lda, docs, coherence_type="c_v"))), 3),
+      "diversity:", round(topica.evaluate.topic_diversity(lda, topn=15), 3))
 ```
 
 ```

--- a/docs/examples/guided.md
+++ b/docs/examples/guided.md
@@ -25,7 +25,7 @@ import topica
 
 df = topica.datasets.load_congress()
 corpus = topica.from_dataframe(df, text_col="text", strip_html=True,
-                               stopwords=topica.ENGLISH_STOPWORDS,
+                               stopwords=topica.data.ENGLISH_STOPWORDS,
                                min_doc_freq=10, max_doc_fraction=0.4)
 
 keywords = {

--- a/docs/examples/llm-topics.md
+++ b/docs/examples/llm-topics.md
@@ -38,7 +38,7 @@ the matrix to disk so re-running the script reloads it instead of re-embedding
 (embeddings are the costly step).
 
 ```python
-doc_emb = topica.llm_embed(
+doc_emb = topica.embeddings.llm_embed(
     texts, model="sentence-transformers/all-MiniLM-L6-v2", cache="crisis_emb.npz"
 )
 doc_emb.shape          # (704, 384)

--- a/docs/examples/nmf-neural.md
+++ b/docs/examples/nmf-neural.md
@@ -38,7 +38,7 @@ labels = np.array(b.labels)
 corpus = topica.Corpus.from_documents(docs, min_doc_freq=10, max_doc_fraction=0.4)
 
 for family in ("nmf", "lsa"):
-    scan = topica.search_k(corpus, [3, 4, 5, 6, 8], model=family)
+    scan = topica.select.search_k(corpus, [3, 4, 5, 6, 8], model=family)
     print(family, scan.best_k("reconstruction_error", rule="elbow"))
 ```
 
@@ -103,7 +103,7 @@ LSA's `topic_word` rows are signed SVD loadings, not a word distribution, so
 coherence computed on them is not on the same footing as NMF's — topica warns you:
 
 ```python
-topica.coherence(lsa, corpus)   # UserWarning: topic_word has negative entries,
+topica.evaluate.coherence(lsa, corpus)   # UserWarning: topic_word has negative entries,
                                 # not comparable across model families ...
 ```
 

--- a/docs/examples/poliblog.md
+++ b/docs/examples/poliblog.md
@@ -39,7 +39,7 @@ print(corpus.num_docs, "docs, vocab", corpus.num_words)
 ## 3. Choose and justify K
 
 ```python
-for r in topica.search_k(docs, ks=[10, 15, 20], iters=500):
+for r in topica.select.search_k(docs, ks=[10, 15, 20], iters=500):
     print(f"K={r['k']:>2}  coherence={r['coherence']:.1f}  exclusivity={r['exclusivity']:.3f}")
 ```
 
@@ -82,11 +82,11 @@ the financial crisis, the primaries. Validate them with a human intrusion test
 and with bootstrap stability:
 
 ```python
-print(topica.word_intrusion(model, n_words=5, seed=0)[0])
+print(topica.evaluate.word_intrusion(model, n_words=5, seed=0)[0])
 # {'topic': 0, 'words': ['voter','mccain','poll','state','obama','investig'],
 #  'intruder': 'investig', 'intruder_index': 5}
 
-boot = topica.bootstrap_stability(docs, k=15, n_boot=20, iters=400)
+boot = topica.evaluate.bootstrap_stability(docs, k=15, n_boot=20, iters=400)
 print("mean topic stability:", round(boot["mean"], 2))   # 0.36
 ```
 

--- a/docs/examples/short-text.md
+++ b/docs/examples/short-text.md
@@ -27,7 +27,7 @@ import topica
 
 df = topica.datasets.load_congress()
 corpus = topica.from_dataframe(df, text_col="title",     # the headline, not the body
-                               stopwords=topica.ENGLISH_STOPWORDS,
+                               stopwords=topica.data.ENGLISH_STOPWORDS,
                                min_doc_freq=5, max_doc_fraction=0.3)
 model = topica.GSDMM(num_topics=20, seed=13).fit(corpus.documents(), iters=40)
 ```

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -15,7 +15,7 @@ df = topica.datasets.load_gadarian()          # bundled; loads offline
 corpus = topica.from_dataframe(
     df,
     text_col="open.ended.response",
-    stopwords=topica.ENGLISH_STOPWORDS,        # without this, every topic is "the, and, of"
+    stopwords=topica.data.ENGLISH_STOPWORDS,        # without this, every topic is "the, and, of"
     min_doc_freq=2,                            # drop words in fewer than 2 documents
 )
 
@@ -32,7 +32,7 @@ and set `text_col` to your text column.
     everywhere in *your* corpus but not in general English can still lead a topic
     — a publication's own name, a boilerplate header word, a survey prompt term.
     If a topic's top words are dominated by one such word, add it to the
-    stoplist: `stopwords=topica.ENGLISH_STOPWORDS | {"crisis", "magazine"}`
+    stoplist: `stopwords=topica.data.ENGLISH_STOPWORDS | {"crisis", "magazine"}`
     (or start from a larger base list). The [preprocessing
     guide](../guides/preprocessing.md) covers stoplist choices in full.
 
@@ -50,13 +50,13 @@ on coherence and exclusivity by default; pass `held_out=make_heldout(corpus)` to
 add a held-out likelihood column too:
 
 ```python
-result = topica.search_k(corpus, ks=[5, 10, 20, 30], seed=13)
+result = topica.select.search_k(corpus, ks=[5, 10, 20, 30], seed=13)
 print(result.best_k())                 # the coherence/exclusivity frontier knee
 print(result.best_k(explain=True))     # ...and the per-K scores behind the pick
 
 # add held-out likelihood as a selection criterion
-ho = topica.search_k(corpus, ks=[5, 10, 20, 30], seed=13,
-                     held_out=topica.make_heldout(corpus))
+ho = topica.select.search_k(corpus, ks=[5, 10, 20, 30], seed=13,
+                     held_out=topica.evaluate.make_heldout(corpus))
 ```
 
 The [choosing K guide](../publishing/choosing-k.md) walks through how to justify
@@ -69,10 +69,10 @@ print(model.topic_word.shape)   # (K, V) — φ, topics × words
 print(model.doc_topic.shape)    # (D, K) — θ, docs × topics (rows sum to 1)
 
 # Publication-ready: prevalence + top words + distinctive (FREX) words per topic
-table = topica.topic_table(model)
+table = topica.inspect.topic_table(model)
 
 # The documents most associated with a topic — read these to name it
-examples = topica.find_thoughts(model, topic=0, n=3)
+examples = topica.inspect.find_thoughts(model, topic=0, n=3)
 ```
 
 !!! note "Stemmed words in the output?"
@@ -89,7 +89,7 @@ If your documents are not in a DataFrame, tokenize them yourself into a
 `list[list[str]]`:
 
 ```python
-docs = [topica.tokenize(t, stopwords=topica.ENGLISH_STOPWORDS) for t in texts]
+docs = [topica.tokenize(t, stopwords=topica.data.ENGLISH_STOPWORDS) for t in texts]
 corpus = topica.Corpus.from_documents(docs, min_doc_freq=5, rm_top=15)
 ```
 
@@ -111,11 +111,11 @@ Fits are deterministic for a fixed `seed`.
 ```python
 # Per-topic coherence and exclusivity — the standard quality pair.
 coherence   = model.coherence(n=10)                 # UMass, per topic
-exclusivity = topica.exclusivity(model, n=10)       # per topic
-diversity   = topica.topic_diversity(model, topn=25)
+exclusivity = topica.evaluate.exclusivity(model, n=10)       # per topic
+diversity   = topica.evaluate.topic_diversity(model, topn=25)
 
 # Windowed, human-aligned coherence (gensim-style); needs the reference texts:
-cv = topica.coherence(model, corpus.documents(), coherence_type="c_v", topn=10)
+cv = topica.evaluate.coherence(model, corpus.documents(), coherence_type="c_v", topn=10)
 ```
 
 ## Infer topics for new documents

--- a/docs/guides/covariates.md
+++ b/docs/guides/covariates.md
@@ -5,20 +5,21 @@ The Structural Topic Model lets topics depend on document metadata in two ways:
 topic is worded). For the publication-grade version of this workflow, with proper
 uncertainty and clustered errors, see [Measure effects properly](../publishing/effects.md).
 
-!!! tip "Importing the covariate helpers"
-    All of the design-matrix and effect helpers are top-level: `topica.one_hot`,
-    `topica.design_matrix`, `topica.spline`, `topica.interaction`,
-    `topica.estimate_effect`, and `topica.posterior_theta_samples`. That is the
-    canonical path used throughout these docs. The same names are also reachable
-    under `topica.stm.*` (they are the identical objects, kept as a compatibility
-    alias), but prefer the top-level form.
+!!! tip "Where the covariate helpers live"
+    Design-matrix helpers live in `topica.design` (`topica.design.one_hot`,
+    `topica.design.design_matrix`, `topica.design.spline`, `topica.design.interaction`)
+    and effect helpers in `topica.effects` (`topica.effects.estimate_effect`,
+    `topica.effects.posterior_theta_samples`). That is the canonical path used
+    throughout these docs. The same names are also reachable bare at the top level
+    (`topica.estimate_effect`, …) and under `topica.stm.*` — identical objects kept
+    as compatibility aliases — but prefer the namespaced form.
 
 ## End to end: from a DataFrame to effects
 
 The whole covariate workflow in one block: build an aligned corpus from a
 DataFrame, turn the metadata into a design matrix with an R-style formula, fit
 the STM, and read the effects as a tidy table. Every step uses the canonical
-top-level helpers.
+namespaced helpers.
 
 ```python
 import pandas as pd
@@ -29,24 +30,24 @@ corpus = topica.from_dataframe(df, text_col="text")     # metadata kept aligned
 
 # Design matrix from a formula (needs the optional topica[formula] extra).
 # corpus.metadata is the surviving rows, already aligned to the documents.
-X, names = topica.design_matrix("~ party + spline(year, df=3)", corpus.metadata)
+X, names = topica.design.design_matrix("~ party + spline(year, df=3)", corpus.metadata)
 
 # Pick K at the coherence/exclusivity frontier (a knee, not a coherence max,
 # which would just return the smallest K), then fit at that K.
-scan = topica.search_k(corpus, [10, 20, 30], model="stm", prevalence=X, iters=200)
+scan = topica.select.search_k(corpus, [10, 20, 30], model="stm", prevalence=X, iters=200)
 model = topica.STM(num_topics=scan.best_k(), seed=1)
 model.fit(corpus, prevalence=X, prevalence_names=names)
 
 # Effects with method-of-composition uncertainty, as a tidy long table.
 # Passing the model + nsims draws the theta posterior for you, with R
 # estimateEffect's default Global uncertainty.
-effects = topica.estimate_effect(model, X=X, feature_names=names, nsims=50, seed=0)
+effects = topica.effects.estimate_effect(model, X=X, feature_names=names, nsims=50, seed=0)
 table = pd.concat([e.to_frame() for e in effects], ignore_index=True)
 ```
 
 If you would rather not add the `formulaic` dependency, replace `design_matrix`
-with hand-built blocks: `X, names = topica.one_hot(df["party"])` combined with
-`topica.spline` / `topica.interaction` via `numpy.hstack`.
+with hand-built blocks: `X, names = topica.design.one_hot(df["party"])` combined with
+`topica.design.spline` / `topica.design.interaction` via `numpy.hstack`.
 
 `one_hot` drops one level as the reference (baseline), so every coefficient is a
 contrast against it. With three or more levels, name the baseline yourself with
@@ -57,7 +58,7 @@ often reads better than a set of dummies: it gives one interpretable per-step
 slope, which is what a "how does prevalence move along the scale" question wants.
 
 For a sentiment or rating study, build the corpus with
-`stopwords=topica.SENTIMENT_STOPWORDS`, not the default `ENGLISH_STOPWORDS`: the
+`stopwords=topica.data.SENTIMENT_STOPWORDS`, not the default `ENGLISH_STOPWORDS`: the
 default strips `not`/`no`/`very`/`too`, which would collapse "not clean" into
 "clean" in exactly the study whose outcome is valence.
 
@@ -66,12 +67,12 @@ default strips `not`/`no`/`very`/`too`, which would collapse "not clean" into
 ```python
 import topica
 
-X, names = topica.one_hot(party)                      # design matrix + column names
+X, names = topica.design.one_hot(party)                      # design matrix + column names
 model = topica.STM(num_topics=20, seed=1)
 model.fit(docs, prevalence=X, prevalence_names=names)
 
 model.prevalence_effects        # learned γ
-topica.topic_correlation(model.doc_topic)
+topica.inspect.topic_correlation(model.doc_topic)
 ```
 
 ## Content covariates
@@ -125,7 +126,7 @@ GLM links:
 import pandas as pd
 import topica
 
-effects = topica.estimate_effect(
+effects = topica.effects.estimate_effect(
     model, X=X, feature_names=names, nsims=50, seed=0,
     cluster=source_id,     # cluster-robust SEs for nested data
     weights=survey_weight,  # weighted least squares (e.g. survey weights)
@@ -137,8 +138,8 @@ effects = topica.estimate_effect(
 table = pd.concat([e.to_frame() for e in effects], ignore_index=True)
 ```
 
-Build non-linear and interaction terms with `topica.spline` and
-`topica.interaction`. Full detail and the journal-grade treatment are in the
+Build non-linear and interaction terms with `topica.design.spline` and
+`topica.design.interaction`. Full detail and the journal-grade treatment are in the
 [Publishing](../publishing/effects.md) track.
 
 ### On a plain LDA model (not only STM)
@@ -156,8 +157,8 @@ direct path.
 model = topica.LDA(num_topics=20, seed=1)
 model.fit(corpus, iters=1000)
 
-X, names = topica.one_hot(corpus.metadata["rating"], prefix="rating_")
-effects = topica.estimate_effect(model, X=X, feature_names=names, corpus=corpus, nsims=50)
+X, names = topica.design.one_hot(corpus.metadata["rating"], prefix="rating_")
+effects = topica.effects.estimate_effect(model, X=X, feature_names=names, corpus=corpus, nsims=50)
 ```
 
 **Read effects by name, not by position.** `add_intercept=True` is the default, so
@@ -187,7 +188,7 @@ The estimated group and residual standard deviations come back on
 and reproduces `lme4::lmer`'s fixed effects exactly.
 
 ```python
-effects = topica.estimate_effect(
+effects = topica.effects.estimate_effect(
     draws, formula="~ party", data=meta, random="(1 | state)",
 )
 effects[0].varcomp   # {"state": sd_between, "residual": sd_within}
@@ -199,7 +200,7 @@ and without `cluster`/`weights`.
 ### Average marginal effects
 
 When the design has splines or interactions, no single coefficient is "the
-effect" of a covariate. `topica.average_marginal_effects` (alias `topica.ame`)
+effect" of a covariate. `topica.effects.average_marginal_effects` (alias `topica.effects.ame`)
 reports the average change in a topic's proportion per unit of a covariate —
 the average derivative for a continuous covariate, or the average
 level-vs-reference contrast for a factor — averaged over the observed documents,
@@ -207,7 +208,7 @@ with standard errors that propagate the topic-estimation uncertainty:
 
 ```python
 # Average marginal effect of `year` on every topic (year enters via a spline).
-ame = topica.average_marginal_effects(
+ame = topica.effects.average_marginal_effects(
     model, "year", formula="~ party + spline(year, df=4)", data=meta, nsims=50,
 )
 ame.to_frame()   # tidy: topic, term, ame, se, ci_low, ci_high
@@ -227,7 +228,7 @@ ame.to_frame()   # tidy: topic, term, ame, se, ci_low, ci_high
 
 ## Predicted prevalence
 
-`topica.predicted_prevalence` computes predicted topic prevalence at chosen
+`topica.effects.predicted_prevalence` computes predicted topic prevalence at chosen
 covariate values with simulation-based credible intervals — the direct
 counterpart of R `stm`'s `plot.estimateEffect`. Three modes mirror `stm`'s
 `method` argument:
@@ -236,7 +237,7 @@ counterpart of R `stm`'s `plot.estimateEffect`. Three modes mirror `stm`'s
 import topica
 
 # Point grid: predicted prevalence when party is "D" vs "R"
-pp = topica.predicted_prevalence(
+pp = topica.effects.predicted_prevalence(
     model,
     formula="~ party + year",
     data=meta,
@@ -246,13 +247,13 @@ for result in pp:
     print(result.topic_name, result.estimate, result.ci_low, result.ci_high)
 
 # Continuous sweep: prevalence as year varies, other covariates at their means
-pp = topica.predicted_prevalence(
+pp = topica.effects.predicted_prevalence(
     model, formula="~ party + year", data=meta,
     continuous="year",
 )
 
 # Contrast: difference in prevalence between two covariate settings
-pp = topica.predicted_prevalence(
+pp = topica.effects.predicted_prevalence(
     model, formula="~ party", data=meta,
     contrast={"party": ["D", "R"]},
 )
@@ -260,12 +261,12 @@ pp = topica.predicted_prevalence(
 
 ## Permutation test for binary covariates
 
-`topica.permutation_test` assesses whether a binary covariate genuinely shifts
+`topica.effects.permutation_test` assesses whether a binary covariate genuinely shifts
 topic prevalence, using permutation resampling rather than parametric
 assumptions:
 
 ```python
-results = topica.permutation_test(
+results = topica.effects.permutation_test(
     model, corpus=docs, covariate=treated,   # treated: 0/1 array
     n_perm=100, seed=0,
 )
@@ -332,7 +333,7 @@ under the default `inference="context"`).
 
 ```python
 # You bring pretrained word embeddings as {word: vector} (GloVe, word2vec, ...).
-fit = topica.embedding_regression(
+fit = topica.embeddings.embedding_regression(
     docs,                       # tokenized documents (word order matters)
     covariates=party,           # numeric (N,)/(N, p), or category labels (dummy-coded)
     pre_trained=glove,          # {word: vector} or (matrix, vocab)

--- a/docs/guides/cross-validation.md
+++ b/docs/guides/cross-validation.md
@@ -2,7 +2,7 @@
 
 Cross-validation gives you shared, reproducible evidence about a model's
 *predictive* behavior: refit a fresh model on each training fold, then score the
-held-out documents it never saw. `topica.cross_validate` runs the whole loop and
+held-out documents it never saw. `topica.select.cross_validate` runs the whole loop and
 records the fold assignments and every seed so a rerun reproduces the result.
 
 It reports evidence; it does not adjudicate. Cross-validation here never picks `K`
@@ -20,7 +20,7 @@ import topica
 df = topica.datasets.load_poliblog()      # a real bundled dataset
 docs = [t.split() for t in df["text"]]    # -> list[list[str]]
 
-result = topica.cross_validate(
+result = topica.select.cross_validate(
     lambda seed: topica.LDA(10, seed=seed),   # a factory: seed -> fresh model
     docs,
     folds=5,
@@ -87,8 +87,8 @@ plain `topica.LDA(K, seed=s)` pattern):
 
 ```python
 keywords = {"econ": ["market", "tax"], "social": ["family", "church"]}
-X, names = topica.one_hot(df["rating"])   # (matrix, names) — unpack it
-result = topica.cross_validate(
+X, names = topica.design.one_hot(df["rating"])   # (matrix, names) — unpack it
+result = topica.select.cross_validate(
     lambda s: topica.KeyATM(keywords, num_topics=10, seed=s),
     docs,
     covariates={"covariates": X},         # D x F numeric matrix
@@ -133,7 +133,7 @@ predict the held-out response, assemble the out-of-fold (OOF) prediction vector,
 report regression error, calibration, and interval coverage.
 
 ```python
-result = topica.cross_validate(
+result = topica.select.cross_validate(
     lambda seed: topica.SupervisedLDA(10, seed=seed),
     docs,
     y=response,                 # per-document numeric response, length n_docs
@@ -179,8 +179,8 @@ is the single place leakage is guarded:
 | `"temporal"` | ordered, test always after train | `times=` | `max(train) < min(test)`; tied timestamps stay together |
 
 ```python
-folds = topica.make_folds(len(docs), strategy="grouped", folds=5, groups=author_id)
-result = topica.cross_validate(factory, docs, folds=folds)
+folds = topica.select.make_folds(len(docs), strategy="grouped", folds=5, groups=author_id)
+result = topica.select.cross_validate(factory, docs, folds=folds)
 ```
 
 For `temporal`, the training window **expands** by default; pass `window=` for a
@@ -197,9 +197,9 @@ dict keyed by the model's fit keyword:
 ```python
 # Covariates must be a numeric matrix. Encode a categorical column first.
 # one_hot returns (matrix, names) — unpack it; passing the tuple raises.
-X, names = topica.one_hot(df["rating"])     # or topica.design_matrix(...)
+X, names = topica.design.one_hot(df["rating"])     # or topica.design.design_matrix(...)
 
-result = topica.cross_validate(
+result = topica.select.cross_validate(
     lambda seed: topica.STM(10, seed=seed),
     docs,
     covariates={"prevalence": X},           # D x P, aligned to docs
@@ -266,7 +266,7 @@ say) raises with the list of keys that model does accept.
 ```python
 import topica.viz as viz
 
-result = topica.cross_validate(lambda s: topica.LDA(10, seed=s), docs, folds=5)
+result = topica.select.cross_validate(lambda s: topica.LDA(10, seed=s), docs, folds=5)
 viz.plot_cv(result).to_png("cv.pdf")   # or .to_frame() for the numbers
 ```
 

--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -1,10 +1,11 @@
 # Diagnostics & validation
 
 All of these are **model-agnostic**: they take any fitted model's `topic_word` /
-`doc_topic`, so they work the same across LDA, STM, HDP, and the rest. They're
-exported at the top level (`topica.<name>`) and in `topica.diagnostics`. For how
-to *use* them to make an analysis publishable, see
-[Validate the topics](../publishing/validation.md).
+`doc_topic`, so they work the same across LDA, STM, HDP, and the rest. They live
+in the `topica.evaluate` namespace (`topica.evaluate.coherence`,
+`topica.evaluate.exclusivity`, …); every name is also reachable bare at the top
+level (`topica.<name>`) as a compatibility alias. For how to *use* them to make an
+analysis publishable, see [Validate the topics](../publishing/validation.md).
 
 ## Quality metrics
 
@@ -12,14 +13,14 @@ to *use* them to make an analysis publishable, see
 import topica
 
 model.coherence(10)                                   # per-topic UMass (built in)
-topica.coherence(model, texts, coherence_type="c_v")      # windowed, human-aligned
-topica.exclusivity(model, n=10)                           # per topic
-topica.topic_diversity(model, topn=25)                    # fraction of unique top words
-topica.topic_semantic_diversity(model, topn=25)           # fraction of unique top-word *pairs*
-topica.inverted_rbo(model, topn=10)                       # rank-weighted diversity (RBO)
-topica.embedding_coherence(model, word_embeddings, topn=10)  # top-word proximity in embedding space
+topica.evaluate.coherence(model, texts, coherence_type="c_v")      # windowed, human-aligned
+topica.evaluate.exclusivity(model, n=10)                           # per topic
+topica.evaluate.topic_diversity(model, topn=25)                    # fraction of unique top words
+topica.evaluate.topic_semantic_diversity(model, topn=25)           # fraction of unique top-word *pairs*
+topica.evaluate.inverted_rbo(model, topn=10)                       # rank-weighted diversity (RBO)
+topica.evaluate.embedding_coherence(model, word_embeddings, topn=10)  # top-word proximity in embedding space
 
-qf = topica.quality_frontier(model, n=10)                 # coherence, exclusivity, prevalence
+qf = topica.select.quality_frontier(model, n=10)                 # coherence, exclusivity, prevalence
 # qf["coherence"], qf["exclusivity"] -> the canonical STM quality scatter
 ```
 
@@ -42,15 +43,15 @@ reads as a misleadingly low diversity, so set `topn` explicitly when comparing.
 word-embedding space — the intrinsic middle ground between corpus-based
 `coherence` and LLM-based `topica.llm.coherence`. Bring your own embedding (it is
 only comparable across models scored on the *same* one, with no absolute
-threshold); `topica.llm_embed` builds one:
+threshold); `topica.embeddings.llm_embed` builds one:
 
 ```python
-emb = topica.llm_embed(model.vocabulary)                 # (V, E) word table
-topica.embedding_coherence(model, emb, model.vocabulary) # per-topic, higher = better
+emb = topica.embeddings.llm_embed(model.vocabulary)                 # (V, E) word table
+topica.evaluate.embedding_coherence(model, emb, model.vocabulary) # per-topic, higher = better
 ```
 
 !!! tip "Coherence is fast, even at large K"
-    `topica.coherence` runs its co-occurrence counting in the Rust core, scoring only
+    `topica.evaluate.coherence` runs its co-occurrence counting in the Rust core, scoring only
     the word pairs that actually occur within a topic's top-N rather than a full
     vocabulary×vocabulary matrix. `c_v` on a 500-topic model that took minutes in
     a pure-Python loop now takes a fraction of a second. Two habits still help on
@@ -63,12 +64,12 @@ topica.embedding_coherence(model, emb, model.vocabulary) # per-topic, higher = b
 ## Labeling and interpretation
 
 ```python
-topica.label_topics(model.topic_word, model.vocabulary, n=10)   # prob / frex / lift / score
-topica.label_topics(model.topic_word, corpus=corpus, n=10)     # stm-faithful: lift + FREX James-Stein shrinkage from corpus word counts
-topica.frex(model.topic_word, model.vocabulary, n=10)           # frequent + exclusive
-topica.relevance(model.topic_word, model.vocabulary, lam=0.6)   # LDAvis relevance
-topica.find_thoughts(model.doc_topic, texts, topic=0, n=3)      # representative docs
-topica.find_thoughts_html(model, texts, n_docs=3)               # highlighted close-reading
+topica.inspect.label_topics(model.topic_word, model.vocabulary, n=10)   # prob / frex / lift / score
+topica.inspect.label_topics(model.topic_word, corpus=corpus, n=10)     # stm-faithful: lift + FREX James-Stein shrinkage from corpus word counts
+topica.inspect.frex(model.topic_word, model.vocabulary, n=10)           # frequent + exclusive
+topica.inspect.relevance(model.topic_word, model.vocabulary, lam=0.6)   # LDAvis relevance
+topica.inspect.find_thoughts(model.doc_topic, texts, topic=0, n=3)      # representative docs
+topica.inspect.find_thoughts_html(model, texts, n_docs=3)               # highlighted close-reading
 ```
 
 For readable labels, `llm_topic_labels` asks an LLM to name each topic from its
@@ -96,8 +97,8 @@ and keep `label_topics` (FREX / probability / lift) as the defensible descriptor
 ## Human validation: intrusion tests
 
 ```python
-topica.word_intrusion(model, n_words=5, seed=0)           # top words + an intruder
-topica.document_intrusion(model, texts=texts, n_docs=3)   # top docs + an intruder
+topica.evaluate.word_intrusion(model, n_words=5, seed=0)           # top words + an intruder
+topica.evaluate.document_intrusion(model, texts=texts, n_docs=3)   # top docs + an intruder
 ```
 
 ## LLM-based evaluation
@@ -271,11 +272,11 @@ of these numbers.
 ## Stability and model selection
 
 ```python
-topica.search_k(docs, ks=[10, 20, 30], held_out=test)     # coherence, exclusivity, held-out, dispersion per K
-topica.bootstrap_stability(docs, k=20, n_boot=50)         # per-topic stability under resampling
-topica.align_topics(model_a, model_b)                     # one-to-one match across fits
-topica.topic_stability([model_a, model_b], topn=10)       # cross-fit term overlap
-topica.check_residuals(model, docs)                       # Taddy dispersion: is K too small?
+topica.select.search_k(docs, ks=[10, 20, 30], held_out=test)     # coherence, exclusivity, held-out, dispersion per K
+topica.evaluate.bootstrap_stability(docs, k=20, n_boot=50)         # per-topic stability under resampling
+topica.evaluate.align_topics(model_a, model_b)                     # one-to-one match across fits
+topica.evaluate.topic_stability([model_a, model_b], topn=10)       # cross-fit term overlap
+topica.evaluate.check_residuals(model, docs)                       # Taddy dispersion: is K too small?
 ```
 
 `search_k` returns a `SearchKResult` whose rows carry `coherence`, `exclusivity`,
@@ -295,7 +296,7 @@ guide works a full example on `poliblog`.
 
 ### Topic alignment
 
-To compare topics across different runs, seeds, or even architectures, `topica.align_topics(model_a, model_b)` performs Kuhn-Munkres (Hungarian) matching to align topics one-to-one. It returns a custom `AlignmentResult` object containing matched tuples of `(topic_a, topic_b, distance)`.
+To compare topics across different runs, seeds, or even architectures, `topica.evaluate.align_topics(model_a, model_b)` performs Kuhn-Munkres (Hungarian) matching to align topics one-to-one. It returns a custom `AlignmentResult` object containing matched tuples of `(topic_a, topic_b, distance)`.
 
 It supports several distance metrics:
 - `metric="cosine"` (default): Cosine distance.
@@ -307,7 +308,7 @@ If the models have different vocabularies, `align_topics` automatically intersec
 
 You can inspect relationship classifications (matches, splits, merges, and unaligned topics):
 ```python
-result = topica.align_topics(model_a, model_b, metric="cosine", threshold=0.3)
+result = topica.evaluate.align_topics(model_a, model_b, metric="cosine", threshold=0.3)
 
 result.matches     # Hungarian 1-to-1 pairs whose similarity clears `threshold`
 result.splits      # topic in A splitting to multiple in B (overlay on the matches)
@@ -331,18 +332,18 @@ Three post-hoc, no-refit diagnostics that read a fitted model's `topic_word` and
 
 ```python
 # Is K=20 really a few super-themes, and are any topics near-duplicates?
-dnd = topica.topic_dendrogram(model, metric="js")     # needs scipy
+dnd = topica.evaluate.topic_dendrogram(model, metric="js")     # needs scipy
 dnd.cut(6)                                             # group label per topic at 6 super-topics
 dnd.groups(6, n=10)                                    # {group: (member topics, merged top words)}
 dnd.merge_candidates()                                 # near-duplicate pairs (relative threshold)
 dnd.linkage                                            # SciPy linkage matrix for plotting
 
 # Are these topics real, or did I forget to clean my corpus?
-rows = topica.flag_topics(model, docs)                 # per-topic quality + a junk flag
+rows = topica.evaluate.flag_topics(model, docs)                 # per-topic quality + a junk flag
 junk = [r for r in rows if r["junk"]]                  # reasons: stopword-soup / dead-tiny / incoherent+flat
 
 # Which documents does the model fail to explain?
-res = topica.document_residuals(model, docs)           # per-doc novelty, most anomalous first
+res = topica.evaluate.document_residuals(model, docs)           # per-doc novelty, most anomalous first
 res[:10]                                               # off-topic, repetitive, or anomalous docs
 ```
 
@@ -381,14 +382,14 @@ it carries `topic_word`, `doc_topic`, and `vocabulary`, so it flows straight int
 on is marked rather than trusted.
 
 ```python
-runs = topica.select_model(docs, K=20, runs=10)   # ten initializations
+runs = topica.select.select_model(docs, K=20, runs=10)   # ten initializations
 cons = topica.ensemble(runs)                       # combine them
 
 cons.topic_word.shape       # (20, V)
 cons.stability              # per-topic agreement across runs, in [0, 1]
 cons.reliable               # per-topic: consistent AND well-supported?
 cons.agreement              # scalar: mean stability, "how reproducible is this K?"
-topica.coherence(cons, docs)
+topica.evaluate.coherence(cons, docs)
 ```
 
 `agreement` and `stability` are point estimates. Pass `n_boot>0` to bootstrap
@@ -566,7 +567,7 @@ log-likelihood is permutation-invariant, so it compares chains directly with no
 alignment. The **per-topic R-hat** is finer but needs care — topic 3 in one chain
 need not be topic 3 in another, so `multichain_diagnostics` first aligns the
 topics across chains (a Hungarian match on the topic-word matrix, the same
-machinery [`align_topics`](../api/diagnostics.md#topica.align_topics) uses) and then compares each
+machinery [`align_topics`](../api/diagnostics.md#topica.evaluate.align_topics) uses) and then compares each
 aligned topic's per-draw prevalence. Read `topic_rhat` next to `topic_alignment`:
 a topic with a low alignment Jaccard did not line up across chains, so its R-hat
 is comparing different topics and means nothing.
@@ -578,6 +579,6 @@ the same spirit as the single-chain primitives above.
 ## Visualization
 
 ```python
-viz = topica.prepare_pyldavis(model, docs)                # pyLDAvis PreparedData if installed
-qf, fig = topica.quality_frontier(model, plot=True)       # matplotlib scatter if installed
+viz = topica.inspect.prepare_pyldavis(model, docs)                # pyLDAvis PreparedData if installed
+qf, fig = topica.select.quality_frontier(model, plot=True)       # matplotlib scatter if installed
 ```

--- a/docs/guides/embedding.md
+++ b/docs/guides/embedding.md
@@ -13,14 +13,14 @@ document-vector matrix (and, for Top2Vec, a matching word-vector matrix) from
 wherever you like, a sentence-transformer, an API, or a local model such as
 ollama. Everything downstream is in the wheel.
 
-If you would rather not wire up an embedder yourself, `topica.llm_embed` produces
+If you would rather not wire up an embedder yourself, `topica.embeddings.llm_embed` produces
 the matrix through Simon Willison's [`llm`](https://llm.datasette.io/) library
 (the optional `topica[llm]` extra), which reaches OpenAI embeddings and local
 sentence-transformers via plugins:
 
 ```python
-doc_emb = topica.llm_embed(texts, model="text-embedding-3-small")          # API
-doc_emb = topica.llm_embed(texts, model="sentence-transformers/all-MiniLM-L6-v2")  # local
+doc_emb = topica.embeddings.llm_embed(texts, model="text-embedding-3-small")          # API
+doc_emb = topica.embeddings.llm_embed(texts, model="sentence-transformers/all-MiniLM-L6-v2")  # local
 ```
 
 Embeddings are costly, so cache them. Pass `cache=path` to embed a corpus once and
@@ -28,10 +28,10 @@ reuse it on later runs (it reloads when the file matches the same `texts`, and
 recomputes otherwise), or save and load any embedding matrix yourself:
 
 ```python
-doc_emb = topica.llm_embed(texts, model="text-embedding-3-small", cache="emb.npz")
+doc_emb = topica.embeddings.llm_embed(texts, model="text-embedding-3-small", cache="emb.npz")
 
-topica.save_embeddings("emb.npz", doc_emb, texts=texts, model="all-MiniLM-L6-v2")
-doc_emb = topica.load_embeddings("emb.npz")
+topica.embeddings.save_embeddings("emb.npz", doc_emb, texts=texts, model="all-MiniLM-L6-v2")
+doc_emb = topica.embeddings.load_embeddings("emb.npz")
 ```
 
 End to end, from raw text to a fitted model, with `llm_embed` doing the
@@ -50,9 +50,9 @@ texts = [
 ]
 
 # text -> (num_docs, E) vectors; the topica[llm] extra, sentence-transformers backend
-doc_emb = topica.llm_embed(texts, model="sentence-transformers/all-MiniLM-L6-v2")
+doc_emb = topica.embeddings.llm_embed(texts, model="sentence-transformers/all-MiniLM-L6-v2")
 
-docs = [topica.tokenize(t, stopwords=topica.ENGLISH_STOPWORDS) for t in texts]
+docs = [topica.tokenize(t, stopwords=topica.data.ENGLISH_STOPWORDS) for t in texts]
 model = topica.BERTopic(min_cluster_size=2, seed=1)
 model.fit(docs, doc_emb)
 print(topica.report(model))
@@ -340,7 +340,7 @@ ng = topica.datasets.load_ng20_minilm()   # documents + labels + MiniLM embeddin
 docs = [t.split() for t in ng["texts"]]
 
 # Word-seed mode: the vocabulary embeddings anchor the topics.
-model = topica.EmbeddingLDA(
+model = topica.embeddings.EmbeddingLDA(
     num_topics=5,
     embeddings=ng["word_embeddings"],      # (vocab, E), one row per word
     vocabulary=ng["vocab"],                # aligned to the embedding rows
@@ -368,7 +368,7 @@ pruning (on the fully-covered `load_ng20_minilm` demo it is the same 3521 words,
 just reordered, but a real corpus with externally-sourced embeddings will drop
 words). Index `topic_word` with `model.vocabulary`,
 never with the `vocabulary=` you passed, or use the helpers that already pair them:
-`model.top_words(n)` and `topica.label_topics(model.topic_word, model.vocabulary)`.
+`model.top_words(n)` and `topica.inspect.label_topics(model.topic_word, model.vocabulary)`.
 
 **Document-embedding prior.** Pass `doc_embeddings=` (one row per document, same
 space as the words) to `fit` to add the document-topic prior. `doc_anchor` sets its
@@ -384,8 +384,8 @@ The fitted-model *attributes and methods* (`topic_word`, `doc_topic`,
 `top_words()`, `coherence()`, `document_topic_prior()`) are delegated to the
 underlying SeededLDA. The [effects](../publishing/effects.md) and reporting stack
 are **module functions** that take the fitted model as their first argument, not
-methods on it. Call `topica.estimate_effect(model, ...)`, `topica.topic_table(model)`,
-`topica.report(model)`, `topica.label_topics(model.topic_word, model.vocabulary)`.
+methods on it. Call `topica.effects.estimate_effect(model, ...)`, `topica.inspect.topic_table(model)`,
+`topica.report(model)`, `topica.inspect.label_topics(model.topic_word, model.vocabulary)`.
 Two conventions to keep straight:
 
 - `coherence(n)` returns a **per-topic** vector (UMass here, so more-negative is
@@ -697,13 +697,13 @@ model = topica.BERTopic.load("topics.tt")   # reload, then transform() forever
 ## Richer topic words: n-grams
 
 The c-TF-IDF topic words are over the tokens you pass in, so bigrams are a
-preprocessing choice. `topica.add_ngrams` adds them (the mechanical analog of
+preprocessing choice. `topica.data.add_ngrams` adds them (the mechanical analog of
 scikit-learn's `CountVectorizer(ngram_range=..., min_df=...)`), keeping every
 document so the rows stay aligned with the embeddings:
 
 ```python
-docs = [topica.tokenize(t, stopwords=topica.ENGLISH_STOPWORDS) for t in texts]
-docs = topica.add_ngrams(docs, ngram_range=(1, 2), min_df=5)   # unigrams + bigrams
+docs = [topica.tokenize(t, stopwords=topica.data.ENGLISH_STOPWORDS) for t in texts]
+docs = topica.data.add_ngrams(docs, ngram_range=(1, 2), min_df=5)   # unigrams + bigrams
 model.fit(docs, doc_emb)        # topic words can now read "machine_learning"
 ```
 

--- a/docs/guides/guided.md
+++ b/docs/guides/guided.md
@@ -92,7 +92,7 @@ model.fit(docs, covariates=is_dem, feature_names=["is_dem"], iters=1000)
 
 # Report predicted topic proportions at each covariate value, with CIs — the
 # interpretable, on-the-proportion-scale answer (R keyATM's predicted props).
-pp = topica.predicted_prevalence(
+pp = topica.effects.predicted_prevalence(
     model, X=is_dem, feature_names=["is_dem"], at={"is_dem": [0, 1]}
 )
 print(pp)   # per topic (with topic_name): predicted share at is_dem=0 vs 1, 95% CI
@@ -177,7 +177,7 @@ topica.enable_experimental()   # EmbeddingLDA is experimental and gated
 vocab = sorted({w for d in docs for w in d})
 emb = SentenceTransformer("all-MiniLM-L6-v2").encode(vocab)
 
-model = topica.EmbeddingLDA(num_topics=10, embeddings=emb, vocabulary=vocab,
+model = topica.embeddings.EmbeddingLDA(num_topics=10, embeddings=emb, vocabulary=vocab,
                             top_m=20)   # weight defaults to a light 0.1
 model.fit(docs, iters=1000)
 for i, words in enumerate(model.top_words(8)):
@@ -192,7 +192,7 @@ necessarily co-occur, so anchoring them hard lowers topic coherence (see the
 hold topics closer to their semantic cluster.
 The whole fitted-model surface (`topic_word`, `doc_topic`, `top_words`,
 `coherence`, ...) is delegated to the underlying `SeededLDA`, and `model.seeds`
-holds the embedding-derived seed sets. `topica.embedding_seeds(...)` exposes just
+holds the embedding-derived seed sets. `topica.embeddings.embedding_seeds(...)` exposes just
 the clustering step if you want to inspect or edit the seeds before fitting.
 
 ## GuidedNMF

--- a/docs/guides/model-comparison.md
+++ b/docs/guides/model-comparison.md
@@ -355,8 +355,8 @@ remain, `compare` can still align them — as long as each fit was recorded with
 top words retained:
 
 ```python
-ra = topica.record_fit(fit_a, corpus_a, topic_words_n=25)   # opt-in: top words are content
-rb = topica.record_fit(fit_b, corpus_b, topic_words_n=25)
+ra = topica.provenance.record_fit(fit_a, corpus_a, topic_words_n=25)   # opt-in: top words are content
+rb = topica.provenance.record_fit(fit_b, corpus_b, topic_words_n=25)
 cmp = topica.compare(ra, rb)                                 # same CompareResult, no refit
 ```
 

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -407,7 +407,7 @@ each, so you can tell a real effect from noise.
 
 ```python
 import numpy as np
-X, names = topica.one_hot(party)
+X, names = topica.design.one_hot(party)
 model = topica.DMR(num_topics=20, seed=1)
 model.fit(docs, X, feature_names=names)
 z = model.feature_effects / model.feature_effect_se   # |z| > ~2 ⇒ notable
@@ -1059,7 +1059,7 @@ When every document has exactly **one** author/group, ATM is essentially equival
 
 ```python
 df = topica.datasets.load_dubois().drop_duplicates("text")
-corpus = topica.from_dataframe(df, text_col="text", stopwords=topica.ENGLISH_STOPWORDS)
+corpus = topica.from_dataframe(df, text_col="text", stopwords=topica.data.ENGLISH_STOPWORDS)
 decade = [[f"{int(y) // 10 * 10}s"] for y in df.year]      # grouping variable as "author"
 m = topica.AuthorTopic(12, seed=13).fit(corpus, decade, iters=500)
 dict(zip(m.authors, m.author_doc_counts))                 # docs behind each decade
@@ -1091,7 +1091,7 @@ m.top_words(10, topic=0)          # global topic 0 (topics 0..4 global, 5..14 lo
 ```python
 import re
 raw = topica.datasets.load_dubois()["text"]
-stop = topica.ENGLISH_STOPWORDS
+stop = topica.data.ENGLISH_STOPWORDS
 def to_sentences(text):
     sents = [re.findall(r"[a-z]+", s.lower()) for s in re.split(r"[.!?]", text)]
     sents = [[w for w in s if w not in stop and len(w) > 2] for s in sents]
@@ -1137,7 +1137,7 @@ Gaussian LDA ([Das, Zaheer & Dyer 2015](https://aclanthology.org/P15-1077/)) mov
 
 ```python
 vocab = [...]                                   # your vocabulary
-rho = topica.llm_embed(vocab, model=...)        # (len(vocab), E) word embeddings
+rho = topica.embeddings.llm_embed(vocab, model=...)        # (len(vocab), E) word embeddings
 rho = (rho - rho.mean(0)) / rho.std(0)          # standardize: avoids mode collapse on
                                                 # dense contextual embeddings (see below)
 m = topica.GaussianLDA(num_topics=10, seed=13).fit(docs, rho, vocab)
@@ -1166,7 +1166,7 @@ We validate in `parity/gaussian_lda_gold.py` against the authors' Apache-2.0 Jav
 
 Semantic Signal Separation ([S³; Kardos, Kostkan, Enevoldsen, Vermillet, Nielbo & Rocca, ACL 2025](https://aclanthology.org/2025.acl-long.32/)) treats topics as *independent axes* of semantic space rather than distributions over a bag of words. It runs FastICA on the document embeddings; each recovered independent component is a topic axis. A word's importance to a topic comes from projecting the vocabulary embeddings onto that axis, so the topics are described in words without any bag-of-words modelling. The reference is the flagship model of [turftopic](https://github.com/x-tabdeveloping/turftopic), and the authors report it is the fastest contextual topic model.
 
-Like topica's other embedding-native models, you bring the embeddings: a `doc_embeddings` matrix (one row per document) and a `vocab_embeddings` matrix (one row per vocabulary term) in the same space. `topica.llm_embed(texts, model=...)` can build them.
+Like topica's other embedding-native models, you bring the embeddings: a `doc_embeddings` matrix (one row per document) and a `vocab_embeddings` matrix (one row per vocabulary term) in the same space. `topica.embeddings.llm_embed(texts, model=...)` can build them.
 
 ```python
 m = topica.SemanticSignalSeparation(num_topics=10, seed=1)
@@ -1201,7 +1201,7 @@ The anchor-words algorithm ([Arora et al. 2013](https://proceedings.mlr.press/v2
 `AnchorLDA` is validated against the [`anchor-topic`](https://pypi.org/project/anchor-topic/) RecoverL2 reference: the co-occurrence matrix agrees to numerical precision, and given the same anchors topica's `recover="l2"` recovery matches the reference to cosine ~1.0 on both a planted corpus and real survey text (`parity/anchor_compare.py`). The two libraries use different (both valid) greedy anchor selectors, so end-to-end agreement is corpus-dependent; the untempered configuration matches the full reference pipeline on a planted separable fixture. The default `frequency_temper=0.5` tempers frequent-word dominance for more distinctive topics — a deliberate, corpus-dependent departure from the reference-exact inversion, not reference parity.
 
 ```python
-m = topica.AnchorLDA(num_topics=20, min_count=5, seed=0)
+m = topica.embeddings.AnchorLDA(num_topics=20, min_count=5, seed=0)
 m.fit(docs)
 m.anchors                # the anchor word identifying each topic
 m.top_words(10)          # the recovered topic-word distributions

--- a/docs/guides/preprocessing.md
+++ b/docs/guides/preprocessing.md
@@ -19,8 +19,8 @@ you need it.
 
 ### Stopword lists (58 languages)
 
-`topica.ENGLISH_STOPWORDS` is a short, stable English default. For other
-languages — or a fuller English list — `topica.stopwords(lang)` serves the
+`topica.data.ENGLISH_STOPWORDS` is a short, stable English default. For other
+languages — or a fuller English list — `topica.data.stopwords(lang)` serves the
 [stopwords-iso](https://github.com/stopwords-iso/stopwords-iso) lists (58
 languages, MIT licensed, bundled in the wheel). Accepts an ISO 639-1 code or an
 English name:
@@ -28,17 +28,17 @@ English name:
 ```python
 import topica
 
-fr = topica.stopwords("fr")            # or "french"; case-insensitive
+fr = topica.data.stopwords("fr")            # or "french"; case-insensitive
 corpus = topica.from_dataframe(df, text_col="texte", stopwords=fr)
 
-topica.stopword_languages()            # ['af', 'ar', 'bg', ..., 'zh']
+topica.data.stopword_languages()            # ['af', 'ar', 'bg', ..., 'zh']
 ```
 
 Unknown languages raise with the list of available codes. For the cross-lingual
 models ([`InfoCTM`](models.md#infoctm), [`ZeroShotTM`](embedding.md#zeroshottm)),
 pass the matching list per language. Anything not covered: supply your own list.
 
-For a sentiment or rating study, use `topica.SENTIMENT_STOPWORDS` instead of the
+For a sentiment or rating study, use `topica.data.SENTIMENT_STOPWORDS` instead of the
 default: `ENGLISH_STOPWORDS` strips `not`/`no`/`very`/`too`, which would collapse
 "not clean" into "clean" in exactly the analysis whose outcome is valence.
 
@@ -114,7 +114,7 @@ from nltk.stem import WordNetLemmatizer   # pip install nltk; nltk.download("wor
 _lemm = WordNetLemmatizer()
 def lemmatize(text):
     return [_lemm.lemmatize(w)
-            for w in topica.tokenize(text, stopwords=topica.ENGLISH_STOPWORDS, min_length=3)]
+            for w in topica.tokenize(text, stopwords=topica.data.ENGLISH_STOPWORDS, min_length=3)]
 
 corpus = topica.from_dataframe(df, text_col="text", tokenizer=lemmatize)
 # top words now read "military", "economy" — not "militari", "economi"
@@ -173,7 +173,7 @@ boilerplate-or-names topic, add the offending terms to a custom stopword list an
 rebuild:
 
 ```python
-stop = topica.stopwords("en") | {"print", "tweet", "share", "email"}
+stop = topica.data.stopwords("en") | {"print", "tweet", "share", "email"}
 stop |= {"durbin", "tester", "schumer"}   # actor names, if they are not the object of study
 corpus = topica.from_dataframe(df, text_col="text", stopwords=stop)
 ```
@@ -221,8 +221,8 @@ tokens before modeling:
 
 ```python
 import topica
-phrases = topica.learn_phrases(docs, min_count=8, threshold=12.0)
-docs = topica.apply_phrases(docs, phrases)            # "health care" -> "health_care"
+phrases = topica.data.learn_phrases(docs, min_count=8, threshold=12.0)
+docs = topica.data.apply_phrases(docs, phrases)            # "health care" -> "health_care"
 ```
 
 ## Split long documents
@@ -231,7 +231,7 @@ Long, heterogeneous documents violate the bag-of-words assumption. Segment them
 into comparable chunks, copying each source's metadata onto every chunk:
 
 ```python
-chunks, chunk_meta = topica.split_documents(
+chunks, chunk_meta = topica.data.split_documents(
     texts, metadata, max_words=200, min_words=50,
 )
 # chunk_meta[j] = the source row + {"parent": i, "chunk": j}

--- a/docs/guides/transform.md
+++ b/docs/guides/transform.md
@@ -74,7 +74,7 @@ New documents may contain tokens not seen at fit time. Use `align_corpus` to
 drop out-of-vocabulary tokens before passing the documents to `transform`:
 
 ```python
-aligned = topica.align_corpus(new_docs, stm_model)
+aligned = topica.design.align_corpus(new_docs, stm_model)
 theta = topica.stm.transform(stm_model, aligned, prevalence=X_new)
 ```
 

--- a/docs/guides/uncertainty.md
+++ b/docs/guides/uncertainty.md
@@ -2,14 +2,14 @@
 
 Topic estimates are estimates. The proportions `θ`, the top words, the covariate
 effects you put in a table all carry sampling error, and a credible result
-reports it. `topica.standard_errors` is one entry point for the quantities people
+reports it. `topica.effects.standard_errors` is one entry point for the quantities people
 publish, and it propagates the topic-estimation uncertainty rather than treating
 the fit as if it were observed exactly.
 
 ```python
 import topica
 
-se = topica.standard_errors(model, corpus, of="effect", formula="~ year", data=meta)
+se = topica.effects.standard_errors(model, corpus, of="effect", formula="~ year", data=meta)
 ```
 
 There are two distinct uncertainties, and they call for two methods.
@@ -42,13 +42,13 @@ be wider than the real posterior for short documents and narrower for long ones.
 
 ```python
 # Covariate effects, uncertainty propagated (one regression per topic):
-eff = topica.standard_errors(model, corpus, of="effect",
+eff = topica.effects.standard_errors(model, corpus, of="effect",
                              formula="~ party", data=meta, nsims=50)
 for e in eff:
     print(e.topic, e.as_dict())
 
 # Each topic's mean prevalence, with an interval:
-prev = topica.standard_errors(model, corpus, of="prevalence", nsims=50)
+prev = topica.effects.standard_errors(model, corpus, of="prevalence", nsims=50)
 ```
 
 The effect result is the same `TopicEffect` list as `estimate_effect` (so
@@ -70,7 +70,7 @@ models and the only way to get top-word or topic-quality intervals.
 
 ```python
 # How stable is each topic's top-word list?
-tw = topica.standard_errors(model, corpus, of="top_words", method="bootstrap",
+tw = topica.effects.standard_errors(model, corpus, of="top_words", method="bootstrap",
                             n_boot=200, topn=10)
 for t in tw:
     for word, prob, lo, hi in t.words:
@@ -98,7 +98,7 @@ standard error (sets it to `NaN`, `reliable=False`) when matching is unstable**:
   interchangeable and the match is arbitrary, which the Jaccard alone would miss.
 
 ```python
-for t in topica.standard_errors(model, corpus, of="prevalence", method="bootstrap"):
+for t in topica.effects.standard_errors(model, corpus, of="prevalence", method="bootstrap"):
     if not t.reliable:
         print(f"topic {t.topic}: unstable alignment "
               f"(quality={t.alignment_quality:.2f}, margin={t.alignment_margin:.2f}) "
@@ -117,7 +117,7 @@ def refit(doc_indices):
     m.fit([docs[i] for i in doc_indices], doc_emb[doc_indices])
     return m
 
-tw = topica.standard_errors(bertopic, corpus, of="top_words",
+tw = topica.effects.standard_errors(bertopic, corpus, of="top_words",
                             method="bootstrap", refit=refit, n_boot=200)
 ```
 

--- a/docs/guides/visualization.md
+++ b/docs/guides/visualization.md
@@ -66,7 +66,7 @@ ep.to_frame()              # coef / se / ci / reliable per topic
 Reuse `search_k` / `quality_frontier`, with the data export and a clean figure:
 
 ```python
-rows = topica.search_k(docs, ks=[10, 20, 30, 40], held_out=test_docs)
+rows = topica.select.search_k(docs, ks=[10, 20, 30, 40], held_out=test_docs)
 viz.search_k(rows).to_png("choose_k.png")          # coherence / exclusivity / perplexity vs K
 viz.coherence_frontier(model, texts).to_png("frontier.png")   # per-topic, defend dropping topics
 ```

--- a/docs/publishing/choosing-k.md
+++ b/docs/publishing/choosing-k.md
@@ -48,9 +48,9 @@ import topica
 
 # 1) Scan a theoretically plausible range. num_seeds>1 refits each K several
 #    times so every metric carries a standard error; n_jobs parallelizes the fits.
-held = topica.make_heldout(topica.Corpus.from_documents(train_docs),
+held = topica.evaluate.make_heldout(topica.Corpus.from_documents(train_docs),
                            prop_docs=0.3, prop_words=0.5, seed=0)
-results = topica.search_k(
+results = topica.select.search_k(
     held.documents, ks=[10, 15, 20, 25, 30],
     held_out=held, num_seeds=4, n_jobs=-1, iters=800,
 )
@@ -78,16 +78,16 @@ coherence×exclusivity spread, and check held-out perplexity directly:
 model = topica.STM(num_topics=20, seed=1)
 model.fit(docs, prevalence=X)
 
-table = topica.diagnostics(model, texts)          # one row per topic: coherence,
+table = topica.evaluate.diagnostics(model, texts)          # one row per topic: coherence,
                                                    # exclusivity, FREX, size, ...
-pp = topica.perplexity(model, held_out)            # held-out, lower is better
+pp = topica.evaluate.perplexity(model, held_out)            # held-out, lower is better
 
-frontier = topica.quality_frontier(model, n=10)   # per-topic coherence & exclusivity
+frontier = topica.select.quality_frontier(model, n=10)   # per-topic coherence & exclusivity
 # scatter frontier["coherence"] vs frontier["exclusivity"];
 # weak topics cluster in the lower-left.
 ```
 
-`topica.perplexity(model, held_out)` works across the generative models (LDA,
+`topica.evaluate.perplexity(model, held_out)` works across the generative models (LDA,
 DMR, CTM, STM, HDP, …) by inferring each held-out document's topic mixture from
 half its tokens and scoring the other half, so it is comparable across `K`.
 
@@ -101,11 +101,11 @@ then score the withheld words:
 ```python
 import topica
 
-h = topica.make_heldout(corpus, prop_docs=0.5, prop_words=0.5, seed=0)
+h = topica.evaluate.make_heldout(corpus, prop_docs=0.5, prop_words=0.5, seed=0)
 model = topica.STM(num_topics=20, seed=1)
 model.fit(h.documents, prevalence=X)
 
-result = topica.eval_heldout(model, h)
+result = topica.evaluate.eval_heldout(model, h)
 print(f"mean per-doc held-out log-likelihood: {result.mean_per_doc_loglik:.3f}")
 ```
 
@@ -119,7 +119,7 @@ values. `select_model` runs `runs` initializations at a fixed K and returns all
 fitted models with their coherence and exclusivity scores:
 
 ```python
-result = topica.select_model(
+result = topica.select.select_model(
     docs, K=20,
     runs=20,           # number of random initializations
     model="stm",       # "lda" or "stm"
@@ -127,7 +127,7 @@ result = topica.select_model(
     fraction=0.5,      # keep only the top 50% after a short burn-in
 )
 # inspect the coherence-exclusivity frontier across all runs:
-topica.plot_models(result)
+topica.select.plot_models(result)
 
 # pick the run in the upper-right corner and use that model:
 best_idx = result.coherence.argmax()   # or use exclusivity, or visual inspection
@@ -159,10 +159,10 @@ metric carries a standard error, add a held-out set, and report the extra
 import topica
 
 docs = load_poliblog()                                  # list[list[str]], ~2000 docs
-held = topica.make_heldout(topica.Corpus.from_documents(docs),
+held = topica.evaluate.make_heldout(topica.Corpus.from_documents(docs),
                            prop_docs=0.3, prop_words=0.5, seed=0)
 
-res = topica.search_k(
+res = topica.select.search_k(
     held.documents, ks=[10, 20, 30, 40, 60, 80, 100, 120],
     held_out=held,
     num_seeds=4,                        # each K refit 4 times -> mean +/- SE
@@ -271,8 +271,8 @@ docs = [t.split() for t in b.texts]
 for k in [4, 5, 6, 8, 10]:
     m = topica.BERTopic(clusterer="kmeans", num_clusters=k,
                         reduce_frequent=True, seed=1).fit(docs, b.doc_embeddings)
-    cv  = float(np.mean(topica.coherence(m, docs, coherence_type="c_v")))
-    div = topica.topic_diversity(m, topn=25)
+    cv  = float(np.mean(topica.evaluate.coherence(m, docs, coherence_type="c_v")))
+    div = topica.evaluate.topic_diversity(m, topn=25)
     print(f"K={k:>2}  c_v={cv:.3f}  diversity={div:.2f}  topics={m.num_topics}")
 ```
 
@@ -301,10 +301,10 @@ b = topica.datasets.load_ng20_minilm()
 docs = [t.split() for t in b.texts]
 
 for k in [4, 5, 6, 8, 10]:
-    m = topica.EmbeddingLDA(num_topics=k, embeddings=b.word_embeddings,
+    m = topica.embeddings.EmbeddingLDA(num_topics=k, embeddings=b.word_embeddings,
                             vocabulary=b.vocab, seed=1).fit(docs, iters=1000)
     coh = float(m.coherence(10).mean())     # per-topic UMass vector -> mean
-    div = topica.topic_diversity(m, topn=25)
+    div = topica.evaluate.topic_diversity(m, topn=25)
     print(f"K={k:>2}  coherence={coh:.1f}  diversity={div:.2f}")
 ```
 
@@ -331,7 +331,7 @@ import topica
 df = topica.datasets.load_poliblog()      # a DataFrame; the text is already stemmed
 corpus = topica.Corpus.from_documents([t.split() for t in df["text"]])
 
-rows = topica.search_k(corpus, [10, 15, 20, 30, 40], model="nmf")
+rows = topica.select.search_k(corpus, [10, 15, 20, 30, 40], model="nmf")
 for r in rows:
     print(f"K={r['k']:>2}  coherence={r['coherence']:.1f}  "
           f"exclusivity={r['exclusivity']:.2f}  "
@@ -344,7 +344,7 @@ model` that closes over the corpus and any covariates or embeddings it needs, so
 `search_k` never has to know the model's fit signature:
 
 ```python
-rows = topica.search_k(corpus, [10, 20, 30],
+rows = topica.select.search_k(corpus, [10, 20, 30],
                        fit=lambda k, s: topica.DMR(k, seed=s).fit(corpus, X))
 ```
 

--- a/docs/publishing/corpus.md
+++ b/docs/publishing/corpus.md
@@ -24,7 +24,7 @@ keeping each chunk tied to its source document's metadata.
 import topica
 
 # `texts` are long documents; `meta` is one dict of covariates per document.
-chunks, chunk_meta = topica.split_documents(
+chunks, chunk_meta = topica.data.split_documents(
     texts, meta,
     max_words=200,     # target chunk length
     min_words=50,      # merge a short tail back rather than drop it
@@ -76,8 +76,8 @@ meaning together than apart. Detect them first so a topic can be about the
 phrase, not its scattered parts.
 
 ```python
-phrase_model = topica.learn_phrases(docs, min_count=8, threshold=12.0)
-docs = topica.apply_phrases(docs, phrase_model)
+phrase_model = topica.data.learn_phrases(docs, min_count=8, threshold=12.0)
+docs = topica.data.apply_phrases(docs, phrase_model)
 ```
 
 ## Inspect what survived
@@ -91,7 +91,7 @@ Those three numbers belong in your methods section.
 
 ## Choosing vocabulary thresholds with prep_documents
 
-`topica.prep_documents` prunes a `Corpus` by document frequency — dropping
+`topica.data.prep_documents` prunes a `Corpus` by document frequency — dropping
 terms that appear in fewer than `lower_thresh` documents — and keeps the
 metadata frame aligned with the surviving documents. This is the analogue of
 R `stm`'s `prepDocuments`:
@@ -99,7 +99,7 @@ R `stm`'s `prepDocuments`:
 ```python
 import topica
 
-corpus_pruned, meta_pruned = topica.prep_documents(
+corpus_pruned, meta_pruned = topica.data.prep_documents(
     corpus, meta=meta_df,
     lower_thresh=5,   # drop terms appearing in fewer than 5 docs
     rm_top=20,        # also drop the 20 most frequent residual terms
@@ -110,7 +110,7 @@ Before committing to a threshold, sweep a range and visualize how many
 documents and vocabulary terms each level removes:
 
 ```python
-topica.plot_removed(corpus, thresholds=range(1, 15))
+topica.data.plot_removed(corpus, thresholds=range(1, 15))
 ```
 
 The chart shows two lines: documents removed (left axis) and vocabulary terms

--- a/docs/publishing/effects.md
+++ b/docs/publishing/effects.md
@@ -13,7 +13,7 @@ metadata. Fit prevalence as a regression on your covariates:
 ```python
 import topica
 
-X, names = topica.one_hot(party)                     # or build any design matrix
+X, names = topica.design.one_hot(party)                     # or build any design matrix
 model = topica.STM(num_topics=20, seed=1)
 model.fit(docs, prevalence=X, prevalence_names=names)
 ```
@@ -48,22 +48,22 @@ For non-linear time trends and interactions, build the design matrix with
 `stm.spline` and `stm.interaction`, the same `~ s(year)` and `~ a*b` you'd write
 in R.
 
-`topica.standard_errors` wraps this in one call: it detects the model family,
+`topica.effects.standard_errors` wraps this in one call: it detects the model family,
 draws the right posterior for you, and returns the same effects. It also reaches
 quantities the manual path doesn't, group prevalence and bootstrap intervals on
 the top words, with an alignment-quality flag for the embedding models. See
 [Reporting uncertainty](../guides/uncertainty.md).
 
 ```python
-eff = topica.standard_errors(model, corpus, of="effect",
+eff = topica.effects.standard_errors(model, corpus, of="effect",
                              formula="~ party", data=meta, nsims=50)
 ```
 
 ## It is not just for STM
 
-`topica.estimate_effect` regresses *any* model's θ on covariates, and
-`topica.by_strata` (mean prevalence by group, with intervals) and
-`topica.top_topics` work on any model's θ too.
+`topica.effects.estimate_effect` regresses *any* model's θ on covariates, and
+`topica.effects.by_strata` (mean prevalence by group, with intervals) and
+`topica.effects.top_topics` work on any model's θ too.
 
 STM and CTM have a logistic-normal posterior, so `posterior_theta_samples` draws
 from it directly. A Gibbs model (LDA, keyATM, SeededLDA, ...) has no such
@@ -78,8 +78,8 @@ model = topica.LDA(num_topics=20, seed=1)
 model.fit(docs, iters=1000)
 
 lengths = np.array([len(d) for d in docs])
-draws = topica.dirichlet_theta_samples(model.doc_topic, lengths, nsims=50, seed=0)
-effects = topica.estimate_effect(draws, X, feature_names=names)
+draws = topica.effects.dirichlet_theta_samples(model.doc_topic, lengths, nsims=50, seed=0)
+effects = topica.effects.estimate_effect(draws, X, feature_names=names)
 ```
 
 Pass the point θ (`model.doc_topic`) instead of draws and you get a plain OLS fit

--- a/docs/publishing/reporting.md
+++ b/docs/publishing/reporting.md
@@ -39,7 +39,7 @@ A complete methods section covers the corpus, the preprocessing, the model and
 import pandas as pd
 import topica
 
-labels = topica.label_topics(model.topic_word, model.vocabulary, n=7)
+labels = topica.inspect.label_topics(model.topic_word, model.vocabulary, n=7)
 prevalence = model.doc_topic.mean(axis=0)
 table = pd.DataFrame({
     "topic": range(model.num_topics),
@@ -97,7 +97,7 @@ model.save("model.tt")                                    # full state, reloadab
 - **Share the model.** `model.save(path)` writes the complete fitted state;
   `Model.load(path)` brings it back, so reviewers can reproduce every number
   without refitting.
-- **Record the analysis, not just the model.** `topica.record_fit(model, corpus,
+- **Record the analysis, not just the model.** `topica.provenance.record_fit(model, corpus,
   ...)` writes an [analysis manifest](../api/manifest.md): a small, privacy-aware
   JSON record of the fit's inputs, settings, environment, and your interpretive
   decisions, plus fingerprints that let `record.verify(corpus, model)` report

--- a/docs/publishing/validation.md
+++ b/docs/publishing/validation.md
@@ -15,7 +15,7 @@ you, with an answer key.
 ```python
 import topica
 
-tests = topica.word_intrusion(model, n_words=5, seed=0)
+tests = topica.evaluate.word_intrusion(model, n_words=5, seed=0)
 for t in tests:
     print(f"Topic {t['topic']}: {t['words']}")
     # answer key for coding:
@@ -30,7 +30,7 @@ topic is nearly absent. This tests whether the topic captures real document
 similarity.
 
 ```python
-tests = topica.document_intrusion(model, texts=texts, n_docs=3, seed=0)
+tests = topica.evaluate.document_intrusion(model, texts=texts, n_docs=3, seed=0)
 ```
 
 Report intrusion accuracy (and, ideally, inter-coder agreement) in your
@@ -43,10 +43,10 @@ topic is coherent **and** exclusive.
 
 ```python
 coherence   = model.coherence(10)               # UMass, per topic
-cv          = topica.coherence(model, texts, coherence_type="c_v", topn=10)
-exclusivity = topica.exclusivity(model, 10)          # per topic
+cv          = topica.evaluate.coherence(model, texts, coherence_type="c_v", topn=10)
+exclusivity = topica.evaluate.exclusivity(model, 10)          # per topic
 
-frontier = topica.quality_frontier(model, n=10)      # tidy: coherence, exclusivity, prevalence
+frontier = topica.select.quality_frontier(model, n=10)      # tidy: coherence, exclusivity, prevalence
 ```
 
 `c_v` correlates best with human judgement; UMass is a fast intrinsic check;
@@ -80,7 +80,7 @@ A topic that dissolves when you perturb the corpus is not a finding. Refit on
 bootstrap resamples and report which topics are robust:
 
 ```python
-boot = topica.bootstrap_stability(docs, k=20, n_boot=50, iters=800)
+boot = topica.evaluate.bootstrap_stability(docs, k=20, n_boot=50, iters=800)
 for t, s in zip(boot["topic"], boot["stability"]):
     print(f"Topic {t}: stability {s:.2f}")     # mean top-word Jaccard across resamples
 print("overall:", boot["mean"])
@@ -92,9 +92,9 @@ same per-document design you fit with, and it is resampled in lock-step with the
 documents so the covariate rows stay aligned:
 
 ```python
-X, names = topica.one_hot(df["party"])
+X, names = topica.design.one_hot(df["party"])
 stm = topica.STM(num_topics=20, seed=13).fit(docs, prevalence=X, prevalence_names=names)
-boot = topica.bootstrap_stability(
+boot = topica.evaluate.bootstrap_stability(
     docs, reference=stm,
     model_factory=lambda s: topica.STM(num_topics=20, seed=s),
     prevalence=X, prevalence_names=names,      # design resampled with the docs
@@ -111,8 +111,8 @@ between fits and scoring their overlap:
 ```python
 a = topica.LDA(num_topics=20, seed=1); a.fit(docs, iters=800)
 b = topica.LDA(num_topics=20, seed=2); b.fit(docs, iters=800)
-pairs = topica.align_topics(a, b)                    # one-to-one matching (Hungarian)
-print("stability across seeds:", topica.topic_stability([a, b], topn=10))
+pairs = topica.evaluate.align_topics(a, b)                    # one-to-one matching (Hungarian)
+print("stability across seeds:", topica.evaluate.topic_stability([a, b], topn=10))
 ```
 
 Flag fragile topics explicitly. A paper that says "topics 4 and 11 were unstable
@@ -125,8 +125,8 @@ required. Pull a topic's most representative documents and read them, with the
 topic's words highlighted in your notebook:
 
 ```python
-labels = topica.label_topics(model.topic_word, model.vocabulary, n=8)  # prob & FREX
-html = topica.find_thoughts_html(model, texts, n_docs=3, n_words=8)    # highlighted quotes
+labels = topica.inspect.label_topics(model.topic_word, model.vocabulary, n=8)  # prob & FREX
+html = topica.inspect.find_thoughts_html(model, texts, n_docs=3, n_words=8)    # highlighted quotes
 ```
 
 Use **FREX** (frequent *and* exclusive) words, not just the most probable ones,


### PR DESCRIPTION
**Stage 2 of the namespace-default switch** (stage 1 = #769). Converts the analysis-helper call sites throughout the docs and README to the namespaced idiom stage 1 made the default.

Scope: guides, examples, quickstart, publishing pages, the `docs/api/` reference, and the README — **35 files, 271 call sites** (208 prose/usage + 63 API-reference autodoc directives).

How:
- Codemod driven by the compat map, so only genuine helpers move (`topica.search_k` → `topica.select.search_k`, `topica.topic_table` → `topica.inspect.topic_table`, `topica.coherence` → `topica.evaluate.coherence`, `topica.estimate_effect` → `topica.effects.estimate_effect`, `topica.one_hot` → `topica.design.one_hot`, …). **Model constructors and Corpus ingress stay at the top level** (nouns at root).
- The held-out trio (`make_heldout`/`eval_heldout`/`perplexity`, in both `select` and `evaluate`) is taught under `topica.evaluate`, matching the stage-1 module docstring.
- Rewrote the prose that described the old flat structure (covariates "importing the helpers" tip, diagnostics intros, README covariate bullet) to name the namespaces and note the flat names remain as compatibility aliases.
- Root-only helpers with no namespace home (e.g. `topica.summary`) stay at the top level. `conventions.md`'s deeper "flat-function rule" prose is deferred to stage 4.

Verification: `mkdocs --strict` clean (griffe resolves the namespaced re-exports; autodoc directives render with namespaced anchors; no broken cross-refs). Spot-ran a converted end-to-end example — all namespaced calls execute.

Remaining: docstrings sweep (stage 3), CLAUDE.md + conventions.md (stage 4), paper refresh (stage 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)