### PR TITLE
feat(progress): topica.progress() — live fit bar + ETA + metric sparkline (#785)

### DIFF
--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -242,6 +242,7 @@ from .coherence import (  # noqa: E402
     document_intrusion,
 )
 from .agreement import agreement  # noqa: E402  (external validation vs gold labels)
+from .progress import progress, sparkline  # noqa: E402  (live fit-progress callback: bar + ETA + metric sparkline)
 # LLM-based evaluation is exposed as a namespace, topica.llm.* (coherence,
 # intrusion, select_k, backend, PROMPTS) -- it is an llm-bounded family, kept
 # distinct from the bit-exact diagnostics above. See topica/llm.py.
@@ -420,6 +421,8 @@ __all__ = [
     "effects", "compare", "embeddings", "provenance",
     # corpus ingress (nouns / constructors stay at the top level)
     "Corpus", "tokenize", "from_dataframe",
+    # live fit-progress callback (bar + ETA + metric sparkline)
+    "progress",
     # flagship models (the newcomer starting set; the rest stay importable)
     "LDA", "STM", "NMF", "KeyATM", "GSDMM", "BERTopic",
     # discovery / experimental gate / identity

--- a/python/topica/progress.py
+++ b/python/topica/progress.py
@@ -23,6 +23,7 @@ import sys
 import time
 
 _BLOCKS = "▁▂▃▄▅▆▇█"
+_UNSET = object()
 
 
 def sparkline(values, width=None):
@@ -64,8 +65,10 @@ class _ProgressReporter:
     metric to draw its sparkline and estimates the remaining time from the mean
     time per completed step."""
 
-    def __init__(self, metric=None, *, width=20, spark_width=40, label="fit", stream=None):
+    def __init__(self, metric=None, *, total=None, width=20, spark_width=40,
+                 label="fit", stream=None):
         self.metric = metric
+        self.total = total
         self.width = width
         self.spark_width = spark_width
         self.label = label
@@ -74,7 +77,18 @@ class _ProgressReporter:
         self._start = None
         self._done = False
 
-    def __call__(self, iteration, total, info=None):
+    def __call__(self, iteration, second=_UNSET, third=_UNSET):
+        # Two shapes, disambiguated by argument count (reliable — a bare metric
+        # and a total cannot be told apart positionally):
+        #   3-arg  callback(iteration, total, info)   — the standard contract
+        #   2-arg  callback(iteration, metric)        — legacy models (LDA/DMR/…);
+        #          `total` then comes from progress(total=…) if the user set it.
+        if third is _UNSET:
+            total = self.total
+            info = None if second is _UNSET else second
+        else:
+            total = second
+            info = third
         if self._start is None:
             self._start = time.perf_counter()
         primary, extras = self._split(info)
@@ -109,12 +123,18 @@ class _ProgressReporter:
 
     def _render(self, iteration, total, primary, extras):
         elapsed = time.perf_counter() - self._start
-        frac = (iteration / total) if total else 0.0
-        eta = (elapsed / frac - elapsed) if frac > 0 else float("nan")
-        parts = [f"{self.label} |{self._bar(frac)}| {int(frac * 100):3d}%"]
         if total:
-            parts.append(f"{iteration}/{total}")
-        parts.append(f"ETA {_fmt_secs(eta)}")
+            frac = iteration / total
+            eta = (elapsed / frac - elapsed) if frac > 0 else float("nan")
+            parts = [
+                f"{self.label} |{self._bar(frac)}| {int(frac * 100):3d}%",
+                f"{iteration}/{total}",
+                f"ETA {_fmt_secs(eta)}",
+            ]
+        else:
+            # Total unknown (a 2-arg legacy callback with no progress(total=…)):
+            # no bar/%/ETA, just the running count and elapsed.
+            parts = [f"{self.label}  {iteration}  {_fmt_secs(elapsed)}"]
         if self._history:
             sk = sparkline(self._history, width=self.spark_width)
             key = next(iter(extras)) if extras else "metric"
@@ -135,7 +155,7 @@ def _fmt(v):
     return str(v)
 
 
-def progress(metric=None, *, width=20, spark_width=40, label="fit", stream=None):
+def progress(metric=None, *, total=None, width=20, spark_width=40, label="fit", stream=None):
     """Return a live-progress callback for ``fit(progress=...)``.
 
     `metric` selects which named entry of the model's ``info`` dict to draw as the
@@ -143,9 +163,15 @@ def progress(metric=None, *, width=20, spark_width=40, label="fit", stream=None)
     is the bar width; `spark_width` caps the sparkline to a rolling last-N window;
     `label` prefixes the line; `stream` defaults to ``sys.stderr``.
 
+    `total` is only needed for models whose callback is the older 2-arg
+    ``(iteration, metric)`` form (e.g. today's ``LDA``/``DMR``): pass the same
+    ``iters`` you give ``fit`` and you get the full bar + ETA; omit it and the line
+    shows the running iteration count and elapsed time instead. Models on the
+    3-arg ``(iteration, total, info)`` contract supply the total themselves.
+
     The returned object is a fresh reporter (keeps its own metric history and
     start time), so use a new ``progress()`` per fit.
     """
     return _ProgressReporter(
-        metric, width=width, spark_width=spark_width, label=label, stream=stream
+        metric, total=total, width=width, spark_width=spark_width, label=label, stream=stream
     )

--- a/python/topica/progress.py
+++ b/python/topica/progress.py
@@ -1,0 +1,151 @@
+"""Live one-line fit progress: a bar, an ETA, and a sparkline of a fit metric
+over time.
+
+``topica.progress()`` returns a *callback* that a model's ``fit`` drives once per
+recorded sweep/iteration. It renders a single line that updates in place, so a
+long single-threaded fit does not look hung and you can watch the metric converge:
+
+    model.fit(corpus, progress=topica.progress())
+
+    fit  |████████░░░░░░░░| 52%  26/50  ETA 3.1s  ll ▁▂▄▆▇███ -7.81  clusters=30
+
+The callback is model-agnostic. A model calls it as
+``callback(iteration, total, info)`` where ``info`` is a dict of named scalar
+metrics (e.g. ``{"ll": -7.8, "clusters": 30}``), a single number, or ``None``.
+``metric=`` picks which entry to sparkline (default: the first key); the rest are
+shown as ``key=value`` postfix. Rendering is dependency-free (Unicode block
+sparkline, carriage-return redraw to stderr), so it needs neither tqdm nor a
+notebook. You can also drive it yourself from any loop.
+"""
+from __future__ import annotations
+
+import sys
+import time
+
+_BLOCKS = "▁▂▃▄▅▆▇█"
+
+
+def sparkline(values, width=None):
+    """A Unicode block sparkline for `values`, normalized over the shown window.
+
+    With `width`, only the last `width` values are drawn (a rolling window, so a
+    long fit keeps a fixed-width line). A flat series renders as a low baseline.
+    """
+    vals = [float(v) for v in values if v is not None and _finite(v)]
+    if not vals:
+        return ""
+    if width is not None and len(vals) > width:
+        vals = vals[-width:]
+    lo, hi = min(vals), max(vals)
+    span = hi - lo
+    if span <= 0:
+        return _BLOCKS[0] * len(vals)
+    return "".join(_BLOCKS[min(7, int((v - lo) / span * 7.999))] for v in vals)
+
+
+def _finite(x):
+    return x == x and x not in (float("inf"), float("-inf"))
+
+
+def _fmt_secs(s):
+    if s < 0 or s != s:
+        return "?"
+    if s < 60:
+        return f"{s:.1f}s"
+    m, s = divmod(int(s), 60)
+    if m < 60:
+        return f"{m}m{s:02d}s"
+    h, m = divmod(m, 60)
+    return f"{h}h{m:02d}m"
+
+
+class _ProgressReporter:
+    """The stateful callback returned by :func:`progress`. Accumulates the chosen
+    metric to draw its sparkline and estimates the remaining time from the mean
+    time per completed step."""
+
+    def __init__(self, metric=None, *, width=20, spark_width=40, label="fit", stream=None):
+        self.metric = metric
+        self.width = width
+        self.spark_width = spark_width
+        self.label = label
+        self.stream = stream if stream is not None else sys.stderr
+        self._history = []
+        self._start = None
+        self._done = False
+
+    def __call__(self, iteration, total, info=None):
+        if self._start is None:
+            self._start = time.perf_counter()
+        primary, extras = self._split(info)
+        if primary is not None:
+            self._history.append(primary)
+        self._render(iteration, total, primary, extras)
+        # Close the line once the last iteration reports.
+        if total and iteration >= total and not self._done:
+            self._done = True
+            self.stream.write("\n")
+            self.stream.flush()
+        return None
+
+    def _split(self, info):
+        """(value_to_sparkline, {label: value} to show as postfix)."""
+        if info is None:
+            return None, {}
+        if isinstance(info, dict):
+            if not info:
+                return None, {}
+            key = self.metric if self.metric in info else next(iter(info))
+            primary = info.get(key)
+            extras = {k: v for k, v in info.items() if k != key}
+            return primary, {key: primary, **extras}
+        # a bare scalar
+        return info, {}
+
+    def _bar(self, frac):
+        frac = 0.0 if frac < 0 else 1.0 if frac > 1 else frac
+        full = int(frac * self.width)
+        return "█" * full + "░" * (self.width - full)
+
+    def _render(self, iteration, total, primary, extras):
+        elapsed = time.perf_counter() - self._start
+        frac = (iteration / total) if total else 0.0
+        eta = (elapsed / frac - elapsed) if frac > 0 else float("nan")
+        parts = [f"{self.label} |{self._bar(frac)}| {int(frac * 100):3d}%"]
+        if total:
+            parts.append(f"{iteration}/{total}")
+        parts.append(f"ETA {_fmt_secs(eta)}")
+        if self._history:
+            sk = sparkline(self._history, width=self.spark_width)
+            key = next(iter(extras)) if extras else "metric"
+            parts.append(f"{key} {sk} {_fmt(primary)}")
+            rest = list(extras.items())[1:]
+        else:
+            rest = list(extras.items())
+        for k, v in rest:
+            parts.append(f"{k}={_fmt(v)}")
+        line = "  ".join(parts)
+        self.stream.write("\r" + line)
+        self.stream.flush()
+
+
+def _fmt(v):
+    if isinstance(v, float):
+        return f"{v:.3f}" if abs(v) < 1e4 else f"{v:.3g}"
+    return str(v)
+
+
+def progress(metric=None, *, width=20, spark_width=40, label="fit", stream=None):
+    """Return a live-progress callback for ``fit(progress=...)``.
+
+    `metric` selects which named entry of the model's ``info`` dict to draw as the
+    sparkline (default: the first key); the others render as ``key=value``. `width`
+    is the bar width; `spark_width` caps the sparkline to a rolling last-N window;
+    `label` prefixes the line; `stream` defaults to ``sys.stderr``.
+
+    The returned object is a fresh reporter (keeps its own metric history and
+    start time), so use a new ``progress()`` per fit.
+    """
+    return _ProgressReporter(
+        metric, width=width, spark_width=spark_width, label=label, stream=stream
+    )

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -1,0 +1,64 @@
+"""topica.progress() live fit-progress callback + sparkline (#785)."""
+
+import io
+
+import topica
+from topica.progress import _fmt_secs
+
+
+def test_sparkline_basic_shapes():
+    assert topica.sparkline([1, 2, 3, 4, 3, 2, 1]) == "▁▃▆█▆▃▁"
+    assert topica.sparkline([5, 5, 5]) == "▁▁▁"      # flat -> low baseline
+    assert topica.sparkline([]) == ""
+    assert topica.sparkline([7]) == "▁"
+
+
+def test_sparkline_ignores_non_finite_and_rolls():
+    # NaN / inf are dropped, not rendered as garbage.
+    s = topica.sparkline([1.0, float("nan"), 2.0, float("inf"), 3.0])
+    assert set(s) <= set("▁▂▃▄▅▆▇█") and len(s) == 3
+    # rolling window keeps a fixed width on a long series.
+    assert len(topica.sparkline(list(range(1000)), width=40)) == 40
+
+
+def test_fmt_secs():
+    assert _fmt_secs(3.1) == "3.1s"
+    assert _fmt_secs(90).endswith("s") and "m" in _fmt_secs(90)
+    assert "h" in _fmt_secs(7200)
+    assert _fmt_secs(float("nan")) == "?"
+
+
+def test_progress_renders_bar_eta_and_sparkline():
+    buf = io.StringIO()
+    cb = topica.progress(metric="ll", stream=buf, label="GSDMM")
+    lls = [-9.5, -9.0, -8.4, -8.0, -7.85, -7.82]
+    ks = [50, 48, 42, 36, 31, 30]
+    for i, (ll, k) in enumerate(zip(lls, ks), 1):
+        cb(i, len(lls), {"ll": ll, "clusters": k})
+    frames = [f for f in buf.getvalue().replace("\n", "").split("\r") if f.strip()]
+    first, last = frames[0], frames[-1]
+    assert first.startswith("GSDMM |") and "10" not in first[:8]
+    assert "0%" in first or "16%" in first  # 1/6
+    assert last.strip().endswith("clusters=30")
+    assert "100%" in last and "6/6" in last
+    # the ll sparkline accumulates across calls and climbs to convergence
+    assert "ll " in last
+    # a trailing newline closes the line once the final iteration reports
+    assert buf.getvalue().endswith("\n")
+
+
+def test_progress_accepts_scalar_and_none_metric():
+    buf = io.StringIO()
+    cb = topica.progress(stream=buf)
+    cb(1, 2, -5.0)      # bare scalar metric
+    cb(2, 2, None)      # no metric this step
+    out = buf.getvalue()
+    assert "fit |" in out and out.endswith("\n")
+
+
+def test_progress_metric_selection_defaults_to_first_key():
+    buf = io.StringIO()
+    cb = topica.progress(stream=buf)  # no metric= -> first key ("perplexity")
+    cb(1, 1, {"perplexity": 120.0, "iters_run": 5})
+    last = buf.getvalue().split("\r")[-1]
+    assert "perplexity " in last and "iters_run=5" in last

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -56,6 +56,26 @@ def test_progress_accepts_scalar_and_none_metric():
     assert "fit |" in out and out.endswith("\n")
 
 
+def test_progress_two_arg_legacy_callback_without_total():
+    # Legacy (iteration, metric) callback (today's LDA/DMR): no total -> running
+    # count + elapsed + sparkline, no bar/ETA, and no crash.
+    buf = io.StringIO()
+    cb = topica.progress(stream=buf, label="LDA")
+    for i, ll in enumerate([-9.0, -8.5, -8.1, -8.0], 1):
+        cb(i, ll)  # 2 positional args
+    last = buf.getvalue().split("\r")[-1]
+    assert last.startswith("LDA  4") and "%" not in last and "▁" in last
+
+
+def test_progress_two_arg_with_total_gives_full_bar():
+    buf = io.StringIO()
+    cb = topica.progress(total=4, stream=buf, label="LDA")
+    for i, ll in enumerate([-9.0, -8.5, -8.1, -8.0], 1):
+        cb(i, ll)
+    out = buf.getvalue()
+    assert "100%" in out and "4/4" in out and "ETA" in out
+
+
 def test_progress_metric_selection_defaults_to_first_key():
     buf = io.StringIO()
     cb = topica.progress(stream=buf)  # no metric= -> first key ("perplexity")

--- a/tests/test_toplevel_compat.py
+++ b/tests/test_toplevel_compat.py
@@ -21,7 +21,7 @@ _LEGACY_NAMES = [ln.strip() for ln in _LEGACY.read_text().splitlines() if ln.str
 _CURATED = {
     "data", "design", "select", "inspect", "evaluate",
     "effects", "compare", "embeddings", "provenance",
-    "Corpus", "tokenize", "from_dataframe",
+    "Corpus", "tokenize", "from_dataframe", "progress",
     "LDA", "STM", "NMF", "KeyATM", "GSDMM", "BERTopic",
     "list_models", "enable_experimental",
     "__version__", "__citation__",
@@ -30,7 +30,7 @@ _CURATED = {
 
 def test_curated_all_is_exactly_the_surface():
     assert set(topica.__all__) == _CURATED
-    assert len(topica.__all__) == 22
+    assert len(topica.__all__) == 23
 
 
 def test_flagship_models_match_common_start_set():


### PR DESCRIPTION
The model-independent **first piece** of the progress rollout (#785): a dependency-free `topica.progress()` renderer. Wiring the `progress=` callback into the fit path (keyATM + LDA first) is the next #785 item; this PR ships the renderer + its tests.

## What it does
`topica.progress()` returns a callback a model's `fit` drives once per recorded sweep. It renders a single line that updates in place — a bar, `%`, `iter/total`, an **ETA**, and a **Unicode sparkline of a fit metric over time** so you watch convergence, plus live postfix metrics:

```
GSDMM |█████████░░░░░░░░| 50%  20/40  ETA 1.2s  ll ▁▃▅▇█▇▆▆▆▆ -7.93  clusters=43
```

The ll sparkline climbs and flattens as the fit converges; for GSDMM the collapsing `clusters=` count is the intuitive second signal.

## Design
- **Model-agnostic contract**: `callback(iteration, total, info)` where `info` is a dict of named scalar metrics (`{"ll": -7.8, "clusters": 30}`), a bare number, or `None`. `progress(metric=...)` picks which to sparkline (default: first key); the rest render as `key=value`.
- **Dependency-free**: no tqdm required — Unicode block sparkline (`▁▂▃▄▅▆▇█`), carriage-return redraw to stderr. Rolling `spark_width` keeps the line fixed-width on long fits. Also usable standalone from any loop.
- **Zero overhead** (measured in the #785 thread): driving the callback from Rust via `Python::with_gil` at the trace cadence was within timing noise of no-progress, even every sweep (~11 µs ≈ 0.03% of a 40 ms sweep).

## Surface
`progress` joins the curated top-level surface (a peer of `tokenize`); `sparkline` stays importable (`topica.sparkline`) but off the curated set.

## Tests
`tests/test_progress.py` (6): sparkline shapes / non-finite handling / rolling window, `_fmt_secs`, reporter renders bar+ETA+sparkline, scalar/None/dict metric handling, default-first-key selection. Full pytest **5025 passed, 38 skipped**; preflight + `mkdocs --strict` green.

## Not in this PR
The `progress=` fit-callback plumbing (Rust) for keyATM/LDA/GSDMM — tracked as the remaining #785 items. Until then `progress()` is driven manually or awaits that wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)