### PR TITLE
fix(progress): propagate KeyboardInterrupt and validate progress= (#794)

### DIFF
--- a/src/btm.rs
+++ b/src/btm.rs
@@ -339,7 +339,7 @@ fn parallel_sweep_btm(
 /// runs MALLET-style approximate-parallel (AD-LDA) sampling over the biterms,
 /// deterministic for a fixed `num_threads` + seed.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_btm<R: Rng, F: FnMut(usize, usize)>(
+pub fn fit_btm<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     num_topics: usize,
     num_types: usize,
@@ -422,7 +422,9 @@ pub fn fit_btm<R: Rng, F: FnMut(usize, usize)>(
                 sweep_seed,
             );
         }
-        on_progress(it + 1, iters);
+        if !on_progress(it + 1, iters) {
+            break;
+        }
     }
 
     // θ_k = (nb_z[k] + α) / (B + Kα).
@@ -551,7 +553,7 @@ mod tests {
             15,
             false,
             1,
-            |_, _| {},
+            |_, _| true,
             &mut rng,
         );
 
@@ -590,7 +592,7 @@ mod tests {
                 15,
                 false,
                 1,
-                |_, _| {},
+                |_, _| true,
                 &mut rng,
             )
         };

--- a/src/conformance.rs
+++ b/src/conformance.rs
@@ -436,7 +436,7 @@ mod ctm_conformance_tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
 

