### PR TITLE
feat(progress): GSDMM.fit(progress=) 3-arg callback with clusters + ll sparkline (#785)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2774,6 +2774,7 @@ class GSDMM:
         report_interval: Optional[int] = None,
         num_threads: int = 1,
         verbose: bool = False,
+        progress: Any = None,
     ) -> "GSDMM":
         """Fit by the Movie Group Process. progress_interval controls the
         cluster-discovery trace (0 = auto ~50 points).

--- a/src/gsdmm.rs
+++ b/src/gsdmm.rs
@@ -349,7 +349,7 @@ fn sweep<R: Rng>(model: &mut GsdmmModel, docs: &[Vec<u32>], rng: &mut R) {
 /// * `rng`       — random-number source; determines all randomness (deterministic
 ///                 for a fixed seed)
 #[allow(clippy::too_many_arguments)]
-pub fn fit_gsdmm<R: Rng>(
+pub fn fit_gsdmm<R: Rng, F: FnMut(usize, usize, usize, f64)>(
     docs: &[Vec<u32>],
     num_types: usize,
     k_max: usize,
@@ -358,6 +358,7 @@ pub fn fit_gsdmm<R: Rng>(
     iters: usize,
     report_interval: usize,
     verbose: bool,
+    mut on_progress: F,
     rng: &mut R,
 ) -> GsdmmModel {
     let d_count = docs.len();
@@ -403,6 +404,7 @@ pub fn fit_gsdmm<R: Rng>(
             let ll = model.cluster_log_likelihood(docs);
             let nc = model.num_clusters();
             model.trace.push((it + 1, nc, ll));
+            on_progress(it + 1, iters, nc, ll);
             if verbose {
                 // Progress to stderr (not stdout), so a long single-threaded fit
                 // does not look hung. The elapsed seconds let a user extrapolate
@@ -495,7 +497,18 @@ mod tests {
 
         let mut rng = ChaCha8Rng::seed_from_u64(42);
         // k_max=10, expect it to collapse toward 3 non-empty clusters.
-        let model = fit_gsdmm(&docs, v, 10, 0.1, 0.1, 200, 0, false, &mut rng);
+        let model = fit_gsdmm(
+            &docs,
+            v,
+            10,
+            0.1,
+            0.1,
+            200,
+            0,
+            false,
+            |_, _, _, _| {},
+            &mut rng,
+        );
 
         let nc = model.num_clusters();
         // MGP may over- or under-cluster a bit; just assert it is in a sane range.
@@ -545,8 +558,30 @@ mod tests {
 
         let mut r1 = ChaCha8Rng::seed_from_u64(99);
         let mut r2 = ChaCha8Rng::seed_from_u64(99);
-        let m1 = fit_gsdmm(&docs, v, 8, 0.1, 0.1, 50, 0, false, &mut r1);
-        let m2 = fit_gsdmm(&docs, v, 8, 0.1, 0.1, 50, 0, false, &mut r2);
+        let m1 = fit_gsdmm(
+            &docs,
+            v,
+            8,
+            0.1,
+            0.1,
+            50,
+            0,
+            false,
+            |_, _, _, _| {},
+            &mut r1,
+        );
+        let m2 = fit_gsdmm(
+            &docs,
+            v,
+            8,
+            0.1,
+            0.1,
+            50,
+            0,
+            false,
+            |_, _, _, _| {},
+            &mut r2,
+        );
 
         assert_eq!(
             m1.doc_cluster(),
@@ -572,7 +607,18 @@ mod tests {
             .collect();
 
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        let model = fit_gsdmm(&docs, v, 6, 0.1, 0.1, 30, 0, false, &mut rng);
+        let model = fit_gsdmm(
+            &docs,
+            v,
+            6,
+            0.1,
+            0.1,
+            30,
+            0,
+            false,
+            |_, _, _, _| {},
+            &mut rng,
+        );
 
         // doc_cluster() has length D.
         assert_eq!(
@@ -629,7 +675,18 @@ mod tests {
         // K=12 on 5 docs guarantees many empty clusters, exercising the
         // empty-cluster memoization against the naive dense reference below (#781).
         let mut rng = ChaCha8Rng::seed_from_u64(7);
-        let model = fit_gsdmm(&docs, v, 12, 0.1, 0.1, 40, 0, false, &mut rng);
+        let model = fit_gsdmm(
+            &docs,
+            v,
+            12,
+            0.1,
+            0.1,
+            40,
+            0,
+            false,
+            |_, _, _, _| {},
+            &mut rng,
+        );
 
         // Independent dense reference: full 0..V scan, skipping zero counts.
         let dense = |doc: &[u32]| -> Vec<f64> {
@@ -692,7 +749,18 @@ mod tests {
             }
         }
         let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let model = fit_gsdmm(&docs, v, 10, 0.1, 0.1, 200, 0, false, &mut rng);
+        let model = fit_gsdmm(
+            &docs,
+            v,
+            10,
+            0.1,
+            0.1,
+            200,
+            0,
+            false,
+            |_, _, _, _| {},
+            &mut rng,
+        );
         let base = crate::conformance::check_conformance(&model);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -13164,8 +13164,12 @@ impl GSDMM {
     /// (iteration, cluster count, log-likelihood) to stderr so a long
     /// single-threaded fit does not look hung; it prints at the same cadence as
     /// the recorded trace (`progress_interval`, ~50 points by default).
+    /// `progress`, if given, is called as ``progress(iteration, total_iters,
+    /// {"clusters": n, "ll": ll})`` at that same cadence — pass
+    /// :func:`topica.progress` (e.g. ``topica.progress(metric="clusters")``) for a
+    /// live bar + ETA + cluster-count/log-likelihood sparkline.
     #[pyo3(signature = (data, *, iters=30, progress_interval=0, report_interval=None,
-                        num_threads=1, verbose=false))]
+                        num_threads=1, verbose=false, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -13175,6 +13179,7 @@ impl GSDMM {
         report_interval: Option<usize>,
         num_threads: usize,
         verbose: bool,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         gsdmm_reject_threads(num_threads)?;
         let progress_interval = if let Some(old_val) = report_interval {
@@ -13251,6 +13256,19 @@ impl GSDMM {
                 iters,
                 ll_interval,
                 verbose,
+                |it, total, nc, ll| {
+                    // GSDMM surfaces two live signals: the cluster count collapsing
+                    // toward the discovered K, and the plug-in log-likelihood. The
+                    // callback is best-effort (a raise never aborts the fit) (#785).
+                    if let Some(cb) = &progress {
+                        Python::with_gil(|py| {
+                            let info = PyDict::new_bound(py);
+                            let _ = info.set_item("clusters", nc);
+                            let _ = info.set_item("ll", ll);
+                            let _ = cb.call1(py, (it, total, info));
+                        });
+                    }
+                },
                 &mut rng,
             );
             (m, corpus)

--- a/tests/test_issue_781.py
+++ b/tests/test_issue_781.py
@@ -37,6 +37,32 @@ def test_quiet_by_default(capfd):
     assert "[GSDMM] sweep" not in capfd.readouterr().err
 
 
+def test_gsdmm_progress_callback_and_topica_progress(capfd):
+    # #785: GSDMM.fit(progress=) calls (iteration, total, {"clusters", "ll"}) and
+    # topica.progress() renders the live bar + cluster-count sparkline.
+    docs = [["cat", "dog", "pet"], ["star", "moon", "sky"]] * 60
+    calls = []
+    topica.GSDMM(8, seed=13).fit(
+        docs, iters=20, progress_interval=4,
+        progress=lambda it, total, info: calls.append((it, total, dict(info))),
+    )
+    assert calls and all(t == 20 for _, t, _ in calls)
+    assert all({"clusters", "ll"} <= set(info) for _, _, info in calls)
+    # the shipped renderer draws a bar with the clusters sparkline
+    topica.GSDMM(8, seed=13).fit(docs, iters=20, progress_interval=4,
+                                 progress=topica.progress(metric="clusters", label="GSDMM"))
+    err = capfd.readouterr().err
+    assert "GSDMM |" in err and "clusters " in err and "100%" in err
+
+
+def test_gsdmm_progress_does_not_change_the_fit():
+    docs = [["cat", "dog", "pet"], ["star", "moon", "sky"], ["cat", "pet", "dog"]] * 20
+    a = topica.GSDMM(8, seed=13).fit(docs, iters=25)
+    b = topica.GSDMM(8, seed=13).fit(docs, iters=25,
+                                     progress=lambda *xs: None, progress_interval=3)
+    assert np.array_equal(np.asarray(a.doc_cluster), np.asarray(b.doc_cluster))
+
+
 def test_verbose_does_not_change_the_fit():
     docs = [["cat", "dog", "pet"], ["star", "moon", "sky"], ["cat", "pet", "dog"]] * 30
     with warnings.catch_warnings():


### PR DESCRIPTION
Phase-1b of the progress rollout (#785), on top of the `topica.progress()` helper (#787). Independent of the LDA-family PR (#788).

## Change
`GSDMM.fit` gains a `progress=` callback. The core `fit_gsdmm` takes a generic `on_progress` closure called at the trace cadence; the binding builds `{"clusters": n, "ll": ll}` and calls `progress(iteration, total_iters, info)` via `Python::with_gil` (best-effort — a raising callback never aborts the fit).

GSDMM has two live signals, so `topica.progress(metric="clusters")` sparklines the **cluster count collapsing** toward the discovered K, with ll as postfix:

```
GSDMM |████████████████████| 100%  20/20  ETA 0.0s  clusters █████████▁ 28  ll=-7.506
```

Complements the existing `verbose=` stderr line.

## Correctness
- The callback does **not** change the draws (asserted); GSDMM gold unchanged.
- 6 in-core `fit_gsdmm` test call sites pass a no-op closure.

## Tests
`test_issue_781.py` gains: the 3-arg contract fires with `{clusters, ll}` and auto-total; `topica.progress()` renders the clusters sparkline; `progress` is a no-op on the fit. Full pytest **5029 passed, 38 skipped**; preflight + `mkdocs --strict` green.

## Remaining on #785
**keyATM** — bigger: it has four fit functions in the Rust core (base / cvb0 / covariate-DMR / dynamic-HMM), so it's a dedicated follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)