### PR TITLE
feat(progress): default-on progress bar in interactive terminals (#785)

### DIFF
--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1523,7 +1523,9 @@ impl LDA {
                     for iter in 1..=iters {
                         let change = cv.sweep();
                         if let Some(cb) = &progress {
-                            if progress_interval > 0 && iter % progress_interval == 0 {
+                            if progress_interval > 0
+                                && (iter % progress_interval == 0 || iter == iters)
+                            {
                                 let m = cv.to_topic_model(&corpus);
                                 let ll = output::model_log_likelihood(&m, &corpus) / total_tokens;
                                 Python::with_gil(|py| {
@@ -1722,7 +1724,8 @@ impl LDA {
                     }
 
                     if let Some(cb) = &progress {
-                        if progress_interval > 0 && crossed_multiple(prev, iter, progress_interval)
+                        if progress_interval > 0
+                            && (crossed_multiple(prev, iter, progress_interval) || iter == iters)
                         {
                             let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
                             Python::with_gil(|py| {
@@ -2893,7 +2896,7 @@ fn run_mh_training<S: crate::mh::MhSampler>(
         }
 
         if let Some(cb) = progress {
-            if progress_interval > 0 && iter % progress_interval == 0 {
+            if progress_interval > 0 && (iter % progress_interval == 0 || iter == iters) {
                 let m = sampler.to_topic_model();
                 let ll = output::model_log_likelihood(&m, &corpus) / total_tokens;
                 Python::with_gil(|py| {
@@ -4632,7 +4635,8 @@ impl DMR {
                     }
 
                     if let Some(cb) = &progress {
-                        if progress_interval > 0 && iter % progress_interval == 0 {
+                        if progress_interval > 0 && (iter % progress_interval == 0 || iter == iters)
+                        {
                             let dtc = doc_topic_counts(ws.doc_topics(), k);
                             let (ll, _) = dmr::dmr_objective_and_gradient(
                                 &lambda,
@@ -4796,7 +4800,8 @@ impl DMR {
                     }
 
                     if let Some(cb) = &progress {
-                        if progress_interval > 0 && iter % progress_interval == 0 {
+                        if progress_interval > 0 && (iter % progress_interval == 0 || iter == iters)
+                        {
                             let dtc = doc_topic_counts(&model.doc_topics, k);
                             let (ll, _) = dmr::dmr_objective_and_gradient(
                                 &lambda,
@@ -5758,7 +5763,8 @@ impl LabeledLDA {
                         push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
                     }
                     if let Some(cb) = &progress {
-                        if progress_interval > 0 && iter % progress_interval == 0 {
+                        if progress_interval > 0 && (iter % progress_interval == 0 || iter == iters)
+                        {
                             let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
                             Python::with_gil(|py| {
                                 emit_progress(py, cb, iter, iters, ll);
@@ -6565,7 +6571,7 @@ impl SAGE {
                     push_capped(&mut theta_draw_buf, snap, draws_opts.cap);
                 }
                 if let Some(cb) = &progress {
-                    if progress_interval > 0 && iter % progress_interval == 0 {
+                    if progress_interval > 0 && (iter % progress_interval == 0 || iter == iters) {
                         let llpt = compute_ll(&model) / total_tokens;
                         Python::with_gil(|py| {
                             emit_progress(py, cb, iter, iters, llpt);

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1030,6 +1030,32 @@ fn emit_progress(py: Python<'_>, cb: &PyObject, iter: usize, total: usize, ll: f
     let _ = cb.call1(py, (iter, total, info));
 }
 
+/// When the caller did not pass a `progress` callback, default to a live
+/// `topica.progress()` bar **only if stderr is an interactive terminal**, so
+/// interactive users get progress for free while scripts, pipelines, notebooks
+/// saving to a file, and CI stay silent (#785). `label` names the model in the bar.
+fn resolve_progress(py: Python<'_>, progress: Option<PyObject>, label: &str) -> Option<PyObject> {
+    if progress.is_some() {
+        return progress;
+    }
+    let is_tty = py
+        .import_bound("sys")
+        .and_then(|s| s.getattr("stderr"))
+        .and_then(|e| e.call_method0("isatty"))
+        .and_then(|r| r.extract::<bool>())
+        .unwrap_or(false);
+    if !is_tty {
+        return None;
+    }
+    let kwargs = PyDict::new_bound(py);
+    let _ = kwargs.set_item("label", label);
+    py.import_bound("topica")
+        .and_then(|t| t.getattr("progress"))
+        .and_then(|p| p.call((), Some(&kwargs)))
+        .ok()
+        .map(|obj| obj.unbind())
+}
+
 /// Like `emit_progress` but for models that surface a perplexity alongside the
 /// log-likelihood (keyATM): `callback(iteration, total, {"ll": ll, "perplexity":
 /// ppl})`. Best-effort — a raising callback never aborts the fit (#785).
@@ -1391,6 +1417,7 @@ impl LDA {
         turbo_merge_every: usize,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
+        let progress = resolve_progress(py, progress, "LDA");
         if num_samples == 0 {
             return Err(PyValueError::new_err(
                 "num_samples must be >= 1 (num_samples=0 would leave phi/theta all-zero); \
@@ -4331,6 +4358,7 @@ impl DMR {
         num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
+        let progress = resolve_progress(py, progress, "DMR");
         // num_threads: fit()-level value overrides the constructor default; the
         // sparse Gibbs sweep runs AD-LDA partition-and-merge when this is >1.
         let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
@@ -5528,6 +5556,7 @@ impl LabeledLDA {
         num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
+        let progress = resolve_progress(py, progress, "LabeledLDA");
         // num_threads: fit()-level value overrides the constructor default; the
         // sparse restricted-Gibbs sweep runs AD-LDA partition-and-merge when >1.
         let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
@@ -6378,6 +6407,7 @@ impl SAGE {
         convergence_tol: f64,
         check_every: usize,
     ) -> PyResult<Py<Self>> {
+        let progress = resolve_progress(py, progress, "SAGE");
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -13212,6 +13242,7 @@ impl GSDMM {
         progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         gsdmm_reject_threads(num_threads)?;
+        let progress = resolve_progress(py, progress, "GSDMM");
         let progress_interval = if let Some(old_val) = report_interval {
             let warnings = py.import_bound("warnings")?;
             warnings.call_method1(
@@ -15683,6 +15714,7 @@ impl KeyATM {
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         ensure_finite_pos("prior_variance", prior_variance)?;
+        let progress = resolve_progress(py, progress, "keyATM");
         if turbo_alpha_stride < 1 {
             return Err(PyValueError::new_err(
                 "turbo_alpha_stride must be >= 1 (1 = exact; >1 = approximate, subsample documents in the alpha sampler)",


### PR DESCRIPTION
Closes the last piece of #785: fit progress becomes a **zero-config default in interactive terminals**, and fixes two terminal-rendering defects an adversarial pass surfaced.

## What changes

**1. Default-on, TTY-gated.** When `progress=` is not passed, `fit()` now defaults to `topica.progress(label=<Model>)` — but only when `sys.stderr.isatty()`. A new Rust helper `resolve_progress(py, progress, label)` makes the decision and is wired into `LDA`, `DMR`, `LabeledLDA`, `SAGE`, `GSDMM`, and `keyATM`. Piped/redirected/captured stderr (scripts, notebooks, CI, pytest) stays byte-for-byte silent; interactive users get the bar/ETA/sparkline for free. Passing an explicit `progress=` still overrides. Numerics are untouched (the callback is read-only).

**2. Always emit the final iteration.** The fixed-interval models (LDA/DMR/SAGE/LabeledLDA) emitted only on `iter % progress_interval == 0`. When `iters` was not a multiple of the interval, the final frame never fired — the bar stuck below 100% with **no closing newline** (the shell prompt landed mid-line), and short fits with `iters <= progress_interval` rendered **nothing**. Both are now reachable by default via change 1, so these models emit whenever `iter == iters` as well. GSDMM/keyATM already forced the final emit and are unaffected. No double-fire when `iters` is a multiple (single `if`).

## Verification

- Silence guarantee (adversarial-verified): silent across piped stderr, `redirect_stderr`, `subprocess(stderr=PIPE)`, and pathological `.isatty()` (raises / missing / non-bool) — `resolve_progress` returns `None` unless `isatty()` is exactly `True`.
- Numeric invariance: `doc_topic` / `doc_cluster` bit-identical between a non-tty default fit and an explicit `progress=None` fit.
- On a real pty: all six models render with the correct per-model label; the four fixed-interval models now close at `100% N/N` on their own line for non-multiple and short `iters`.
- Full pytest suite green (5032 passed, 38 skipped); preflight clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)