### PR TITLE
feat(gsdmm): fit(verbose=) progress + topica.inspect.topic_crosstab (#781)

### DIFF
--- a/docs/guides/short-text.md
+++ b/docs/guides/short-text.md
@@ -17,8 +17,21 @@ cap nor honours its one-topic-per-document assumption; reach for `LDA` or `STM`
 there instead, or reduce each document to a short field (a title or first
 sentence). `fit` warns you when the average document is long. It is also
 **single-threaded by design** (its cluster-count discovery is inherently
-sequential), so a large corpus fits slowly and silently — subsample while you
-explore, and raise `progress_interval` to watch the discovery trace.
+sequential), so a large corpus fits slowly — subsample while you explore, and
+pass `fit(..., verbose=True)` to print per-sweep progress (iteration, cluster
+count, log-likelihood) to stderr so a long fit does not look hung.
+
+To report which topics load on a covariate — the "which topics do Democrats vs
+Republicans write?" table — cross the assignment against a metadata column:
+
+```python
+topica.inspect.topic_crosstab(model, corpus, "party")                 # counts
+topica.inspect.topic_crosstab(model, corpus, "party", normalize="index")  # row %
+```
+
+It uses `doc_cluster` for GSDMM (and any hard-clustering model) and the dominant
+`doc_topic` topic for mixed-membership models; `corpus.metadata` stays row-aligned
+through pruning, so no manual realignment is needed.
 
 Two caveats to read the discovered count honestly. First, with the default
 `alpha=0.1` an emptied cluster keeps `alpha`-proportional mass and can revive, so

--- a/python/topica/_compat.py
+++ b/python/topica/_compat.py
@@ -110,6 +110,7 @@ LAZY = {
     'stopwords': 'data',
     'top_topics': 'effects',
     'topic_correlation': 'inspect',
+    'topic_crosstab': 'inspect',
     'topic_dendrogram': 'evaluate',
     'topic_diversity': 'evaluate',
     'topic_semantic_diversity': 'evaluate',

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2773,6 +2773,7 @@ class GSDMM:
         progress_interval: int = 0,
         report_interval: Optional[int] = None,
         num_threads: int = 1,
+        verbose: bool = False,
     ) -> "GSDMM":
         """Fit by the Movie Group Process. progress_interval controls the
         cluster-discovery trace (0 = auto ~50 points).
@@ -2780,7 +2781,10 @@ class GSDMM:
         report_interval is a deprecated alias for progress_interval.
 
         num_threads must be 1; GSDMM is not parallelized (cluster-count discovery
-        is inherently sequential). num_threads > 1 raises ValueError."""
+        is inherently sequential). num_threads > 1 raises ValueError.
+
+        verbose=True prints a per-sweep progress line to stderr so a long
+        single-threaded fit does not look hung."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...

--- a/python/topica/inspect.py
+++ b/python/topica/inspect.py
@@ -33,6 +33,7 @@ __all__ = [
     'prepare_pyldavis',
     'relevance',
     'topic_correlation',
+    'topic_crosstab',
     'topic_table',
     'topics_for_term',
 ]
@@ -662,6 +663,72 @@ def find_thoughts(doc_topic, texts=None, *, topic, n=3):
         out.append((int(i), float(theta[i, topic]), text))
     return out
 
