### PR TITLE
fix(effects): predicted_prevalence continuous= works from raw X (#775 T2.1)

### DIFF
--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -1276,41 +1276,52 @@ def _build_reference_rows(
     from .formulas import design_matrix_predict
 
     if continuous is not None:
-        # Sweep the named continuous covariate over its observed range.
-        if data is None:
-            raise ValueError("continuous= requires data= (the training DataFrame).")
+        # Sweep the named continuous covariate over its observed range. The range
+        # comes from data[col] on the formula path, or straight from the design
+        # column on the raw-X path — so a user who built X = design_matrix(...) can
+        # sweep a design column without also passing data= (#775 T2.1).
         col = continuous
-        x_obs = np.asarray(data[col], dtype=np.float64)
+        fn = list(feature_names) if feature_names is not None else None
+        if data is not None:
+            x_obs = np.asarray(data[col], dtype=np.float64)
+        elif fn is not None and col in fn:
+            x_obs = np.asarray(X_train[:, fn.index(col)], dtype=np.float64)
+        else:
+            raise ValueError(
+                f"continuous={col!r} needs the covariate's range. Pass data= (the "
+                "training DataFrame), or pass X=/feature_names= where continuous= "
+                "names one of the design columns"
+                + (f" (feature_names={fn})" if fn is not None else "")
+                + ". Note a basis-expanded term such as a spline (e.g. 'year' behind "
+                "spline(year, df=3)) is not a single design column: sweep it with the "
+                "formula=+data= path so the whole basis is re-evaluated at each grid "
+                "point, not one basis column held against the others' means."
+            )
         grid_vals = np.linspace(x_obs.min(), x_obs.max(), npoints)
-        # Hold all other numeric columns at their means, categoricals at their mode.
-        ref = {}
-        for c in data.columns:
-            if c == col:
-                continue
-            col_vals = data[c]
-            try:
-                ref[c] = float(col_vals.mean())
-            except (TypeError, AttributeError):
-                ref[c] = col_vals.mode()[0] if len(col_vals) > 0 else col_vals.iloc[0]
-        rows = []
-        for v in grid_vals:
-            row_dict = dict(ref)
-            row_dict[col] = v
-            rows.append(row_dict)
-        grid_df = pd.DataFrame(rows)
         if formula is not None:
+            if data is None:
+                raise ValueError("continuous= with formula= requires data= (the training DataFrame).")
+            # Hold all other numeric columns at their means, categoricals at their mode.
+            ref = {}
+            for c in data.columns:
+                if c == col:
+                    continue
+                col_vals = data[c]
+                try:
+                    ref[c] = float(col_vals.mean())
+                except (TypeError, AttributeError):
+                    ref[c] = col_vals.mode()[0] if len(col_vals) > 0 else col_vals.iloc[0]
+            grid_df = pd.DataFrame([{**ref, col: v} for v in grid_vals])
             X_new, _ = design_matrix_predict(formula, grid_df, knot_ctx)
         else:
-            # Raw X path: only the swept column changed; rebuild with the same columns.
-            if feature_names is None:
+            # Raw X path: only the swept column changes; others held at their means.
+            if fn is None:
                 raise ValueError(
                     "continuous= with raw X requires feature_names= to identify the column."
                 )
-            fn = list(feature_names)
             if col not in fn:
                 raise ValueError(f"continuous={col!r} not in feature_names {fn}")
             ci_idx = fn.index(col)
-            # Hold other columns at their column means.
             col_means = X_train.mean(axis=0)
             X_new = np.tile(col_means, (npoints, 1))
             X_new[:, ci_idx] = grid_vals
@@ -1501,8 +1512,13 @@ def predicted_prevalence(
       theta between the two settings per topic, with CI.
     - ``continuous=`` (**smooth curve**) — a column name; sweeps the covariate
       over its observed range on a ``npoints``-point grid, holding all other
-      columns at their means. Spline terms in ``formula`` are evaluated with the
-      training knots, not re-fit to the new grid.
+      columns at their means. Works from either path: with ``formula=``+``data=``
+      the sweep re-evaluates the whole formula (spline terms use the training
+      knots, not re-fit to the new grid); with a raw ``X``+``feature_names`` it
+      sweeps the named **design column** and needs no ``data=`` (the range is read
+      off that column). A basis-expanded term (e.g. ``year`` behind
+      ``spline(year, df=3)``) is not a single column, so sweep it via the
+      ``formula=``+``data=`` path.
 
     Parameters
     ----------

--- a/tests/test_predicted_prevalence.py
+++ b/tests/test_predicted_prevalence.py
@@ -235,6 +235,29 @@ class TestSTM:
             assert r.mode == "continuous"
             assert r.covariate == "x"
 
+    def test_continuous_raw_X_needs_no_data(self, stm_continuous_model):
+        """#775 T2.1: continuous= works from a raw X + feature_names, reading the
+        sweep range off the named design column, without also passing data=."""
+        m, x = stm_continuous_model
+        X = x.reshape(-1, 1)
+        result = predicted_prevalence(m, X=X, feature_names=["x"], continuous="x",
+                                      npoints=8, nsims=8, n_sim=100, seed=0)
+        for r in result:
+            assert r.estimate.shape == (8,)
+            assert r.mode == "continuous" and r.covariate == "x"
+        # grid spans the observed range of the design column
+        grid = [list(g.values())[0] for g in result[0].grid]
+        assert min(grid) == pytest.approx(float(x.min()))
+        assert max(grid) == pytest.approx(float(x.max()))
+
+    def test_continuous_raw_X_unknown_column_is_directive(self, stm_continuous_model):
+        """A column not in feature_names (e.g. the variable behind a spline) points
+        the user at the formula=+data= path rather than failing opaquely."""
+        m, x = stm_continuous_model
+        with pytest.raises(ValueError, match="names one of the design columns"):
+            predicted_prevalence(m, X=x.reshape(-1, 1), feature_names=["x"],
+                                 continuous="year", npoints=5, nsims=5, seed=0)
+
     def test_continuous_ci_ordering(self, stm_continuous_model):
         m, x = stm_continuous_model
         meta = pd.DataFrame({"x": x})


### PR DESCRIPTION
Addresses **T2.1** from the sample-user audit (#775).

## The friction
The covariates guide builds `X, names = design_matrix("~ party + spline(year, df=3)", meta)` and feeds `X=`/`feature_names=` to `estimate_effect` and `predicted_prevalence(contrast=)`. But the smooth time curve — a time paper's headline result — rejected that same design:

```python
predicted_prevalence(model, X=X, feature_names=names, continuous="year")
# ValueError: continuous= requires data= (the training DataFrame).
```

So the working call had to abandon the `X`/`names` objects the guide just built and re-specify `formula=`+`data=`. Both audit users hit this wall precisely at the paper's headline.

## The fix
The raw-X `continuous=` path **already existed** in `_build_reference_rows` but was unreachable behind a premature `data is None` guard. This makes it reachable: when `data=` is absent, read the sweep range off the named design column (`X_train[:, idx]`), so a user can sweep any single design column straight from `X`/`feature_names`.

```python
predicted_prevalence(model, X=X, feature_names=names, continuous="year")  # now works, no data=
```

- The `formula=`+`data=` path is unchanged.
- A **basis-expanded term** (e.g. `year` behind `spline(year, df=3)`) is *not* a single design column — its whole basis must be re-evaluated at each grid point, which needs the formula. When the requested column isn't in `data` or `feature_names`, the error now names the columns and points spline sweeps at the `formula=`+`data=` path, instead of the bare `requires data=`.

## Tests
`tests/test_predicted_prevalence.py`: raw-X `continuous=` needs no `data=` (range read off the column, grid spans the observed range); an unknown column gives the directive error. Full suite 47 passed; broader effects/stm sweep 2339 passed; preflight green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)