--- a/src/detm.rs
+++ b/src/detm.rs
@@ -973,7 +973,7 @@ fn alpha_rw_kl_and_grad(
 /// before every `exp` for numerical stability (see [`clamp_logvar`]); on the stable
 /// training path the clamp is never reached, so default fits are unchanged.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_detm<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_detm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     tokens: &[Vec<u32>],
     counts: &[Vec<u32>],
     times: &[usize],
@@ -1527,12 +1527,14 @@ pub fn fit_detm<R: Rng, F: FnMut(usize, usize, f64)>(
             f64::NAN
         };
         bound_history.push(-avg); // ELBO == negative loss
-        on_progress(epoch + 1, epochs, -avg);
+        if !on_progress(epoch + 1, epochs, -avg) {
+            break;
+        }
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
-                on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
+                let _ = on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }
@@ -1756,7 +1758,7 @@ mod tests {
             1.2e-6,
             0.0,
             None,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         assert_eq!(m.num_topics, k);
@@ -1808,7 +1810,7 @@ mod tests {
             1.2e-6,
             0.0,
             None,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng_a,
         );
         let mut rng_b = ChaCha8Rng::seed_from_u64(123);
@@ -1830,7 +1832,7 @@ mod tests {
             1.2e-6,
             0.0,
             None,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng_b,
         );
         for tt in 0..t {
@@ -1865,7 +1867,7 @@ mod tests {
             1.2e-6,
             0.0,
             None,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         // The time-varying topic prior eta (the latent the random walk regularizes)
@@ -2225,7 +2227,7 @@ mod tests {
             1.2e-6,
             0.0,
             None,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);

--- a/src/dtm.rs
+++ b/src/dtm.rs
@@ -565,7 +565,7 @@ pub(crate) fn init_suffstats<R: Rng>(
 /// Fit a Dynamic Topic Model. `times[d]` is the slice index (0..num_times) of
 /// document `d`. Returns the fitted model. Deterministic for a fixed `rng`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_dtm<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_dtm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     times: &[usize],
     num_types: usize,
@@ -680,7 +680,9 @@ pub fn fit_dtm<R: Rng, F: FnMut(usize, usize, f64)>(
             topic_bound += chains[kk].fit(&sstats[kk]);
         }
         bound = doc_bound + topic_bound;
-        on_progress(iter + 1, em_iters, bound);
+        if !on_progress(iter + 1, em_iters, bound) {
+            break;
+        }
         if bound < old_bound && lda_max_iter < 10 {
             lda_max_iter *= 2; // gensim: back off when the bound dips
         }
@@ -688,7 +690,7 @@ pub fn fit_dtm<R: Rng, F: FnMut(usize, usize, f64)>(
             && old_bound != 0.0
             && ((bound - old_bound) / old_bound).abs() < 1e-4
         {
-            on_progress(iter + 1, iter + 1, bound); // snap bar to 100% (#786)
+            let _ = on_progress(iter + 1, iter + 1, bound); // snap bar to 100% (#786)
             break;
         }
     }
@@ -796,7 +798,7 @@ mod tests {
             0.5,
             20,
             false,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -875,7 +877,7 @@ mod tests {
             0.5,
             8,
             true,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut r1,
         );
         let m2 = fit_dtm(
@@ -889,7 +891,7 @@ mod tests {
             0.5,
             8,
             true,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut r2,
         );
         assert_eq!(m1.topic_word(0, 0), m2.topic_word(0, 0));
@@ -916,7 +918,7 @@ mod tests {
             0.5,
             8,
             false,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut r1,
         );
         let m2 = fit_dtm(
@@ -930,7 +932,7 @@ mod tests {
             0.5,
             8,
             false,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut r2,
         );
         assert_eq!(m1.topic_word(0, 0), m2.topic_word(0, 0));
@@ -1053,7 +1055,7 @@ mod tests {
             0.5,
             6,
             false,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         assert_eq!(m.num_times, 1);
@@ -1090,7 +1092,7 @@ mod tests {
             0.5,
             8,
             true,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         assert_eq!(m.doc_topic.len(), docs.len());
@@ -1123,7 +1125,7 @@ mod tests {
             0.5,
             8,
             true,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);

--- a/src/etm.rs
+++ b/src/etm.rs
@@ -184,7 +184,7 @@ impl EtmModel {
 /// `max_inner` caps the per-iteration L-BFGS steps for the embedding M-step, and
 /// `em_tol` stops EM on the relative change in the corpus bound.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_etm<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_etm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     num_topics: usize,
     num_types: usize,
@@ -279,7 +279,9 @@ pub fn fit_etm<R: Rng, F: FnMut(usize, usize, f64)>(
 
         let total_bound: f64 = doc_results.iter().map(|(_, _, r)| r.bound).sum();
         bound_history.push(total_bound);
-        on_progress(em + 1, em_iters, total_bound);
+        if !on_progress(em + 1, em_iters, total_bound) {
+            break;
+        }
 
         for (di, opt, res) in &doc_results {
             let di = *di;
@@ -302,7 +304,7 @@ pub fn fit_etm<R: Rng, F: FnMut(usize, usize, f64)>(
             let prev = bound_history[bound_history.len() - 2];
             let rel = (total_bound - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
-                on_progress(em + 1, em + 1, total_bound); // snap bar to 100% (#786)
+                let _ = on_progress(em + 1, em + 1, total_bound); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }
@@ -485,7 +487,7 @@ mod tests {
             0.0,
             1e6,
             25,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         assert_eq!(m.beta.len(), k);
@@ -537,7 +539,7 @@ mod tests {
             0.0,
             1e6,
             25,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);

--- a/src/fastopic.rs
+++ b/src/fastopic.rs
@@ -528,7 +528,7 @@ fn theta_scale_grad(g_theta: f64, scale: usize) -> f64 {
 /// topic-word transport (reference defaults 3.0 and 2.0); `theta_temp` is the
 /// inference temperature (Eq. 9). `em_tol` stops on the relative loss change.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_fastopic<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_fastopic<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     doc_emb: &[Vec<f64>],
     num_topics: usize,
@@ -582,7 +582,9 @@ pub fn fit_fastopic<R: Rng, F: FnMut(usize, usize, f64)>(
             sinkhorn_tol,
         );
         loss_history.push(loss);
-        on_progress(epoch + 1, epochs, -loss);
+        if !on_progress(epoch + 1, epochs, -loss) {
+            break;
+        }
 
         // Flatten, step, unflatten the two embedding blocks.
         let mut te_flat: Vec<f64> = topic_emb.iter().flatten().copied().collect();
@@ -604,7 +606,7 @@ pub fn fit_fastopic<R: Rng, F: FnMut(usize, usize, f64)>(
             let prev = loss_history[loss_history.len() - 2];
             let rel = (prev - loss).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
-                on_progress(epoch + 1, epoch + 1, -loss); // snap bar to 100% (#786)
+                let _ = on_progress(epoch + 1, epoch + 1, -loss); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }
@@ -905,7 +907,7 @@ mod tests {
             1e-6,
             50,
             1e-4,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         assert_eq!(m.topic_word.len(), k);
@@ -963,7 +965,7 @@ mod tests {
             1e-6,
             50,
             1e-4,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);

--- a/src/gsdmm.rs
+++ b/src/gsdmm.rs
@@ -349,7 +349,7 @@ fn sweep<R: Rng>(model: &mut GsdmmModel, docs: &[Vec<u32>], rng: &mut R) {
 /// * `rng`       — random-number source; determines all randomness (deterministic
 ///                 for a fixed seed)
 #[allow(clippy::too_many_arguments)]
-pub fn fit_gsdmm<R: Rng, F: FnMut(usize, usize, usize, f64)>(
+pub fn fit_gsdmm<R: Rng, F: FnMut(usize, usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     k_max: usize,
@@ -404,7 +404,9 @@ pub fn fit_gsdmm<R: Rng, F: FnMut(usize, usize, usize, f64)>(
             let ll = model.cluster_log_likelihood(docs);
             let nc = model.num_clusters();
             model.trace.push((it + 1, nc, ll));
-            on_progress(it + 1, iters, nc, ll);
+            if !on_progress(it + 1, iters, nc, ll) {
+                break;
+            }
             if verbose {
                 // Progress to stderr (not stdout), so a long single-threaded fit
                 // does not look hung. The elapsed seconds let a user extrapolate
@@ -506,7 +508,7 @@ mod tests {
             200,
             0,
             false,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
 
@@ -567,7 +569,7 @@ mod tests {
             50,
             0,
             false,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut r1,
         );
         let m2 = fit_gsdmm(
@@ -579,7 +581,7 @@ mod tests {
             50,
             0,
             false,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut r2,
         );
 
@@ -616,7 +618,7 @@ mod tests {
             30,
             0,
             false,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
 
@@ -684,7 +686,7 @@ mod tests {
             40,
             0,
             false,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
 
@@ -758,7 +760,7 @@ mod tests {
             200,
             0,
             false,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&model);

--- a/src/hlda.rs
+++ b/src/hlda.rs
@@ -612,7 +612,7 @@ impl HldaModel {
 /// RNGs (`ChaCha8Rng`, `Pcg64Mcg`) satisfy it. A non-`Send` RNG cannot be used
 /// even at `num_threads = 1`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_hlda<R: Rng + Send, F: FnMut(usize, usize) + Send>(
+pub fn fit_hlda<R: Rng + Send, F: FnMut(usize, usize) -> bool + Send>(
     docs: &[Vec<u32>],
     num_types: usize,
     depth: usize,
@@ -713,7 +713,9 @@ pub fn fit_hlda<R: Rng + Send, F: FnMut(usize, usize) + Send>(
                 model.sample_path(d, doc, parallel, rng);
                 model.sample_levels(d, doc, rng);
             }
-            on_progress(it + 1, iters);
+            if !on_progress(it + 1, iters) {
+                break;
+            }
         }
     };
     if parallel {
@@ -827,7 +829,7 @@ mod tests {
             LevelPrior::Dirichlet(vec![0.5; 2]),
             80,
             1,
-            |_, _| {},
+            |_, _| true,
             &mut rng,
         );
 
@@ -935,7 +937,7 @@ mod tests {
             LevelPrior::Dirichlet(vec![0.5; 2]),
             30,
             1,
-            |_, _| {},
+            |_, _| true,
             &mut r1,
         );
         let m2 = fit_hlda(
@@ -947,7 +949,7 @@ mod tests {
             LevelPrior::Dirichlet(vec![0.5; 2]),
             30,
             1,
-            |_, _| {},
+            |_, _| true,
             &mut r2,
         );
 
@@ -975,7 +977,7 @@ mod tests {
             LevelPrior::Dirichlet(vec![0.5; 2]),
             80,
             1,
-            |_, _| {},
+            |_, _| true,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&model);
@@ -1017,7 +1019,7 @@ mod tests {
                 LevelPrior::Dirichlet(vec![0.5; 5]),
                 80,
                 1,
-                |_, _| {},
+                |_, _| true,
                 &mut rng,
             );
 
@@ -1181,7 +1183,7 @@ mod tests {
 
         let count_level0 = |prior: LevelPrior| -> usize {
             let mut r = ChaCha8Rng::seed_from_u64(99);
-            let m = fit_hlda(&docs, v, 3, 1.0, 0.1, prior, 60, 1, |_, _| {}, &mut r);
+            let m = fit_hlda(&docs, v, 3, 1.0, 0.1, prior, 60, 1, |_, _| true, &mut r);
             m.levels.iter().flatten().filter(|&&l| l == 0).count()
         };
         let sym = count_level0(LevelPrior::Dirichlet(vec![0.5; 3]));
@@ -1210,7 +1212,7 @@ mod tests {
                 },
                 40,
                 1,
-                |_, _| {},
+                |_, _| true,
                 &mut r,
             )
         };
@@ -1239,7 +1241,7 @@ mod tests {
                 LevelPrior::Dirichlet(vec![0.1; 3]),
                 40,
                 threads,
-                |_, _| {},
+                |_, _| true,
                 &mut r,
             )
         };
@@ -1288,7 +1290,7 @@ mod tests {
                 LevelPrior::Dirichlet(vec![0.1; 3]),
                 50,
                 1,
-                |_, _| {},
+                |_, _| true,
                 &mut r,
             );
             let root = (0..model.num_nodes())

--- a/src/infoctm.rs
+++ b/src/infoctm.rs
@@ -338,7 +338,7 @@ pub struct InfoctmModel {
 /// masks. Hyperparameters mirror the reference (lr 0.002, hidden 100, dropout 0,
 /// temperature 0.2, pos_threshold 0.4, weight 30). Returns the two fitted models.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_infoctm<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_infoctm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs_a: &[Vec<u32>],
     docs_b: &[Vec<u32>],
     va: usize,
@@ -428,11 +428,13 @@ pub fn fit_infoctm<R: Rng, F: FnMut(usize, usize, f64)>(
         }
         let avg = epoch_loss / steps.max(1) as f64;
         bound_history.push(-avg);
-        on_progress(epoch + 1, epochs, -avg);
+        if !on_progress(epoch + 1, epochs, -avg) {
+            break;
+        }
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             if (-avg - prev).abs() / (prev.abs() + 1e-12) < em_tol {
-                on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
+                let _ = on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }
@@ -708,7 +710,7 @@ mod tests {
             0.2,
             0.4,
             0.0,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         )
     }

--- a/src/keyatm.rs
+++ b/src/keyatm.rs
@@ -1113,7 +1113,7 @@ fn run_sweep<R: Rng>(
 ///                          Higher γ₁ → more weight on keyword distribution.
 /// * `iters`              — number of full Gibbs sweeps.
 /// * `rng`                — random-number source (deterministic for fixed seed).
-pub fn fit_keyatm<R: Rng, F: FnMut(usize, usize, f64, f64)>(
+pub fn fit_keyatm<R: Rng, F: FnMut(usize, usize, f64, f64) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -1208,7 +1208,9 @@ pub fn fit_keyatm<R: Rng, F: FnMut(usize, usize, f64, f64)>(
             let ll = model.model_loglik();
             let ppl = model.perplexity();
             model.log_likelihood_history.push((it + 1, ll, ppl));
-            on_progress(it + 1, iters, ll, ppl);
+            if !on_progress(it + 1, iters, ll, ppl) {
+                break;
+            }
             // The alpha trace (plot_alpha) is only meaningful when alpha is being
             // learned; with a fixed symmetric prior it would be a flat line.
             if estimate_alpha {
@@ -1821,7 +1823,7 @@ fn covariate_lambda_se(
 /// `iters < burn_in + opt_interval`). The keyword (z, s) sampler is otherwise
 /// identical to the base model.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_keyatm_cov<R: Rng, F: FnMut(usize, usize, f64, f64)>(
+pub fn fit_keyatm_cov<R: Rng, F: FnMut(usize, usize, f64, f64) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -1952,7 +1954,9 @@ pub fn fit_keyatm_cov<R: Rng, F: FnMut(usize, usize, f64, f64)>(
             let ll = model.model_loglik();
             let ppl = model.perplexity();
             model.log_likelihood_history.push((it + 1, ll, ppl));
-            on_progress(it + 1, iters, ll, ppl);
+            if !on_progress(it + 1, iters, ll, ppl) {
+                break;
+            }
             model.pi_history.push((it + 1, model.keyword_rate()));
             if ll_converged(&model.log_likelihood_history, convergence_tol) {
                 model.converged = true;
@@ -2207,7 +2211,7 @@ fn shuffled_topic_ids<R: Rng>(n: usize, rng: &mut R) -> Vec<usize> {
 /// backward sampling (FFBS) of the state path and resamples the left-to-right
 /// transition matrix.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_keyatm_dynamic<R: Rng, F: FnMut(usize, usize, f64, f64)>(
+pub fn fit_keyatm_dynamic<R: Rng, F: FnMut(usize, usize, f64, f64) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -2551,7 +2555,9 @@ pub fn fit_keyatm_dynamic<R: Rng, F: FnMut(usize, usize, f64, f64)>(
             let ll = model.model_loglik();
             let ppl = model.perplexity();
             model.log_likelihood_history.push((it + 1, ll, ppl));
-            on_progress(it + 1, iters, ll, ppl);
+            if !on_progress(it + 1, iters, ll, ppl) {
+                break;
+            }
             model.pi_history.push((it + 1, model.keyword_rate()));
             if ll_converged(&model.log_likelihood_history, convergence_tol) {
                 model.converged = true;
@@ -2794,7 +2800,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
 
@@ -2938,7 +2944,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
 
@@ -2995,7 +3001,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
 
@@ -3071,7 +3077,7 @@ mod tests {
             1,
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
 
@@ -3129,7 +3135,7 @@ mod tests {
             1,
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut r1,
         );
         let m2 = fit_keyatm_dynamic(
@@ -3153,7 +3159,7 @@ mod tests {
             1,
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut r2,
         );
         assert_eq!(
@@ -3198,7 +3204,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut r1,
         );
         let m2 = fit_keyatm(
@@ -3219,7 +3225,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut r2,
         );
 
@@ -3268,7 +3274,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
         let h = &model.log_likelihood_history;
@@ -3307,7 +3313,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng2,
         );
         assert!(none.log_likelihood_history.is_empty());
@@ -3339,7 +3345,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);
@@ -3378,7 +3384,7 @@ mod tests {
                 ThetaDrawOpts::new(false, 0, 0),
                 0.0,
                 stride,
-                |_, _, _, _| {},
+                |_, _, _, _| true,
                 &mut r,
             )
         };
@@ -3468,7 +3474,7 @@ mod tests {
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
             1,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
     }
@@ -3572,7 +3578,7 @@ mod tests {
             1,
             ThetaDrawOpts::new(false, 0, 0),
             0.0,
-            |_, _, _, _| {},
+            |_, _, _, _| true,
             &mut rng,
         );
     }

--- a/src/prodlda.rs
+++ b/src/prodlda.rs
@@ -1965,7 +1965,7 @@ pub fn fit_prodlda<R: Rng>(
         lr,
         em_tol,
         AvitmOptions::default(),
-        |_, _, _| {},
+        |_, _, _| true,
         rng,
     )
 }
@@ -1977,7 +1977,7 @@ pub fn fit_prodlda<R: Rng>(
 /// loss are identical across modes; only the layer-1 input differs. CombinedTM is
 /// [`InputMode::BowEmbAdapt`], ZeroShotTM is [`InputMode::EmbOnly`].
 #[allow(clippy::too_many_arguments)]
-pub fn fit_avitm<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_avitm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     embs: &[Vec<f64>],
     mode: InputMode,
@@ -2096,12 +2096,14 @@ pub fn fit_avitm<R: Rng, F: FnMut(usize, usize, f64)>(
 
         let avg = epoch_loss / batches.max(1) as f64;
         bound_history.push(-avg); // report the ELBO (negative loss)
-        on_progress(epoch + 1, epochs, -avg);
+        if !on_progress(epoch + 1, epochs, -avg) {
+            break;
+        }
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
-                on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
+                let _ = on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }
@@ -2586,7 +2588,7 @@ mod tests {
             0.01,
             0.0,
             AvitmOptions::default(),
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2625,7 +2627,7 @@ mod tests {
             0.01,
             0.0,
             AvitmOptions::default(),
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2667,7 +2669,7 @@ mod tests {
             0.01,
             0.0,
             AvitmOptions::default(),
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2709,7 +2711,7 @@ mod tests {
                 0.01,
                 0.0,
                 AvitmOptions::default(),
-                |_, _, _| {},
+                |_, _, _| true,
                 &mut r1,
             );
             let b = fit_avitm(
@@ -2727,7 +2729,7 @@ mod tests {
                 0.01,
                 0.0,
                 AvitmOptions::default(),
-                |_, _, _| {},
+                |_, _, _| true,
                 &mut r2,
             );
             assert_eq!(
@@ -2775,7 +2777,7 @@ mod tests {
             0.01,
             0.0,
             opts,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2818,7 +2820,7 @@ mod tests {
             0.005,
             0.0,
             opts,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let tw = m.topic_word();
@@ -2890,7 +2892,7 @@ mod tests {
             0.005,
             0.0,
             opts,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         assert!(
@@ -2979,7 +2981,7 @@ mod tests {
             0.005,
             0.0,
             opts,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let tw = m.topic_word();

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -224,12 +224,13 @@ impl BTM {
             slf.seed,
         );
 
-        let progress = resolve_progress(py, progress, "BTM");
+        let progress = resolve_progress(py, progress, "BTM")?;
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let mut on_progress = |it: usize, total: usize| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress_bare(py, cb, it, total));
+            let mut on_progress = |it: usize, total: usize| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress_bare(py, cb, it, total)),
+                    None => true,
                 }
             };
             let m = crate::btm::fit_btm(
@@ -247,6 +248,7 @@ impl BTM {
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.model = Some(model);
         slf.corpus = Some(corpus);
         slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -831,11 +831,12 @@ impl HLDA {
             hlda::LevelPrior::Dirichlet(slf.alpha.clone())
         };
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
-        let progress = resolve_progress(py, progress, "HLDA");
+        let progress = resolve_progress(py, progress, "HLDA")?;
         let (model, corpus) = py.allow_threads(move || {
-            let on_progress = |it: usize, total: usize| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress_bare(py, cb, it, total));
+            let on_progress = |it: usize, total: usize| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress_bare(py, cb, it, total)),
+                    None => true,
                 }
             };
             let m = hlda::fit_hlda(
@@ -852,6 +853,7 @@ impl HLDA {
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         let nn = model.num_nodes();
         let mut tw = Array2::<f64>::zeros((nn, num_types));

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1017,57 +1017,139 @@ fn build_with_fixed_vocab(
 // LDA pyclass
 // ---------------------------------------------------------------------------
 
+/// Deliver one progress tick to `cb` and report whether the fit should keep
+/// going. Returns `true` to continue, `false` to abort.
+///
+/// Two ways a fit aborts here (#794):
+///   * A `Ctrl-C` during the GIL-released fit sets Python's signal flag;
+///     `py.check_signals()` surfaces it as a pending `KeyboardInterrupt` even
+///     before the callback runs.
+///   * The callback itself raises a `BaseException` that is not an ordinary
+///     `Exception` (`KeyboardInterrupt`, `SystemExit`, `GeneratorExit`).
+///
+/// In both cases the exception is re-parked in the interpreter's error
+/// indicator and `false` is returned; the fit loop breaks and the model's
+/// `fit` re-raises it via [`reraise_if_interrupted`] once the fit unwinds. An
+/// ordinary `Exception` from a buggy user callback is still swallowed (returns
+/// `true`) so the progress display can never kill a fit (#785).
+fn deliver_progress(
+    py: Python<'_>,
+    cb: &PyObject,
+    iter: usize,
+    total: usize,
+    info: Bound<'_, PyDict>,
+) -> bool {
+    if let Err(e) = py.check_signals() {
+        e.restore(py);
+        return false;
+    }
+    match cb.call1(py, (iter, total, info)) {
+        Ok(_) => true,
+        Err(e) => {
+            // Let BaseException-only errors (Ctrl-C, sys.exit) abort the fit;
+            // swallow ordinary Exception subclasses from a buggy callback.
+            let fatal = e
+                .get_type_bound(py)
+                .is_subclass_of::<pyo3::exceptions::PyException>()
+                .map(|is_exc| !is_exc)
+                .unwrap_or(true);
+            if fatal {
+                e.restore(py);
+                false
+            } else {
+                true
+            }
+        }
+    }
+}
+
+/// After a GIL-released fit returns, re-raise a progress-triggered interrupt
+/// (`Ctrl-C` / `SystemExit`) that [`deliver_progress`] parked in the error
+/// indicator. No-op when the fit ran to completion. (#794)
+fn reraise_if_interrupted(py: Python<'_>) -> PyResult<()> {
+    match PyErr::take(py) {
+        Some(e) => Err(e),
+        None => Ok(()),
+    }
+}
+
 /// SparseLDA topic model (the MALLET algorithm).
 ///
 /// Invoke a fit progress callback with the standard 3-arg contract
 /// `callback(iteration, total, info)`, where `info` is `{"ll": ll_per_token}`.
 /// This is what `topica.progress()` renders as a live bar + ETA + ll sparkline.
-/// Best-effort: a callback that raises is ignored so the progress display can
-/// never abort a fit (#785).
-fn emit_progress(py: Python<'_>, cb: &PyObject, iter: usize, total: usize, ll: f64) {
+/// Returns `false` if the fit should abort (see [`deliver_progress`]).
+fn emit_progress(py: Python<'_>, cb: &PyObject, iter: usize, total: usize, ll: f64) -> bool {
     let info = PyDict::new_bound(py);
     let _ = info.set_item("ll", ll);
-    let _ = cb.call1(py, (iter, total, info));
+    deliver_progress(py, cb, iter, total, info)
 }
 
 /// Progress with no per-iteration metric: drives the bar/ETA only (empty info
 /// dict, so `topica.progress()` renders no sparkline). For samplers that do not
 /// compute a cheap per-sweep log-likelihood (BTM, HLDA), where the bar's value is
 /// the "is it still running?" signal rather than a convergence trace.
-fn emit_progress_bare(py: Python<'_>, cb: &PyObject, iter: usize, total: usize) {
+/// Returns `false` if the fit should abort (see [`deliver_progress`]).
+fn emit_progress_bare(py: Python<'_>, cb: &PyObject, iter: usize, total: usize) -> bool {
     let info = PyDict::new_bound(py);
-    let _ = cb.call1(py, (iter, total, info));
+    deliver_progress(py, cb, iter, total, info)
 }
 
 /// When the caller did not pass a `progress` callback, default to a live
 /// `topica.progress()` bar **only if stderr is an interactive terminal**, so
 /// interactive users get progress for free while scripts, pipelines, notebooks
 /// saving to a file, and CI stay silent (#785). `label` names the model in the bar.
-fn resolve_progress(py: Python<'_>, progress: Option<PyObject>, label: &str) -> Option<PyObject> {
-    if progress.is_some() {
-        return progress;
-    }
-    let is_tty = py
-        .import_bound("sys")
-        .and_then(|s| s.getattr("stderr"))
-        .and_then(|e| e.call_method0("isatty"))
-        .and_then(|r| r.extract::<bool>())
-        .unwrap_or(false);
+///
+/// A non-`None`, non-callable `progress` is a `TypeError` here (with the GIL,
+/// before `allow_threads`), so a typo'd callback fails loudly instead of a
+/// silent no-op fit (#794).
+fn resolve_progress(
+    py: Python<'_>,
+    progress: Option<PyObject>,
+    label: &str,
+) -> PyResult<Option<PyObject>> {
+    // `progress=True/False` is the long-standing on/off toggle: `False` disables
+    // the bar (like `None` in a non-terminal), `True` forces the default bar even
+    // when stderr is not a TTY. A non-bool, non-callable value is a typo -> raise.
+    let force_default = match &progress {
+        Some(obj) => match obj.bind(py).extract::<bool>() {
+            Ok(false) => return Ok(None),
+            Ok(true) => true,
+            Err(_) => {
+                if !obj.bind(py).is_callable() {
+                    return Err(pyo3::exceptions::PyTypeError::new_err(format!(
+                        "progress must be callable, a bool, or None, got {}",
+                        obj.bind(py).get_type().name()?,
+                    )));
+                }
+                return Ok(Some(progress.unwrap()));
+            }
+        },
+        None => false,
+    };
+    let is_tty = force_default
+        || py
+            .import_bound("sys")
+            .and_then(|s| s.getattr("stderr"))
+            .and_then(|e| e.call_method0("isatty"))
+            .and_then(|r| r.extract::<bool>())
+            .unwrap_or(false);
     if !is_tty {
-        return None;
+        return Ok(None);
     }
     let kwargs = PyDict::new_bound(py);
     let _ = kwargs.set_item("label", label);
-    py.import_bound("topica")
+    Ok(py
+        .import_bound("topica")
         .and_then(|t| t.getattr("progress"))
         .and_then(|p| p.call((), Some(&kwargs)))
         .ok()
-        .map(|obj| obj.unbind())
+        .map(|obj| obj.unbind()))
 }
 
 /// Like `emit_progress` but for models that surface a perplexity alongside the
 /// log-likelihood (keyATM): `callback(iteration, total, {"ll": ll, "perplexity":
-/// ppl})`. Best-effort — a raising callback never aborts the fit (#785).
+/// ppl})`. Returns `false` if the fit should abort (see [`deliver_progress`]).
 fn emit_progress_ll_ppl(
     py: Python<'_>,
     cb: &PyObject,
@@ -1075,11 +1157,11 @@ fn emit_progress_ll_ppl(
     total: usize,
     ll: f64,
     ppl: f64,
-) {
+) -> bool {
     let info = PyDict::new_bound(py);
     let _ = info.set_item("ll", ll);
     let _ = info.set_item("perplexity", ppl);
-    let _ = cb.call1(py, (iter, total, info));
+    deliver_progress(py, cb, iter, total, info)
 }
 
 /// Construct with the hyperparameters, then call :meth:`fit` on a
@@ -1373,7 +1455,10 @@ impl LDA {
     /// `progress`, if given, is called as ``progress(iteration, total_iters,
     /// {"ll": ll_per_token})`` every `progress_interval` iterations during the main
     /// loop. Pass :func:`topica.progress` for a live bar + ETA + log-likelihood
-    /// sparkline, or your own callback.
+    /// sparkline, or your own callback. ``progress=True``/``False`` force the
+    /// default bar on/off. A callback that raises an ordinary exception is
+    /// ignored (a broken display never kills a fit); a ``KeyboardInterrupt``
+    /// (Ctrl-C) does abort the fit and propagate.
     ///
     /// `convergence_tol` (default 0.0, disabled) enables early stopping: after
     /// each `check_every` sweeps the relative change in a smoothed log-likelihood
@@ -1426,7 +1511,7 @@ impl LDA {
         turbo_merge_every: usize,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
-        let progress = resolve_progress(py, progress, "LDA");
+        let progress = resolve_progress(py, progress, "LDA")?;
         if num_samples == 0 {
             return Err(PyValueError::new_err(
                 "num_samples must be >= 1 (num_samples=0 would leave phi/theta all-zero); \
@@ -1537,9 +1622,9 @@ impl LDA {
                             {
                                 let m = cv.to_topic_model(&corpus);
                                 let ll = output::model_log_likelihood(&m, &corpus) / total_tokens;
-                                Python::with_gil(|py| {
-                                    emit_progress(py, cb, iter, iters, ll);
-                                });
+                                if !Python::with_gil(|py| emit_progress(py, cb, iter, iters, ll)) {
+                                    break;
+                                }
                             }
                         }
                         if check_every > 0 && iter % check_every == 0 {
@@ -1558,6 +1643,7 @@ impl LDA {
                     let model = cv.to_topic_model(&corpus);
                     (acc_phi, acc_theta, ll_history, converged, model, corpus)
                 });
+            reraise_if_interrupted(py)?;
             slf.theta_draws = None;
             slf.finalize_fit(
                 num_topics, num_types, num_docs, acc_phi, acc_theta, model, corpus, ll_history,
@@ -1622,6 +1708,7 @@ impl LDA {
                     )
                 }
             });
+            reraise_if_interrupted(py)?;
             slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
             slf.finalize_fit(
                 num_topics,
@@ -1737,9 +1824,9 @@ impl LDA {
                             && (crossed_multiple(prev, iter, progress_interval) || iter == iters)
                         {
                             let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
-                            Python::with_gil(|py| {
-                                emit_progress(py, cb, iter, iters, ll);
-                            });
+                            if !Python::with_gil(|py| emit_progress(py, cb, iter, iters, ll)) {
+                                break;
+                            }
                         }
                     }
                 }
@@ -1787,6 +1874,7 @@ impl LDA {
                     (model, corpus),
                 )
             });
+        reraise_if_interrupted(py)?;
         let (model, corpus) = model;
         slf.theta_draws = draws_to_array3(&theta_draw_buf, num_docs, num_topics, None);
         slf.finalize_fit(
@@ -2908,9 +2996,9 @@ fn run_mh_training<S: crate::mh::MhSampler>(
             if progress_interval > 0 && (iter % progress_interval == 0 || iter == iters) {
                 let m = sampler.to_topic_model();
                 let ll = output::model_log_likelihood(&m, &corpus) / total_tokens;
-                Python::with_gil(|py| {
-                    emit_progress(py, cb, iter, iters, ll);
-                });
+                if !Python::with_gil(|py| emit_progress(py, cb, iter, iters, ll)) {
+                    break;
+                }
             }
         }
     }
@@ -4370,7 +4458,7 @@ impl DMR {
         num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
-        let progress = resolve_progress(py, progress, "DMR");
+        let progress = resolve_progress(py, progress, "DMR")?;
         // num_threads: fit()-level value overrides the constructor default; the
         // sparse Gibbs sweep runs AD-LDA partition-and-merge when this is >1.
         let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
@@ -4659,9 +4747,9 @@ impl DMR {
                                 offset.as_deref(),
                             );
                             let llpt = ll / total_tokens;
-                            Python::with_gil(|py| {
-                                emit_progress(py, cb, iter, iters, llpt);
-                            });
+                            if !Python::with_gil(|py| emit_progress(py, cb, iter, iters, llpt)) {
+                                break;
+                            }
                         }
                     }
                 }
@@ -4824,9 +4912,9 @@ impl DMR {
                                 offset.as_deref(),
                             );
                             let llpt = ll / total_tokens;
-                            Python::with_gil(|py| {
-                                emit_progress(py, cb, iter, iters, llpt);
-                            });
+                            if !Python::with_gil(|py| emit_progress(py, cb, iter, iters, llpt)) {
+                                break;
+                            }
                         }
                     }
 
@@ -4934,6 +5022,7 @@ impl DMR {
                 )
             })
         };
+        reraise_if_interrupted(py)?;
         let _ = model;
 
         let mut phi = Array2::<f64>::zeros((k, num_types));
@@ -5570,7 +5659,7 @@ impl LabeledLDA {
         num_threads: Option<usize>,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
-        let progress = resolve_progress(py, progress, "LabeledLDA");
+        let progress = resolve_progress(py, progress, "LabeledLDA")?;
         // num_threads: fit()-level value overrides the constructor default; the
         // sparse restricted-Gibbs sweep runs AD-LDA partition-and-merge when >1.
         let num_threads = num_threads.unwrap_or(slf.num_threads).max(1);
@@ -5775,9 +5864,9 @@ impl LabeledLDA {
                         if progress_interval > 0 && (iter % progress_interval == 0 || iter == iters)
                         {
                             let ll = output::model_log_likelihood(&model, &corpus) / total_tokens;
-                            Python::with_gil(|py| {
-                                emit_progress(py, cb, iter, iters, ll);
-                            });
+                            if !Python::with_gil(|py| emit_progress(py, cb, iter, iters, ll)) {
+                                break;
+                            }
                         }
                     }
                     // Trace recording and optional convergence check (never alters RNG).
@@ -5860,6 +5949,7 @@ impl LabeledLDA {
                     corpus,
                 )
             });
+        reraise_if_interrupted(py)?;
         let _ = model;
 
         let mut phi = Array2::<f64>::zeros((k, num_types));
@@ -6422,7 +6512,7 @@ impl SAGE {
         convergence_tol: f64,
         check_every: usize,
     ) -> PyResult<Py<Self>> {
-        let progress = resolve_progress(py, progress, "SAGE");
+        let progress = resolve_progress(py, progress, "SAGE")?;
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
         } else {
@@ -6582,9 +6672,9 @@ impl SAGE {
                 if let Some(cb) = &progress {
                     if progress_interval > 0 && (iter % progress_interval == 0 || iter == iters) {
                         let llpt = compute_ll(&model) / total_tokens;
-                        Python::with_gil(|py| {
-                            emit_progress(py, cb, iter, iters, llpt);
-                        });
+                        if !Python::with_gil(|py| emit_progress(py, cb, iter, iters, llpt)) {
+                            break;
+                        }
                     }
                 }
                 // Trace recording and optional convergence check (never alters RNG).
@@ -6640,6 +6730,7 @@ impl SAGE {
                 corpus,
             )
         });
+        reraise_if_interrupted(py)?;
 
         if !kappa_ok {
             let warnings = py.import_bound("warnings")?;
@@ -7477,11 +7568,12 @@ impl CTM {
 
         let init_beta = parse_init_beta(beta_init, k, num_types, svi)?;
 
-        let progress = resolve_progress(py, progress, "CTM");
+        let progress = resolve_progress(py, progress, "CTM")?;
         let (model, corpus) = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             let m = run_with_threads(num_threads, || {
@@ -7530,6 +7622,7 @@ impl CTM {
             });
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         let mut beta = Array2::<f64>::zeros((k, num_types));
         for t in 0..k {
@@ -8612,13 +8705,14 @@ impl STM {
 
         let init_beta = parse_init_beta(beta_init, k, num_types, false)?;
 
-        let progress = resolve_progress(py, progress, "STM");
+        let progress = resolve_progress(py, progress, "STM")?;
         let (model, corpus) = py.allow_threads(move || {
             let prev_ref = prevalence_x.as_deref();
             let cont_ref = content_groups.as_ref().map(|(g, n)| (g.as_slice(), *n));
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             let m = run_with_threads(num_threads, || {
@@ -8646,6 +8740,7 @@ impl STM {
             });
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         let mut beta = Array2::<f64>::zeros((k, num_types));
         for t in 0..k {
@@ -11572,11 +11667,12 @@ impl DTM {
         let init_spectral = slf.init_spectral;
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
-        let progress = resolve_progress(py, progress, "DTM");
+        let progress = resolve_progress(py, progress, "DTM")?;
         let (model, corpus) = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             let m = dtm::fit_dtm(
@@ -11595,6 +11691,7 @@ impl DTM {
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         // Precompute p(word | topic, time) for every slice.
         let tw: Vec<Vec<Vec<f64>>> = (0..num_times).map(|t| model.topic_word_matrix(t)).collect();
@@ -13360,7 +13457,7 @@ impl GSDMM {
         progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         gsdmm_reject_threads(num_threads)?;
-        let progress = resolve_progress(py, progress, "GSDMM");
+        let progress = resolve_progress(py, progress, "GSDMM")?;
         let progress_interval = if let Some(old_val) = report_interval {
             let warnings = py.import_bound("warnings")?;
             warnings.call_method1(
@@ -13437,21 +13534,23 @@ impl GSDMM {
                 verbose,
                 |it, total, nc, ll| {
                     // GSDMM surfaces two live signals: the cluster count collapsing
-                    // toward the discovered K, and the plug-in log-likelihood. The
-                    // callback is best-effort (a raise never aborts the fit) (#785).
-                    if let Some(cb) = &progress {
-                        Python::with_gil(|py| {
+                    // toward the discovered K, and the plug-in log-likelihood. A raise
+                    // never aborts the fit, but Ctrl-C / SystemExit does (#785, #794).
+                    match &progress {
+                        Some(cb) => Python::with_gil(|py| {
                             let info = PyDict::new_bound(py);
                             let _ = info.set_item("clusters", nc);
                             let _ = info.set_item("ll", ll);
-                            let _ = cb.call1(py, (it, total, info));
-                        });
+                            deliver_progress(py, cb, it, total, info)
+                        }),
+                        None => true,
                     }
                 },
                 &mut rng,
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         // Keep only non-empty clusters; remap their ids to a dense 0..num_used.
         let used = model.used_clusters();
@@ -14387,11 +14486,12 @@ impl SeededLDA {
             return Ok(slf.into());
         }
 
-        let progress = resolve_progress(py, progress, "SeededLDA");
+        let progress = resolve_progress(py, progress, "SeededLDA")?;
         let (model, ll_history, converged, corpus) = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             let (m, ll, conv) = seeded::fit_seeded_lda(
@@ -14414,6 +14514,7 @@ impl SeededLDA {
             );
             (m, ll, conv, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.phi = Some(vecs_to_arr2(&model.topic_word_all()));
         slf.theta = Some(vecs_to_arr2(&model.doc_topic()));
         slf.theta_draws = draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);
@@ -15218,11 +15319,12 @@ impl FASTopic {
             slf.sinkhorn_tol,
         );
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
-        let progress = resolve_progress(py, progress, "FASTopic");
+        let progress = resolve_progress(py, progress, "FASTopic")?;
         let model = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             fastopic::fit_fastopic(
@@ -15242,6 +15344,7 @@ impl FASTopic {
                 &mut rng,
             )
         });
+        reraise_if_interrupted(py)?;
         slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
         slf.model = Some(model);
         slf.corpus = Some(corpus);
@@ -15865,7 +15968,7 @@ impl KeyATM {
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         ensure_finite_pos("prior_variance", prior_variance)?;
-        let progress = resolve_progress(py, progress, "keyATM");
+        let progress = resolve_progress(py, progress, "keyATM")?;
         if turbo_alpha_stride < 1 {
             return Err(PyValueError::new_err(
                 "turbo_alpha_stride must be >= 1 (1 = exact; >1 = approximate, subsample documents in the alpha sampler)",
@@ -16131,14 +16234,16 @@ impl KeyATM {
                     nthreads,
                     draws_opts,
                     convergence_tol,
-                    |it, total, ll, ppl| {
-                        if let Some(cb) = &progress_dyn {
-                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl));
+                    |it, total, ll, ppl| match &progress_dyn {
+                        Some(cb) => {
+                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl))
                         }
+                        None => true,
                     },
                     &mut rng,
                 )
             });
+            reraise_if_interrupted(py)?;
 
             // θ comes back in sorted order; scatter it to the original doc order.
             let theta_sorted = model.doc_topic();
@@ -16306,10 +16411,11 @@ impl KeyATM {
                     offset.as_deref(),
                     draws_opts,
                     convergence_tol,
-                    |it, total, ll, ppl| {
-                        if let Some(cb) = &progress {
-                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl));
+                    |it, total, ll, ppl| match &progress {
+                        Some(cb) => {
+                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl))
                         }
+                        None => true,
                     },
                     &mut rng,
                 ),
@@ -16345,16 +16451,18 @@ impl KeyATM {
                     draws_opts,
                     convergence_tol,
                     turbo_alpha_stride,
-                    |it, total, ll, ppl| {
-                        if let Some(cb) = &progress {
-                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl));
+                    |it, total, ll, ppl| match &progress {
+                        Some(cb) => {
+                            Python::with_gil(|py| emit_progress_ll_ppl(py, cb, it, total, ll, ppl))
                         }
+                        None => true,
                     },
                     &mut rng,
                 ),
             };
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.phi = Some(vecs_to_arr2(&model.topic_word_all()));
         slf.theta = Some(vecs_to_arr2(&model.doc_topic()));
         slf.theta_draws = draws_to_array3(&model.theta_draws, corpus.num_docs(), num_topics, None);

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -429,11 +429,12 @@ impl ETM {
                 slf.prior_variance,
                 slf.max_inner,
             );
-            let progress = resolve_progress(py, progress, "ETM");
+            let progress = resolve_progress(py, progress, "ETM")?;
             let model = py.allow_threads(move || {
-                let mut on_progress = |it: usize, total: usize, ll: f64| {
-                    if let Some(cb) = &progress {
-                        Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+                let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                    match &progress {
+                        Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                        None => true,
                     }
                 };
                 etm::fit_etm(
@@ -450,6 +451,7 @@ impl ETM {
                     &mut rng,
                 )
             });
+            reraise_if_interrupted(py)?;
             slf.model = Some(model);
             slf.vae = None;
         }
@@ -1184,11 +1186,12 @@ impl DETM {
             slf.wdecay,
             slf.grad_clip,
         );
-        let progress = resolve_progress(py, progress, "DETM");
+        let progress = resolve_progress(py, progress, "DETM")?;
         let model = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             detm::fit_detm(
@@ -1213,6 +1216,7 @@ impl DETM {
                 &mut rng,
             )
         });
+        reraise_if_interrupted(py)?;
 
         slf.num_times = num_times;
         slf.model = Some(model);
@@ -1857,11 +1861,12 @@ impl InfoCTM {
 
         let docs_a = corpus_a.docs.clone();
         let docs_b = corpus_b.docs.clone();
-        let progress = resolve_progress(py, progress, "InfoCTM");
+        let progress = resolve_progress(py, progress, "InfoCTM")?;
         let model = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             infoctm::fit_infoctm(
@@ -1886,6 +1891,7 @@ impl InfoCTM {
                 &mut rng,
             )
         });
+        reraise_if_interrupted(py)?;
         slf.model = Some(model);
         slf.corpus_a = Some(corpus_a);
         slf.corpus_b = Some(corpus_b);
@@ -2406,11 +2412,12 @@ impl ProdLDA {
         );
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
         let empty: Vec<Vec<f64>> = vec![Vec::new(); corpus.docs.len()];
-        let progress = resolve_progress(py, progress, "ProdLDA");
+        let progress = resolve_progress(py, progress, "ProdLDA")?;
         let (model, corpus) = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             let m = prodlda::fit_avitm(
@@ -2433,6 +2440,7 @@ impl ProdLDA {
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.model = Some(model);
         slf.corpus = Some(corpus);
         slf.topic_names = (0..slf.num_topics).map(|i| format!("topic_{i}")).collect();
@@ -3092,7 +3100,7 @@ macro_rules! ctm_embedding_model {
                         lr,
                         tol,
                         opts,
-                        |_, _, _| {},
+                        |_, _, _| true,
                         &mut rng,
                     );
                     (m, corpus)

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -502,12 +502,13 @@ impl Scholar {
             slf.l1_content_reg,
         );
         let seed = slf.seed;
-        let progress = resolve_progress(py, progress, "Scholar");
+        let progress = resolve_progress(py, progress, "Scholar")?;
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let mut on_progress = |it: usize, total: usize, ll: f64| {
-                if let Some(cb) = &progress {
-                    Python::with_gil(|py| emit_progress(py, cb, it, total, ll));
+            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
+                match &progress {
+                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+                    None => true,
                 }
             };
             let m = crate::scholar::fit_scholar(
@@ -535,6 +536,7 @@ impl Scholar {
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.model = Some(model);
         slf.corpus = Some(corpus);
         slf.covariate_names = Some(names);

--- a/src/scholar.rs
+++ b/src/scholar.rs
@@ -184,7 +184,7 @@ fn prior_mean_for(prior_w: &[f64], pc: &[f64], k: usize, n_pc: usize) -> Vec<f64
 /// covariate prior-mean update and, when labeled, a softmax classifier off `theta`
 /// whose cross-entropy loss trains `wc`/`bc` and pushes a gradient back into `theta`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_scholar<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_scholar<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     pcs: &[Vec<f64>],
     labels: Option<&[usize]>,
@@ -502,12 +502,14 @@ pub fn fit_scholar<R: Rng, F: FnMut(usize, usize, f64)>(
 
         let avg = epoch_loss / batches.max(1) as f64;
         bound_history.push(-avg); // report the ELBO (negative loss)
-        on_progress(epoch + 1, epochs, -avg);
+        if !on_progress(epoch + 1, epochs, -avg) {
+            break;
+        }
         if em_tol > 0.0 && bound_history.len() >= 2 {
             let prev = bound_history[bound_history.len() - 2];
             let rel = (-avg - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
-                on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
+                let _ = on_progress(epoch + 1, epoch + 1, -avg); // snap bar to 100% (#786)
                 converged = true;
                 break;
             }
@@ -799,7 +801,7 @@ mod tests {
             0.01,
             0.0,
             0.0,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -868,7 +870,7 @@ mod tests {
                 0.01,
                 0.01,
                 0.0,
-                |_, _, _| {},
+                |_, _, _| true,
                 &mut rng,
             )
         };
@@ -1022,7 +1024,7 @@ mod tests {
             0.01,
             0.0,
             0.0,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -1073,7 +1075,7 @@ mod tests {
                 0.01,
                 0.0,
                 0.0,
-                |_, _, _| {},
+                |_, _, _| true,
                 &mut rng,
             )
         };
@@ -1305,7 +1307,7 @@ mod tests {
             0.01,
             0.0,
             0.0,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let eff = m.content_effects();
@@ -1365,7 +1367,7 @@ mod tests {
                 0.01,
                 0.0,
                 0.0,
-                |_, _, _| {},
+                |_, _, _| true,
                 &mut rng,
             )
         };

--- a/src/seeded.rs
+++ b/src/seeded.rs
@@ -534,7 +534,7 @@ fn parallel_sweep_seeded(
 /// Returns `(model, ll_history, converged)` where `ll_history` is a vector of
 /// `(iteration, log_likelihood)` pairs recorded every `check_every` sweeps.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_seeded_lda<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_seeded_lda<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -739,12 +739,14 @@ pub fn fit_seeded_lda<R: Rng, F: FnMut(usize, usize, f64)>(
         if check_every > 0 && iter % check_every == 0 {
             let ll = compute_ll(&nkw, &nk, &ndk);
             ll_history.push((iter, ll));
-            on_progress(iter, iters, ll);
+            if !on_progress(iter, iters, ll) {
+                break;
+            }
             if convergence_tol > 0.0 && ll_history.len() >= 2 {
                 let prev = ll_history[ll_history.len() - 2].1;
                 let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
                 if rel < convergence_tol {
-                    on_progress(iter, iter, ll); // snap bar to 100% (#786)
+                    let _ = on_progress(iter, iter, ll); // snap bar to 100% (#786)
                     converged = true;
                     break;
                 }
@@ -866,7 +868,7 @@ mod tests {
             0.0,
             0,
             1,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -930,7 +932,7 @@ mod tests {
             0.0,
             0,
             1,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -992,7 +994,7 @@ mod tests {
             0.0,
             20, // check_every: record the trace
             1,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -1055,7 +1057,7 @@ mod tests {
             0.0,
             25,
             1,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -1097,7 +1099,7 @@ mod tests {
             0.0,
             0,
             1,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut r1,
         );
         let (m2, _, _) = fit_seeded_lda(
@@ -1115,7 +1117,7 @@ mod tests {
             0.0,
             0,
             1,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut r2,
         );
 
@@ -1156,7 +1158,7 @@ mod tests {
             0.0,
             0,
             1,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let base = crate::conformance::check_conformance(&m);

--- a/tests/test_progress_interrupt.py
+++ b/tests/test_progress_interrupt.py
@@ -1,0 +1,118 @@
+"""Interrupt propagation + progress= validation for the shared emitters (#794).
+
+Two guarantees, fixed once in the shared progress helpers (`deliver_progress`,
+`resolve_progress`) and therefore covering every progress-enabled model:
+
+1. A ``KeyboardInterrupt`` / ``SystemExit`` raised in the callback -- or a real
+   Ctrl-C (SIGINT) that arrives while the GIL-released fit is running -- aborts
+   the fit and propagates, so a long fit can actually be interrupted. An
+   ordinary ``Exception`` from a buggy callback is still swallowed (a broken
+   progress display must never kill a fit, #785).
+2. A non-callable ``progress=`` raises ``TypeError`` up front instead of a
+   silent no-op fit.
+"""
+
+import os
+import signal
+
+import pytest
+
+import topica
+
+# One small corpus, reused. Two clear word-blocks so every model has something
+# to fit; token-list input keeps the models that take a Corpus or a list happy.
+DOCS = [["tax", "budget", "vote", "senate"]] * 60 + [
+    ["health", "care", "clinic", "nurse"]
+] * 60
+
+
+def _fit(model_name, progress, iters):
+    """Kick off a fit with `progress` for a representative model per emit path.
+
+    Covers the three shared emitters: `emit_progress` (LDA direct-in-loop, CTM
+    closure), `emit_progress_bare` (BTM), and `emit_progress_ll_ppl` (keyATM),
+    plus the custom GSDMM closure.
+    """
+    if model_name == "LDA":
+        topica.LDA(2, seed=13).fit(DOCS, iters=iters, progress_interval=1, progress=progress)
+    elif model_name == "CTM":
+        topica.CTM(2, seed=13).fit(DOCS, iters=iters, progress=progress)
+    elif model_name == "BTM":
+        topica.BTM(2, seed=13).fit(DOCS, iters=iters, progress=progress)
+    elif model_name == "GSDMM":
+        topica.GSDMM(4, seed=13).fit(DOCS, iters=iters, progress_interval=1, progress=progress)
+    elif model_name == "keyATM":
+        import warnings
+
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            topica.KeyATM({"fiscal": ["tax", "budget"]}, num_topics=2, seed=13).fit(
+                DOCS, iters=iters, progress_interval=1, progress=progress
+            )
+    else:  # pragma: no cover
+        raise ValueError(model_name)
+
+
+MODELS = ["LDA", "CTM", "BTM", "GSDMM", "keyATM"]
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_non_callable_progress_raises_typeerror(model):
+    with pytest.raises(TypeError, match="callable"):
+        _fit(model, progress=5, iters=20)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_keyboardinterrupt_in_callback_aborts_and_propagates(model):
+    calls = {"n": 0}
+
+    def cb(*args):
+        calls["n"] += 1
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit(model, progress=cb, iters=500)
+    # aborted at the first tick, not run to completion
+    assert calls["n"] == 1
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_systemexit_in_callback_propagates(model):
+    def cb(*args):
+        raise SystemExit(2)
+
+    with pytest.raises(SystemExit):
+        _fit(model, progress=cb, iters=500)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_ordinary_exception_in_callback_is_swallowed(model):
+    def cb(*args):
+        raise ValueError("buggy user callback")
+
+    # A raising-but-ordinary callback must not abort the fit (#785).
+    _fit(model, progress=cb, iters=20)
+
+
+def test_real_sigint_during_fit_is_surfaced():
+    # The reported bug: with progress default-on, a Ctrl-C during a slow fit was
+    # swallowed at the callback and the fit ran to completion. The callback here
+    # sends a real SIGINT to this process (without raising); the abort must come
+    # from `py.check_signals()` surfacing the pending signal at the next tick.
+    calls = {"n": 0}
+
+    def cb(*args):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            os.kill(os.getpid(), signal.SIGINT)
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit("LDA", progress=cb, iters=1000)
+    assert calls["n"] >= 2
+
+
+def test_progress_none_and_valid_callback_still_complete():
+    # Regression guard: the abort plumbing does not disturb ordinary fits.
+    seen = []
+    _fit("LDA", progress=lambda it, total, info: seen.append(it), iters=20)
+    assert seen  # ran to completion, callback fired

--- a/tests/test_progress_interrupt.py
+++ b/tests/test_progress_interrupt.py
@@ -14,6 +14,7 @@ Two guarantees, fixed once in the shared progress helpers (`deliver_progress`,
 
 import os
 import signal
+import sys
 
 import pytest
 
@@ -94,6 +95,13 @@ def test_ordinary_exception_in_callback_is_swallowed(model):
     _fit(model, progress=cb, iters=20)
 
 
+@pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="os.kill(pid, SIGINT) is not a portable Ctrl-C simulation on Windows "
+    "(it maps to TerminateProcess, not a KeyboardInterrupt); the check_signals "
+    "abort path itself is platform-independent and covered by the callback-raises "
+    "cases above.",
+)
 def test_real_sigint_during_fit_is_surfaced():
     # The reported bug: with progress default-on, a Ctrl-C during a slow fit was
     # swallowed at the callback and the fit ran to completion. The callback here

--- a/topica-core/src/ctm.rs
+++ b/topica-core/src/ctm.rs
@@ -1107,7 +1107,7 @@ fn mu_from(x_d: &[f64], gamma: &[Vec<f64>], km1: usize) -> Vec<f64> {
 /// [`crate::spectral::DEFAULT_PROJ_THRESHOLD`] to match R `stm`. It only matters
 /// when `init_spectral` is set.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_ctm<R: Rng, F: FnMut(usize, usize, f64)>(
+pub fn fit_ctm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     num_topics: usize,
     num_types: usize,
@@ -1385,7 +1385,9 @@ pub fn fit_ctm<R: Rng, F: FnMut(usize, usize, f64)>(
         // computed with the parameters from the previous M-step — the quantity
         // whose relative change drives convergence.
         bound_history.push(total_bound);
-        on_progress(em + 1, em_iters, total_bound);
+        if !on_progress(em + 1, em_iters, total_bound) {
+            break;
+        }
 
         // Convergence: stop once the relative change in the corpus bound falls
         // below `em_tol`. Break before the M-step, so the returned β/Σ/γ are the
@@ -1397,7 +1399,7 @@ pub fn fit_ctm<R: Rng, F: FnMut(usize, usize, f64)>(
             if rel < em_tol {
                 // Snap the progress bar to 100% on early convergence so it does
                 // not read as a hang at, e.g., 70/150 (#786).
-                on_progress(em + 1, em + 1, total_bound);
+                let _ = on_progress(em + 1, em + 1, total_bound);
                 converged = true;
                 break;
             }
@@ -1922,7 +1924,7 @@ mod tests {
                 true,
                 false,
                 crate::spectral::DEFAULT_PROJ_THRESHOLD,
-                |_, _, _| {},
+                |_, _, _| true,
                 &mut rng,
             )
         };
@@ -2330,7 +2332,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let theta = model.doc_topics();
@@ -2381,7 +2383,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let cb = model.content_beta.expect("content_beta present");
@@ -2459,7 +2461,7 @@ mod tests {
                 true,
                 false,
                 crate::spectral::DEFAULT_PROJ_THRESHOLD,
-                |_, _, _| {},
+                |_, _, _| true,
                 &mut rng,
             )
             .content_beta
@@ -2529,7 +2531,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         // The bound trajectory is (weakly) monotone increasing.
@@ -2565,7 +2567,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng2,
         );
         assert!(!capped.converged);
@@ -2608,7 +2610,7 @@ mod tests {
             true,
             true,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         assert!(model.diagonal, "model should record diagonal mode");
@@ -2869,7 +2871,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let stored = m_keep.nu.clone(); // per-group E-step ν (keep_nu = true)
@@ -2895,7 +2897,7 @@ mod tests {
             false,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng2,
         );
         assert!(model.content_beta.is_some(), "content_beta present");
@@ -2981,7 +2983,7 @@ mod tests {
             true,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng,
         );
         let stored = m_keep.nu.clone();
@@ -3004,7 +3006,7 @@ mod tests {
             false,
             false,
             crate::spectral::DEFAULT_PROJ_THRESHOLD,
-            |_, _, _| {},
+            |_, _, _| true,
             &mut rng2,
         );
         assert!(


### PR DESCRIPTION
Closes #794.

Two pre-existing defects in the **shared** fit-progress emitters (`emit_progress`, `emit_progress_bare`, `emit_progress_ll_ppl`, `resolve_progress`), fixed once in the shared layer so every progress-enabled model benefits at once.

## 1. Ctrl-C could not abort a fit (should-fix)
The emitters discarded the callback result with `let _ = cb.call1(...)`, which clears CPython's error indicator — so a `KeyboardInterrupt` raised while the callback ran (or a SIGINT pending from a real Ctrl-C during the GIL-released fit) was lost, and the fit ran to completion.

A new `deliver_progress` now:
- calls `py.check_signals()` before invoking the callback, surfacing a real SIGINT that arrived during `allow_threads`;
- lets `BaseException`-only errors (`KeyboardInterrupt` / `SystemExit`) propagate — it re-parks the exception in the error indicator and returns an abort signal;
- still swallows ordinary `Exception`s from a buggy callback, so a broken progress display never kills a fit (#785).

The 3-arg core progress callbacks now return `bool` (continue/abort). The ~14 core `fit_*` loops (`src/*.rs` + `topica-core/src/ctm.rs`) break on abort, and each binding calls `reraise_if_interrupted` after `allow_threads` unwinds to re-raise the parked interrupt.

## 2. A non-callable `progress=` was a silent no-op (nit)
`resolve_progress` now validates the argument up front (with the GIL, before `allow_threads`) and raises `TypeError` for a non-callable, non-bool value. `progress=True/False` is kept as the on/off toggle (`False` disables, `True` forces the default bar).

## Tests / verification
- New `tests/test_progress_interrupt.py`: interrupt propagation, the real-SIGINT `check_signals` path, ordinary-exception swallowing, and `progress=` type validation across representative models (LDA, CTM, BTM, GSDMM, keyATM).
- Full local gate green: `cargo test --lib` (341), `scripts/preflight.sh` (fmt + clippy + tables + stub + compat), `pytest tests/` (**5079 passed, 38 skipped**).
- An independent verification agent exercised 20 model configs / 120 case-combinations plus edge probes (real SIGINT, error-indicator cleanliness incl. SAGE/LabeledLDA, wrong-arity, threaded fits, output integrity) — all pass, no `SystemError`/hang/silent-completion/corruption.

🤖 Generated with [Claude Code](https://claude.com/claude-code)