### PR TITLE
feat(progress): live fit progress for the 12 slow models (#786)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -4599,6 +4599,7 @@ class Scholar:
         content: object | None = None,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "Scholar":
         """Fit on a Corpus or list of token lists with prior ``covariates``, supervised
         ``labels`` (str/int, one per document), and/or topic-covariate ``content``. At
@@ -6141,6 +6142,7 @@ class FASTopic:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "FASTopic":
         """Fit on token documents plus frozen document embeddings (num_docs x E).
         The vocabulary is taken from the corpus; the word embeddings are learned.

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -1476,6 +1476,7 @@ class DETM:
         timestamps: Sequence[int] | None = None,
         iters: int = 100,
         convergence_tol: float | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "DETM":
         """Fit on `data` with `word_embeddings` (len(vocabulary), L) aligned to
         `vocabulary`. `times` is each document's integer time-slice index (0-based,
@@ -4278,6 +4279,7 @@ class ETM:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "ETM":
         """Fit on token documents plus word embeddings (len(vocabulary) x E) and
         the aligned vocabulary, which defines the word ids. `iters` sets the number
@@ -4395,6 +4397,7 @@ class InfoCTM:
         embeddings_b: dict[str, Sequence[float]] | None = None,
         iters: int | None = None,
         batch_size: int = 128,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "InfoCTM":
         """Fit both languages jointly. ``dictionary`` is an iterable of
         ``(word_a, word_b)`` pairs; ``embeddings_*`` are optional ``{word: vector}``
@@ -4487,6 +4490,7 @@ class ProdLDA:
         *,
         iters: int | None = None,
         convergence_tol: Optional[float] = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "ProdLDA":
         """Fit on a Corpus or a list of token lists. `iters` sets the number of epochs.
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -569,6 +569,7 @@ class CTM:
         keep_eta_cov: bool = True,
         num_threads: Optional[int] = None,
         spectral_projection_threshold: int = 10000,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "CTM":
         """EM stops once the relative change in the variational bound falls below
         convergence_tol or after iters iterations, whichever comes first. Pass
@@ -753,6 +754,7 @@ class STM:
         keep_eta_cov: bool = True,
         num_threads: Optional[int] = None,
         spectral_projection_threshold: int = 10000,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "STM":
         """Fit. prevalence (or covariates, a symmetric alias) is (num_docs, F)
         covariates driving topic proportions (mu_d = X_d gamma; intercept
@@ -1336,6 +1338,7 @@ class DTM:
         times: Sequence[int],
         *,
         iters: int = 20,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "DTM":
         """Fit by variational EM. `times` is each document's integer time-slice
         index (0-based, contiguous); the slice count is max(times)+1."""

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2921,6 +2921,7 @@ class BTM:
     def fit(
         self, data: Corpus | Sequence[Sequence[str]], *, iters: int | None = None,
         num_threads: int | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "BTM":
         """num_threads overrides the constructor's worker count for this fit only
         (None = constructor value); >1 runs the biterm sweep as approximate-parallel
@@ -3631,7 +3632,7 @@ class HLDA:
 
         eta is a deprecated alias for beta."""
         ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 500, num_threads: int = 1) -> "HLDA": ...
+    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 500, num_threads: int = 1, progress: Callable[[int, int, dict], object] | None = None) -> "HLDA": ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]:
         """Node-word matrix, shape (num_nodes, num_words); rows sum to 1."""
