### PR TITLE
feat(progress): wire LDA/DMR/LabeledLDA/SAGE to the 3-arg progress contract (#785)

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1019,6 +1019,17 @@ fn build_with_fixed_vocab(
 
 /// SparseLDA topic model (the MALLET algorithm).
 ///
+/// Invoke a fit progress callback with the standard 3-arg contract
+/// `callback(iteration, total, info)`, where `info` is `{"ll": ll_per_token}`.
+/// This is what `topica.progress()` renders as a live bar + ETA + ll sparkline.
+/// Best-effort: a callback that raises is ignored so the progress display can
+/// never abort a fit (#785).
+fn emit_progress(py: Python<'_>, cb: &PyObject, iter: usize, total: usize, ll: f64) {
+    let info = PyDict::new_bound(py);
+    let _ = info.set_item("ll", ll);
+    let _ = cb.call1(py, (iter, total, info));
+}
+
 /// Construct with the hyperparameters, then call :meth:`fit` on a
 /// :class:`Corpus` or a list of token lists. After fitting, the estimated
 /// distributions are available as :attr:`topic_word` (φ) and
@@ -1307,8 +1318,10 @@ impl LDA {
     /// strings). When a token-list is passed, an internal corpus is built with
     /// no frequency filtering — build a :class:`Corpus` explicitly for that.
     ///
-    /// `progress`, if given, is called as ``progress(iteration, ll_per_token)``
-    /// every `progress_interval` iterations during the main loop.
+    /// `progress`, if given, is called as ``progress(iteration, total_iters,
+    /// {"ll": ll_per_token})`` every `progress_interval` iterations during the main
+    /// loop. Pass :func:`topica.progress` for a live bar + ETA + log-likelihood
+    /// sparkline, or your own callback.
     ///
     /// `convergence_tol` (default 0.0, disabled) enables early stopping: after
     /// each `check_every` sweeps the relative change in a smoothed log-likelihood
@@ -1470,7 +1483,7 @@ impl LDA {
                                 let m = cv.to_topic_model(&corpus);
                                 let ll = output::model_log_likelihood(&m, &corpus) / total_tokens;
                                 Python::with_gil(|py| {
-                                    let _ = cb.call1(py, (iter, ll));
+                                    emit_progress(py, cb, iter, iters, ll);
                                 });
                             }
                         }
@@ -1669,7 +1682,7 @@ impl LDA {
                         {
                             let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
                             Python::with_gil(|py| {
-                                let _ = cb.call1(py, (iter, ll));
+                                emit_progress(py, cb, iter, iters, ll);
                             });
                         }
                     }
@@ -2840,7 +2853,7 @@ fn run_mh_training<S: crate::mh::MhSampler>(
                 let m = sampler.to_topic_model();
                 let ll = output::model_log_likelihood(&m, &corpus) / total_tokens;
                 Python::with_gil(|py| {
-                    let _ = cb.call1(py, (iter, ll));
+                    emit_progress(py, cb, iter, iters, ll);
                 });
             }
         }
@@ -4589,7 +4602,7 @@ impl DMR {
                             );
                             let llpt = ll / total_tokens;
                             Python::with_gil(|py| {
-                                let _ = cb.call1(py, (iter, llpt));
+                                emit_progress(py, cb, iter, iters, llpt);
                             });
                         }
                     }
@@ -4753,7 +4766,7 @@ impl DMR {
                             );
                             let llpt = ll / total_tokens;
                             Python::with_gil(|py| {
-                                let _ = cb.call1(py, (iter, llpt));
+                                emit_progress(py, cb, iter, iters, llpt);
                             });
                         }
                     }
@@ -5702,7 +5715,7 @@ impl LabeledLDA {
                         if progress_interval > 0 && iter % progress_interval == 0 {
                             let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
                             Python::with_gil(|py| {
-                                let _ = cb.call1(py, (iter, ll));
+                                emit_progress(py, cb, iter, iters, ll);
                             });
                         }
                     }
@@ -6508,7 +6521,7 @@ impl SAGE {
                     if progress_interval > 0 && iter % progress_interval == 0 {
                         let llpt = compute_ll(&model) / total_tokens;
                         Python::with_gil(|py| {
-                            let _ = cb.call1(py, (iter, llpt));
+                            emit_progress(py, cb, iter, iters, llpt);
                         });
                     }
                 }

--- a/tests/test_determinism.py
+++ b/tests/test_determinism.py
@@ -74,8 +74,8 @@ class TestProgressCallback:
         """Progress callback must be called at least once."""
         calls = []
 
