### PR TITLE
fix: sample-user audit follow-ups — T1.2/T2.2/T3.1/T3.2/T3.3/T4.2 (#775)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -236,15 +236,17 @@ class Corpus:
         ...
 
     @property
-    def doc_lengths(self) -> list[int]:
+    def doc_lengths(self) -> numpy.typing.NDArray[numpy.int64]:
         """Tokens per document in the pruned vocabulary, parallel to a model's
-        ``doc_topic`` rows. The N_d that ``dirichlet_theta_samples`` needs."""
+        ``doc_topic`` rows. The N_d that ``dirichlet_theta_samples`` needs. A numpy
+        array, so ``.mean()``/``.sum()`` work directly."""
         ...
 
     @property
-    def word_counts(self) -> list[int]:
+    def word_counts(self) -> numpy.typing.NDArray[numpy.int64]:
         """Total occurrences of each vocabulary term across all documents, parallel
-        to ``vocabulary``. The empirical P(w) for stm's lift / FREX shrinkage."""
+        to ``vocabulary``. The empirical P(w) for stm's lift / FREX shrinkage. A
+        numpy array, so ``.mean()``/``.sum()`` work directly."""
         ...
 
     @property

--- a/python/topica/evaluate.py
+++ b/python/topica/evaluate.py
@@ -1113,7 +1113,8 @@ def _kl(p, q):
 
 
 def topic_stability(runs, *, num_topics=None, k=None, seeds=None, model_factory=None,
-                    topn=10, metric="cosine", fit_kwargs=None, **extra_fit_kwargs):
+                    topn=10, metric="cosine", per_topic=False, fit_kwargs=None,
+                    **extra_fit_kwargs):
     """Term-centric stability of topics across multiple fits (Greene, O'Callaghan
     & Cunningham 2014): a "how robust is this K?" score.
 
@@ -1132,7 +1133,10 @@ def topic_stability(runs, *, num_topics=None, k=None, seeds=None, model_factory=
 
     Either way, each later run's topics are matched to the first run's, and
     stability is the mean Jaccard overlap of their top-`topn` words. Returns a
-    float in ``[0, 1]``; higher means more reproducible topics.
+    float in ``[0, 1]``; higher means more reproducible topics. Pass
+    ``per_topic=True`` for the per-topic vector instead — one matched-Jaccard mean
+    per reference topic (index-aligned to ``runs[0]``), so you can see *which*
+    topics are fragile rather than only the corpus-wide average (#775 T3.3).
 
     If every run is bit-identical to the first, a stability of 1.0 is
     meaningless — the runs never varied. This most often bites when the runs are
@@ -1234,12 +1238,18 @@ def topic_stability(runs, *, num_topics=None, k=None, seeds=None, model_factory=
         )
     k = ref.shape[0]
     ref_top = [set(np.argsort(ref[t])[::-1][:topn]) for t in range(k)]
-    scores = []
+    # Accumulate per reference topic (i) across the other runs, so we can report a
+    # per-topic vector as well as the overall mean (#775 T3.3).
+    per = [[] for _ in range(k)]
     for mat in mats[1:]:
         for i, j, _ in align_topics(ref, mat, metric=metric):
             other = set(np.argsort(mat[j])[::-1][:topn])
             union = ref_top[i] | other
-            scores.append(len(ref_top[i] & other) / len(union) if union else 0.0)
+            per[i].append(len(ref_top[i] & other) / len(union) if union else 0.0)
+    if per_topic:
+        # One matched-Jaccard mean per reference topic, index-aligned to runs[0].
+        return np.array([float(np.mean(s)) if s else float("nan") for s in per])
+    scores = [s for topic_scores in per for s in topic_scores]
     return float(np.mean(scores)) if scores else float("nan")
 
 
@@ -1274,7 +1284,7 @@ def _take_rows(value, pick):
 
 def bootstrap_stability(
     docs,
-    *,
+    *args,
     k=None,
     num_topics=None,
     n_boot=20,
@@ -1344,6 +1354,34 @@ def bootstrap_stability(
     per-topic ``(topic, stability)`` DataFrame.
     """
     from . import LDA  # local import to avoid a cycle at module load
+
+    # bootstrap_stability REFITS on resamples, so its first argument is the corpus,
+    # not a fitted model, and everything else is keyword-only. The natural wrong
+    # guesses — `bootstrap_stability(model)` or `bootstrap_stability(model, corpus)`
+    # (a #775 T2.2 finding) — otherwise die with an opaque positional-argument
+    # error. Redirect to the docs-first signature and the reference= param, which is
+    # how you measure a *specific* fitted model. (`*args` exists only to catch the
+    # second-positional mistake; all real arguments are keyword-only.)
+    _looks_like_model = hasattr(docs, "topic_word") or hasattr(docs, "num_topics")
+    if _looks_like_model or args:
+        if _looks_like_model:
+            raise TypeError(
+                "bootstrap_stability(docs, ...) takes the corpus (token lists or a "
+                "Corpus) as its only positional argument and refits on bootstrap "
+                "resamples — it does not take a fitted model. To measure a fitted "
+                "model's stability, pass the corpus and name the model with "
+                "reference=:\n"
+                "    bootstrap_stability(docs, reference=model,\n"
+                "        model_factory=lambda seed: type(model)(model.num_topics, seed=seed))\n"
+                "or just bootstrap_stability(docs, num_topics=model.num_topics)."
+            )
+        raise TypeError(
+            f"bootstrap_stability takes one positional argument (the corpus); got "
+            f"{1 + len(args)}. Everything else is keyword-only (num_topics=, "
+            "n_boot=, reference=, ...). If you meant bootstrap_stability(model, "
+            "corpus), note it refits from the documents: pass the corpus first and "
+            "the model as reference=."
+        )
 
     # num_topics= is the library-wide name for the topic count (every constructor
     # is Model(num_topics=...)); accept it as an alias for this function's k= so a

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -827,8 +827,24 @@ def estimate_effect(
     if len(names) != X.shape[1]:
         raise ValueError("feature_names length must match X columns")
     if add_intercept:
-        X = np.hstack([np.ones((n, 1)), X])
-        names = ["intercept"] + names
+        # If X already carries a constant column, prepending another intercept makes
+        # the design collinear and shifts every coefficient label by one, so coef[1]
+        # is a duplicate intercept rather than the first real covariate (#775 T1.2).
+        # Skip the auto-add and say which column looked like an intercept, instead of
+        # silently producing a rank-deficient design.
+        const = [i for i in range(X.shape[1]) if np.ptp(X[:, i]) == 0.0]
+        if const:
+            warnings.warn(
+                f"add_intercept=True but X already has a constant column at index "
+                f"{const[0]} ({names[const[0]]!r}); not adding a second intercept "
+                "(that would split the intercept across collinear columns and shift "
+                "every coefficient label). Pass add_intercept=False to silence this.",
+                UserWarning,
+                stacklevel=2,
+            )
+        else:
+            X = np.hstack([np.ones((n, 1)), X])
+            names = ["intercept"] + names
 
     if link not in ("identity", "logit", "log"):
         raise ValueError("link must be 'identity', 'logit', or 'log'")
@@ -1223,6 +1239,20 @@ class PredictedPrevalence:
                 f"{lo.size}. Use ci_low/ci_high (arrays) or to_frame()."
             )
         return float(lo[0]), float(hi[0])
+
+    @property
+    def grid_values(self) -> list:
+        """The grid as a flat list, uniform across modes — so you can zip it with
+        ``estimate`` without special-casing the mode (#775 T3.2). ``grid`` itself
+        holds dicts for ``at``/``continuous`` but the two setting labels for
+        ``contrast``, so indexing it directly (e.g. ``float(pp.grid[i])``) breaks
+        across modes. This returns the swept covariate's value per point for
+        ``continuous`` (floats), the two labels for ``contrast``, and one dict per
+        row for ``at``."""
+        if self.mode == "continuous" and self.covariate is not None:
+            return [float(g[self.covariate]) if isinstance(g, dict) else float(g)
+                    for g in self.grid]
+        return list(self.grid)
 
     def to_frame(self):
         """Return a tidy pandas DataFrame with one row per grid point.
@@ -1895,7 +1925,7 @@ def topic_correlation_ci(model, *, nsims=200, ci=0.9, seed=0):
     return TopicCorrelationCI(estimate, se, ci_low, ci_high)
 
 
-def spline(x, df=4, knots=None):
+def spline(x, df=4, knots=None, name="x"):
     """Restricted (natural) cubic-spline basis for a covariate — the building
     block for nonlinear prevalence terms like R ``stm``'s ``~ s(day)``.
 
@@ -1903,6 +1933,12 @@ def spline(x, df=4, knots=None):
     evenly spaced quantiles of `x` unless `knots` is given) yield `df` basis
     columns whose first is the linear term. ``np.column_stack`` the result into
     your design matrix and extend ``feature_names`` with the returned names.
+
+    Columns are named ``spline(<name>, df=<df>)[<i>]`` — the same convention the
+    ``spline(...)`` term in a formula produces (#775 T4.2), so a raw-``X`` design
+    built with this helper labels its columns identically to
+    :func:`design_matrix`. Pass ``name=`` (the covariate's name) to match a
+    specific formula column; it defaults to ``"x"``.
 
     Returns ``(basis (n, df), names)``.
     """
@@ -1929,7 +1965,7 @@ def spline(x, df=4, knots=None):
         ) / denom
         cols.append(term)
     basis = np.column_stack(cols)
-    names = ["spline_lin"] + [f"spline_{j + 1}" for j in range(basis.shape[1] - 1)]
+    names = [f"spline({name}, df={df})[{j}]" for j in range(basis.shape[1])]
     return basis, names
 
 

--- a/src/python/corpus.rs
+++ b/src/python/corpus.rs
@@ -9,6 +9,8 @@ use std::fs;
 use std::io::{Read, Seek, SeekFrom, Write};
 use std::path::Path;
 
+use numpy::ndarray::Array1;
+use numpy::{PyArray1, ToPyArray};
 use pyo3::exceptions::PyValueError;
 use pyo3::prelude::*;
 use pyo3::types::{PyBytes, PyDict, PyString};
@@ -506,8 +508,17 @@ impl Corpus {
     /// recover each document's Dirichlet posterior for method-of-composition
     /// standard errors.
     #[getter]
-    fn doc_lengths(&self) -> Vec<usize> {
-        self.inner.docs.iter().map(|d| d.len()).collect()
+    fn doc_lengths<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i64>> {
+        // A numpy array, not a list, so `.mean()`/`.sum()` work directly on the
+        // numpy-native corpus (#775 T3.1).
+        Array1::from(
+            self.inner
+                .docs
+                .iter()
+                .map(|d| d.len() as i64)
+                .collect::<Vec<_>>(),
+        )
+        .to_pyarray_bound(py)
     }
 
     /// The pruned vocabulary as a list of word strings, indexed by word id
@@ -526,8 +537,16 @@ impl Corpus {
     /// James-Stein shrinkage use; pass it (or the corpus) to
     /// :func:`topica.inspect.label_topics` / :func:`topica.inspect.frex` for stm-faithful labels.
     #[getter]
-    fn word_counts(&self) -> Vec<u32> {
-        self.inner.total_freqs.clone()
+    fn word_counts<'py>(&self, py: Python<'py>) -> Bound<'py, PyArray1<i64>> {
+        // A numpy array, not a list, parallel to `vocabulary` (#775 T3.1).
+        Array1::from(
+            self.inner
+                .total_freqs
+                .iter()
+                .map(|&c| c as i64)
+                .collect::<Vec<_>>(),
+        )
+        .to_pyarray_bound(py)
     }
 
     /// The corpus as token lists — one list of word strings per document, in the

--- a/tests/test_corpus.py
+++ b/tests/test_corpus.py
@@ -1,8 +1,22 @@
 """Tests for the Corpus class."""
 
+import numpy as np
 import pytest
 
 from topica import Corpus
+
+
+def test_doc_lengths_word_counts_are_numpy_arrays():
+    # #775 T3.1: doc_lengths / word_counts are numpy arrays (not lists) on the
+    # numpy-native corpus, so .mean()/.sum() work directly. vocabulary stays a list.
+    docs = [["cat", "dog", "fish"], ["cat", "dog"], ["cat"]]
+    c = Corpus.from_documents(docs)
+    assert isinstance(c.doc_lengths, np.ndarray)
+    assert isinstance(c.word_counts, np.ndarray)
+    assert c.doc_lengths.tolist() == [3, 2, 1]
+    assert float(c.doc_lengths.mean()) == pytest.approx(2.0)
+    assert int(c.word_counts.sum()) == 6  # total token occurrences
+    assert isinstance(c.vocabulary, list) and all(isinstance(w, str) for w in c.vocabulary)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_formulas.py
+++ b/tests/test_formulas.py
@@ -36,6 +36,21 @@ def test_design_matrix_spline_columns(frame):
     assert X.shape == (20, 3)
 
 
+def test_standalone_spline_names_match_formula_convention(frame):
+    # #775 T4.2: topica.design.spline() names columns spline(<name>, df=<k>)[i] —
+    # the same convention as the spline() term in a formula — instead of the old
+    # spline_lin/spline_1/spline_2, so a raw-X design labels columns identically.
+    year = frame["year"].to_numpy()
+    _, names = topica.design.spline(year, df=3, name="year")
+    assert names == ["spline(year, df=3)[0]", "spline(year, df=3)[1]", "spline(year, df=3)[2]"]
+    # matches the formula path's column names exactly
+    _, form_names = topica.design_matrix("~ spline(year, df=3)", frame)
+    assert names == form_names
+    # default name is "x"
+    _, dflt = topica.design.spline(year, df=2)
+    assert dflt == ["spline(x, df=2)[0]", "spline(x, df=2)[1]"]
+
+
 def test_formula_path_matches_manual_X(frame):
     theta = np.random.default_rng(0).dirichlet([1, 1, 1], size=20)
     X, names = topica.design_matrix("~ party + x", frame)

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -915,3 +915,33 @@ def test_stability_helpers_discoverable_under_robustness():
     assert topica.robustness.topic_stability is topica.evaluate.topic_stability
     assert topica.robustness.bootstrap_stability is topica.evaluate.bootstrap_stability
     assert {"topic_stability", "bootstrap_stability"} <= set(topica.robustness.__all__)
+
+
+def test_bootstrap_stability_rejects_fitted_model_directively():
+    # #775 T2.2: bootstrap_stability refits from the corpus, so bootstrap_stability(
+    # model) and bootstrap_stability(model, corpus) — the natural guesses — used to
+    # die on an opaque positional-arg error. Redirect to docs-first + reference=.
+    docs = [["cat", "dog", "pet"]] * 15 + [["star", "moon", "sky"]] * 15
+    m = topica.LDA(2, seed=1).fit(docs, iters=50)
+    for call in (lambda: topica.evaluate.bootstrap_stability(m),
+                 lambda: topica.evaluate.bootstrap_stability(m, docs)):
+        with pytest.raises(TypeError, match="does not take a fitted model|reference="):
+            call()
+    # a second positional that is NOT a model still gets a clear keyword-only error
+    with pytest.raises(TypeError, match="one positional argument"):
+        topica.evaluate.bootstrap_stability(docs, docs)
+    # the correct call still works
+    r = topica.evaluate.bootstrap_stability(docs, num_topics=2, n_boot=3, iters=40)
+    assert 0.0 <= r["mean"] <= 1.0
+
+
+def test_topic_stability_per_topic_vector():
+    # #775 T3.3: per_topic=True returns a per-topic vector (index-aligned to
+    # runs[0]) alongside the scalar default, so a lone 0.46 isn't the only signal.
+    docs = [["cat", "dog", "pet"]] * 12 + [["star", "moon", "sky"]] * 12
+    runs = [topica.LDA(3, seed=s).fit(docs, iters=60) for s in (1, 2, 3)]
+    overall = topica.topic_stability(runs)
+    per = topica.topic_stability(runs, per_topic=True)
+    assert isinstance(overall, float)
+    assert per.shape == (3,)
+    assert np.all((per >= 0.0) & (per <= 1.0))

--- a/tests/test_predicted_prevalence.py
+++ b/tests/test_predicted_prevalence.py
@@ -258,6 +258,23 @@ class TestSTM:
             predicted_prevalence(m, X=x.reshape(-1, 1), feature_names=["x"],
                                  continuous="year", npoints=5, nsims=5, seed=0)
 
+    def test_grid_values_uniform_across_modes(self, stm_continuous_model):
+        """#775 T3.2: grid_values is a flat list in every mode — floats for
+        continuous, the two labels for contrast — so it can be zipped with estimate
+        without special-casing grid's per-mode element type (dict vs string)."""
+        m, x = stm_continuous_model
+        X = x.reshape(-1, 1)
+        cont = predicted_prevalence(m, X=X, feature_names=["x"], continuous="x",
+                                    npoints=5, nsims=5, n_sim=100, seed=0)[0]
+        gv = cont.grid_values
+        assert len(gv) == len(cont.estimate)
+        assert all(isinstance(v, float) for v in gv)
+        assert min(gv) == pytest.approx(float(x.min()))
+        contr = predicted_prevalence(m, X=X, feature_names=["x"],
+                                     contrast={"x": [float(x.min()), float(x.max())]},
+                                     nsims=5, n_sim=100, seed=0)[0]
+        assert len(contr.grid_values) == 2  # two setting labels, not dicts
+
     def test_continuous_ci_ordering(self, stm_continuous_model):
         m, x = stm_continuous_model
         meta = pd.DataFrame({"x": x})

--- a/tests/test_stm.py
+++ b/tests/test_stm.py
@@ -155,6 +155,27 @@ class TestEstimateEffect:
         assert "intercept" not in eff.feature_names
         assert len(eff.coef) == 1
 
+    def test_intercept_not_doubled_when_x_has_constant(self, synthetic_model_and_x, space_topic_idx):
+        """#775 T1.2: if X already carries a constant column, add_intercept=True must
+        not prepend a *second* intercept (which splits it across collinear columns
+        and shifts every coefficient label). It warns and skips instead."""
+        import numpy as np
+        model, x = synthetic_model_and_x
+        x2 = np.atleast_2d(x)
+        if x2.shape[0] == 1:
+            x2 = x2.T
+        Xc = np.column_stack([np.ones(x2.shape[0]), x2])  # user-supplied intercept
+        with pytest.warns(UserWarning, match="already has a constant column"):
+            effects = stm.estimate_effect(
+                model.doc_topic, Xc, feature_names=["Intercept", "x"],
+                add_intercept=True, topics=[space_topic_idx],
+            )
+        eff = effects[0]
+        # exactly one intercept column, and 'x' still at the index the user gave it
+        assert [n.lower() for n in eff.feature_names].count("intercept") == 1
+        assert eff.feature_names == ["Intercept", "x"]
+        assert len(eff.coef) == 2
+
     def test_all_topics_default(self, synthetic_model_and_x):
         """Default topics=None returns one effect per topic."""
         model, x = synthetic_model_and_x


### PR DESCRIPTION
The remaining findings from the sample-user audit (#775), bundled. Each is small and independently testable; grouped since they're all the same audit.

| Item | Tier | Fix |
|---|---|---|
| **T1.2** `estimate_effect` double-intercept | 3 | When `X` already has a constant column, `add_intercept=True` skips the auto-add and warns, instead of silently prepending a second intercept and shifting every coefficient label. |
| **T2.2** `bootstrap_stability(model, corpus)` | 2 | A fitted model as the first arg (incl. the two-positional `(model, corpus)`) now raises a directive `TypeError` — it refits from documents; use `reference=` to measure a specific model — instead of an opaque positional-arg error. |
| **T3.1** `Corpus.doc_lengths`/`word_counts` | 3 | Return numpy arrays, not lists, so `.mean()`/`.sum()` work on the numpy-native corpus. `vocabulary` stays a list of strings. (Rust getters + `.pyi`.) |
| **T3.2** `PredictedPrevalence.grid` | 3 | New `grid_values` accessor — flat and mode-uniform (floats for `continuous`, two labels for `contrast`) — so it zips with `estimate` without special-casing the per-mode element type. |
| **T3.3** `topic_stability` bare float | 3 | `per_topic=True` returns the per-topic vector (index-aligned to `runs[0]`) alongside the scalar default. |
| **T4.2** spline naming | 4 | `design.spline()` names columns `spline(<name>, df=<k>)[i]` (optional `name=`, default `"x"`), matching the formula path instead of `spline_lin/spline_1/spline_2`. Nothing referenced the old names. |

Not in this PR (resolved earlier): T1.1 (kept as-is, per maintainer), T2.1 (#777), T4.1 (#776).

**Tests:** Rust 340 passed; full pytest **4993 passed, 38 skipped**; preflight green. New regression tests in `test_corpus.py`, `test_stm.py`, `test_predicted_prevalence.py`, `test_formulas.py`, `test_issue_fixes.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)