### PR TITLE
fix(evaluate): perplexity() rejects a Heldout, redirects to eval_heldout (#767)

### DIFF
--- a/python/topica/evaluate.py
+++ b/python/topica/evaluate.py
@@ -465,8 +465,21 @@ def perplexity(model, held_out, *, seed=0):
             "held-out perplexity. Compare clustering models with coherence or "
             "topic_diversity instead."
         )
-    # Corpus.documents is a method; Heldout.documents is a plain list attribute.
-    # Accept both (and raw token lists) rather than assuming a callable (#761).
+    # A Heldout is not a corpus (#767). make_heldout withholds words in place, and
+    # that word-holdout is scored by eval_heldout, not by perplexity's own
+    # document-completion split. Passing the object would silently score the
+    # reduced training corpus under a different scheme than the user intends, so we
+    # redirect — mirroring the Heldout.corpus directive guard shipped in #765.
+    if isinstance(held_out, Heldout):
+        raise TypeError(
+            "perplexity() does not take a Heldout. make_heldout() withholds words "
+            "in place, and that word-holdout is scored with eval_heldout:\n"
+            "    model.fit(ho.documents); topica.eval_heldout(model, ho)\n"
+            "If you instead want document-completion perplexity on the reduced "
+            "corpus, pass the documents explicitly: perplexity(model, ho.documents)."
+        )
+    # Corpus.documents is a method; a raw token list has none. Accept both a Corpus
+    # and raw token lists rather than assuming a callable (#761).
     docs_attr = getattr(held_out, "documents", None)
     if callable(docs_attr):
         held_out = docs_attr()

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -868,19 +868,30 @@ def test_diagnostics_no_spurious_warning_after_top_words_bare_strings():
     assert len(rows) == 3
 
 
-def test_perplexity_accepts_heldout_object():
-    # #761: perplexity called held_out.documents() unconditionally, but
-    # Heldout.documents is a list attribute (only Corpus.documents is a method),
-    # so perplexity(model, make_heldout(corpus)) crashed with 'list' not callable.
+def test_perplexity_rejects_heldout_object():
+    # #767: perplexity() must not silently accept a Heldout. make_heldout withholds
+    # words in place; that word-holdout is scored by eval_heldout, not by
+    # perplexity's own document-completion split. Passing the object would score the
+    # reduced training corpus under a different scheme than the user intends, so we
+    # redirect (mirroring the Heldout.corpus guard from #765). The earlier #761/#762
+    # accept behavior is deliberately reversed here.
     docs = [["housing", "rent", "tenant", "landlord", "evict"] * 3,
             ["health", "clinic", "doctor", "patient", "care"] * 3,
             ["school", "teacher", "student", "class", "grade"] * 3] * 20
     c = topica.Corpus.from_documents(docs)
     m = topica.LDA(3, seed=13).fit(c, iters=80)
     ho = topica.make_heldout(c)
-    pp_heldout = float(topica.perplexity(m, ho))
-    pp_corpus = float(topica.perplexity(m, c))
-    assert pp_heldout > 0 and pp_corpus > 0
+
+    with pytest.raises(TypeError) as exc:
+        topica.perplexity(m, ho)
+    # The error must hand the user both correct paths.
+    assert "eval_heldout" in str(exc.value)
+    assert "ho.documents" in str(exc.value)
+
+    # A plain Corpus is still accepted, and the explicit escape hatch
+    # (document-completion perplexity on the reduced corpus) still returns a number.
+    assert float(topica.perplexity(m, c)) > 0
+    assert float(topica.perplexity(m, ho.documents)) > 0
 
 
 def test_topic_stability_fitted_runs_with_num_topics_is_directive():


### PR DESCRIPTION
Resolves #767 (Option 2).

## What
`perplexity(model, heldout)` used to silently accept a `Heldout` and score `heldout.documents` — the reduced *training* corpus — under perplexity's own even/odd document-completion split, ignoring `heldout.missing`. A `make_heldout` user who reaches for `perplexity` (instead of `eval_heldout`) gets a plausible number under a different evaluation scheme than they intend.

This reverses the #761/#762 accept behavior and raises a directive `TypeError` that names both correct paths:
- `eval_heldout(model, ho)` for the word-holdout the `Heldout` was built for, or
- `perplexity(model, ho.documents)` if you explicitly want document-completion perplexity on the reduced corpus.

## Why Option 2 (not warn)
Symmetry with #765: `Heldout.corpus` already raises a directive `AttributeError` pointing at `.documents`/`eval_heldout`, closing the `model.fit(ho.corpus)` half of the #758 confusion. This closes the `perplexity(model, ho)` half the same way. A one-time `UserWarning` (Option 3) would still emit the wrong-scheme number and is easily missed in notebooks; the only "convenience" removed is passing `ho` instead of `ho.documents`.

## Scope
- Guard is `isinstance(held_out, Heldout)` only — a plain `Corpus` and raw token lists are unchanged.
- `search_k` already branches Heldout → `eval_heldout` before the `perplexity` call (select.py), so it is unaffected. Verified by the full `tests/test_heldout.py` suite.

## Tests
`test_perplexity_accepts_heldout_object` → `test_perplexity_rejects_heldout_object`: asserts the `TypeError` names both `eval_heldout` and `ho.documents`, and that the `Corpus` and explicit-`.documents` paths still return a number. Local run: 122 passed across the perplexity/heldout/search_k selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)