### PR TITLE
feat(guidednmf): warn + expose seed_topic_map on seed-group collapse (#686)

### DIFF
--- a/docs/guides/guided.md
+++ b/docs/guides/guided.md
@@ -207,9 +207,15 @@ the same `seed_match`/`case_insensitive` matcher as `SeededLDA`.
 seeds = {"economy": ["tax", "market", "jobs"], "foreign": ["war", "troops"]}
 m = topica.GuidedNMF(num_topics=10, seed_words=seeds, seed=1).fit(docs)  # guidance defaults to 3.0
 m.seed_topic_indices           # which learned topic each group steered
-dict(zip(m.seed_group_names, m.seed_topic_indices))   # name -> topic
+m.seed_topic_map               # {group name -> topic index}, the same pairing
 m.top_words(10, topic=m.seed_topic_indices[0])
 ```
+
+If two seed groups steer the *same* learned topic — their indices repeat in
+`seed_topic_indices` / collide in `seed_topic_map` — `fit` warns: the groups
+collapsed onto one topic, so their document prevalence is indistinguishable and
+you must not report one group's `doc_topic` share as another's. Give the groups
+more distinctive seed words, raise `num_topics`, or raise `guidance`.
 
 The full model reference and its ssnmf validation are in
 [models.md#guidednmf](models.md#guidednmf). Two things to know before you report

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -5180,6 +5180,10 @@ class GuidedNMF:
         """The seed-group names, ordered to index seed_topic_indices."""
         ...
     @property
+    def seed_topic_map(self) -> dict[str, int]:
+        """{seed_group_name: learned_topic_index}; duplicate indices = a collapse (fit warns)."""
+        ...
+    @property
     def guidance(self) -> float: ...
     @property
     def reconstruction_error(self) -> float:

--- a/src/python/guided_nmf.rs
+++ b/src/python/guided_nmf.rs
@@ -117,6 +117,44 @@ impl GuidedNMF {
     }
 }
 
+/// Warn when two or more seed groups steer the SAME learned topic (#686): their
+/// document prevalence is then indistinguishable, so a user could report one
+/// group's `doc_topic` share as another's. Silent when every group owns a distinct
+/// topic. Collisions are sorted so the message is deterministic.
+fn guided_nmf_collapse_warning(
+    py: Python<'_>,
+    seed_topic_indices: &[usize],
+    seed_names: &[String],
+) {
+    let mut by_topic: std::collections::HashMap<usize, Vec<&str>> =
+        std::collections::HashMap::new();
+    for (i, &k) in seed_topic_indices.iter().enumerate() {
+        let name = seed_names.get(i).map(String::as_str).unwrap_or("?");
+        by_topic.entry(k).or_default().push(name);
+    }
+    let mut collisions: Vec<String> = by_topic
+        .iter()
+        .filter(|(_, names)| names.len() > 1)
+        .map(|(k, names)| format!("topic {k}: {}", names.join(", ")))
+        .collect();
+    if collisions.is_empty() {
+        return;
+    }
+    collisions.sort();
+    if let Ok(warnings) = py.import_bound("warnings") {
+        let _ = warnings.call_method1(
+            "warn",
+            (format!(
+                "GuidedNMF: seed groups collapsed onto a shared topic ({}). Their \
+                 document prevalence is indistinguishable — do not report one group's \
+                 doc_topic share as another's (see seed_topic_map). Try a larger \
+                 num_topics, a higher guidance, or more distinctive seed words.",
+                collisions.join("; ")
+            ),),
+        );
+    }
+}
+
 #[pymethods]
 impl GuidedNMF {
     /// The random seed the model was constructed with.
@@ -384,6 +422,11 @@ impl GuidedNMF {
         slf.corpus = Some(corpus);
         slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
         slf.fitted = true;
+        guided_nmf_collapse_warning(
+            py,
+            &slf.model.as_ref().unwrap().seed_topic_indices,
+            &slf.seed_names,
+        );
         Ok(slf.into())
     }
 
@@ -427,6 +470,20 @@ impl GuidedNMF {
     #[getter]
     fn seed_group_names(&self) -> Vec<String> {
         self.seed_names.clone()
+    }
+
+    /// Convenience map ``{seed_group_name: learned_topic_index}`` — the same pairing
+    /// as ``dict(zip(seed_group_names, seed_topic_indices))``. When two group names
+    /// point at the *same* index they collapsed onto a shared topic (:meth:`fit`
+    /// warns), and their document prevalence cannot be told apart.
+    #[getter]
+    fn seed_topic_map<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        let idx = &self.fitted_model()?.seed_topic_indices;
+        let d = PyDict::new_bound(py);
+        for (name, &k) in self.seed_names.iter().zip(idx.iter()) {
+            d.set_item(name, k)?;
+        }
+        Ok(d)
     }
     /// The guidance weight lambda.
     #[getter]

--- a/tests/test_guided_nmf.py
+++ b/tests/test_guided_nmf.py
@@ -6,6 +6,8 @@ recovery, determinism, save-load + bad-params) plus the guidance-specific surfac
 (seed_topic_indices, raw factors) and edge cases.
 """
 
+import warnings
+
 import numpy as np
 import pytest
 
@@ -70,6 +72,40 @@ def test_guidance_steers_seeded_topics():
     top1 = [w for w, _ in m.top_words(3, topic=idx[1], weights=True)]
     assert {"a", "b"} & set(top0)
     assert {"x", "y"} & set(top1)
+
+
+def test_seed_topic_map_matches_indices():
+    # #686: seed_topic_map is dict(zip(seed_group_names, seed_topic_indices)).
+    docs = _planted_docs()
+    m = topica.GuidedNMF(3, SEEDS, weighting="count", seed=0).fit(docs, iters=80)
+    assert m.seed_topic_map == dict(zip(m.seed_group_names, list(m.seed_topic_indices)))
+
+
+def test_warns_when_seed_groups_collapse_onto_one_topic():
+    # #686: two seed groups that both point at the same content should collapse
+    # onto a shared topic, and fit() must warn (their prevalence is then
+    # indistinguishable) and expose the collision via seed_topic_map.
+    t1 = ["tax", "vote", "law", "bill", "budget", "senate"]
+    t2 = ["health", "clinic", "patient", "doctor", "care", "nurse"]
+    docs = [[t1[i % 6] for i in range(d, d + 4)] for d in range(120)]
+    docs += [[t2[i % 6] for i in range(d, d + 4)] for d in range(120)]
+    seeds = {"fiscal": ["tax", "vote"], "legislative": ["law", "bill"],
+             "medical": ["health", "clinic"]}
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        m = topica.GuidedNMF(3, seeds, seed=13).fit(docs)
+    idx = list(m.seed_topic_indices)
+    assert len(idx) != len(set(idx)), "expected two groups to share a topic"
+    assert any("collapsed onto a shared topic" in str(x.message) for x in w)
+
+
+def test_no_collapse_warning_when_groups_own_distinct_topics():
+    docs = _planted_docs()
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        m = topica.GuidedNMF(3, SEEDS, weighting="count", seed=0).fit(docs, iters=80)
+    assert len(set(m.seed_topic_indices)) == len(list(m.seed_topic_indices))
+    assert not any("collapsed onto a shared topic" in str(x.message) for x in w)
 
 
 def test_objective_decreases():


### PR DESCRIPTION
Closes #686 — the last remaining item from the GuidedNMF sample-user audit.

## The one remaining item

Two seed groups can steer the **same** learned topic (`seed_topic_indices` repeats) with no signal, so a user could report one group's `doc_topic` prevalence as another's.

- **New `seed_topic_map` getter** — `{seed_group_name: learned_topic_index}`, the same pairing as `dict(zip(seed_group_names, seed_topic_indices))`.
- **`fit()` warns on collapse** — when two+ groups map to a shared topic, it names the colliding groups and steers to more distinctive seeds / larger `num_topics` / higher `guidance`. Silent when every group owns a distinct topic.
- **`guided.md`** documents both.

## Everything else in #686 was already resolved (verified against current code)

| Item | Status |
|---|---|
| Tier 1 — `convergence_tol` early-stop; `guidance=20` zero-prevalence | Fixed in #684 |
| Tier 2 — inconsistent `topica.datasets` loader shapes | Fixed in #700 (`as_bunch=`) |
| Tier 3 — `topic_table` signature | Fixed in #700 (polymorphic) |
| Tier 4 — `coherence()` docs roster-wide | Fixed in #702 |

**The `doc_topic` collapse** flagged in the 2026-08-09 benchmark comment (1399/1450 docs on one topic, recovery 0.19 on 20NG) **no longer reproduces**: `doc_topic` already applies H-row-mass scaling (`theta_dk ∝ A_dk·‖S_k‖₁`, `src/guided_nmf.rs:238`) and the `guidance=3` default (#684) fixed the low-prevalence cause. A synthetic 5-group K=8 fit now spreads docs (max single-topic share **0.20**, not the reported 0.965).

## Tests

New regression tests in `test_guided_nmf.py`: `seed_topic_map` matches indices, collapse warning fires when two groups share a topic, and stays silent on a clean fit. Full pytest **5010 passed, 38 skipped**; preflight + `mkdocs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)