### PR TITLE
docs(conventions): record the namespace-default as a contributor rule (stage 4)

### DIFF
--- a/docs/contributing/conventions.md
+++ b/docs/contributing/conventions.md
@@ -80,6 +80,20 @@ by construction rather than by memory.
    raises a directive `TypeError` naming the `texts=` keyword rather than an
    opaque "cannot be interpreted as an integer" (issues #752, #755).
 
+8. **Helper functions live in workflow namespaces; models and corpus ingress stay
+   at the top level** (issue #757). The taught surface is `topica.<stage>`:
+   `select` (choosing K), `inspect` (reading topics), `evaluate` (validation),
+   `effects` (covariate effects), `data` / `design` (corpus and design-matrix
+   prep), and `compare` / `provenance` / `embeddings`. Write new docs, docstrings,
+   examples, and error messages in the namespaced form
+   (`topica.select.search_k`, `topica.inspect.topic_table`,
+   `topica.effects.estimate_effect`). Model constructors (`topica.LDA`) and corpus
+   ingress (`topica.Corpus`, `topica.from_dataframe`, `topica.tokenize`) stay at the
+   root — nouns at the top level, verbs in namespaces. Every flat helper name still
+   resolves as a legacy compatibility alias (`topica.search_k` is the same object as
+   `topica.select.search_k`), but it is no longer part of the advertised surface; a
+   new helper should be exported from the namespace that owns it, not added flat.
+
 ## Threads and stopping rules
 
 Reproducibility is the default. Gibbs samplers use `num_threads=1` by default:
@@ -178,17 +192,17 @@ names.
 These were the candidate inconsistencies (#155). Each is now decided, so the
 `KNOWN_DRIFT` list in `tests/test_naming_conventions.py` is empty.
 
-- **LLM-based evaluation is a namespace, `topica.llm.*`, not flat `llm_*`.** The
-  diagnostics that call an external model (`topica.llm.coherence`,
+- **LLM-based evaluation is its own namespace, `topica.llm.*`, not `llm_*`
+  helpers.** The diagnostics that call an external model (`topica.llm.coherence`,
   `topica.llm.intrusion`, `topica.llm.select_k`, and the future
   `outlier`/`repetitiveness`/`diversity`/`alignment`) are grouped under
-  `topica.llm` rather than spread as top-level `llm_*` functions. This is a
-  deliberate carve-out from the flat-function rule: the suite is a coherent,
-  growing family that shares one property the rest of the library does not —
-  `llm-bounded` non-determinism — and the namespace signals that at the call site.
-  `topica.llm.backend` is the same constructor as the top-level `topica.llm_backend`
-  (kept flat because it is also the bring-your-own-model adapter for `TopicGPT` and
-  `label_topics`, not only an eval metric).
+  `topica.llm` rather than named `llm_*`. Beyond the general namespace organization
+  (rule 8 in [Structural rules](#structural-rules)), the LLM suite has its own
+  reason to be set apart: it is a coherent, growing family that shares one property
+  the rest of the library does not — `llm-bounded` non-determinism — and the
+  dedicated namespace signals that at the call site. `topica.llm.backend` is the
+  same constructor as `topica.llm_backend` (the bring-your-own-model adapter that
+  `TopicGPT` and `label_topics` also use, so it stays reachable at the root too).
 
 - **Temporal index — `times`.** Canonical across models (DTM's positional arg).
   KeyATM now accepts `times=` and keeps `timestamps=` as an alias. A

--- a/python/topica/registry.py
+++ b/python/topica/registry.py
@@ -2,11 +2,12 @@
 for every model list (the README table, the docs roster, and the programmatic
 ``topica.list_models`` discovery helper).
 
-The flat ``from topica import X`` namespace is frozen and stays flat; this module
-is a *presentation and discovery* layer over it, not a second import path. A
-conformance test (``tests/test_registry.py``) asserts the registry and the
-exported model classes stay in one-to-one correspondence, so neither drifts as
-models are added.
+Model classes stay at the top level (``from topica import LDA``) — the analysis
+*helpers* moved into workflow namespaces (issue #757), but the model constructors
+are nouns and remain flat. This module is a *presentation and discovery* layer
+over them, not a second import path. A conformance test
+(``tests/test_registry.py``) asserts the registry and the exported model classes
+stay in one-to-one correspondence, so neither drifts as models are added.
 
 Adding a model: export its class from ``__init__`` and add one ``ModelInfo`` here.
 """


### PR DESCRIPTION
**Final stage of the namespace-default switch** (stages 1–3 = #769, #770, #771). Makes the contributor-facing convention docs describe the new default so future work follows it.

- **`conventions.md`** gains a structural rule (rule 8): analysis helpers live in the workflow namespaces (`select`/`inspect`/`evaluate`/`effects`/`data`/`design`/`compare`/`provenance`/`embeddings`), the taught surface; model constructors and Corpus ingress stay at the top level (nouns at root, verbs in namespaces); flat helper names remain as legacy aliases, but a new helper is exported from its namespace, not added flat.
- **Reframed the `topica.llm` section:** namespacing is now the norm (rule 8), so the LLM suite is no longer described as "a deliberate carve-out from the flat-function rule" — it keeps its own namespace for the additional reason of `llm-bounded` non-determinism.
- **`registry.py` docstring:** scoped "stays flat" to *model classes* (which do stay at the root), clarifying that the analysis helpers moved to namespaces.

The local, git-ignored CLAUDE.md convention note was updated to match (not part of this PR).

`mkdocs --strict` + registry/naming/compat tests green.

**This lands the namespace-default program.** Remaining top-level work is the paper refresh (stage 5), which now sits on the new default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)