+
+
+def topic_crosstab(model, metadata, column=None, *, normalize=None):
+    """Crosstab each document's dominant topic against a covariate — the standard
+    "which topics do Democrats vs Republicans write?" reporting table.
+
+    Returns a pandas ``DataFrame`` with one row per topic and one column per
+    distinct value of the covariate. Cells are document counts by default;
+    ``normalize`` follows :func:`pandas.crosstab` — ``"index"`` for row
+    proportions (each topic's split across the covariate), ``"columns"`` for
+    column proportions (each group's split across topics), ``"all"``, or ``None``.
+
+    `model` is a fitted model. Hard-clustering models (``GSDMM``) use
+    :attr:`doc_cluster`; every other model uses ``doc_topic.argmax(axis=1)`` (the
+    dominant topic — for mixed-membership models this is a summary, not the full
+    mixture). `metadata` is a :class:`~topica.Corpus` (uses its row-aligned
+    ``.metadata``), a ``DataFrame``, or a 1-D array / ``Series`` of covariate
+    values; pass `column` to name the field when it is a Corpus or DataFrame.
+
+    The covariate must be row-aligned to the model's documents. ``from_dataframe``
+    keeps ``corpus.metadata`` aligned through pruning, so ``topic_crosstab(model,
+    corpus, "party")`` just works; if you pass an external array, index it by
+    ``corpus.kept_indices`` first.
+    """
+    import pandas as pd
+
+    if hasattr(model, "doc_cluster"):
+        assign = np.asarray(model.doc_cluster)
+        row_name = "cluster"
+    else:
+        assign = np.asarray(model.doc_topic).argmax(axis=1)
+        row_name = "topic"
+
+    # Resolve the covariate values.
+    if hasattr(metadata, "metadata"):  # a Corpus
+        md = metadata.metadata
+        if md is None:
+            raise ValueError(
+                "the Corpus carries no metadata; build it with from_dataframe(..., "
+                "metadata_cols=[...]) or pass the covariate array directly"
+            )
+        if column is None:
+            raise ValueError("pass column= to select a metadata field from the Corpus")
+        values = np.asarray(md[column])
+        col_name = column
+    elif hasattr(metadata, "columns"):  # a DataFrame
+        if column is None:
+            raise ValueError("pass column= to select a field from the DataFrame")
+        values = np.asarray(metadata[column])
+        col_name = column
+    else:  # a 1-D array / Series
+        values = np.asarray(metadata)
+        col_name = column or "covariate"
+
+    if values.shape[0] != assign.shape[0]:
+        raise ValueError(
+            f"covariate has {values.shape[0]} rows but the model has {assign.shape[0]} "
+            "documents; align the covariate to the fitted documents "
+            "(corpus.kept_indices) — pruning may have dropped some"
+        )
+    ct = pd.crosstab(
+        pd.Series(assign, name=row_name),
+        pd.Series(values, name=col_name),
+        normalize=normalize if normalize is not None else False,
+    )
+    return ct
 
 
 # ---------------------------------------------------------------------------

