### PR TITLE
feat(robustness): re-export stability helpers under topica.robustness (#775 T4.1)

### DIFF
--- a/python/topica/robustness.py
+++ b/python/topica/robustness.py
@@ -33,10 +33,18 @@ from typing import Any, Sequence
 
 import numpy as np
 
+# Topic-stability helpers live in `evaluate`, but "does a topic survive a
+# different seed?" is a robustness question, so users reach for
+# `topica.robustness.topic_stability` first and hit AttributeError (#775 T4.1).
+# Re-export them here for discoverability; `topica.evaluate` remains their home.
+from .evaluate import bootstrap_stability, topic_stability
+
 __all__ = [
     "effects_across_k",
     "effects_across_seeds",
     "RobustnessResult",
+    "bootstrap_stability",
+    "topic_stability",
 ]
 
 

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -906,3 +906,12 @@ def test_topic_stability_fitted_runs_with_num_topics_is_directive():
         topica.topic_stability(runs, num_topics=3)
     # the plain fitted-runs path still works
     assert 0.0 <= float(topica.topic_stability(runs)) <= 1.0
+
+
+def test_stability_helpers_discoverable_under_robustness():
+    # #775 T4.1: "does a topic survive a different seed?" is a robustness question,
+    # so users reach for topica.robustness.topic_stability first. Re-export the
+    # stability helpers there (evaluate stays their home) so the guess resolves.
+    assert topica.robustness.topic_stability is topica.evaluate.topic_stability
+    assert topica.robustness.bootstrap_stability is topica.evaluate.bootstrap_stability
+    assert {"topic_stability", "bootstrap_stability"} <= set(topica.robustness.__all__)


### PR DESCRIPTION
Addresses **T4.1** from the sample-user audit (#775).

Both first-time users reached for `topica.robustness.topic_stability` — "does a topic survive a different seed?" reads as a robustness question — and hit `AttributeError`, because `topic_stability`/`bootstrap_stability` live only under `topica.evaluate`.

This re-exports both from `topica.robustness` (evaluate stays their canonical home) so the natural guess resolves:

```python
topica.robustness.topic_stability   is topica.evaluate.topic_stability      # True
topica.robustness.bootstrap_stability is topica.evaluate.bootstrap_stability  # True
```

Pure re-export — no behavior change, no signature change, no `.pyi` change. Regression test added in `test_issue_fixes.py`. Preflight green.

Note: T2.2 (the `bootstrap_stability(model, corpus)` *signature* confusion) is separate and not addressed here — this only fixes discovery.

🤖 Generated with [Claude Code](https://claude.com/claude-code)