@@ -3762,6 +3763,7 @@ class SeededLDA:
         convergence_tol: float = 0.0,
         check_every: int = 10,
         num_threads: int | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "SeededLDA":
         """Fit the seeded model. `convergence_tol` (default 0.0, disabled) enables
         opt-in log-likelihood early stopping on the default ("sparse") sampler,

--- a/src/btm.rs
+++ b/src/btm.rs
@@ -339,7 +339,7 @@ fn parallel_sweep_btm(
 /// runs MALLET-style approximate-parallel (AD-LDA) sampling over the biterms,
 /// deterministic for a fixed `num_threads` + seed.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_btm<R: Rng>(
+pub fn fit_btm<R: Rng, F: FnMut(usize, usize)>(
     docs: &[Vec<u32>],
     num_topics: usize,
     num_types: usize,
@@ -349,6 +349,7 @@ pub fn fit_btm<R: Rng>(
     window: usize,
     background: bool,
     num_threads: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> BtmModel {
     let k = num_topics;
@@ -383,7 +384,7 @@ pub fn fit_btm<R: Rng>(
     let denom_z = b as f64 + k as f64 * alpha;
     let mut pz = vec![0.0f64; k];
 
-    for _ in 0..iters {
+    for it in 0..iters {
         if num_threads <= 1 {
             // Exact serial path — byte-identical to the pre-threading loop.
             run_sweep_btm_range(
@@ -421,6 +422,7 @@ pub fn fit_btm<R: Rng>(
                 sweep_seed,
             );
         }
+        on_progress(it + 1, iters);
     }
 
     // θ_k = (nb_z[k] + α) / (B + Kα).
@@ -549,6 +551,7 @@ mod tests {
             15,
             false,
             1,
+            |_, _| {},
             &mut rng,
         );
 
@@ -577,7 +580,19 @@ mod tests {
         let (docs, v) = planted(k, block, 60, 4, 123);
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(99);
-            fit_btm(&docs, k, v, 1.0, 0.01, 80, 15, false, 1, &mut rng)
+            fit_btm(
+                &docs,
+                k,
+                v,
+                1.0,
+                0.01,
+                80,
+                15,
+                false,
+                1,
+                |_, _| {},
+                &mut rng,
+            )
         };
         let a = run();
         let b = run();

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -436,6 +436,7 @@ mod ctm_conformance_tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng,
         );
 

--- a/src/detm.rs
+++ b/src/detm.rs
@@ -973,7 +973,7 @@ fn alpha_rw_kl_and_grad(
 /// before every `exp` for numerical stability (see [`clamp_logvar`]); on the stable
 /// training path the clamp is never reached, so default fits are unchanged.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_detm<R: Rng>(
+pub fn fit_detm<R: Rng, F: FnMut(usize, usize, f64)>(
     tokens: &[Vec<u32>],
     counts: &[Vec<u32>],
     times: &[usize],
@@ -991,6 +991,7 @@ pub fn fit_detm<R: Rng>(
     wdecay: f64,
     em_tol: f64,
     grad_clip: Option<f64>,
+    mut on_progress: F,
     rng: &mut R,
 ) -> DetmModel {
     let (k, v, t, l) = (
@@ -1526,6 +1527,7 @@ pub fn fit_detm<R: Rng>(
             f64::NAN
         };
         bound_history.push(-avg); // ELBO == negative loss
+        on_progress(epoch + 1, epochs, -avg);
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
@@ -1736,8 +1738,25 @@ mod tests {
         let (k, block, t, d_per_t) = (3usize, 6usize, 4usize, 20usize);
         let (tokens, counts, times, rho, v) = planted_corpus(&mut rng, k, block, t, d_per_t);
         let m = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 32, 16, 2, 30, 64, 0.02, 1.2e-6, 0.0,
-            None, &mut rng,
+            &tokens,
+            &counts,
+            &times,
+            k,
+            v,
+            t,
+            &rho,
+            0.005,
+            32,
+            16,
+            2,
+            30,
+            64,
+            0.02,
+            1.2e-6,
+            0.0,
+            None,
+            |_, _, _| {},
+            &mut rng,
         );
         assert_eq!(m.num_topics, k);
         assert_eq!(m.num_times, t);
@@ -1771,13 +1790,47 @@ mod tests {
 
         let mut rng_a = ChaCha8Rng::seed_from_u64(123);
         let a = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 20, 64, 0.02, 1.2e-6, 0.0,
-            None, &mut rng_a,
+            &tokens,
+            &counts,
+            &times,
+            k,
+            v,
+            t,
+            &rho,
+            0.005,
+            16,
+            16,
+            2,
+            20,
+            64,
+            0.02,
+            1.2e-6,
+            0.0,
+            None,
+            |_, _, _| {},
+            &mut rng_a,
         );
         let mut rng_b = ChaCha8Rng::seed_from_u64(123);
         let b = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 20, 64, 0.02, 1.2e-6, 0.0,
-            None, &mut rng_b,
+            &tokens,
+            &counts,
+            &times,
+            k,
+            v,
+            t,
+            &rho,
+            0.005,
+            16,
+            16,
+            2,
+            20,
+            64,
+            0.02,
+            1.2e-6,
+            0.0,
+            None,
+            |_, _, _| {},
+            &mut rng_b,
         );
         for tt in 0..t {
             for kk in 0..k {
@@ -1794,8 +1847,25 @@ mod tests {
         let (k, block, t, d_per_t) = (3usize, 8usize, 5usize, 40usize);
         let (tokens, counts, times, rho, v) = planted_corpus(&mut rng, k, block, t, d_per_t);
         let m = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 32, 32, 2, 300, 1000, 0.02, 1.2e-6,
-            0.0, None, &mut rng,
+            &tokens,
+            &counts,
+            &times,
+            k,
+            v,
+            t,
+            &rho,
+            0.005,
+            32,
+            32,
+            2,
+            300,
+            1000,
+            0.02,
+            1.2e-6,
+            0.0,
+            None,
+            |_, _, _| {},
+            &mut rng,
         );
         // The time-varying topic prior eta (the latent the random walk regularizes)
         // should move across the slices for at least one topic, recovering the
@@ -2137,8 +2207,25 @@ mod tests {
         let (k, block, t, d_per_t) = (3usize, 6usize, 4usize, 20usize);
         let (tokens, counts, times, rho, v) = planted_corpus(&mut rng, k, block, t, d_per_t);
         let m = fit_detm(
-            &tokens, &counts, &times, k, v, t, &rho, 0.005, 16, 16, 2, 25, 64, 0.02, 1.2e-6, 0.0,
-            None, &mut rng,
+            &tokens,
+            &counts,
+            &times,
+            k,
+            v,
+            t,
+            &rho,
+            0.005,
+            16,
+            16,
+            2,
+            25,
+            64,
+            0.02,
+            1.2e-6,
+            0.0,
+            None,
+            |_, _, _| {},
+            &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/src/detm.rs
+++ b/src/detm.rs
@@ -1532,6 +1532,7 @@ pub fn fit_detm<R: Rng, F: FnMut(usize, usize, f64)>(
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
+                on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }

--- a/src/dtm.rs
+++ b/src/dtm.rs
@@ -565,7 +565,7 @@ pub(crate) fn init_suffstats<R: Rng>(
 /// Fit a Dynamic Topic Model. `times[d]` is the slice index (0..num_times) of
 /// document `d`. Returns the fitted model. Deterministic for a fixed `rng`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_dtm<R: Rng>(
+pub fn fit_dtm<R: Rng, F: FnMut(usize, usize, f64)>(
     docs: &[Vec<u32>],
     times: &[usize],
     num_types: usize,
@@ -576,6 +576,7 @@ pub fn fit_dtm<R: Rng>(
     obs_variance: f64,
     em_iters: usize,
     init_spectral: bool,
+    mut on_progress: F,
     rng: &mut R,
 ) -> DtmModel {
     let k = num_topics;
@@ -679,6 +680,7 @@ pub fn fit_dtm<R: Rng>(
             topic_bound += chains[kk].fit(&sstats[kk]);
         }
         bound = doc_bound + topic_bound;
+        on_progress(iter + 1, em_iters, bound);
         if bound < old_bound && lda_max_iter < 10 {
             lda_max_iter *= 2; // gensim: back off when the bound dips
         }
@@ -782,7 +784,20 @@ mod tests {
 
         // Looser chain variance: the planted drift is abrupt (disjoint vocab per
         // slice), so the random walk needs room to move between slices.
-        let model = fit_dtm(&docs, &times, v, 2, 3, 0.01, 0.5, 0.5, 20, false, &mut rng);
+        let model = fit_dtm(
+            &docs,
+            &times,
+            v,
+            2,
+            3,
+            0.01,
+            0.5,
+            0.5,
+            20,
+            false,
+            |_, _, _| {},
+            &mut rng,
+        );
 
         // Identify the drifting topic as the one whose top word changes across
         // slices; the other should be the stable {10,11,12} topic.
@@ -848,8 +863,34 @@ mod tests {
         let times: Vec<usize> = (0..30).map(|d| d % 3).collect();
         let mut r1 = ChaCha8Rng::seed_from_u64(5);
         let mut r2 = ChaCha8Rng::seed_from_u64(99);
-        let m1 = fit_dtm(&docs, &times, v, 2, 3, 0.01, 0.005, 0.5, 8, true, &mut r1);
-        let m2 = fit_dtm(&docs, &times, v, 2, 3, 0.01, 0.005, 0.5, 8, true, &mut r2);
+        let m1 = fit_dtm(
+            &docs,
+            &times,
+            v,
+            2,
+            3,
+            0.01,
+            0.005,
+            0.5,
+            8,
+            true,
+            |_, _, _| {},
+            &mut r1,
+        );
+        let m2 = fit_dtm(
+            &docs,
+            &times,
+            v,
+            2,
+            3,
+            0.01,
+            0.005,
+            0.5,
+            8,
+            true,
+            |_, _, _| {},
+            &mut r2,
+        );
         assert_eq!(m1.topic_word(0, 0), m2.topic_word(0, 0));
         assert_eq!(m1.topic_word(1, 2), m2.topic_word(1, 2));
     }
@@ -863,8 +904,34 @@ mod tests {
         let times: Vec<usize> = (0..30).map(|d| d % 3).collect();
         let mut r1 = ChaCha8Rng::seed_from_u64(5);
         let mut r2 = ChaCha8Rng::seed_from_u64(5);
-        let m1 = fit_dtm(&docs, &times, v, 2, 3, 0.01, 0.005, 0.5, 8, false, &mut r1);
-        let m2 = fit_dtm(&docs, &times, v, 2, 3, 0.01, 0.005, 0.5, 8, false, &mut r2);
+        let m1 = fit_dtm(
+            &docs,
+            &times,
+            v,
+            2,
+            3,
+            0.01,
+            0.005,
+            0.5,
+            8,
+            false,
+            |_, _, _| {},
+            &mut r1,
+        );
+        let m2 = fit_dtm(
+            &docs,
+            &times,
+            v,
+            2,
+            3,
+            0.01,
+            0.005,
+            0.5,
+            8,
+            false,
+            |_, _, _| {},
+            &mut r2,
+        );
         assert_eq!(m1.topic_word(0, 0), m2.topic_word(0, 0));
         assert_eq!(m1.topic_word(1, 2), m2.topic_word(1, 2));
     }
@@ -974,7 +1041,20 @@ mod tests {
             .collect();
         let times: Vec<usize> = vec![0; docs.len()];
         let mut rng = ChaCha8Rng::seed_from_u64(3);
-        let m = fit_dtm(&docs, &times, v, 2, 1, 0.01, 0.005, 0.5, 6, false, &mut rng);
+        let m = fit_dtm(
+            &docs,
+            &times,
+            v,
+            2,
+            1,
+            0.01,
+            0.005,
+            0.5,
+            6,
+            false,
+            |_, _, _| {},
+            &mut rng,
+        );
         assert_eq!(m.num_times, 1);
         for k in 0..2 {
             let row = m.topic_word(k, 0);
@@ -998,7 +1078,20 @@ mod tests {
             .collect();
         let times: Vec<usize> = (0..30).map(|d| d % 3).collect();
         let mut rng = ChaCha8Rng::seed_from_u64(5);
-        let m = fit_dtm(&docs, &times, v, 2, 3, 0.01, 0.005, 0.5, 8, true, &mut rng);
+        let m = fit_dtm(
+            &docs,
+            &times,
+            v,
+            2,
+            3,
+            0.01,
+            0.005,
+            0.5,
+            8,
+            true,
+            |_, _, _| {},
+            &mut rng,
+        );
         assert_eq!(m.doc_topic.len(), docs.len());
         for row in &m.doc_topic {
             assert_eq!(row.len(), 2);
@@ -1018,7 +1111,20 @@ mod tests {
             .collect();
         let times: Vec<usize> = (0..30).map(|d| d % 3).collect();
         let mut rng = ChaCha8Rng::seed_from_u64(5);
-        let m = fit_dtm(&docs, &times, v, 2, 3, 0.01, 0.005, 0.5, 8, true, &mut rng);
+        let m = fit_dtm(
+            &docs,
+            &times,
+            v,
+            2,
+            3,
+            0.01,
+            0.005,
+            0.5,
+            8,
+            true,
+            |_, _, _| {},
+            &mut rng,
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/dtm.rs
+++ b/src/dtm.rs
@@ -688,6 +688,7 @@ pub fn fit_dtm<R: Rng, F: FnMut(usize, usize, f64)>(
             && old_bound != 0.0
             && ((bound - old_bound) / old_bound).abs() < 1e-4
         {
+            on_progress(iter + 1, iter + 1, bound); // snap bar to 100% (#786)
             break;
         }
     }

--- a/src/etm.rs
+++ b/src/etm.rs
@@ -184,7 +184,7 @@ impl EtmModel {
 /// `max_inner` caps the per-iteration L-BFGS steps for the embedding M-step, and
 /// `em_tol` stops EM on the relative change in the corpus bound.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_etm<R: Rng>(
+pub fn fit_etm<R: Rng, F: FnMut(usize, usize, f64)>(
     docs: &[Vec<u32>],
     num_topics: usize,
     num_types: usize,
@@ -194,6 +194,7 @@ pub fn fit_etm<R: Rng>(
     sigma_shrink: f64,
     prior_variance: f64,
     max_inner: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> EtmModel {
     let k = num_topics;
@@ -278,6 +279,7 @@ pub fn fit_etm<R: Rng>(
 
         let total_bound: f64 = doc_results.iter().map(|(_, _, r)| r.bound).sum();
         bound_history.push(total_bound);
+        on_progress(em + 1, em_iters, total_bound);
 
         for (di, opt, res) in &doc_results {
             let di = *di;
@@ -472,7 +474,19 @@ mod tests {
             })
             .collect();
 
-        let m = fit_etm(&docs, k, v, &rho, 50, 1e-5, 0.0, 1e6, 25, &mut rng);
+        let m = fit_etm(
+            &docs,
+            k,
+            v,
+            &rho,
+            50,
+            1e-5,
+            0.0,
+            1e6,
+            25,
+            |_, _, _| {},
+            &mut rng,
+        );
         assert_eq!(m.beta.len(), k);
         // Each fitted topic's top words come from one block, and all blocks appear.
         let mut covered = std::collections::HashSet::new();
@@ -512,7 +526,19 @@ mod tests {
                     .collect()
             })
             .collect();
-        let m = fit_etm(&docs, k, v, &rho, 50, 1e-5, 0.0, 1e6, 25, &mut rng);
+        let m = fit_etm(
+            &docs,
+            k,
+            v,
+            &rho,
+            50,
+            1e-5,
+            0.0,
+            1e6,
+            25,
+            |_, _, _| {},
+            &mut rng,
+        );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/etm.rs
+++ b/src/etm.rs
@@ -302,6 +302,7 @@ pub fn fit_etm<R: Rng, F: FnMut(usize, usize, f64)>(
             let prev = bound_history[bound_history.len() - 2];
             let rel = (total_bound - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
+                on_progress(em + 1, em + 1, total_bound); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }

--- a/src/fastopic.rs
+++ b/src/fastopic.rs
@@ -604,6 +604,7 @@ pub fn fit_fastopic<R: Rng, F: FnMut(usize, usize, f64)>(
             let prev = loss_history[loss_history.len() - 2];
             let rel = (prev - loss).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
+                on_progress(epoch + 1, epoch + 1, -loss); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }

--- a/src/fastopic.rs
+++ b/src/fastopic.rs
@@ -528,7 +528,7 @@ fn theta_scale_grad(g_theta: f64, scale: usize) -> f64 {
 /// topic-word transport (reference defaults 3.0 and 2.0); `theta_temp` is the
 /// inference temperature (Eq. 9). `em_tol` stops on the relative loss change.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_fastopic<R: Rng>(
+pub fn fit_fastopic<R: Rng, F: FnMut(usize, usize, f64)>(
     docs: &[Vec<u32>],
     doc_emb: &[Vec<f64>],
     num_topics: usize,
@@ -541,6 +541,7 @@ pub fn fit_fastopic<R: Rng>(
     em_tol: f64,
     sinkhorn_iters: usize,
     sinkhorn_tol: f64,
+    mut on_progress: F,
     rng: &mut R,
 ) -> FastopicModel {
     let k = num_topics;
@@ -581,6 +582,7 @@ pub fn fit_fastopic<R: Rng>(
             sinkhorn_tol,
         );
         loss_history.push(loss);
+        on_progress(epoch + 1, epochs, -loss);
 
         // Flatten, step, unflatten the two embedding blocks.
         let mut te_flat: Vec<f64> = topic_emb.iter().flatten().copied().collect();
@@ -890,7 +892,20 @@ mod tests {
             .collect();
 
         let m = fit_fastopic(
-            &docs, &doc_emb, k, v, 300, 0.05, 3.0, 2.0, 1.0, 1e-6, 50, 1e-4, &mut rng,
+            &docs,
+            &doc_emb,
+            k,
+            v,
+            300,
+            0.05,
+            3.0,
+            2.0,
+            1.0,
+            1e-6,
+            50,
+            1e-4,
+            |_, _, _| {},
+            &mut rng,
         );
         assert_eq!(m.topic_word.len(), k);
         // Loss decreases overall.
@@ -935,7 +950,20 @@ mod tests {
             })
             .collect();
         let m = fit_fastopic(
-            &docs, &doc_emb, k, v, 300, 0.05, 3.0, 2.0, 1.0, 1e-6, 50, 1e-4, &mut rng,
+            &docs,
+            &doc_emb,
+            k,
+            v,
+            300,
+            0.05,
+            3.0,
+            2.0,
+            1.0,
+            1e-6,
+            50,
+            1e-4,
+            |_, _, _| {},
+            &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);

--- a/src/hlda.rs
+++ b/src/hlda.rs
@@ -612,7 +612,7 @@ impl HldaModel {
 /// RNGs (`ChaCha8Rng`, `Pcg64Mcg`) satisfy it. A non-`Send` RNG cannot be used
 /// even at `num_threads = 1`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_hlda<R: Rng + Send>(
+pub fn fit_hlda<R: Rng + Send, F: FnMut(usize, usize) + Send>(
     docs: &[Vec<u32>],
     num_types: usize,
     depth: usize,
@@ -621,6 +621,7 @@ pub fn fit_hlda<R: Rng + Send>(
     level_prior: LevelPrior,
     iters: usize,
     num_threads: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> HldaModel {
     assert!(depth >= 2, "hLDA needs depth >= 2");
@@ -706,12 +707,13 @@ pub fn fit_hlda<R: Rng + Send>(
     // computations, the result is bit-for-bit identical for any `num_threads` — the
     // fit is deterministic and unchanged by threading.
     let parallel = num_threads > 1;
-    let sweep = |model: &mut HldaModel, rng: &mut R| {
-        for _ in 0..iters {
+    let sweep = |model: &mut HldaModel, rng: &mut R, on_progress: &mut F| {
+        for it in 0..iters {
             for (d, doc) in docs.iter().enumerate() {
                 model.sample_path(d, doc, parallel, rng);
                 model.sample_levels(d, doc, rng);
             }
+            on_progress(it + 1, iters);
         }
     };
     if parallel {
@@ -719,9 +721,9 @@ pub fn fit_hlda<R: Rng + Send>(
             .num_threads(num_threads)
             .build()
             .expect("failed to build rayon thread pool");
-        pool.install(|| sweep(&mut model, rng));
+        pool.install(|| sweep(&mut model, rng, &mut on_progress));
     } else {
-        sweep(&mut model, rng);
+        sweep(&mut model, rng, &mut on_progress);
     }
 
     model
@@ -825,6 +827,7 @@ mod tests {
             LevelPrior::Dirichlet(vec![0.5; 2]),
             80,
             1,
+            |_, _| {},
             &mut rng,
         );
 
@@ -932,6 +935,7 @@ mod tests {
             LevelPrior::Dirichlet(vec![0.5; 2]),
             30,
             1,
+            |_, _| {},
             &mut r1,
         );
         let m2 = fit_hlda(
@@ -943,6 +947,7 @@ mod tests {
             LevelPrior::Dirichlet(vec![0.5; 2]),
             30,
             1,
+            |_, _| {},
             &mut r2,
         );
 
@@ -970,6 +975,7 @@ mod tests {
             LevelPrior::Dirichlet(vec![0.5; 2]),
             80,
             1,
+            |_, _| {},
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&model);
@@ -1011,6 +1017,7 @@ mod tests {
                 LevelPrior::Dirichlet(vec![0.5; 5]),
                 80,
                 1,
+                |_, _| {},
                 &mut rng,
             );
 
@@ -1174,7 +1181,7 @@ mod tests {
 
         let count_level0 = |prior: LevelPrior| -> usize {
             let mut r = ChaCha8Rng::seed_from_u64(99);
-            let m = fit_hlda(&docs, v, 3, 1.0, 0.1, prior, 60, 1, &mut r);
+            let m = fit_hlda(&docs, v, 3, 1.0, 0.1, prior, 60, 1, |_, _| {}, &mut r);
             m.levels.iter().flatten().filter(|&&l| l == 0).count()
         };
         let sym = count_level0(LevelPrior::Dirichlet(vec![0.5; 3]));
@@ -1203,6 +1210,7 @@ mod tests {
                 },
                 40,
                 1,
+                |_, _| {},
                 &mut r,
             )
         };
@@ -1231,6 +1239,7 @@ mod tests {
                 LevelPrior::Dirichlet(vec![0.1; 3]),
                 40,
                 threads,
+                |_, _| {},
                 &mut r,
             )
         };
@@ -1279,6 +1288,7 @@ mod tests {
                 LevelPrior::Dirichlet(vec![0.1; 3]),
                 50,
                 1,
+                |_, _| {},
                 &mut r,
             );
             let root = (0..model.num_nodes())

--- a/src/infoctm.rs
+++ b/src/infoctm.rs
@@ -338,7 +338,7 @@ pub struct InfoctmModel {
 /// masks. Hyperparameters mirror the reference (lr 0.002, hidden 100, dropout 0,
 /// temperature 0.2, pos_threshold 0.4, weight 30). Returns the two fitted models.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_infoctm<R: Rng>(
+pub fn fit_infoctm<R: Rng, F: FnMut(usize, usize, f64)>(
     docs_a: &[Vec<u32>],
     docs_b: &[Vec<u32>],
     va: usize,
@@ -356,6 +356,7 @@ pub fn fit_infoctm<R: Rng>(
     temperature: f64,
     pos_threshold: f64,
     em_tol: f64,
+    mut on_progress: F,
     rng: &mut R,
 ) -> InfoctmModel {
     let k = num_topics;
@@ -427,6 +428,7 @@ pub fn fit_infoctm<R: Rng>(
         }
         let avg = epoch_loss / steps.max(1) as f64;
         bound_history.push(-avg);
+        on_progress(epoch + 1, epochs, -avg);
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             if (-avg - prev).abs() / (prev.abs() + 1e-12) < em_tol {
@@ -688,8 +690,25 @@ mod tests {
         let trans = block_dict(va, vb, k);
         let mut rng = ChaCha8Rng::seed_from_u64(seed);
         fit_infoctm(
-            &docs_a, &docs_b, va, vb, &trans, None, None, k, 32, 0.0, 60, 40, 0.01, 30.0, 0.2, 0.4,
-            0.0, &mut rng,
+            &docs_a,
+            &docs_b,
+            va,
+            vb,
+            &trans,
+            None,
+            None,
+            k,
+            32,
+            0.0,
+            60,
+            40,
+            0.01,
+            30.0,
+            0.2,
+            0.4,
+            0.0,
+            |_, _, _| {},
+            &mut rng,
         )
     }
 

--- a/src/infoctm.rs
+++ b/src/infoctm.rs
@@ -432,6 +432,7 @@ pub fn fit_infoctm<R: Rng, F: FnMut(usize, usize, f64)>(
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             if (-avg - prev).abs() / (prev.abs() + 1e-12) < em_tol {
+                on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -1965,6 +1965,7 @@ pub fn fit_prodlda<R: Rng>(
         lr,
         em_tol,
         AvitmOptions::default(),
+        |_, _, _| {},
         rng,
     )
 }
@@ -1976,7 +1977,7 @@ pub fn fit_prodlda<R: Rng>(
 /// loss are identical across modes; only the layer-1 input differs. CombinedTM is
 /// [`InputMode::BowEmbAdapt`], ZeroShotTM is [`InputMode::EmbOnly`].
 #[allow(clippy::too_many_arguments)]
-pub fn fit_avitm<R: Rng>(
+pub fn fit_avitm<R: Rng, F: FnMut(usize, usize, f64)>(
     docs: &[Vec<u32>],
     embs: &[Vec<f64>],
     mode: InputMode,
@@ -1991,6 +1992,7 @@ pub fn fit_avitm<R: Rng>(
     lr: f64,
     em_tol: f64,
     opts: AvitmOptions,
+    mut on_progress: F,
     rng: &mut R,
 ) -> ProdldaModel {
     let (k, v) = (num_topics, num_types);
@@ -2094,6 +2096,7 @@ pub fn fit_avitm<R: Rng>(
 
         let avg = epoch_loss / batches.max(1) as f64;
         bound_history.push(-avg); // report the ELBO (negative loss)
+        on_progress(epoch + 1, epochs, -avg);
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
@@ -2582,6 +2585,7 @@ mod tests {
             0.01,
             0.0,
             AvitmOptions::default(),
+            |_, _, _| {},
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2620,6 +2624,7 @@ mod tests {
             0.01,
             0.0,
             AvitmOptions::default(),
+            |_, _, _| {},
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2661,6 +2666,7 @@ mod tests {
             0.01,
             0.0,
             AvitmOptions::default(),
+            |_, _, _| {},
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2766,6 +2772,7 @@ mod tests {
             0.01,
             0.0,
             opts,
+            |_, _, _| {},
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2808,6 +2815,7 @@ mod tests {
             0.005,
             0.0,
             opts,
+            |_, _, _| {},
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2879,6 +2887,7 @@ mod tests {
             0.005,
             0.0,
             opts,
+            |_, _, _| {},
             &mut rng,
         );
         assert!(
@@ -2967,6 +2976,7 @@ mod tests {
             0.005,
             0.0,
             opts,
+            |_, _, _| {},
             &mut rng,
         );
         let tw = m.topic_word();

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -2708,6 +2708,7 @@ mod tests {
                 0.01,
                 0.0,
                 AvitmOptions::default(),
+                |_, _, _| {},
                 &mut r1,
             );
             let b = fit_avitm(
@@ -2725,6 +2726,7 @@ mod tests {
                 0.01,
                 0.0,
                 AvitmOptions::default(),
+                |_, _, _| {},
                 &mut r2,
             );
             assert_eq!(

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -2101,6 +2101,7 @@ pub fn fit_avitm<R: Rng, F: FnMut(usize, usize, f64)>(
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
+                on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -179,13 +179,14 @@ impl BTM {
     /// value); `>1` runs the biterm Gibbs sweep as approximate-parallel AD-LDA
     /// (deterministic for a fixed `num_threads`+`seed`), `1` is the exact serial
     /// path.
-    #[pyo3(signature = (data, *, iters=None, num_threads=None))]
+    #[pyo3(signature = (data, *, iters=None, num_threads=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
         num_threads: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -223,8 +224,14 @@ impl BTM {
             slf.seed,
         );
 
+        let progress = resolve_progress(py, progress, "BTM");
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut on_progress = |it: usize, total: usize| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress_bare(py, cb, it, total));
+                }
+            };
             let m = crate::btm::fit_btm(
                 &corpus.docs,
                 k,
@@ -235,6 +242,7 @@ impl BTM {
                 window,
                 background,
                 num_threads,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -790,13 +790,14 @@ impl HLDA {
     /// inside each path resample across that many threads; the document loop and
     /// every tree mutation stay serial, so the fit is **bit-for-bit identical for any
     /// `num_threads`** — threading only speeds it up, it never changes the result.
-    #[pyo3(signature = (data, *, iters=500, num_threads=1))]
+    #[pyo3(signature = (data, *, iters=500, num_threads=1, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
         num_threads: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -830,7 +831,13 @@ impl HLDA {
             hlda::LevelPrior::Dirichlet(slf.alpha.clone())
         };
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
+        let progress = resolve_progress(py, progress, "HLDA");
         let (model, corpus) = py.allow_threads(move || {
+            let on_progress = |it: usize, total: usize| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress_bare(py, cb, it, total));
+                }
+            };
             let m = hlda::fit_hlda(
                 &corpus.docs,
                 num_types,
@@ -840,6 +847,7 @@ impl HLDA {
                 level_prior,
                 iters,
                 num_threads.max(1),
+                on_progress,
                 &mut rng,
             );
             (m, corpus)

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7395,7 +7395,8 @@ impl CTM {
     #[pyo3(signature = (data, *, iters=500, convergence_tol=1e-5, inference="batch",
                         batch_size=256, tau=64.0, kappa=0.7, beta_init=None, em_tol=None,
                         keep_eta_cov=true, num_threads=None,
-                        spectral_projection_threshold=spectral::DEFAULT_PROJ_THRESHOLD))]
+                        spectral_projection_threshold=spectral::DEFAULT_PROJ_THRESHOLD,
+                        progress=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -7412,6 +7413,7 @@ impl CTM {
         keep_eta_cov: bool,
         num_threads: Option<usize>,
         spectral_projection_threshold: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
@@ -7473,9 +7475,17 @@ impl CTM {
 
         let init_beta = parse_init_beta(beta_init, k, num_types, svi)?;
 
+        let progress = resolve_progress(py, progress, "CTM");
         let (model, corpus) = py.allow_threads(move || {
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             let m = run_with_threads(num_threads, || {
                 if svi {
+                    // The stochastic (SVI) inference path is not yet wired for
+                    // progress; only the default batch EM below reports (#786).
                     ctm::fit_ctm_svi(
                         &corpus.docs,
                         k,
@@ -7511,6 +7521,7 @@ impl CTM {
                         keep_eta_cov,
                         diagonal,
                         spectral_projection_threshold,
+                        &mut on_progress,
                         &mut rng,
                     )
                 }
@@ -8297,7 +8308,8 @@ impl STM {
                         iters=500, convergence_tol=1e-5,
                         gamma_prior="pooled", gamma_enet=1.0, beta_init=None, em_tol=None,
                         covariates=None, keep_eta_cov=true, num_threads=None,
-                        spectral_projection_threshold=spectral::DEFAULT_PROJ_THRESHOLD))]
+                        spectral_projection_threshold=spectral::DEFAULT_PROJ_THRESHOLD,
+                        progress=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -8321,6 +8333,7 @@ impl STM {
         keep_eta_cov: bool,
         num_threads: Option<usize>,
         spectral_projection_threshold: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
@@ -8595,9 +8608,15 @@ impl STM {
 
         let init_beta = parse_init_beta(beta_init, k, num_types, false)?;
 
+        let progress = resolve_progress(py, progress, "STM");
         let (model, corpus) = py.allow_threads(move || {
             let prev_ref = prevalence_x.as_deref();
             let cont_ref = content_groups.as_ref().map(|(g, n)| (g.as_slice(), *n));
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             let m = run_with_threads(num_threads, || {
                 ctm::fit_ctm(
                     &corpus.docs,
@@ -8617,6 +8636,7 @@ impl STM {
                     keep_eta_cov,
                     diagonal,
                     spectral_projection_threshold,
+                    &mut on_progress,
                     &mut rng,
                 )
             });
@@ -11487,13 +11507,14 @@ impl DTM {
     /// `times` gives each document's integer time-slice index (0-based,
     /// contiguous). The number of slices is inferred as ``max(times) + 1``.
     /// `iters` is the number of variational-EM iterations.
-    #[pyo3(signature = (data, times, *, iters=20))]
+    #[pyo3(signature = (data, times, *, iters=20, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         times: Vec<i64>,
         iters: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -11545,7 +11566,13 @@ impl DTM {
         let init_spectral = slf.init_spectral;
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
+        let progress = resolve_progress(py, progress, "DTM");
         let (model, corpus) = py.allow_threads(move || {
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             let m = dtm::fit_dtm(
                 &corpus.docs,
                 &times_u,
@@ -11557,6 +11584,7 @@ impl DTM {
                 ov,
                 iters,
                 init_spectral,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -15095,7 +15095,7 @@ impl FASTopic {
     /// the corpus; FASTopic learns the word embeddings itself, so none are passed.
     /// `iters` sets the number of training epochs (default 200).
     /// `convergence_tol` overrides the constructor value for this run (when given).
-    #[pyo3(signature = (data, doc_embeddings, *, iters=None, convergence_tol=None))]
+    #[pyo3(signature = (data, doc_embeddings, *, iters=None, convergence_tol=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -15103,6 +15103,7 @@ impl FASTopic {
         doc_embeddings: &Bound<'_, PyAny>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         if let Some(t) = convergence_tol {
             // Guard-parity (#517): the fit-time override must satisfy the same
@@ -15161,9 +15162,28 @@ impl FASTopic {
             slf.sinkhorn_tol,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
+        let progress = resolve_progress(py, progress, "FASTopic");
         let model = py.allow_threads(move || {
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             fastopic::fit_fastopic(
-                &docs_ids, &doc_emb, k, num_types, ep, lr, dta, twa, tt, et, si, st, &mut rng,
+                &docs_ids,
+                &doc_emb,
+                k,
+                num_types,
+                ep,
+                lr,
+                dta,
+                twa,
+                tt,
+                et,
+                si,
+                st,
+                &mut on_progress,
+                &mut rng,
             )
         });
         slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
@@ -15342,7 +15362,7 @@ impl FASTopic {
         data: &Bound<'py, PyAny>,
         doc_embeddings: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        let fitted = Self::fit(slf, py, data, doc_embeddings, None, None)?;
+        let fitted = Self::fit(slf, py, data, doc_embeddings, None, None, None)?;
         Ok(vecs_to_arr2(&fitted.bind(py).borrow().fitted_model()?.doc_topic).to_pyarray_bound(py))
     }
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7392,6 +7392,8 @@ impl CTM {
     /// deterministic random projection. The default (10000) matches R `stm`, which
     /// stays exact up to that size; lower it to force the cheaper approximate path
     /// on smaller vocabularies. It only affects `init="spectral"` runs.
+    /// `progress` is an optional `(iteration, total, info)` callback for a live
+    /// progress bar (see `topica.progress`); omitted, a bar shows in an interactive terminal.
     #[pyo3(signature = (data, *, iters=500, convergence_tol=1e-5, inference="batch",
                         batch_size=256, tau=64.0, kappa=0.7, beta_init=None, em_tol=None,
                         keep_eta_cov=true, num_threads=None,
@@ -8302,6 +8304,8 @@ impl STM {
     /// exact init for any vocabulary at or below 10000 types. Lower it to force the
     /// cheaper approximate path on smaller vocabularies (trading fidelity for
     /// speed/memory). It has no effect when the constructor sets `init="random"`.
+    /// `progress` is an optional `(iteration, total, info)` callback for a live
+    /// progress bar (see `topica.progress`); omitted, a bar shows in an interactive terminal.
     #[pyo3(signature = (data, prevalence=None, *, prevalence_names=None,
                         content=None, content_names=None, content_time=None, content_smooth=1.0,
                         content_prior_var=0.5, content_prior="l2",
@@ -11507,6 +11511,8 @@ impl DTM {
     /// `times` gives each document's integer time-slice index (0-based,
     /// contiguous). The number of slices is inferred as ``max(times) + 1``.
     /// `iters` is the number of variational-EM iterations.
+    /// `progress` is an optional `(iteration, total, info)` callback for a live
+    /// progress bar (see `topica.progress`); omitted, a bar shows in an interactive terminal.
     #[pyo3(signature = (data, times, *, iters=20, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -14166,6 +14172,8 @@ impl SeededLDA {
     /// (`None` = constructor value); `>1` runs the sparse seeded-Gibbs sweep as
     /// approximate-parallel AD-LDA (deterministic for a fixed `num_threads`+`seed`),
     /// `1` is the exact serial path, and it is ignored by the warp/cvb0 backends.
+    /// `progress` is an optional `(iteration, total, info)` callback for a live
+    /// progress bar (see `topica.progress`); omitted, a bar shows in an interactive terminal.
     #[pyo3(signature = (data, *, iters=2000, doc_topic_prior=None,
                         keep_theta_draws=true, num_theta_draws=25,
                         convergence_tol=0.0_f64, check_every=10_usize, num_threads=None,
@@ -15141,6 +15149,8 @@ impl FASTopic {
     /// the corpus; FASTopic learns the word embeddings itself, so none are passed.
     /// `iters` sets the number of training epochs (default 200).
     /// `convergence_tol` overrides the constructor value for this run (when given).
+    /// `progress` is an optional `(iteration, total, info)` callback for a live
+    /// progress bar (see `topica.progress`); omitted, a bar shows in an interactive terminal.
     #[pyo3(signature = (data, doc_embeddings, *, iters=None, convergence_tol=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1030,6 +1030,15 @@ fn emit_progress(py: Python<'_>, cb: &PyObject, iter: usize, total: usize, ll: f
     let _ = cb.call1(py, (iter, total, info));
 }
 
+/// Progress with no per-iteration metric: drives the bar/ETA only (empty info
+/// dict, so `topica.progress()` renders no sparkline). For samplers that do not
+/// compute a cheap per-sweep log-likelihood (BTM, HLDA), where the bar's value is
+/// the "is it still running?" signal rather than a convergence trace.
+fn emit_progress_bare(py: Python<'_>, cb: &PyObject, iter: usize, total: usize) {
+    let info = PyDict::new_bound(py);
+    let _ = cb.call1(py, (iter, total, info));
+}
+
 /// When the caller did not pass a `progress` callback, default to a live
 /// `topica.progress()` bar **only if stderr is an interactive terminal**, so
 /// interactive users get progress for free while scripts, pipelines, notebooks
@@ -14131,7 +14140,8 @@ impl SeededLDA {
     /// `1` is the exact serial path, and it is ignored by the warp/cvb0 backends.
     #[pyo3(signature = (data, *, iters=2000, doc_topic_prior=None,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None))]
+                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None,
+                        progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -14143,6 +14153,7 @@ impl SeededLDA {
         convergence_tol: f64,
         check_every: usize,
         num_threads: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         // num_threads: fit()-level value overrides the constructor default; the
@@ -14340,7 +14351,13 @@ impl SeededLDA {
             return Ok(slf.into());
         }
 
+        let progress = resolve_progress(py, progress, "SeededLDA");
         let (model, ll_history, converged, corpus) = py.allow_threads(move || {
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             let (m, ll, conv) = seeded::fit_seeded_lda(
                 &corpus.docs,
                 num_types,
@@ -14356,6 +14373,7 @@ impl SeededLDA {
                 convergence_tol,
                 check_every,
                 num_threads,
+                &mut on_progress,
                 &mut rng,
             );
             (m, ll, conv, corpus)

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -846,7 +846,16 @@ impl ETM {
         vocabulary: Vec<String>,
         iters: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        let fitted = Self::fit(slf, py, data, word_embeddings, vocabulary, iters, None, None)?;
+        let fitted = Self::fit(
+            slf,
+            py,
+            data,
+            word_embeddings,
+            vocabulary,
+            iters,
+            None,
+            None,
+        )?;
         Ok(vecs_to_arr2(&fitted.bind(py).borrow().surf_doc_topic()?).to_pyarray_bound(py))
     }
 

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -329,7 +329,7 @@ impl ETM {
     /// defines the word ids; tokens outside it are dropped.
     /// `iters` sets the number of training iterations (EM iterations or VAE epochs).
     /// `convergence_tol` overrides the constructor value for this run (when given).
-    #[pyo3(signature = (data, word_embeddings, vocabulary, *, iters=None, convergence_tol=None))]
+    #[pyo3(signature = (data, word_embeddings, vocabulary, *, iters=None, convergence_tol=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -338,6 +338,7 @@ impl ETM {
         vocabulary: Vec<String>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         // Use fit()-level convergence_tol if given, else fall back to constructor value.
         let tol = convergence_tol.unwrap_or(slf.em_tol);
@@ -428,8 +429,26 @@ impl ETM {
                 slf.prior_variance,
                 slf.max_inner,
             );
+            let progress = resolve_progress(py, progress, "ETM");
             let model = py.allow_threads(move || {
-                etm::fit_etm(&docs_ids, k, num_types, &rho, ei, et, ss, pv, mi, &mut rng)
+                let mut on_progress = |it: usize, total: usize, ll: f64| {
+                    if let Some(cb) = &progress {
+                        Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                    }
+                };
+                etm::fit_etm(
+                    &docs_ids,
+                    k,
+                    num_types,
+                    &rho,
+                    ei,
+                    et,
+                    ss,
+                    pv,
+                    mi,
+                    &mut on_progress,
+                    &mut rng,
+                )
             });
             slf.model = Some(model);
             slf.vae = None;
@@ -827,7 +846,7 @@ impl ETM {
         vocabulary: Vec<String>,
         iters: Option<usize>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        let fitted = Self::fit(slf, py, data, word_embeddings, vocabulary, iters, None)?;
+        let fitted = Self::fit(slf, py, data, word_embeddings, vocabulary, iters, None, None)?;
         Ok(vecs_to_arr2(&fitted.bind(py).borrow().surf_doc_topic()?).to_pyarray_bound(py))
     }
 
@@ -1027,7 +1046,7 @@ impl DETM {
     /// the run stops when the relative change in the variational evidence bound
     /// falls below it.
     #[pyo3(signature = (data, word_embeddings, vocabulary, *, times=None, timestamps=None,
-                        iters=100, convergence_tol=None))]
+                        iters=100, convergence_tol=None, progress=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -1039,6 +1058,7 @@ impl DETM {
         timestamps: Option<Vec<i64>>,
         iters: usize,
         convergence_tol: Option<f64>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         // times is canonical; timestamps is the accepted alias.
         let times = match (times, timestamps) {
@@ -1155,10 +1175,33 @@ impl DETM {
             slf.wdecay,
             slf.grad_clip,
         );
+        let progress = resolve_progress(py, progress, "DETM");
         let model = py.allow_threads(move || {
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             detm::fit_detm(
-                &tokens, &counts, &times_u, k, num_types, num_times, &rho, delta, h, eh, enl,
-                iters, bs, lr, wd, tol, gc, &mut rng,
+                &tokens,
+                &counts,
+                &times_u,
+                k,
+                num_types,
+                num_times,
+                &rho,
+                delta,
+                h,
+                eh,
+                enl,
+                iters,
+                bs,
+                lr,
+                wd,
+                tol,
+                gc,
+                &mut on_progress,
+                &mut rng,
             )
         });
 
@@ -1711,7 +1754,7 @@ impl InfoCTM {
     /// epochs (reference 500).
     /// `batch_size` is the number of documents per minibatch.
     #[pyo3(signature = (data_a, data_b, *, dictionary, embeddings_a=None,
-                        embeddings_b=None, iters=None, batch_size=128))]
+                        embeddings_b=None, iters=None, batch_size=128, progress=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -1723,6 +1766,7 @@ impl InfoCTM {
         embeddings_b: Option<std::collections::HashMap<String, Vec<f64>>>,
         iters: Option<usize>,
         batch_size: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let to_corpus = |data: &Bound<'_, PyAny>| -> PyResult<corpus::Corpus> {
             if let Ok(c) = data.extract::<Corpus>() {
@@ -1804,7 +1848,13 @@ impl InfoCTM {
 
         let docs_a = corpus_a.docs.clone();
         let docs_b = corpus_b.docs.clone();
+        let progress = resolve_progress(py, progress, "InfoCTM");
         let model = py.allow_threads(move || {
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             infoctm::fit_infoctm(
                 &docs_a,
                 &docs_b,
@@ -1823,6 +1873,7 @@ impl InfoCTM {
                 mt,
                 pt,
                 et,
+                &mut on_progress,
                 &mut rng,
             )
         });
@@ -2291,13 +2342,14 @@ impl ProdLDA {
     /// Fit on `data` (a Corpus or list of token lists).
     /// `iters` sets the number of training epochs (default 200).
     /// `convergence_tol` overrides the constructor value for this run (when given).
-    #[pyo3(signature = (data, *, iters=None, convergence_tol=None))]
+    #[pyo3(signature = (data, *, iters=None, convergence_tol=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let tol = convergence_tol.unwrap_or(slf.em_tol);
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -2345,7 +2397,13 @@ impl ProdLDA {
         );
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
         let empty: Vec<Vec<f64>> = vec![Vec::new(); corpus.docs.len()];
+        let progress = resolve_progress(py, progress, "ProdLDA");
         let (model, corpus) = py.allow_threads(move || {
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             let m = prodlda::fit_avitm(
                 &corpus.docs,
                 &empty,
@@ -2361,6 +2419,7 @@ impl ProdLDA {
                 lr,
                 et,
                 opts,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)
@@ -2528,7 +2587,7 @@ impl ProdLDA {
         py: Python<'py>,
         data: &Bound<'py, PyAny>,
     ) -> PyResult<Bound<'py, PyArray2<f64>>> {
-        let fitted = Self::fit(slf, py, data, None, None)?;
+        let fitted = Self::fit(slf, py, data, None, None, None)?;
         Ok(vecs_to_arr2(&fitted.bind(py).borrow().fitted_model()?.doc_topic).to_pyarray_bound(py))
     }
 
@@ -3024,6 +3083,7 @@ macro_rules! ctm_embedding_model {
                         lr,
                         tol,
                         opts,
+                        |_, _, _| {},
                         &mut rng,
                     );
                     (m, corpus)

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -383,7 +383,7 @@ impl Scholar {
     /// must be given. `iters` sets the number of epochs (default 200);
     /// `convergence_tol` overrides the constructor value for this run.
     #[pyo3(signature = (data, *, covariates=None, labels=None, content=None, iters=None,
-                        convergence_tol=None))]
+                        convergence_tol=None, progress=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -394,6 +394,7 @@ impl Scholar {
         content: Option<&Bound<'_, PyAny>>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -501,8 +502,14 @@ impl Scholar {
             slf.l1_content_reg,
         );
         let seed = slf.seed;
+        let progress = resolve_progress(py, progress, "Scholar");
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut on_progress = |it: usize, total: usize, ll: f64| {
+                if let Some(cb) = &progress {
+                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                }
+            };
             let m = crate::scholar::fit_scholar(
                 &corpus.docs,
                 &pcs,
@@ -523,6 +530,7 @@ impl Scholar {
                 lr,
                 l2,
                 tol,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)

--- a/src/scholar.rs
+++ b/src/scholar.rs
@@ -507,6 +507,7 @@ pub fn fit_scholar<R: Rng, F: FnMut(usize, usize, f64)>(
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
+                on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }

--- a/src/scholar.rs
+++ b/src/scholar.rs
@@ -184,7 +184,7 @@ fn prior_mean_for(prior_w: &[f64], pc: &[f64], k: usize, n_pc: usize) -> Vec<f64
 /// covariate prior-mean update and, when labeled, a softmax classifier off `theta`
 /// whose cross-entropy loss trains `wc`/`bc` and pushes a gradient back into `theta`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_scholar<R: Rng>(
+pub fn fit_scholar<R: Rng, F: FnMut(usize, usize, f64)>(
     docs: &[Vec<u32>],
     pcs: &[Vec<f64>],
     labels: Option<&[usize]>,
@@ -204,6 +204,7 @@ pub fn fit_scholar<R: Rng>(
     lr: f64,
     l2_prior_reg: f64,
     em_tol: f64,
+    mut on_progress: F,
     rng: &mut R,
 ) -> ScholarModel {
     let (k, v, pc, tc) = (num_topics, num_types, n_prior_covars, n_topic_covars);
@@ -501,6 +502,7 @@ pub fn fit_scholar<R: Rng>(
 
         let avg = epoch_loss / batches.max(1) as f64;
         bound_history.push(-avg); // report the ELBO (negative loss)
+        on_progress(epoch + 1, epochs, -avg);
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
@@ -777,8 +779,27 @@ mod tests {
         }
 
         let m = fit_scholar(
-            &docs, &pcs, None, 0, NO_TC, 0, false, 0.0, k, v, 2, 20, 1.0, 0.2, 120, 40, 0.01, 0.0,
-            0.0, &mut rng,
+            &docs,
+            &pcs,
+            None,
+            0,
+            NO_TC,
+            0,
+            false,
+            0.0,
+            k,
+            v,
+            2,
+            20,
+            1.0,
+            0.2,
+            120,
+            40,
+            0.01,
+            0.0,
+            0.0,
+            |_, _, _| {},
+            &mut rng,
         );
 
         // Topic-word rows are valid distributions.
@@ -827,8 +848,27 @@ mod tests {
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(3);
             fit_scholar(
-                &docs, &pcs, None, 0, NO_TC, 0, false, 0.0, 2, 6, 2, 8, 1.0, 0.2, 15, 4, 0.01,
-                0.01, 0.0, &mut rng,
+                &docs,
+                &pcs,
+                None,
+                0,
+                NO_TC,
+                0,
+                false,
+                0.0,
+                2,
+                6,
+                2,
+                8,
+                1.0,
+                0.2,
+                15,
+                4,
+                0.01,
+                0.01,
+                0.0,
+                |_, _, _| {},
+                &mut rng,
             )
         };
         let a = run();
@@ -981,6 +1021,7 @@ mod tests {
             0.01,
             0.0,
             0.0,
+            |_, _, _| {},
             &mut rng,
         );
 
@@ -1031,6 +1072,7 @@ mod tests {
                 0.01,
                 0.0,
                 0.0,
+                |_, _, _| {},
                 &mut rng,
             )
         };
@@ -1243,8 +1285,27 @@ mod tests {
         }
         let pcs: Vec<Vec<f64>> = vec![Vec::new(); docs.len()];
         let m = fit_scholar(
-            &docs, &pcs, None, 0, &tcs, 2, false, 0.0, k, v, 0, 20, 1.0, 0.2, 200, 40, 0.01, 0.0,
-            0.0, &mut rng,
+            &docs,
+            &pcs,
+            None,
+            0,
+            &tcs,
+            2,
+            false,
+            0.0,
+            k,
+            v,
+            0,
+            20,
+            1.0,
+            0.2,
+            200,
+            40,
+            0.01,
+            0.0,
+            0.0,
+            |_, _, _| {},
+            &mut rng,
         );
         let eff = m.content_effects();
         assert_eq!(eff.len(), 2);
@@ -1284,8 +1345,27 @@ mod tests {
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(5);
             fit_scholar(
-                &docs, &pcs, None, 0, &tcs, 2, true, 0.0, 2, 6, 0, 8, 1.0, 0.2, 15, 4, 0.01, 0.0,
-                0.0, &mut rng,
+                &docs,
+                &pcs,
+                None,
+                0,
+                &tcs,
+                2,
+                true,
+                0.0,
+                2,
+                6,
+                0,
+                8,
+                1.0,
+                0.2,
+                15,
+                4,
+                0.01,
+                0.0,
+                0.0,
+                |_, _, _| {},
+                &mut rng,
             )
         };
         let a = run();

--- a/src/seeded.rs
+++ b/src/seeded.rs
@@ -744,6 +744,7 @@ pub fn fit_seeded_lda<R: Rng, F: FnMut(usize, usize, f64)>(
                 let prev = ll_history[ll_history.len() - 2].1;
                 let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
                 if rel < convergence_tol {
+                    on_progress(iter, iter, ll); // snap bar to 100% (#786)
                     converged = true;
                     break;
                 }

--- a/src/seeded.rs
+++ b/src/seeded.rs
@@ -534,7 +534,7 @@ fn parallel_sweep_seeded(
 /// Returns `(model, ll_history, converged)` where `ll_history` is a vector of
 /// `(iteration, log_likelihood)` pairs recorded every `check_every` sweeps.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_seeded_lda<R: Rng>(
+pub fn fit_seeded_lda<R: Rng, F: FnMut(usize, usize, f64)>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -549,6 +549,7 @@ pub fn fit_seeded_lda<R: Rng>(
     convergence_tol: f64,
     check_every: usize,
     num_threads: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> (SeededModel, Vec<(usize, f64)>, bool) {
     let k = num_topics;
@@ -738,6 +739,7 @@ pub fn fit_seeded_lda<R: Rng>(
         if check_every > 0 && iter % check_every == 0 {
             let ll = compute_ll(&nkw, &nk, &ndk);
             ll_history.push((iter, ll));
+            on_progress(iter, iters, ll);
             if convergence_tol > 0.0 && ll_history.len() >= 2 {
                 let prev = ll_history[ll_history.len() - 2].1;
                 let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
@@ -863,6 +865,7 @@ mod tests {
             0.0,
             0,
             1,
+            |_, _, _| {},
             &mut rng,
         );
 
@@ -926,6 +929,7 @@ mod tests {
             0.0,
             0,
             1,
+            |_, _, _| {},
             &mut rng,
         );
 
@@ -987,6 +991,7 @@ mod tests {
             0.0,
             20, // check_every: record the trace
             1,
+            |_, _, _| {},
             &mut rng,
         );
 
@@ -1049,6 +1054,7 @@ mod tests {
             0.0,
             25,
             1,
+            |_, _, _| {},
             &mut rng,
         );
 
@@ -1090,6 +1096,7 @@ mod tests {
             0.0,
             0,
             1,
+            |_, _, _| {},
             &mut r1,
         );
         let (m2, _, _) = fit_seeded_lda(
@@ -1107,6 +1114,7 @@ mod tests {
             0.0,
             0,
             1,
+            |_, _, _| {},
             &mut r2,
         );
 
@@ -1147,6 +1155,7 @@ mod tests {
             0.0,
             0,
             1,
+            |_, _, _| {},
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);

--- a/tests/test_progress_models.py
+++ b/tests/test_progress_models.py
@@ -91,9 +91,13 @@ def test_progress_fires_with_iteration_total_info(model_name):
     its, totals, infos = zip(*calls)
     assert all(isinstance(i, int) and isinstance(t, int) for i, t, _ in calls)
     assert all(isinstance(inf, dict) for inf in infos)
-    # iteration is 1-based, monotonically non-decreasing, never past total.
+    # iteration is 1-based, monotonically non-decreasing, never past its own total.
     assert its[0] >= 1 and all(a <= b for a, b in zip(its, its[1:]))
-    assert all(t == totals[0] for t in totals) and its[-1] <= totals[0]
+    assert all(i <= t for i, t in zip(its, totals))
+    # In-progress frames report the iteration budget as total; on early
+    # convergence the fit emits a final snap frame with iteration == total (100%),
+    # so the last frame always closes the bar even when it stopped short of budget.
+    assert its[-1] == totals[-1], f"{model_name}: bar did not close at 100%"
     if model_name in LL_MODELS:
         assert all("ll" in inf for inf in infos), f"{model_name}: missing ll metric"
     else:

--- a/tests/test_progress_models.py
+++ b/tests/test_progress_models.py
@@ -1,0 +1,129 @@
+"""Live fit-progress callback across the slow high-value models (#786 phase 2).
+
+Each model's fit(progress=cb) must call cb(iteration, total, info) with a dict
+info, drive iteration up to total (for the ones that run a fixed budget), and not
+change the fit. LDA/DMR/LabeledLDA/SAGE/GSDMM/keyATM/HDP are covered elsewhere
+(phase 1); this pins the twelve wired in phase 2.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+DOCS = [["tax", "budget", "vote", "tax", "bill"]] * 30 + [
+    ["health", "care", "clinic", "care", "doctor"]
+] * 30
+VOCAB = sorted({w for d in DOCS for w in d})
+EMB = np.random.RandomState(0).randn(len(VOCAB), 8)
+DOC_EMB = np.random.RandomState(1).randn(len(DOCS), 16)
+COV = np.array([[0.0]] * 30 + [[1.0]] * 30)
+TIMES = [0] * 30 + [1] * 30
+
+
+def _fit(model_name, cb):
+    """Fit one model with progress=cb at a small iters; return (model, iters)."""
+    if model_name == "CTM":
+        return topica.CTM(3, seed=13).fit(DOCS, iters=12, progress=cb), 12
+    if model_name == "STM":
+        return topica.STM(3, seed=13).fit(DOCS, COV, iters=12, progress=cb), 12
+    if model_name == "DTM":
+        # DTM early-stops on its bound, so total is the cap, not necessarily reached.
+        return topica.DTM(3, seed=13).fit(DOCS, TIMES, iters=10, progress=cb), 10
+    if model_name == "ProdLDA":
+        return topica.ProdLDA(3, seed=13).fit(DOCS, iters=12, progress=cb), 12
+    if model_name == "ETM":
+        return topica.ETM(3, seed=13).fit(DOCS, EMB, VOCAB, iters=12, progress=cb), 12
+    if model_name == "DETM":
+        return (
+            topica.DETM(3, seed=13).fit(
+                DOCS, EMB, VOCAB, times=TIMES, iters=8, progress=cb
+            ),
+            8,
+        )
+    if model_name == "Scholar":
+        return (
+            topica.Scholar(3, seed=13).fit(
+                DOCS, covariates=COV, iters=12, progress=cb
+            ),
+            12,
+        )
+    if model_name == "FASTopic":
+        return topica.FASTopic(3, seed=13).fit(DOCS, DOC_EMB, iters=12, progress=cb), 12
+    if model_name == "InfoCTM":
+        docs_b = [["impuesto", "voto"]] * 30 + [["salud", "clinica"]] * 30
+        dic = [("tax", "impuesto"), ("health", "salud")]
+        return (
+            topica.InfoCTM(num_topics=3, seed=13).fit(
+                DOCS, docs_b, dictionary=dic, iters=15, batch_size=8, progress=cb
+            ),
+            15,
+        )
+    if model_name == "SeededLDA":
+        seeds = {"fiscal": ["tax", "budget"], "health": ["health", "care"]}
+        return (
+            topica.SeededLDA(seeds, seed=13).fit(
+                DOCS, iters=60, check_every=10, progress=cb
+            ),
+            60,
+        )
+    if model_name == "BTM":
+        return topica.BTM(3, seed=13).fit(DOCS, iters=40, progress=cb), 40
+    if model_name == "HLDA":
+        return topica.HLDA(seed=13).fit(DOCS, iters=30, progress=cb), 30
+    raise AssertionError(model_name)
+
+
+# ll-reporting models (info carries a real metric) vs bare (empty info dict).
+LL_MODELS = [
+    "CTM", "STM", "DTM", "ProdLDA", "ETM", "DETM",
+    "Scholar", "FASTopic", "InfoCTM", "SeededLDA",
+]
+BARE_MODELS = ["BTM", "HLDA"]
+
+
+@pytest.mark.parametrize("model_name", LL_MODELS + BARE_MODELS)
+def test_progress_fires_with_iteration_total_info(model_name):
+    calls = []
+    with _no_warn():
+        _fit(model_name, lambda it, total, info: calls.append((it, total, dict(info))))
+    assert calls, f"{model_name}: progress never fired"
+    its, totals, infos = zip(*calls)
+    assert all(isinstance(i, int) and isinstance(t, int) for i, t, _ in calls)
+    assert all(isinstance(inf, dict) for inf in infos)
+    # iteration is 1-based, monotonically non-decreasing, never past total.
+    assert its[0] >= 1 and all(a <= b for a, b in zip(its, its[1:]))
+    assert all(t == totals[0] for t in totals) and its[-1] <= totals[0]
+    if model_name in LL_MODELS:
+        assert all("ll" in inf for inf in infos), f"{model_name}: missing ll metric"
+    else:
+        assert all(inf == {} for inf in infos), f"{model_name}: expected bare info"
+
+
+@pytest.mark.parametrize(
+    "model_name", ["CTM", "ProdLDA", "SeededLDA", "BTM", "FASTopic"]
+)
+def test_progress_does_not_change_the_fit(model_name):
+    m_a, _ = _fit(model_name, None)
+    m_b, _ = _fit(model_name, lambda *xs: None)
+
+    def topic_word(m):
+        tw = m.topic_word
+        return np.asarray(tw() if callable(tw) else tw)
+
+    assert np.allclose(topic_word(m_a), topic_word(m_b))
+
+
+class _no_warn:
+    """Context manager that silences warnings (some fits warn on tiny corpora)."""
+
+    def __enter__(self):
+        import warnings
+
+        self._cm = warnings.catch_warnings()
+        self._cm.__enter__()
+        warnings.simplefilter("ignore")
+        return self
+
+    def __exit__(self, *a):
+        return self._cm.__exit__(*a)

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -1395,6 +1395,9 @@ pub fn fit_ctm<R: Rng, F: FnMut(usize, usize, f64)>(
             let prev = bound_history[bound_history.len() - 2];
             let rel = (total_bound - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
+                // Snap the progress bar to 100% on early convergence so it does
+                // not read as a hang at, e.g., 70/150 (#786).
+                on_progress(em + 1, em + 1, total_bound);
                 converged = true;
                 break;
             }

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -1107,7 +1107,7 @@ fn mu_from(x_d: &[f64], gamma: &[Vec<f64>], km1: usize) -> Vec<f64> {
 /// [`crate::spectral::DEFAULT_PROJ_THRESHOLD`] to match R `stm`. It only matters
 /// when `init_spectral` is set.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_ctm<R: Rng>(
+pub fn fit_ctm<R: Rng, F: FnMut(usize, usize, f64)>(
     docs: &[Vec<u32>],
     num_topics: usize,
     num_types: usize,
@@ -1125,6 +1125,7 @@ pub fn fit_ctm<R: Rng>(
     keep_nu: bool,
     diagonal: bool,
     spectral_proj_threshold: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> CtmModel {
     let k = num_topics;
@@ -1384,6 +1385,7 @@ pub fn fit_ctm<R: Rng>(
         // computed with the parameters from the previous M-step — the quantity
         // whose relative change drives convergence.
         bound_history.push(total_bound);
+        on_progress(em + 1, em_iters, total_bound);
 
         // Convergence: stop once the relative change in the corpus bound falls
         // below `em_tol`. Break before the M-step, so the returned β/Σ/γ are the
@@ -1917,6 +1919,7 @@ mod tests {
                 true,
                 false,
                 crate::spectral::DEFAULT_PROJ_THRESHOLD,
+                |_, _, _| {},
                 &mut rng,
             )
         };
@@ -2324,6 +2327,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng,
         );
         let theta = model.doc_topics();
@@ -2374,6 +2378,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng,
         );
         let cb = model.content_beta.expect("content_beta present");
@@ -2451,6 +2456,7 @@ mod tests {
                 true,
                 false,
                 crate::spectral::DEFAULT_PROJ_THRESHOLD,
+                |_, _, _| {},
                 &mut rng,
             )
             .content_beta
@@ -2520,6 +2526,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng,
         );
         // The bound trajectory is (weakly) monotone increasing.
@@ -2555,6 +2562,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng2,
         );
         assert!(!capped.converged);
@@ -2597,6 +2605,7 @@ mod tests {
             true,
             true,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng,
         );
         assert!(model.diagonal, "model should record diagonal mode");
@@ -2857,6 +2866,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng,
         );
         let stored = m_keep.nu.clone(); // per-group E-step ν (keep_nu = true)
@@ -2882,6 +2892,7 @@ mod tests {
             false,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng2,
         );
         assert!(model.content_beta.is_some(), "content_beta present");
@@ -2967,6 +2978,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng,
         );
         let stored = m_keep.nu.clone();
