### PR TITLE
docs(stopwords): cross-reference the two English lists (#766)

### DIFF
--- a/python/topica/stopwords.py
+++ b/python/topica/stopwords.py
@@ -15,8 +15,11 @@ licensed; see ``_data/STOPWORDS_ISO_LICENSE.txt``)::
     corpus = topica.from_dataframe(df, text_col="texte", stopwords=fr)
     topica.data.stopword_languages()                 # the available ISO 639-1 codes
 
-``ENGLISH_STOPWORDS`` is kept as the short, stable default; ``stopwords("en")``
-is the larger stopwords-iso English list.
+There are two English lists, of different sizes on purpose:
+``ENGLISH_STOPWORDS`` (~115 words) is the short, curated, stable default;
+``stopwords("en")`` (~1300 words) is the larger, more aggressive stopwords-iso
+English list. Pick the curated list for a conservative, predictable cut and the
+ISO list when you want to strip more.
 """
 from __future__ import annotations
 
@@ -62,6 +65,13 @@ def stopwords(language: str) -> frozenset:
 
         corpus = topica.from_dataframe(df, text_col="texte",
                                        stopwords=topica.data.stopwords("fr"))
+
+    For English there are two bundled lists, and they differ in size on purpose:
+    ``stopwords("en")`` is the stopwords-iso list (~1300 words, aggressive),
+    while :data:`ENGLISH_STOPWORDS` is a short, curated frozenset (~115 common
+    function words) kept as the stable default. Reach for ``stopwords("en")``
+    when you want a heavier cut; reach for :data:`ENGLISH_STOPWORDS` when you
+    want a conservative, predictable list.
 
     Raises ``ValueError`` with the available codes if the language is unknown.
     """

--- a/tests/test_issue_fixes.py
+++ b/tests/test_issue_fixes.py
@@ -935,6 +935,19 @@ def test_bootstrap_stability_rejects_fitted_model_directively():
     assert 0.0 <= r["mean"] <= 1.0
 
 
+def test_stopword_lists_cross_reference_each_other():
+    # #766: the two English lists differ in size on purpose (ENGLISH_STOPWORDS ~115
+    # curated vs stopwords("en") ~1300 iso). help() on either must point at the
+    # other so a newcomer can tell which is "the" list.
+    small = topica.ENGLISH_STOPWORDS
+    big = topica.stopwords("en")
+    assert len(small) < len(big)
+    # stopwords() docstring names the curated frozenset; the module docstring names both.
+    assert "ENGLISH_STOPWORDS" in topica.stopwords.__doc__
+    import topica.stopwords as sw_mod
+    assert "ENGLISH_STOPWORDS" in sw_mod.__doc__ and 'stopwords("en")' in sw_mod.__doc__
+
+
 def test_topic_stability_per_topic_vector():
     # #775 T3.3: per_topic=True returns a per-topic vector (index-aligned to
     # runs[0]) alongside the scalar default, so a lone 0.46 isn't the only signal.


### PR DESCRIPTION
Closes the remaining actionable item from the #766 sample-user review.

## Status of #766

Most of #766 had already shipped before this PR:

| Item | Status |
|---|---|
| `stopwords="english"` silent no-op (high priority) | Fixed in #768 — `stopwords_set` resolves a bare string via `topica.stopwords()` for `tokenize`, `Corpus.from_documents`, and `from_dataframe`. |
| Opaque `**kwargs` signatures on `from_dataframe`/`LDA`/`STM` | Already resolved — all three expose explicit params via `inspect.signature`/`help()`. |
| `perplexity(Heldout)` semantics | Split to #767, shipped. |
| **Two English stopword lists, different sizes** | **This PR.** |
| `doc_topic()` parens error cryptic | Won't-fix — see below. |

## This change (item 3)

`ENGLISH_STOPWORDS` (~115, curated) and `stopwords("english")` (~1298, stopwords-iso) are two similarly-named English lists with no signal for which is "the" list. This adds symmetric docstring cross-references:

- `stopwords()` docstring now names `ENGLISH_STOPWORDS`, states both sizes, and says when to pick each.
- The module docstring states both counts explicitly.
- A regression test guards the cross-note.

## `doc_topic()` cryptic error — won't-fix (matches scikit-learn)

`model.doc_topic()` (calling a property) raises the generic `'numpy.ndarray' object is not callable`. A directive error would require returning an ndarray *subclass* with a custom `__call__` from the array getters (186 of them across 29 files). scikit-learn does exactly nothing here — `LogisticRegression().fit(X,y).coef_()` and `LatentDirichletAllocation().fit(X).components_()` raise the identical generic `TypeError`; sklearn's whole mitigation is the naming convention plus documented attributes. topica already exposes these as documented properties, so adding subclass machinery would make it *less* conventional than the library it mirrors, for a standard Python error. Resolving as won't-fix.

## Tests

Docstring-only source change plus one regression test. `test_issue_fixes.py`, `test_stopwords.py`, `test_frames.py`: 113 passed. `mkdocs build --strict`: clean. preflight: green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)