--- a/python/topica/inspect.py
+++ b/python/topica/inspect.py
@@ -669,8 +669,11 @@ def topic_crosstab(model, metadata, column=None, *, normalize=None):
     """Crosstab each document's dominant topic against a covariate — the standard
     "which topics do Democrats vs Republicans write?" reporting table.
 
-    Returns a pandas ``DataFrame`` with one row per topic and one column per
-    distinct value of the covariate. Cells are document counts by default;
+    Returns a pandas ``DataFrame`` with one row per topic (index-aligned to
+    :func:`topic_table` / ``top_words`` — row ``t`` is topic/cluster ``t``, so the
+    two tables join on the index) and one column per distinct value of the
+    covariate. Every topic gets a row even if it is never any document's dominant
+    topic (its row is all zeros). Cells are document counts by default;
     ``normalize`` follows :func:`pandas.crosstab` — ``"index"`` for row
     proportions (each topic's split across the covariate), ``"columns"`` for
     column proportions (each group's split across topics), ``"all"``, or ``None``.
@@ -680,7 +683,10 @@ def topic_crosstab(model, metadata, column=None, *, normalize=None):
     dominant topic — for mixed-membership models this is a summary, not the full
     mixture). `metadata` is a :class:`~topica.Corpus` (uses its row-aligned
     ``.metadata``), a ``DataFrame``, or a 1-D array / ``Series`` of covariate
-    values; pass `column` to name the field when it is a Corpus or DataFrame.
+    values; pass `column` to name the field when it is a Corpus or DataFrame. A
+    ``Series`` is aligned to the documents by *position*, not by its index.
+    Missing covariate values (``NaN`` / ``None``) are kept as their own column
+    rather than silently dropped, so the table always accounts for every document.
 
     The covariate must be row-aligned to the model's documents. ``from_dataframe``
     keeps ``corpus.metadata`` aligned through pruning, so ``topic_crosstab(model,
@@ -691,12 +697,29 @@ def topic_crosstab(model, metadata, column=None, *, normalize=None):
 
     if hasattr(model, "doc_cluster"):
         assign = np.asarray(model.doc_cluster)
+        n_topics = int(getattr(model, "num_topics", 0)) or (int(assign.max()) + 1 if assign.size else 0)
         row_name = "cluster"
-    else:
-        assign = np.asarray(model.doc_topic).argmax(axis=1)
+    elif hasattr(model, "doc_topic"):
+        dt = np.asarray(model.doc_topic)
+        assign = dt.argmax(axis=1)
+        n_topics = dt.shape[1]
         row_name = "topic"
+    else:
+        raise TypeError(
+            "topic_crosstab needs a fitted model exposing doc_cluster (GSDMM) or "
+            "doc_topic (every other model)"
+        )
 
     # Resolve the covariate values.
+    def _select(frame, kind):
+        if column is None:
+            raise ValueError(f"pass column= to select a field from the {kind}")
+        try:
+            return np.asarray(frame[column])
+        except KeyError:
+            avail = ", ".join(map(str, list(frame.columns)))
+            raise ValueError(f"column {column!r} not found; available: {avail}") from None
+
     if hasattr(metadata, "metadata"):  # a Corpus
         md = metadata.metadata
         if md is None:
@@ -704,19 +727,17 @@ def topic_crosstab(model, metadata, column=None, *, normalize=None):
                 "the Corpus carries no metadata; build it with from_dataframe(..., "
                 "metadata_cols=[...]) or pass the covariate array directly"
             )
-        if column is None:
-            raise ValueError("pass column= to select a metadata field from the Corpus")
-        values = np.asarray(md[column])
+        values = _select(md, "Corpus")
         col_name = column
     elif hasattr(metadata, "columns"):  # a DataFrame
-        if column is None:
-            raise ValueError("pass column= to select a field from the DataFrame")
-        values = np.asarray(metadata[column])
+        values = _select(metadata, "DataFrame")
         col_name = column
     else:  # a 1-D array / Series
         values = np.asarray(metadata)
         col_name = column or "covariate"
 
+    if values.ndim != 1:
+        raise ValueError(f"covariate must be 1-D, got a {values.ndim}-D array")
     if values.shape[0] != assign.shape[0]:
         raise ValueError(
             f"covariate has {values.shape[0]} rows but the model has {assign.shape[0]} "
@@ -727,7 +748,13 @@ def topic_crosstab(model, metadata, column=None, *, normalize=None):
         pd.Series(assign, name=row_name),
         pd.Series(values, name=col_name),
         normalize=normalize if normalize is not None else False,
+        dropna=False,  # keep NaN covariate values visible, not silently dropped
     )
+    # Give every topic a row (a never-dominant topic is otherwise missing), and
+    # keep the index dense so it lines up with topic_table / top_words by number.
+    if n_topics:
+        ct = ct.reindex(range(n_topics), fill_value=0)
+        ct.index.name = row_name
     return ct
 
 

--- a/src/gsdmm.rs
+++ b/src/gsdmm.rs
@@ -357,6 +357,7 @@ pub fn fit_gsdmm<R: Rng>(
     beta: f64,
     iters: usize,
     report_interval: usize,
+    verbose: bool,
     rng: &mut R,
 ) -> GsdmmModel {
     let d_count = docs.len();
@@ -397,7 +398,17 @@ pub fn fit_gsdmm<R: Rng>(
         sweep(&mut model, docs, rng);
         if report_interval > 0 && ((it + 1) % report_interval == 0 || it + 1 == iters) {
             let ll = model.cluster_log_likelihood(docs);
-            model.trace.push((it + 1, model.num_clusters(), ll));
+            let nc = model.num_clusters();
+            model.trace.push((it + 1, nc, ll));
+            if verbose {
+                // Progress to stderr (not stdout), so a long single-threaded fit
+                // does not look hung. Opt-in; off during tests and pipelines.
+                eprintln!(
+                    "[GSDMM] sweep {}/{}  {nc} clusters  ll={ll:.4}",
+                    it + 1,
+                    iters
+                );
+            }
         }
     }
 
@@ -478,7 +489,7 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         // k_max=10, expect it to collapse toward 3 non-empty clusters.
-        let model = fit_gsdmm(&docs, v, 10, 0.1, 0.1, 200, 0, &mut rng);
+        let model = fit_gsdmm(&docs, v, 10, 0.1, 0.1, 200, 0, false, &mut rng);
 
         let nc = model.num_clusters();
         // MGP may over- or under-cluster a bit; just assert it is in a sane range.
@@ -528,8 +539,8 @@ mod tests {
 
         let mut r1 = ChaCha8Rng::seed_from_u64(99);
         let mut r2 = ChaCha8Rng::seed_from_u64(99);
-        let m1 = fit_gsdmm(&docs, v, 8, 0.1, 0.1, 50, 0, &mut r1);
-        let m2 = fit_gsdmm(&docs, v, 8, 0.1, 0.1, 50, 0, &mut r2);
+        let m1 = fit_gsdmm(&docs, v, 8, 0.1, 0.1, 50, 0, false, &mut r1);
+        let m2 = fit_gsdmm(&docs, v, 8, 0.1, 0.1, 50, 0, false, &mut r2);
 
         assert_eq!(
             m1.doc_cluster(),
@@ -555,7 +566,7 @@ mod tests {
             .collect();
 
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        let model = fit_gsdmm(&docs, v, 6, 0.1, 0.1, 30, 0, &mut rng);
+        let model = fit_gsdmm(&docs, v, 6, 0.1, 0.1, 30, 0, false, &mut rng);
 
         // doc_cluster() has length D.
         assert_eq!(
@@ -612,7 +623,7 @@ mod tests {
         // K=12 on 5 docs guarantees many empty clusters, exercising the
         // empty-cluster memoization against the naive dense reference below (#781).
         let mut rng = ChaCha8Rng::seed_from_u64(7);
-        let model = fit_gsdmm(&docs, v, 12, 0.1, 0.1, 40, 0, &mut rng);
+        let model = fit_gsdmm(&docs, v, 12, 0.1, 0.1, 40, 0, false, &mut rng);
 
         // Independent dense reference: full 0..V scan, skipping zero counts.
         let dense = |doc: &[u32]| -> Vec<f64> {
@@ -675,7 +686,7 @@ mod tests {
             }
         }
         let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let model = fit_gsdmm(&docs, v, 10, 0.1, 0.1, 200, 0, &mut rng);
+        let model = fit_gsdmm(&docs, v, 10, 0.1, 0.1, 200, 0, false, &mut rng);
         let base = crate::conformance::check_conformance(&model);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/gsdmm.rs
+++ b/src/gsdmm.rs
@@ -394,6 +394,9 @@ pub fn fit_gsdmm<R: Rng>(
         trace: Vec::new(),
     };
 
+    // Wall-clock only for the opt-in progress line (never used in any
+    // computation, so it does not affect determinism).
+    let start = std::time::Instant::now();
     for it in 0..iters {
         sweep(&mut model, docs, rng);
         if report_interval > 0 && ((it + 1) % report_interval == 0 || it + 1 == iters) {
@@ -402,9 +405,12 @@ pub fn fit_gsdmm<R: Rng>(
             model.trace.push((it + 1, nc, ll));
             if verbose {
                 // Progress to stderr (not stdout), so a long single-threaded fit
-                // does not look hung. Opt-in; off during tests and pipelines.
+                // does not look hung. The elapsed seconds let a user extrapolate
+                // how long the remaining sweeps will take. Opt-in; off during
+                // tests and pipelines.
+                let elapsed = start.elapsed().as_secs_f64();
                 eprintln!(
-                    "[GSDMM] sweep {}/{}  {nc} clusters  ll={ll:.4}",
+                    "[GSDMM] sweep {}/{}  {nc} clusters  ll={ll:.4}  ({elapsed:.1}s)",
                     it + 1,
                     iters
                 );

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13160,9 +13160,12 @@ impl GSDMM {
     /// `report_interval` is a deprecated alias for `progress_interval`.
     /// `num_threads` must be `1`; GSDMM is not parallelized (its cluster-count
     /// discovery is inherently sequential — see the constructor). `num_threads > 1`
-    /// raises `ValueError`.
+    /// raises `ValueError`. `verbose=True` prints a per-sweep progress line
+    /// (iteration, cluster count, log-likelihood) to stderr so a long
+    /// single-threaded fit does not look hung; it prints at the same cadence as
+    /// the recorded trace (`progress_interval`, ~50 points by default).
     #[pyo3(signature = (data, *, iters=30, progress_interval=0, report_interval=None,
-                        num_threads=1))]
+                        num_threads=1, verbose=false))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -13171,6 +13174,7 @@ impl GSDMM {
         progress_interval: usize,
         report_interval: Option<usize>,
         num_threads: usize,
+        verbose: bool,
     ) -> PyResult<Py<Self>> {
         gsdmm_reject_threads(num_threads)?;
         let progress_interval = if let Some(old_val) = report_interval {
@@ -13246,6 +13250,7 @@ impl GSDMM {
                 b,
                 iters,
                 ll_interval,
+                verbose,
                 &mut rng,
             );
             (m, corpus)

--- a/tests/test_issue_781.py
+++ b/tests/test_issue_781.py
@@ -80,3 +80,40 @@ def test_topic_crosstab_accepts_bare_array_and_checks_length():
     assert ct.values.sum() == len(docs)
     with pytest.raises(ValueError, match="align the covariate"):
         topica.inspect.topic_crosstab(m, np.array(party[:-5]))
+
+
+def test_topic_crosstab_keeps_missing_values_visible():
+    # #784 review: NaN/None covariate values must NOT be silently dropped — the
+    # table has to account for every document.
+    corpus, docs, party = _corpus_with_party()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        m = topica.GSDMM(6, seed=13).fit(corpus, iters=30)
+    cov = np.array(party, dtype=object)
+    cov[:20] = None  # 20 missing
+    ct = topica.inspect.topic_crosstab(m, cov)
+    assert ct.values.sum() == len(docs)  # nothing dropped
+    assert any(isinstance(c, float) and np.isnan(c) for c in ct.columns)  # NaN column present
+
+
+def test_topic_crosstab_gives_every_topic_a_row():
+    # #784 review: a mixture topic that is never the argmax winner still gets a
+    # (zero) row, so the index is dense and lines up with topic_table.
+    corpus, docs, party = _corpus_with_party()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        lda = topica.LDA(6, seed=13).fit(corpus, iters=60)  # more topics than the 2 real ones
+    ct = topica.inspect.topic_crosstab(lda, corpus, "party")
+    assert list(ct.index) == list(range(6))
+
+
+def test_topic_crosstab_directive_errors():
+    # #784 review: wrong column and a 2-D covariate raise clean ValueErrors.
+    corpus, docs, party = _corpus_with_party()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        m = topica.GSDMM(6, seed=13).fit(corpus, iters=30)
+    with pytest.raises(ValueError, match="not found; available"):
+        topica.inspect.topic_crosstab(m, corpus, "partee")
+    with pytest.raises(ValueError, match="1-D"):
+        topica.inspect.topic_crosstab(m, np.array(party).reshape(-1, 1))

--- a/tests/test_issue_781.py
+++ b/tests/test_issue_781.py
@@ -1,0 +1,82 @@
+"""GSDMM UX follow-ups (#781): opt-in fit() progress + topic_crosstab helper."""
+
+import warnings
+
+import numpy as np
+import pytest
+
+import topica
+
+
+def _corpus_with_party():
+    docs = [["tax", "vote", "law"], ["health", "care", "clinic"]] * 60
+    party = ["D", "R"] * 60
+    import pandas as pd
+    df = pd.DataFrame({"text": [" ".join(d) for d in docs], "party": party})
+    return topica.from_dataframe(df, text_col="text", metadata_cols=["party"]), docs, party
+
+
+# --- fit(verbose=) progress ------------------------------------------------
+
+def test_verbose_prints_progress_to_stderr(capfd):
+    docs = [["cat", "dog", "pet"], ["star", "moon", "sky"]] * 40
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        topica.GSDMM(6, seed=13).fit(docs, iters=10, progress_interval=2, verbose=True)
+    err = capfd.readouterr().err
+    assert "[GSDMM] sweep" in err
+    # one line per recorded sweep (every 2 of 10, plus the final) — at least a few.
+    assert err.count("[GSDMM] sweep") >= 3
+
+
+def test_quiet_by_default(capfd):
+    docs = [["cat", "dog", "pet"], ["star", "moon", "sky"]] * 40
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        topica.GSDMM(6, seed=13).fit(docs, iters=10, progress_interval=2)
+    assert "[GSDMM] sweep" not in capfd.readouterr().err
+
+
+def test_verbose_does_not_change_the_fit():
+    docs = [["cat", "dog", "pet"], ["star", "moon", "sky"], ["cat", "pet", "dog"]] * 30
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        a = topica.GSDMM(8, seed=13).fit(docs, iters=20)
+        b = topica.GSDMM(8, seed=13).fit(docs, iters=20, verbose=True)
+    assert np.array_equal(np.asarray(a.doc_cluster), np.asarray(b.doc_cluster))
+
+
+# --- topic_crosstab --------------------------------------------------------
+
+def test_topic_crosstab_hard_clustering_with_corpus():
+    corpus, docs, party = _corpus_with_party()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        m = topica.GSDMM(6, seed=13).fit(corpus, iters=30)
+    ct = topica.inspect.topic_crosstab(m, corpus, "party")
+    # rows = discovered clusters, columns = the two parties, cells = doc counts.
+    assert set(ct.columns) == {"D", "R"}
+    assert ct.values.sum() == len(docs)
+    assert ct.index.name == "cluster"
+
+
+def test_topic_crosstab_mixture_model_uses_argmax():
+    corpus, docs, party = _corpus_with_party()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        m = topica.LDA(2, seed=13).fit(corpus, iters=100)
+    ct = topica.inspect.topic_crosstab(m, corpus, "party", normalize="index")
+    assert ct.index.name == "topic"  # LDA has no doc_cluster -> dominant topic
+    # row-normalized: each topic's split across parties sums to 1.
+    np.testing.assert_allclose(ct.sum(axis=1).values, 1.0, atol=1e-9)
+
+
+def test_topic_crosstab_accepts_bare_array_and_checks_length():
+    corpus, docs, party = _corpus_with_party()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        m = topica.GSDMM(6, seed=13).fit(corpus, iters=30)
+    ct = topica.inspect.topic_crosstab(m, np.array(party))
+    assert ct.values.sum() == len(docs)
+    with pytest.raises(ValueError, match="align the covariate"):
+        topica.inspect.topic_crosstab(m, np.array(party[:-5]))


### PR DESCRIPTION
The two UX follow-ups from the #781 GSDMM sample-user run (the speedup shipped separately in #783).

## 1. `fit(verbose=True)` progress
The sample-user's top pain was a ~9-minute fit that ran **silently** and "looks hung." `GSDMM.fit` gains an opt-in `verbose=False`; when `True` it prints a per-sweep line to **stderr** at the recorded-trace cadence:

```
[GSDMM] sweep 4/10  3 clusters  ll=-1.1023
```

Off by default (tests and pipelines stay quiet), stderr not stdout, and verified it does **not** change the draws (bit-identical `doc_cluster` with/without).

## 2. `topica.inspect.topic_crosstab(model, metadata, column)`
The "which topics do Democrats vs Republicans write?" table the sample-user had to hand-roll. Returns a pandas crosstab of **dominant-topic × covariate**:

```python
topica.inspect.topic_crosstab(model, corpus, "party")                     # counts
topica.inspect.topic_crosstab(model, corpus, "party", normalize="index")  # row %
```

- Uses `doc_cluster` for hard-clustering models (GSDMM); `doc_topic.argmax` for mixture models.
- Accepts a `Corpus` (row-aligned `.metadata`), a `DataFrame`, or a bare array/Series.
- `normalize=` follows `pandas.crosstab`; a length mismatch raises a directive error pointing at `corpus.kept_indices`.

## Tests / docs
6 new tests in `test_issue_781.py` (progress fires/quiet/no-op-on-draws; crosstab hard vs mixture, bare-array + length check). `short-text.md` documents both. Full pytest **5016 passed, 38 skipped**; preflight + `mkdocs --strict` green.

## Scope note
`verbose` is GSDMM-only (the model the audit hit); a shared progress mechanism for every long fit is a larger cross-model follow-up. With these two items, #781 is complete.

🤖 Generated with [Claude Code](https://claude.com/claude-code)