@@ -2989,6 +3001,7 @@ mod tests {
             false,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
+            |_, _, _| {},
             &mut rng2,
         );
         assert!(


### PR DESCRIPTION
Phase 2 of #786: rolls the `fit(progress=)` bar out to the slow, high-value models a user actually waits on. Phase 1 (#785/#792) covered LDA/DMR/LabeledLDA/SAGE/GSDMM/keyATM/HDP and the shared `topica.progress()` renderer + TTY-default-on plumbing; this wires the twelve variational/VAE/EM/Gibbs models that were still silent.

## Models wired (12)

Each core fit fn takes an `on_progress: FnMut` argument called at its existing per-iteration bound/log-likelihood trace point (no extra compute); the binding threads a `resolve_progress` default-on-in-TTY callback through `allow_threads` via `Python::with_gil`, exactly like keyATM/GSDMM.

- **Variational / EM / VAE** (report `{"ll": bound}`): **STM, CTM, DTM, ProdLDA, ETM, DETM, Scholar, FASTopic, InfoCTM, SeededLDA**
- **Gibbs, no cheap per-sweep metric** (bar + ETA only, empty `info` via `emit_progress_bare`): **BTM, HLDA**

STM and CTM both route through `fit_ctm` (STM always; CTM's default batch EM). HLDA threads its bare callback through the `pool.install` sweep closure (`F: Send`).

## Bar closes on early convergence

The EM/variational models stop early on their convergence tolerance (**on by default** for these, unlike phase-1's `convergence_tol=0`). Previously the last frame was left at e.g. `111/200 55%` and the bar never closed — reading like a hang. Each core now emits a final `on_progress(run, run, metric)` at the convergence break, so the bar snaps to `100% run/run` and closes. (Sample-user gate finding.)

## Three-agent review gate

- **Faithfulness**: bit-identity **holds exactly** (`np.array_equal`, not just `allclose`) for all 12 models across `progress=None` / no-op / recording callbacks. Shared cores confirmed untouched — CombinedTM/ZeroShotTM (which share `fit_avitm`) reject `progress=` and are exact-equal; CTM's `inference="svi"` path fires the callback 0 times.
- **Adversarial**: no crashes, deadlocks, worker-poisoning, GIL corruption, or threading nondeterminism (incl. HLDA's `Send`/`pool.install` path with `num_threads>1`, raising callbacks, re-entrancy, `iters=0/1`). TTY silence gate verified. Two findings in the shared emitters (KeyboardInterrupt propagation, callback validation) → **#794** (deferred: they affect phase-1 models equally, so they belong in a focused shared-helper fix).
- **Sample-user** (congress corpus, STM/ProdLDA/CTM/SeededLDA/BTM/HLDA): "a real improvement, I'd use it on every slow fit." Headline finding (bar stranded on early convergence) **fixed in this PR**.

## Scope notes (deferred, out of the slow-12)
- CTM's opt-in **SVI** path (`fit_ctm_svi`) and **CombinedTM/ZeroShotTM** (share ProdLDA's `fit_avitm`) get a no-op closure for now — they belong to the later breadth phase of #786.
- Shared-helper polish (Ctrl-C, callable validation) tracked in **#794**.

## Tests
`tests/test_progress_models.py` (17): per-model `fit(progress=)` contract — callback fires, iteration 1-based and monotonic, bar always closes at 100% (incl. early convergence), `ll` present for the 10 metric models and empty for BTM/HLDA, and fit unchanged with vs without a callback. Full suite green (5057 passed); preflight clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)