### PR TITLE
feat(progress): wire keyATM (base/covariate/dynamic) to the progress contract (#785)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -6268,6 +6268,7 @@ class KeyATM:
         convergence_tol: float = 0.0,
         report_interval: Optional[int] = None,
         turbo_alpha_stride: int = 1,
+        progress: Any = None,
     ) -> "KeyATM":
         """Fit by collapsed Gibbs. Pass `covariates` (num_docs x F) for the
         covariate keyATM: the document-topic prior becomes a DMR,

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -1113,7 +1113,7 @@ fn run_sweep<R: Rng>(
 ///                          Higher γ₁ → more weight on keyword distribution.
 /// * `iters`              — number of full Gibbs sweeps.
 /// * `rng`                — random-number source (deterministic for fixed seed).
-pub fn fit_keyatm<R: Rng>(
+pub fn fit_keyatm<R: Rng, F: FnMut(usize, usize, f64, f64)>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -1131,6 +1131,7 @@ pub fn fit_keyatm<R: Rng>(
     draws: ThetaDrawOpts,
     convergence_tol: f64,
     alpha_stride: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> KeyAtmModel {
     // A fixed symmetric α (estimate_alpha = false) must be a valid Dirichlet
@@ -1204,9 +1205,10 @@ pub fn fit_keyatm<R: Rng>(
         draws.maybe_collect(&mut theta_draw_buf, it + 1, &model.ndk, &doc_alpha);
         if record_ll(it + 1, ll_interval, iters) {
             model.alpha_vec = Some(alpha_vec.clone());
-            model
-                .log_likelihood_history
-                .push((it + 1, model.model_loglik(), model.perplexity()));
+            let ll = model.model_loglik();
+            let ppl = model.perplexity();
+            model.log_likelihood_history.push((it + 1, ll, ppl));
+            on_progress(it + 1, iters, ll, ppl);
             // The alpha trace (plot_alpha) is only meaningful when alpha is being
             // learned; with a fixed symmetric prior it would be a flat line.
             if estimate_alpha {
@@ -1819,7 +1821,7 @@ fn covariate_lambda_se(
 /// `iters < burn_in + opt_interval`). The keyword (z, s) sampler is otherwise
 /// identical to the base model.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_keyatm_cov<R: Rng>(
+pub fn fit_keyatm_cov<R: Rng, F: FnMut(usize, usize, f64, f64)>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -1841,6 +1843,7 @@ pub fn fit_keyatm_cov<R: Rng>(
     offset: Option<&[Vec<f64>]>,
     draws: ThetaDrawOpts,
     convergence_tol: f64,
+    mut on_progress: F,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(
@@ -1946,9 +1949,10 @@ pub fn fit_keyatm_cov<R: Rng>(
             model.lambda = Some(lambda.clone());
             model.features = Some(features_std.clone());
             model.prior_offset = offset.map(|o| o.to_vec());
-            model
-                .log_likelihood_history
-                .push((it + 1, model.model_loglik(), model.perplexity()));
+            let ll = model.model_loglik();
+            let ppl = model.perplexity();
+            model.log_likelihood_history.push((it + 1, ll, ppl));
+            on_progress(it + 1, iters, ll, ppl);
             model.pi_history.push((it + 1, model.keyword_rate()));
             if ll_converged(&model.log_likelihood_history, convergence_tol) {
                 model.converged = true;
@@ -2203,7 +2207,7 @@ fn shuffled_topic_ids<R: Rng>(n: usize, rng: &mut R) -> Vec<usize> {
 /// backward sampling (FFBS) of the state path and resamples the left-to-right
 /// transition matrix.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_keyatm_dynamic<R: Rng>(
+pub fn fit_keyatm_dynamic<R: Rng, F: FnMut(usize, usize, f64, f64)>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -2224,6 +2228,7 @@ pub fn fit_keyatm_dynamic<R: Rng>(
     num_threads: usize,
     draws: ThetaDrawOpts,
     convergence_tol: f64,
+    mut on_progress: F,
     rng: &mut R,
 ) -> KeyAtmModel {
     assert_eq!(
@@ -2543,9 +2548,10 @@ pub fn fit_keyatm_dynamic<R: Rng>(
                 r_est: r_est.clone(),
                 p_est: p_est.clone(),
             });
-            model
-                .log_likelihood_history
-                .push((it + 1, model.model_loglik(), model.perplexity()));
+            let ll = model.model_loglik();
+            let ppl = model.perplexity();
+            model.log_likelihood_history.push((it + 1, ll, ppl));
+            on_progress(it + 1, iters, ll, ppl);
             model.pi_history.push((it + 1, model.keyword_rate()));
             if ll_converged(&model.log_likelihood_history, convergence_tol) {
                 model.converged = true;
@@ -2788,6 +2794,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut rng,
         );
 
@@ -2931,6 +2938,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut rng,
         );
 
@@ -2987,6 +2995,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut rng,
         );
 
@@ -3062,6 +3071,7 @@ mod tests {
             1,
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
+            |_, _, _, _| {},
             &mut rng,
         );
 
@@ -3119,6 +3129,7 @@ mod tests {
             1,
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
+            |_, _, _, _| {},
             &mut r1,
         );
         let m2 = fit_keyatm_dynamic(
@@ -3142,6 +3153,7 @@ mod tests {
             1,
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
+            |_, _, _, _| {},
             &mut r2,
         );
         assert_eq!(
@@ -3186,6 +3198,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut r1,
         );
         let m2 = fit_keyatm(
@@ -3206,6 +3219,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut r2,
         );
 
@@ -3254,6 +3268,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut rng,
         );
         let h = &model.log_likelihood_history;
@@ -3292,6 +3307,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut rng2,
         );
         assert!(none.log_likelihood_history.is_empty());
@@ -3323,6 +3339,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
@@ -3361,6 +3378,7 @@ mod tests {
                 ThetaDrawOpts::new(false, 0, 0),
                 0.0,
                 stride,
+                |_, _, _, _| {},
                 &mut r,
             )
         };
@@ -3450,6 +3468,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
+            |_, _, _, _| {},
             &mut rng,
         );
     }
@@ -3553,6 +3572,7 @@ mod tests {
             1,
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
+            |_, _, _, _| {},
             &mut rng,
         );
     }

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1030,6 +1030,23 @@ fn emit_progress(py: Python<'_>, cb: &PyObject, iter: usize, total: usize, ll: f
     let _ = cb.call1(py, (iter, total, info));
 }
 
+/// Like `emit_progress` but for models that surface a perplexity alongside the
+/// log-likelihood (keyATM): `callback(iteration, total, {"ll": ll, "perplexity":
+/// ppl})`. Best-effort — a raising callback never aborts the fit (#785).
+fn emit_progress_ll_ppl(
+    py: Python<'_>,
+    cb: &PyObject,
+    iter: usize,
+    total: usize,
+    ll: f64,
+    ppl: f64,
+) {
+    let info = PyDict::new_bound(py);
+    let _ = info.set_item("ll", ll);
+    let _ = info.set_item("perplexity", ppl);
+    let _ = cb.call1(py, (iter, total, info));
+}
+
 /// Construct with the hyperparameters, then call :meth:`fit` on a
 /// :class:`Corpus` or a list of token lists. After fitting, the estimated
 /// distributions are available as :attr:`topic_word` (φ) and
@@ -15615,7 +15632,11 @@ impl KeyATM {
     /// `composition_theta` prefers over the Dirichlet approximation; set it False
     /// to save memory. `progress_interval` sets how often model_fit is recorded for
     /// `log_likelihood_history` (0 = ~50 evenly spaced points); `report_interval` is
-    /// a deprecated alias for it. `convergence_tol` (default 0.0, disabled) enables
+    /// a deprecated alias for it. `progress`, if given, is called as
+    /// ``progress(iteration, total_iters, {"ll": ll, "perplexity": ppl})`` at that
+    /// cadence — pass :func:`topica.progress` for a live bar + ETA + log-likelihood
+    /// sparkline (base, covariate, and dynamic paths; the cvb0 sampler excepted).
+    /// `convergence_tol` (default 0.0, disabled) enables
     /// opt-in early stopping: the run stops once the relative change in the recorded
     /// model-fit log-likelihood between the last two trace points falls below it,
     /// setting `converged` (ignored by the CVB0 backend, which keeps no trace).
@@ -15633,7 +15654,7 @@ impl KeyATM {
                         num_threads=None, optimize_interval=50, burn_in=200, prior_variance=1.0,
                         lbfgs_iters=20, progress_interval=0, prior_offset=None,
                         keep_theta_draws=true, num_theta_draws=25, convergence_tol=0.0_f64,
-                        report_interval=None, turbo_alpha_stride=1))]
+                        report_interval=None, turbo_alpha_stride=1, progress=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -15658,6 +15679,7 @@ impl KeyATM {
         convergence_tol: f64,
         report_interval: Option<usize>,
         turbo_alpha_stride: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         ensure_finite_pos("prior_variance", prior_variance)?;
@@ -15901,6 +15923,9 @@ impl KeyATM {
                 order.iter().map(|&d| corpus.docs[d].clone()).collect();
             let sorted_time: Vec<usize> = order.iter().map(|&d| time_raw[d]).collect();
 
+            // Clone the progress handle for this branch: the non-dynamic path below
+            // moves the original into its own worker closure.
+            let progress_dyn = progress.as_ref().map(|p| p.clone_ref(py));
             let model = py.allow_threads(move || {
                 keyatm::fit_keyatm_dynamic(
                     &sorted_docs,
@@ -15923,6 +15948,11 @@ impl KeyATM {
                     nthreads,
                     draws_opts,
                     convergence_tol,
+                    |it, total, ll, ppl| {
+                        if let Some(cb) = &progress_dyn {
+                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl));
+                        }
+                    },
                     &mut rng,
                 )
             });
@@ -16093,6 +16123,11 @@ impl KeyATM {
                     offset.as_deref(),
                     draws_opts,
                     convergence_tol,
+                    |it, total, ll, ppl| {
+                        if let Some(cb) = &progress {
+                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl));
+                        }
+                    },
                     &mut rng,
                 ),
                 None if cvb0 => keyatm::fit_keyatm_cvb0(
@@ -16127,6 +16162,11 @@ impl KeyATM {
                     draws_opts,
                     convergence_tol,
                     turbo_alpha_stride,
+                    |it, total, ll, ppl| {
+                        if let Some(cb) = &progress {
+                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl));
+                        }
+                    },
                     &mut rng,
                 ),
             };

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -104,6 +104,36 @@ def test_lda_progress_does_not_change_the_fit():
     assert np.array_equal(np.asarray(a.doc_topic), np.asarray(b.doc_topic))
 
 
+def test_keyatm_drives_progress_base_and_covariate(capfd):
+    # #785: keyATM's base and covariate Gibbs paths call the 3-arg contract with
+    # {"ll", "perplexity"} and topica.progress() renders the bar.
+    import warnings
+
+    import numpy as np
+    docs = [["tax", "budget", "vote"]] * 80 + [["health", "care", "clinic"]] * 80
+    keys = {"fiscal": ["tax", "budget"], "health": ["health", "care"]}
+    for kwargs in ({}, dict(covariates=np.array([[0.0]] * 80 + [[1.0]] * 80),
+                            feature_names=["grp"])):
+        calls = []
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            topica.KeyATM(keys, num_topics=3, seed=13).fit(
+                docs, iters=120, progress_interval=20,
+                progress=lambda it, total, info: calls.append((it, total, dict(info))),
+                **kwargs,
+            )
+        assert calls and all(t == 120 for _, t, _ in calls)
+        assert all({"ll", "perplexity"} <= set(info) for _, _, info in calls)
+    # the renderer draws the bar with an ll sparkline
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        topica.KeyATM(keys, num_topics=3, seed=13).fit(
+            docs, iters=120, progress_interval=20,
+            progress=topica.progress(label="keyATM"))
+    err = capfd.readouterr().err
+    assert "keyATM |" in err and "ll " in err and "100%" in err
+
+
 def test_progress_metric_selection_defaults_to_first_key():
     buf = io.StringIO()
     cb = topica.progress(stream=buf)  # no metric= -> first key ("perplexity")


### PR DESCRIPTION
The last model for #785. keyATM now drives `topica.progress()`.

## Change
keyATM's three Gibbs fit functions in the core — `fit_keyatm` (base), `fit_keyatm_cov` (covariate/DMR), `fit_keyatm_dynamic` (HMM) — each take a generic `on_progress` closure, called at the `log_likelihood_history` record cadence with `(iteration, iters, ll, perplexity)`. The `KeyATM.fit` binding gains a `progress=` param and drives the callback via `Python::with_gil` as `progress(iteration, total_iters, {"ll": ll, "perplexity": ppl})`:

```
keyATM |████████████████████| 100% 300/300  ETA 0.0s  ll ▁▁▁▁██ -8550.137  perplexity=5.562
```

`topica.progress()` sparklines `ll` with `perplexity` as postfix (or `metric="perplexity"` to swap).

## Scope / correctness
- **cvb0** (the variational sampler) has no per-iteration ll-trace loop, so it is **not** wired (documented in the fit docstring); its binding arm is unchanged. Base + covariate + dynamic — keyATM's main uses — are all covered.
- The record blocks only **capture** `ll`/`perplexity` into locals (same `&self` method calls, same left-to-right order as the old inline `push`), so `log_likelihood_history` and the **committed keyATM gold are unchanged** — verified by the full suite.
- The dynamic path is an early `timestamps=` branch with its own worker; it clones the progress handle (`clone_ref`) because the non-dynamic path moves the original into its closure.
- 14 in-core test call sites pass a no-op closure.

## Tests
`test_progress.py` gains: base + covariate keyATM fire the 3-arg contract with `{ll, perplexity}` and auto-total, and `topica.progress()` renders the bar. Dynamic path smoke-checked. Full pytest **5032 passed, 38 skipped**; preflight + `mkdocs --strict` green.

## #785 status
Model wiring complete: LDA/DMR/LabeledLDA/SAGE (#788) + GSDMM (#789) + keyATM (this). Remaining: the **default-on vs opt-in** discoverability decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)