### PR TITLE
docs: teach the workflow namespaces in docstrings and error messages (stage 3)

### DIFF
--- a/python/topica/_results.py
+++ b/python/topica/_results.py
@@ -1,12 +1,12 @@
 """Small result containers shared across the diagnostic helper families.
 
-Several diagnostics (:func:`~topica.quality_frontier`,
-:func:`~topica.bootstrap_stability`, :func:`~topica.visualize_keywords`,
+Several diagnostics (:func:`~topica.select.quality_frontier`,
+:func:`~topica.evaluate.bootstrap_stability`, :func:`~topica.visualize_keywords`,
 :func:`~topica.time_prevalence_ci`) historically returned a plain ``dict``. They
 still *are* dicts — every ``result[key]`` access, ``.get``, ``**`` unpacking, and
 JSON round-trip is unchanged, and ``FrameDict({...}) == {...}`` — but they now
 carry the same ``.to_frame()`` a pandas user already reaches for on the other
-result types (:class:`~topica.SearchKResult`, the effect/robustness results).
+result types (:class:`~topica.select.SearchKResult`, the effect/robustness results).
 That converges the "return-type zoo" (#742) onto one idiom without breaking the
 dict contract.
 
@@ -32,14 +32,14 @@ class FrameDict(dict):
 
 
 class QualityFrontier(FrameDict):
-    """:func:`~topica.quality_frontier` result: one row per topic with
+    """:func:`~topica.select.quality_frontier` result: one row per topic with
     ``topic``, ``coherence``, ``exclusivity``, ``prevalence``. The base
     :meth:`~FrameDict.to_frame` (every column an equal-length array) is exactly
     right here."""
 
 
 class BootstrapStability(FrameDict):
-    """:func:`~topica.bootstrap_stability` result. ``topic`` and ``stability``
+    """:func:`~topica.evaluate.bootstrap_stability` result. ``topic`` and ``stability``
     are per-topic arrays; ``mean`` (overall) and ``reference`` (the fitted model)
     are scalars, so :meth:`to_frame` frames only the per-topic columns."""
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -73,7 +73,7 @@ def inspect_frex_scores(
 
     `word_counts` (length V) enables stm's James-Stein exclusivity shrinkage when
     non-empty; pass [] to skip it. Backs the cross-language FREX parity check
-    against the pure-Python topica.frex.
+    against the pure-Python topica.inspect.frex.
     """
     ...
 