-        def cb(iteration, ll):
-            calls.append((iteration, ll))
+        def cb(iteration, total, info):
+            calls.append((iteration, total, info))
 
         model = LDA(2, seed=42, optimize_interval=0)
         model.fit(
@@ -92,8 +92,8 @@ class TestProgressCallback:
         """First element of each callback tuple must be an int."""
         calls = []
 
-        def cb(iteration, ll):
-            calls.append((iteration, ll))
+        def cb(iteration, total, info):
+            calls.append((iteration, total, info))
 
         model = LDA(2, seed=42, optimize_interval=0)
         model.fit(
@@ -104,14 +104,14 @@ class TestProgressCallback:
             progress=cb,
             progress_interval=20,
         )
-        assert all(isinstance(i, int) for i, _ in calls)
+        assert all(isinstance(i, int) for i, _t, _info in calls)
 
     def test_callback_receives_float_ll(self):
         """Second element of each callback tuple must be a float."""
         calls = []
 
-        def cb(iteration, ll):
-            calls.append((iteration, ll))
+        def cb(iteration, total, info):
+            calls.append((iteration, total, info))
 
         model = LDA(2, seed=42, optimize_interval=0)
         model.fit(
@@ -122,13 +122,13 @@ class TestProgressCallback:
             progress=cb,
             progress_interval=20,
         )
-        assert all(isinstance(ll, float) for _, ll in calls)
+        assert all(isinstance(info["ll"], float) for _, _t, info in calls)
 
     def test_callback_cadence(self):
         """Callback should fire every progress_interval iterations (approx)."""
         calls = []
 
-        def cb(iteration, ll):
+        def cb(iteration, total, info):
             calls.append(iteration)
 
         model = LDA(2, seed=42, optimize_interval=0)

--- a/tests/test_lda_turbo_bookkeeping_417.py
+++ b/tests/test_lda_turbo_bookkeeping_417.py
@@ -17,7 +17,7 @@ def _fired_iters(merge_every, progress_interval, iters=200, threads=2):
         sample_interval=10,
         num_threads=threads,
         turbo_merge_every=merge_every,
-        progress=lambda it, ll: fired.append(it),
+        progress=lambda it, total, info: fired.append(it),  # 3-arg contract (#785)
         progress_interval=progress_interval,
     )
     return fired

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -76,6 +76,34 @@ def test_progress_two_arg_with_total_gives_full_bar():
     assert "100%" in out and "4/4" in out and "ETA" in out
 
 
+def test_lda_drives_progress_with_3arg_contract(capfd):
+    # #785: LDA's callback now passes (iteration, total, {"ll": ...}), so
+    # topica.progress() renders the full bar + ETA + "ll" sparkline with no total=.
+    import numpy as np
+    docs = [["a", "b", "c"]] * 60 + [["x", "y", "z"]] * 60
+    calls = []
+    topica.LDA(2, seed=13).fit(
+        docs, iters=40, progress_interval=8,
+        progress=lambda it, total, info: calls.append((it, total, dict(info))),
+    )
+    assert calls and all(t == 40 for _, t, _ in calls)          # auto total
+    assert all("ll" in info for _, _, info in calls)             # named metric
+    # and the shipped renderer produces a bar labelled "ll"
+    topica.LDA(2, seed=13).fit(docs, iters=40, progress_interval=8,
+                               progress=topica.progress(label="LDA"))
+    err = capfd.readouterr().err
+    assert "LDA |" in err and "ll " in err and "100%" in err
+
+
+def test_lda_progress_does_not_change_the_fit():
+    import numpy as np
+    docs = [["a", "b", "c"]] * 40 + [["x", "y", "z"]] * 40
+    a = topica.LDA(2, seed=13).fit(docs, iters=50)
+    b = topica.LDA(2, seed=13).fit(docs, iters=50,
+                                   progress=lambda *xs: None, progress_interval=5)
+    assert np.array_equal(np.asarray(a.doc_topic), np.asarray(b.doc_topic))
+
+
 def test_progress_metric_selection_defaults_to_first_key():
     buf = io.StringIO()
     cb = topica.progress(stream=buf)  # no metric= -> first key ("perplexity")


### PR DESCRIPTION
Phase-1a of the progress rollout (#785), on top of the merged `topica.progress()` helper (#787). Wires the models that **already carry a `progress` callback** to the contract `topica.progress()` renders — so they light up the live bar with no extra API.

## Change
A shared `emit_progress(py, cb, iter, total, ll)` helper now calls the callback as `(iteration, total_iters, {"ll": ll_per_token})` instead of the legacy `(iteration, ll)`, at the 7 existing call sites across **LDA** (sparse/threaded/turbo), **DMR**, **LabeledLDA**, **SAGE**. These models already exposed `progress`, so this is a call-site + docstring change only — no constructor/signature/stub churn.

Result — `LDA(...).fit(corpus, progress=topica.progress())` with **no `total=` needed** and a named `ll` sparkline:

```
LDA |████████████████████| 100% 80/80  ETA 0.4s  ll ▁█▆▅▁▆▇█▂▃ -2.569
```

## Notes
- The callback is **best-effort**: a raising callback is ignored, never aborts a fit.
- `progress` does **not** change the draws (asserted in a new test).
- `topica.progress()` still accepts the legacy 2-arg form (via `progress(total=…)`) for anything not yet migrated.
- Existing 2-arg callback tests (`test_determinism.py::TestProgressCallback`, `test_lda_turbo_bookkeeping_417.py`) updated to the 3-arg shape.

## Not in this PR
keyATM and GSDMM need **new** callback params (their fit loops live in the Rust core, not the binding) — that's the next #785 item (Phase-1b), after which a sample-user tries the full LDA + keyATM set.

## Tests
`test_progress.py` gains: LDA drives the 3-arg contract (auto-total + `ll` label), and `progress` is a no-op on the fit. Full pytest **5029 passed, 38 skipped**; preflight + `mkdocs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)