@@ -126,7 +126,7 @@ def window_cooccurrence(
 
     docs holds relevant-word ids per token, 4294967295 marks a non-relevant
     token; pairs are (a, b) with a < b; window=0 requests document-level
-    co-occurrence. Returns (occ, co, n_windows). Used by topica.coherence.
+    co-occurrence. Returns (occ, co, n_windows). Used by topica.evaluate.coherence.
     """
     ...
 
@@ -6353,7 +6353,7 @@ class KeyATM:
         the intercept. These are the log-alpha regression coefficients
         (alpha_dk = exp(x_d . lambda_k)), NOT differences in topic proportions:
         the sign gives direction, but for the effect on the topic-share scale use
-        topica.predicted_prevalence. lambda is MAP-estimated (not keyATM's
+        topica.effects.predicted_prevalence. lambda is MAP-estimated (not keyATM's
         per-sweep MCMC). Raises if fit without covariates."""
         ...
     @property

--- a/python/topica/agreement.py
+++ b/python/topica/agreement.py
@@ -6,7 +6,7 @@ recover those labels?* It reports the standard partition-comparison metrics (ARI
 NMI, homogeneity, completeness, V-measure, and cluster purity), computed from the
 two label vectors alone.
 
-This complements :func:`topica.coherence`. Coherence rates the *interpretability*
+This complements :func:`topica.evaluate.coherence`. Coherence rates the *interpretability*
 of a topic's top words; it does not tell you whether documents were assigned to the
 right topic, and for embedding-based cluster models it can be actively misleading
 (a model can keep tight, coherent top-words while the document partition drifts).
@@ -153,7 +153,7 @@ def agreement(pred, gold, *, noise="keep"):
     -----
     All metrics are invariant to how the labels are named. Values match
     ``scikit-learn`` (``normalized_mutual_info_score`` with arithmetic averaging).
-    Pair with :func:`topica.coherence`: coherence for whether the top words read as a
+    Pair with :func:`topica.evaluate.coherence`: coherence for whether the top words read as a
     theme, ``agreement`` for whether the document partition is right.
     """
     if noise not in ("keep", "drop"):

--- a/python/topica/analysis.py
+++ b/python/topica/analysis.py
@@ -140,7 +140,7 @@ def topic_labels(model) -> list:
 def representative_docs(model, texts, *, topic=None, n=5):
     """The documents that load most heavily on a topic, with their text.
 
-    Wraps :func:`topica.find_thoughts`, returning ``texts`` for the ``n``
+    Wraps :func:`topica.inspect.find_thoughts`, returning ``texts`` for the ``n``
     highest-``doc_topic`` documents. With ``topic`` given, returns that topic's
     list; with ``topic=None`` returns ``{topic_id: [texts]}`` for every topic.
     Each list is ordered by descending topic proportion.
@@ -252,7 +252,7 @@ def topics_over_time(model, timestamps, *, normalize=True) -> dict:
 def topics_per_class(model, groups, *, ci=0.95):
     """Mean topic prevalence within each level of a grouping variable.
 
-    A thin wrapper over :func:`topica.by_strata` on ``model.doc_topic``:
+    A thin wrapper over :func:`topica.effects.by_strata` on ``model.doc_topic``:
     ``groups`` is one label per document, and the result is a list of
     per-stratum prevalence records (mean and confidence interval per topic).
     """

--- a/python/topica/anchor.py
+++ b/python/topica/anchor.py
@@ -333,7 +333,7 @@ class AnchorLDA:
         """Whether anchor selection hit its seeded degenerate-basis fallback during
         fit (issue #410). ``None`` before fit. When ``True`` the recovered topics are
         seed-dependent (a random anchor was drawn); when ``False`` selection was
-        deterministic. Read by :func:`topica.effective_determinism`."""
+        deterministic. Read by :func:`topica.provenance.effective_determinism`."""
         return self._anchor_fallback_used
 
     # -- fitting ------------------------------------------------------------

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -687,10 +687,10 @@ def embedding_coherence(topics, word_embeddings, vocabulary=None, *,
     a list of word lists. `word_embeddings` is either a ``dict {word: vector}``
     (matched by word, robust to any `topics` form) or a ``(V, E)`` matrix
     aligned to `vocabulary`; vectors need not be unit length. No embedder of
-    your own? :func:`~topica.llm_embed` builds one::
+    your own? :func:`~topica.embeddings.llm_embed` builds one::
 
-        emb = topica.llm_embed(model.vocabulary)          # (V, E) matrix
-        topica.embedding_coherence(model, emb, model.vocabulary)
+        emb = topica.embeddings.llm_embed(model.vocabulary)          # (V, E) matrix
+        topica.evaluate.embedding_coherence(model, emb, model.vocabulary)
 
     Words with no embedding — including any whose vector is NaN/inf or all-zero —
     are dropped from a topic; a topic left with fewer than two embedded words

--- a/python/topica/compare.py
+++ b/python/topica/compare.py
@@ -18,7 +18,7 @@ Three uses, one tool:
 Design commitments:
 
 - **Alignment is reused, not reinvented.** Matching runs through
-  :func:`topica.align_topics`, which pairs two topics by the Hungarian 1-to-1
+  :func:`topica.evaluate.align_topics`, which pairs two topics by the Hungarian 1-to-1
   assignment and keeps a pair when its similarity clears ``threshold``, then reports
   splits, merges, and unaligned topics. Splits/merges are a background-relative overlay
   (an extra partner close to a topic's own best match relative to the fit's cross-topic
@@ -41,7 +41,7 @@ Design commitments:
 
 Manifests, not just live models
 -------------------------------
-``compare`` also accepts two :class:`~topica.AnalysisManifest` records recorded with
+``compare`` also accepts two :class:`~topica.provenance.AnalysisManifest` records recorded with
 ``record_fit(..., topic_words_n>0)``, so two fits can be compared *without refitting*
 — useful when the models themselves are gone but their provenance records remain.
 A manifest stores only each topic's top-N words and mean prevalence, so the manifest
@@ -594,7 +594,7 @@ def compare(
     """Compare two fitted topic models statistically.
 
     ``a``, ``b`` are two fitted models (or ``K×V`` topic-word arrays), **or** two
-    :class:`~topica.AnalysisManifest` records recorded with ``topic_words_n>0`` — in
+    :class:`~topica.provenance.AnalysisManifest` records recorded with ``topic_words_n>0`` — in
     which case topics are aligned by Jaccard overlap of the retained top-word sets
     without refitting (see the module docstring; mixing a model with a manifest is
     refused). Topics are matched one-to-one by the Hungarian assignment

--- a/python/topica/crossval.py
+++ b/python/topica/crossval.py
@@ -629,21 +629,21 @@ def _resolve_covariates(covariates, n_docs):
         raise ValueError("covariates must be a dict {kwarg_name: array}")
     out = {}
     for key, arr in covariates.items():
-        # topica.one_hot / design_matrix return (matrix, names); a common first-timer
+        # topica.design.one_hot / design_matrix return (matrix, names); a common first-timer
         # mistake is to pass that tuple straight through. np.asarray on it yields a
         # ragged object array and a cryptic downstream error — catch it here.
         if isinstance(arr, tuple):
             raise ValueError(
                 f"covariate {key!r} is a tuple, not an array — did you forget to "
                 f"unpack one_hot()/design_matrix()? They return (matrix, names); pass "
-                f"the matrix, e.g. `X, names = topica.one_hot(...)` then "
+                f"the matrix, e.g. `X, names = topica.design.one_hot(...)` then "
                 f"`covariates={{'{key}': X}}`"
             )
         a = np.asarray(arr)
         if a.dtype == object or not np.issubdtype(a.dtype, np.number):
             raise ValueError(
                 f"covariate {key!r} must be a numeric array, got dtype {a.dtype}; "
-                "encode categoricals with topica.one_hot(...) first"
+                "encode categoricals with topica.design.one_hot(...) first"
             )
         if a.shape[0] != n_docs:
             raise ValueError(

--- a/python/topica/design.py
+++ b/python/topica/design.py
@@ -3,7 +3,7 @@
 Build the design a covariate model reads: R-style formulas, one-hot encodings,
 splines, and interactions. Re-exports the helpers that already live in
 :mod:`topica.formulas` and :mod:`topica.stm`; the names are also available at the
-package root (``topica.design_matrix``, ``topica.spline``, ``topica.one_hot`` …).
+package root (``topica.design.design_matrix``, ``topica.design.spline``, ``topica.design.one_hot`` …).
 """
 
 from __future__ import annotations

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -22,7 +22,7 @@ and the matching vocabulary list; it does the clustering and seeding.
     topica.enable_experimental()  # EmbeddingLDA is experimental (see note below)
     vocab = sorted({w for d in docs for w in d})
     emb = SentenceTransformer("all-MiniLM-L6-v2").encode(vocab)
-    model = topica.EmbeddingLDA(num_topics=10, embeddings=emb, vocabulary=vocab)
+    model = topica.embeddings.EmbeddingLDA(num_topics=10, embeddings=emb, vocabulary=vocab)
     model.fit(docs, iters=1000)
     print(model.top_words(8))
 
@@ -299,7 +299,7 @@ class EmbeddingLDA:
        passed; use ``model.vocabulary``, or the helpers that already pair them:
        ``top_words()`` and ``label_topics(model.topic_word, model.vocabulary)``.
 
-    No embedder of your own? :func:`~topica.llm_embed` builds the ``embeddings``
+    No embedder of your own? :func:`~topica.embeddings.llm_embed` builds the ``embeddings``
     matrix (OpenAI, or offline ``sentence-transformers``).
 
     Parameters

--- a/python/topica/ensemble.py
+++ b/python/topica/ensemble.py
@@ -7,7 +7,7 @@ than any one run: across Hoyle et al.'s experiments the ensemble improves on the
 median run in 97% of contexts and never loses to the worst. This module builds
 that consensus.
 
-It is the natural follow-on to :func:`~topica.select_model`, which fits N runs at a
+It is the natural follow-on to :func:`~topica.select.select_model`, which fits N runs at a
 fixed K. Instead of *picking* the best run with ``plot_models``, ``ensemble``
 *combines* all of them.
 
@@ -41,7 +41,7 @@ scan-order-dependent core validation — documented at ``_rank_mask`` and
 
 The result duck-types as a fitted model for the model-neutral analysis surface (it
 exposes ``topic_word``, ``doc_topic``, and ``vocabulary``), so the consensus flows
-straight into :func:`~topica.coherence`, the diagnostics, and the rest. Each
+straight into :func:`~topica.evaluate.coherence`, the diagnostics, and the rest. Each
 ensemble topic carries a ``stability`` score and a ``reliable`` flag, so a
 consensus topic the individual runs do not actually agree on is marked, not
 silently trusted.
@@ -70,7 +70,7 @@ class EnsembleResult:
 
     Exposes ``topic_word``, ``doc_topic``, and ``vocabulary`` so it can be passed
     wherever a fitted model is accepted by the model-neutral analysis functions
-    (:func:`~topica.coherence`, the diagnostics surface, :func:`~topica.align_topics`).
+    (:func:`~topica.evaluate.coherence`, the diagnostics surface, :func:`~topica.evaluate.align_topics`).
 
     Attributes
     ----------
@@ -866,7 +866,7 @@ def ensemble(runs, *, method="cluster", num_topics=None, lambda_=0.5,
 
     The consensus is more reliable than any single run — it beats the median run
     and rarely loses to the best (Hoyle et al. 2022). This is the natural
-    follow-on to :func:`~topica.select_model`: fit N runs, then combine them here
+    follow-on to :func:`~topica.select.select_model`: fit N runs, then combine them here
     instead of picking one.
 
     Parameters
@@ -914,7 +914,7 @@ def ensemble(runs, *, method="cluster", num_topics=None, lambda_=0.5,
     Returns
     -------
     An :class:`EnsembleResult`. It exposes ``topic_word``, ``doc_topic``, and
-    ``vocabulary``, so it passes straight into :func:`~topica.coherence`, the
+    ``vocabulary``, so it passes straight into :func:`~topica.evaluate.coherence`, the
     diagnostics, and other model-neutral analyses. Per-topic ``stability`` and
     ``reliable`` flags mark consensus topics the individual runs do not agree on.
     """

--- a/python/topica/evaluate.py
+++ b/python/topica/evaluate.py
@@ -1315,10 +1315,10 @@ def bootstrap_stability(
         per-feature arrays (e.g. ``prevalence_names``, length ``p``) and scalars
         are passed through unchanged. So a full STM stability check reads::
 
-            X, names = topica.one_hot(df["party"])
+            X, names = topica.design.one_hot(df["party"])
             stm = topica.STM(num_topics=10, seed=13).fit(
                 docs, prevalence=X, prevalence_names=names)
-            bs = topica.bootstrap_stability(
+            bs = topica.evaluate.bootstrap_stability(
                 docs, reference=stm,
                 model_factory=lambda s: topica.STM(num_topics=10, seed=s),
                 prevalence=X, prevalence_names=names)
@@ -1614,8 +1614,8 @@ def flag_topics(model, texts, *, n=10, coherence_type="c_v"):
     """Score every topic on cheap quality features and flag likely junk.
 
     A quick "are these topics real, or did I forget to clean my corpus?" check.
-    For each topic it gathers :func:`topica.coherence`,
-    :func:`topica.exclusivity`, the normalized topic-word entropy (1.0 = a
+    For each topic it gathers :func:`topica.evaluate.coherence`,
+    :func:`topica.evaluate.exclusivity`, the normalized topic-word entropy (1.0 = a
     perfectly flat, uninformative topic), corpus prevalence, and the fraction of
     its top words that are stopwords, then flags a topic as junk when any of:
 

--- a/python/topica/formulas.py
+++ b/python/topica/formulas.py
@@ -3,7 +3,7 @@
 Wraps `formulaic` (an optional dependency) so social scientists can write
 ``"~ treatment * party + spline(year, df=3)"`` instead of hand-stitching
 `one_hot` and `np.hstack`. The library's own restricted-cubic-spline (the same
-one behind :func:`topica.spline`) is exposed inside formulas as ``spline(...)``,
+one behind :func:`topica.design.spline`) is exposed inside formulas as ``spline(...)``,
 so the basis matches what the STM toolkit uses elsewhere.
 """
 
@@ -78,7 +78,7 @@ def _formula_context():
 
     def spline(x, df=4, knots=None):
         # formulaic names the columns spline(col, df=k)[0..]; we return just the
-        # basis (drop the names tuple from topica.spline).
+        # basis (drop the names tuple from topica.design.spline).
         return _spline(x, df=df, knots=knots)[0]
 
     return {"spline": spline}
@@ -90,7 +90,7 @@ def design_matrix(formula, data, _knot_ctx=None):
 
     Returns ``(X, feature_names)`` where ``X`` is a ``(n_rows, p)`` float array
     and ``feature_names`` are the column labels. The intercept that `formulaic`
-    adds is stripped, because :func:`topica.estimate_effect` and the STM
+    adds is stripped, because :func:`topica.effects.estimate_effect` and the STM
     prevalence model add their own. Categorical columns become treatment-coded
     dummies; ``a * b`` / ``a:b`` expand interactions; ``spline(x, df=k)`` uses
     topica's restricted cubic spline. A Polars frame is converted to pandas for
@@ -99,8 +99,8 @@ def design_matrix(formula, data, _knot_ctx=None):
     Requires the optional ``formulaic`` package: install it with
     ``pip install "topica[formula]"`` (or ``pip install formulaic``). Without it,
     this raises ``ImportError`` at call time. If you would rather build the design
-    matrix without that dependency, use :func:`topica.one_hot`,
-    :func:`topica.spline`, and :func:`topica.interaction` directly.
+    matrix without that dependency, use :func:`topica.design.one_hot`,
+    :func:`topica.design.spline`, and :func:`topica.design.interaction` directly.
 
     Parameters
     ----------

--- a/python/topica/frames.py
+++ b/python/topica/frames.py
@@ -114,9 +114,9 @@ def from_dataframe(
     that metadata straight to an STM prevalence design with no manual alignment.
 
     To turn that metadata into a design matrix with an R-style formula, pass
-    ``corpus.metadata`` to :func:`topica.design_matrix`, which needs the optional
+    ``corpus.metadata`` to :func:`topica.design.design_matrix`, which needs the optional
     ``formulaic`` package (``pip install "topica[formula]"``); or build the design
-    by hand with :func:`topica.one_hot` / :func:`topica.spline`, which need no
+    by hand with :func:`topica.design.one_hot` / :func:`topica.design.spline`, which need no
     extra dependency.
 
     Parameters
@@ -139,9 +139,9 @@ def from_dataframe(
         web-boilerplate terms triggers a warning pointing here.
     stopwords : iterable of str or str, optional
         Words to drop during tokenizing. Pass an iterable of words (a set, or the
-        bundled :data:`topica.ENGLISH_STOPWORDS`), or a language name/code string
+        bundled :data:`topica.data.ENGLISH_STOPWORDS`), or a language name/code string
         like ``"english"`` / ``"en"``, which is resolved through
-        :func:`topica.stopwords` (the larger stopwords-iso list). Ignored when a
+        :func:`topica.data.stopwords` (the larger stopwords-iso list). Ignored when a
         custom ``tokenizer`` is given.
     tokenizer : callable, optional
         ``str -> list[str]``. Defaults to :func:`topica.tokenize` with the
@@ -464,7 +464,7 @@ def align(x, corpus):
     the corpus dropped some during pruning::
 
         corpus = topica.Corpus.from_documents(docs, min_doc_freq=5)
-        X = topica.align(X, corpus)          # now aligned to corpus rows
+        X = topica.data.align(X, corpus)          # now aligned to corpus rows
         model.fit(corpus, X, prevalence_names=names)
     """
     idx = corpus.kept_indices

--- a/python/topica/inspect.py
+++ b/python/topica/inspect.py
@@ -212,7 +212,7 @@ def label_topics(topic_word, vocabulary=None, *, n=10, word_counts=None, corpus=
     keys ``prob``, ``frex``, ``lift``, ``score``, and each value is a list of
     ``(word, value)`` pairs — so select a labeling before reading words::
 
-        labels = topica.label_topics(model)     # one TopicLabels per topic
+        labels = topica.inspect.label_topics(model)     # one TopicLabels per topic
         frex_words = [w for w, _ in labels[0]["frex"]]   # top FREX words of topic 0
         prob_score = labels[0]["prob"]                   # [(word, prob), ...]
 
@@ -359,9 +359,9 @@ def topic_table(model, vocabulary=None, *, doc_topic=None, n=7, weights=False):
 def _model_topic_table(self, vocabulary=None, *, doc_topic=None, n=7, weights=False):
     """A publication-ready topic table for this fitted model.
 
-    Method form of :func:`topica.topic_table`, so ``m.topic_table()`` works by
+    Method form of :func:`topica.inspect.topic_table`, so ``m.topic_table()`` works by
     analogy with ``m.top_words()`` / ``m.coherence()``. Equivalent to
-    ``topica.topic_table(m, ...)``; see that function for the full argument and
+    ``topica.inspect.topic_table(m, ...)``; see that function for the full argument and
     return description.
     """
     return topic_table(self, vocabulary, doc_topic=doc_topic, n=n, weights=weights)
@@ -385,7 +385,7 @@ def _bind_topic_table_method(classes):
         # Time-sliced models (e.g. DTM) expose ``topic_word`` as a method that
         # takes a time index rather than a plain ``(K, V)`` property, so a single
         # flat topic table is ill-defined; skip them rather than binding a method
-        # that could only ever raise. ``topica.topic_table(m.topic_word(t), vocab)``
+        # that could only ever raise. ``topica.inspect.topic_table(m.topic_word(t), vocab)``
         # remains the per-slice route.
         if callable(getattr(cls, "topic_word", None)):
             continue

--- a/python/topica/keyatm.py
+++ b/python/topica/keyatm.py
@@ -5,7 +5,7 @@ on a fitted :class:`~topica.KeyATM`'s numpy outputs, so they cover most of the R
 workflow directly:
 
 - ``keyATM::top_words``       -> :meth:`topica.KeyATM.top_words`
-- ``keyATM::top_docs``        -> :func:`topica.find_thoughts`
+- ``keyATM::top_docs``        -> :func:`topica.inspect.find_thoughts`
 - ``keyATM::semantic_coherence`` -> :meth:`topica.KeyATM.coherence`
 - ``keyATM::plot_modelfit``   -> :attr:`topica.KeyATM.log_likelihood_history`
 - ``keyATM::covariates_info`` -> :attr:`topica.KeyATM.feature_effects` / ``feature_names``
@@ -269,8 +269,8 @@ def time_prevalence_ci(model, timestamps, *, ci=0.95, normalize=True):
     .. note::
        This is **dynamic-keyATM only** — it reads that model's retained MCMC draws.
        For prevalence over a time covariate on any other model (LDA, STM, …), use
-       :func:`topica.predicted_prevalence` with a continuous ``year`` (optionally a
-       :func:`topica.spline`), which gives the same over-time curve with intervals
+       :func:`topica.effects.predicted_prevalence` with a continuous ``year`` (optionally a
+       :func:`topica.design.spline`), which gives the same over-time curve with intervals
        via the method of composition.
 
     For a dynamic :class:`~topica.KeyATM` (fit with ``timestamps=`` and

--- a/python/topica/labeling.py
+++ b/python/topica/labeling.py
@@ -11,7 +11,7 @@ provider and local models via plugins.
 
 LLM labels are a readable convenience, not a reproducible measurement. Pin the
 model and set temperature to 0 for stability, and keep FREX / probability / lift
-(:func:`topica.label_topics`) as the defensible, deterministic descriptors.
+(:func:`topica.inspect.label_topics`) as the defensible, deterministic descriptors.
 """
 
 from __future__ import annotations
@@ -135,7 +135,7 @@ def llm_topic_labels(model, texts=None, *, backend=None, llm_model="gpt-4o-mini"
     :func:`topica.topic_labels`, and :func:`topica.plot_report`.
 
     LLM labels are a convenience, not a reproducible measurement: pin the model
-    and set temperature to 0, and keep :func:`topica.label_topics` (FREX /
+    and set temperature to 0, and keep :func:`topica.inspect.label_topics` (FREX /
     probability / lift) for the defensible descriptors.
     """
     fn = backend if backend is not None else llm_backend(llm_model)

--- a/python/topica/llm.py
+++ b/python/topica/llm.py
@@ -27,7 +27,7 @@ The implementations live in :mod:`topica.coherence` (the metrics) and
 :mod:`topica.labeling` (the backend); this module is the curated public surface.
 ``topica.llm.backend`` is the same callable constructor as the top-level
 ``topica.llm_backend`` (kept because it is also the bring-your-own-model adapter for
-:class:`topica.TopicGPT` and :func:`topica.label_topics`).
+:class:`topica.TopicGPT` and :func:`topica.inspect.label_topics`).
 """
 
 from __future__ import annotations

--- a/python/topica/manifest.py
+++ b/python/topica/manifest.py
@@ -6,7 +6,7 @@ than a single green check. It is deliberately **not** a second model
 serialization: it composes with ``Corpus.save`` / ``model.save`` and references
 them by path + digest rather than embedding them.
 
-    record = topica.record_fit(model, corpus, prevalence=X, iters=1000)
+    record = topica.provenance.record_fit(model, corpus, prevalence=X, iters=1000)
     record.add_decision("K", "Chose 20 after inspecting 15/20/25.")
     record.save("analysis.topica.json")
 
@@ -973,7 +973,7 @@ def _capture_diagnostic(name: str, model, corpus, n: int) -> dict[str, Any]:
         if name == "coherence":
             value = float(_np.mean(model.coherence(n)))
         elif name == "exclusivity":
-            value = float(_np.mean(topica.exclusivity(model, n=n)))
+            value = float(_np.mean(topica.evaluate.exclusivity(model, n=n)))
         else:  # pragma: no cover - guarded by BUILTIN_DIAGNOSTICS
             raise KeyError(name)
         entry["value"] = value

--- a/python/topica/mcmc.py
+++ b/python/topica/mcmc.py
@@ -620,7 +620,7 @@ def multichain_diagnostics(
         log-likelihood trace only.
     metric : str, default "cosine"
         Topic-word distance metric for the cross-chain alignment (passed to
-        :func:`topica.align_topics`).
+        :func:`topica.evaluate.align_topics`).
     reference : int, default 0
         Index of the chain whose topic order the others are aligned to.
     warn : bool, default True

--- a/python/topica/robustness.py
+++ b/python/topica/robustness.py
@@ -14,7 +14,7 @@ coefficient, its interval, and whether the sign and significance held.
 Design commitments:
 
 - **Topics are matched, not assumed.** Fits are aligned with
-  :func:`topica.align_topics`' one-to-one Hungarian assignment, so topic 3 in the
+  :func:`topica.evaluate.align_topics`' one-to-one Hungarian assignment, so topic 3 in the
   K=20 fit is compared against whichever topic it actually corresponds to at
   K=25 — never against "topic 3" by index.
 - **Unmatched is reported, never dropped.** When K differs, some reference topics
@@ -318,7 +318,7 @@ def effects_across_k(
     """Is a covariate effect robust to the number of topics?
 
     Refits at each K, aligns every fit's topics back to a reference fit, re-runs
-    :func:`~topica.estimate_effect`, and reports one row per (reference topic, K)
+    :func:`~topica.effects.estimate_effect`, and reports one row per (reference topic, K)
     for the tracked ``feature`` — the robustness table an STM reviewer asks for.
 
     ``docs`` are the tokenized documents (or a :class:`~topica.Corpus`), ``ks`` the
@@ -332,10 +332,10 @@ def effects_across_k(
     ``(num_topics, seed) -> fitted model`` (which are fit without a design). ``fits=``
     reuses models you already fit (one per K, in order) instead of refitting.
 
-    Topics are matched by :func:`~topica.align_topics`' one-to-one assignment, so a
+    Topics are matched by :func:`~topica.evaluate.align_topics`' one-to-one assignment, so a
     topic is compared with its actual counterpart, not its index. A counterpart
     counts only if its similarity clears ``min_similarity`` (default ``0.3``,
-    :func:`~topica.align_topics`' own match threshold); a reference topic with no
+    :func:`~topica.evaluate.align_topics`' own match threshold); a reference topic with no
     counterpart — because K differs, or because the best pairing is below that
     threshold — is reported with ``matched=False`` and verdict ``unmatched`` rather
     than dropped or counted robust. Read the ``similarity`` column to judge

--- a/python/topica/select.py
+++ b/python/topica/select.py
@@ -1216,7 +1216,7 @@ def plot_search_k(rows, *, metrics=("coherence", "exclusivity"), ax=None):
     Returns the primary matplotlib ``Axes`` (consistent with topica's other
     ``plot_*`` helpers). To save the figure, go through the axes' figure::
 
-        ax = topica.plot_search_k(rows)
+        ax = topica.select.plot_search_k(rows)
         ax.figure.savefig("search_k.png", dpi=150, bbox_inches="tight")
 
     Requires matplotlib.

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -45,7 +45,7 @@ class TopicEffect:
 
     ``coef``/``se``/``z``/``ci_low``/``ci_high``/``pvalue`` are aligned to
     ``feature_names`` **positionally**. With ``add_intercept=True`` (the
-    :func:`~topica.estimate_effect` default) ``feature_names[0]`` is ``"intercept"``,
+    :func:`~topica.effects.estimate_effect` default) ``feature_names[0]`` is ``"intercept"``,
     so ``coef[0]`` is the baseline constant, *not* your covariate — a common way to
     accidentally report the wrong number. Prefer name-keyed access
     (:meth:`effect_of`, :attr:`by_feature`, :meth:`to_frame`) over positional
@@ -147,7 +147,7 @@ class TopicEffect:
         :func:`estimate_effect` call gives one row per (topic, feature)::
 
             import pandas as pd
-            effects = topica.estimate_effect(model, X, feature_names=names)
+            effects = topica.effects.estimate_effect(model, X, feature_names=names)
             table = pd.concat([e.to_frame() for e in effects], ignore_index=True)
         """
         import pandas as pd
@@ -210,7 +210,7 @@ def _coerce_design(X, feature_names):
     When ``feature_names`` is not given and the input is a DataFrame, the column
     labels are used as feature names. A non-numeric column (strings, a pandas
     ``Categorical``) raises a directive error pointing at
-    :func:`topica.design_matrix` / :func:`topica.one_hot` rather than surfacing a
+    :func:`topica.design.design_matrix` / :func:`topica.design.one_hot` rather than surfacing a
     cryptic numpy cast failure.
 
     Returns ``(X_float64, names_or_None)``.
@@ -222,7 +222,7 @@ def _coerce_design(X, feature_names):
             raise ValueError(
                 f"covariate column(s) {bad} are non-numeric and cannot be cast to "
                 "float. Encode categorical covariates first with "
-                "topica.design_matrix(formula, data) or topica.one_hot(...), then "
+                "topica.design.design_matrix(formula, data) or topica.design.one_hot(...), then "
                 "pass the resulting numeric matrix."
             )
         inferred = [str(c) for c in X.columns]
@@ -235,7 +235,7 @@ def _coerce_design(X, feature_names):
     except (ValueError, TypeError) as e:
         raise ValueError(
             "could not convert the covariates to a float64 matrix; encode "
-            "categorical covariates with topica.design_matrix / topica.one_hot "
+            "categorical covariates with topica.design.design_matrix / topica.design.one_hot "
             f"first (numpy: {e})"
         ) from e
     if arr.ndim == 1:
@@ -689,7 +689,7 @@ def estimate_effect(
     Specifying the design. Give the covariates one of two ways: a prebuilt design
     matrix as ``X`` (with ``feature_names``), or an R-style ``formula`` together
     with a ``data`` frame, which builds ``X`` for you via
-    :func:`topica.design_matrix`. **Use the same design you fit the model with.**
+    :func:`topica.design.design_matrix`. **Use the same design you fit the model with.**
     The effects regression is on the covariates you pass here, not on whatever
     went into ``STM.fit``; if they differ, the coefficients answer a different
     question than the model. The reliable pattern is to build the design once and
@@ -716,7 +716,7 @@ def estimate_effect(
     formula : str, optional
         R-style formula (e.g. ``"~ party + spline(year, df=3)"``) evaluated
         against ``data`` to build ``X`` and ``feature_names``, via
-        :func:`topica.design_matrix` (needs the optional ``topica[formula]``
+        :func:`topica.design.design_matrix` (needs the optional ``topica[formula]``
         extra). Pass either ``X`` or ``formula`` + ``data``, not both.
     topics : sequence[int], optional
         Restrict to these topics. Defaults to all.
@@ -736,7 +736,7 @@ def estimate_effect(
         like any list). For a tidy long table with one row per (topic, feature),
         call the container's :meth:`~EffectList.to_frame`::
 
-            table = topica.estimate_effect(model, X, feature_names=names).to_frame()
+            table = topica.effects.estimate_effect(model, X, feature_names=names).to_frame()
 
         (equivalent to
         ``pd.concat([e.to_frame() for e in result], ignore_index=True)``).
@@ -2100,7 +2100,7 @@ def transform(model, docs, *, prevalence=None, data=None, formula=None, X=None):
 
 # ---------------------------------------------------------------------------
 # Back-compatibility: the general post-hoc diagnostics were moved to
-# ``topica.diagnostics`` (they apply to any model, not just STM) and are
+# ``topica.evaluate.diagnostics`` (they apply to any model, not just STM) and are
 # also exported at the package top level. They are re-exported here so existing
 # ``topica.stm.<name>`` calls keep working.
 # ---------------------------------------------------------------------------

--- a/python/topica/stopwords.py
+++ b/python/topica/stopwords.py
@@ -4,16 +4,16 @@
 rarely carry topical meaning. Pass it to :func:`topica.tokenize` (or the corpus
 builders) so a first LDA fit is not dominated by ``the`` / ``and`` / ``of``::
 
-    docs = [topica.tokenize(t, stopwords=topica.ENGLISH_STOPWORDS) for t in texts]
+    docs = [topica.tokenize(t, stopwords=topica.data.ENGLISH_STOPWORDS) for t in texts]
 
 For other languages — or a more comprehensive English list — use
 :func:`stopwords`, which serves the `stopwords-iso
 <https://github.com/stopwords-iso/stopwords-iso>`_ lists (58 languages, MIT
 licensed; see ``_data/STOPWORDS_ISO_LICENSE.txt``)::
 
-    fr = topica.stopwords("fr")                 # or "french"
+    fr = topica.data.stopwords("fr")                 # or "french"
     corpus = topica.from_dataframe(df, text_col="texte", stopwords=fr)
-    topica.stopword_languages()                 # the available ISO 639-1 codes
+    topica.data.stopword_languages()                 # the available ISO 639-1 codes
 
 ``ENGLISH_STOPWORDS`` is kept as the short, stable default; ``stopwords("en")``
 is the larger stopwords-iso English list.
@@ -61,7 +61,7 @@ def stopwords(language: str) -> frozenset:
     result to :func:`topica.tokenize` or the corpus builders::
 
         corpus = topica.from_dataframe(df, text_col="texte",
-                                       stopwords=topica.stopwords("fr"))
+                                       stopwords=topica.data.stopwords("fr"))
 
     Raises ``ValueError`` with the available codes if the language is unknown.
     """
@@ -116,5 +116,5 @@ _SENTIMENT_BEARING = frozenset({
 #: outcome is valence::
 #:
 #:     corpus = topica.from_dataframe(df, text_col="review",
-#:                                    stopwords=topica.SENTIMENT_STOPWORDS)
+#:                                    stopwords=topica.data.SENTIMENT_STOPWORDS)
 SENTIMENT_STOPWORDS = ENGLISH_STOPWORDS - _SENTIMENT_BEARING

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -524,7 +524,7 @@ impl Corpus {
     /// all documents, parallel to :attr:`vocabulary` (length ``num_words``). This
     /// is the empirical ``P(w)`` (up to normalization) that stm's lift and FREX
     /// James-Stein shrinkage use; pass it (or the corpus) to
-    /// :func:`topica.label_topics` / :func:`topica.frex` for stm-faithful labels.
+    /// :func:`topica.inspect.label_topics` / :func:`topica.inspect.frex` for stm-faithful labels.
     #[getter]
     fn word_counts(&self) -> Vec<u32> {
         self.inner.total_freqs.clone()

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -3459,7 +3459,7 @@ impl<'py> FromPyObject<'py> for TopN {
 /// The default (``coherence_type="u_mass"`` with no ``texts``) takes the fast in-Rust
 /// UMass path over the training corpus — unchanged from the historical behavior. Any
 /// other metric, or an explicit reference corpus, is delegated to the single Python
-/// implementation ``topica.coherence`` (which owns c_v / c_uci / c_npmi and the
+/// implementation ``topica.evaluate.coherence`` (which owns c_v / c_uci / c_npmi and the
 /// sliding-window logic), so there is exactly one place each metric is defined.
 /// `tops` are the top-``n`` word ids per topic; `corpus` supplies both the default
 /// reference documents and the id→word map for building the topic word lists.
@@ -3934,7 +3934,7 @@ fn features_cast_error(data: &Bound<'_, PyAny>) -> PyErr {
             return PyValueError::new_err(format!(
                 "covariate column(s) {cols:?} are non-numeric and cannot be cast to \
                  float. Encode categorical covariates first with \
-                 topica.design_matrix(formula, data) or topica.one_hot(...), then pass \
+                 topica.design.design_matrix(formula, data) or topica.design.one_hot(...), then pass \
                  the resulting numeric matrix."
             ));
         }
@@ -3942,7 +3942,7 @@ fn features_cast_error(data: &Bound<'_, PyAny>) -> PyErr {
     PyValueError::new_err(
         "could not convert the input to a float64 matrix. Pass a numeric \
          array/DataFrame (a 2-D matrix or a 1-D column); if these are categorical \
-         covariates, encode them first with topica.design_matrix / topica.one_hot.",
+         covariates, encode them first with topica.design.design_matrix / topica.design.one_hot.",
     )
 }
 
@@ -9318,7 +9318,7 @@ fn window_cooccurrence(
 /// probability matrix as a list of lists; `word_counts` (length V) enables stm's
 /// James-Stein exclusivity shrinkage when non-empty (pass `[]` to skip it); `w`
 /// is the frequency/exclusivity weight. Internal: backs the cross-language FREX
-/// parity check against the pure-Python `topica.frex` (issue #260).
+/// parity check against the pure-Python `topica.inspect.frex` (issue #260).
 #[pyfunction]
 #[pyo3(signature = (beta, word_counts, w=0.5))]
 fn inspect_frex_scores(
@@ -16018,7 +16018,7 @@ impl KeyATM {
     /// (``α_{d,k} = exp(x_d · λ_k)``), not differences in topic proportions: the
     /// sign gives the direction of a covariate's effect on topic k, but for the
     /// effect on the topic-share scale (what to report) use
-    /// ``topica.predicted_prevalence``. λ is estimated by L-BFGS MAP (not keyATM's
+    /// ``topica.effects.predicted_prevalence``. λ is estimated by L-BFGS MAP (not keyATM's
     /// per-sweep MCMC sampling). Raises if the model was fit without covariates.
     #[getter]
     fn feature_effects<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {


### PR DESCRIPTION
**Stage 3 of the namespace-default switch** (stage 1 = #769, stage 2 = #770). The docstring / doc-comment sweep.

Converts the flat helper references inside the Python module docstrings, the Rust binding doc comments, the `.pyi` stub, and two user-facing error strings to the namespaced idiom (`topica.select.search_k`, `topica.inspect.topic_table`, `topica.evaluate.coherence`, `topica.effects.estimate_effect`, `topica.design.one_hot`, …).

- **Python docstrings:** codemod over `python/topica/*.py` (86 rewrites, 23 files), compat-map driven, held-out trio pinned to `topica.evaluate`. Module references (`:mod:\`topica.coherence\``, `:mod:\`topica.stopwords\``, `:mod:\`topica.diagnostics\``, …) and the leaf modules a namespace re-exports are correctly left flat — an auto-revert pass restores any `:mod:` target the codemod would have wrongly namespaced. `__init__.py`'s Stage 1 legacy-form mentions ("also importable as `topica.search_k`") are untouched.
- **Rust + stub:** the 6 flat refs in `src/python/*.rs` doc comments (incl. the two "encode covariates with `topica.design_matrix` / `topica.one_hot`" error messages, now `topica.design.*`) and the 3 matching `.pyi` docstrings updated.

Verification: preflight (fmt/clippy/stub/table/compat) + `mkdocs --strict` clean (every namespaced `:func:` cross-ref resolves); rebuilt and confirmed the covariate error message now teaches `topica.design.design_matrix` / `topica.design.one_hot`; full suite **4984 passed, 38 skipped**.

Remaining: CLAUDE.md + `conventions.md` "flat-function rule" prose (stage 4), then the paper refresh (stage 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)