### PR TITLE
feat(progress): live fit progress for 15 more iterative models (#786)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -980,6 +980,7 @@ class STS:
         covariates: Optional[numpy.typing.NDArray[numpy.float64]] = None,
         keep_eta_cov: bool = True,
         reference: str = "none",
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "STS":
         """Fit. sentiment_seed (required, one value per document) defines the
         aggregation groups for the topic-word (kappa) Poisson M-step and seeds the
@@ -1625,6 +1626,7 @@ class SupervisedLDA:
         convergence_tol: float = 0.0,
         check_every: int = 1,
         num_threads: int | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "SupervisedLDA":
         """Fit the model. `y` is the per-document response (length = number of
         documents). With inference="variational", `iters` is EM iterations and
@@ -2683,6 +2685,7 @@ class PT:
         convergence_tol: float = 0.0,
         check_every: int = 10,
         num_threads: int | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "PT": ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...
@@ -3029,6 +3032,7 @@ class FactorialLDA:
         eval_every: int = 0,
         omega_priors: dict | None = None,
         observed_factors: dict | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "FactorialLDA":
         """``samples`` tail iterations are averaged into the topic-word and
         doc-topic MCEM estimate (a tail mean of the per-sweep predictive
@@ -3154,6 +3158,7 @@ class PolylingualLDA:
         | Sequence[Corpus | Sequence[Sequence[str]]],
         *,
         iters: int | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "PolylingualLDA":
         """Fit on aligned document tuples: a dict {language: docs} (preferred) or a
         list of per-language corpora. Every language must have the same number of
@@ -3260,6 +3265,7 @@ class DiscLDA:
         y: Sequence[str] | Sequence[int],
         *,
         iters: int | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "DiscLDA":
         """Fit on documents with one class label `y` per document (str or int)."""
         ...
@@ -3499,6 +3505,7 @@ class PA:
         convergence_tol: float = 0.0,
         check_every: int = 10,
         num_threads: int | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "PA": ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]:
@@ -5450,6 +5457,7 @@ class AuthorTopic:
         authors: Sequence[Sequence[str]],
         *,
         iters: int = 1000,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "AuthorTopic":
         """Fit on a Corpus or list of token lists. `authors` is parallel to the
         documents; each entry is that document's set of author labels (>= 1;
@@ -5577,6 +5585,7 @@ class MGLDA:
         data: Sequence[Sequence[Sequence[str]]],
         *,
         iters: int = 1000,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "MGLDA":
         """Fit on sentence-segmented documents (list[list[list[str]]]: doc ->
         sentences -> tokens). A flat list[list[str]] is rejected. Out-of-vocabulary
@@ -5698,6 +5707,7 @@ class TopicsOverTime:
         *,
         timestamps: Sequence[float] | None = None,
         iters: int = 1000,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "TopicsOverTime":
         """Fit on documents plus per-document numeric timestamps. times is the canonical
         argument (any numeric scale — year, decade, ordinal date, unix time); timestamps
@@ -5828,6 +5838,7 @@ class GaussianLDA:
         vocabulary: Sequence[str],
         *,
         iters: int | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "GaussianLDA":
         """Fit on token documents plus word embeddings (len(vocabulary) x E) and the
         aligned vocabulary, which defines the word ids. Tokens outside the vocabulary are
@@ -6711,7 +6722,7 @@ class TopicalNGrams:
         unigram/bigram status (balanced by default). min_count drops rare words; a
         dropped word breaks a phrase across it."""
         ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 1000) -> "TopicalNGrams":
+    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int = 1000, progress: Callable[[int, int, dict], object] | None = None) -> "TopicalNGrams":
         """Token ORDER matters. When data is a list of token lists, a word pruned by
         min_count breaks the adjacency of its neighbours (so a phrase never spans a
         dropped stopword/punctuation); a pre-built Corpus has already discarded such

--- a/python/topica/embedding.py
+++ b/python/topica/embedding.py
@@ -423,6 +423,7 @@ class EmbeddingLDA:
         iters: int = 1000,
         convergence_tol: float = 0.0,
         check_every: int = 10,
+        progress=None,
     ) -> "EmbeddingLDA":
         """Fit on ``data`` (a Corpus or list of token lists). If ``doc_embeddings``
         is given (one row per document, same embedding space as the vocabulary),
@@ -438,7 +439,12 @@ class EmbeddingLDA:
         and :attr:`converged` is ``True``. With the default ``0.0`` the fit always
         runs the full ``iters`` and :attr:`converged` stays ``False`` (it means
         "early-stopping never triggered", not "did not mix"); set e.g.
-        ``convergence_tol=1e-4`` to get a genuine verdict and a shorter fit."""
+        ``convergence_tol=1e-4`` to get a genuine verdict and a shorter fit.
+
+        ``progress`` takes an optional ``(iteration, total, info)`` fit-progress
+        callback (see :func:`topica.progress`), forwarded to the underlying
+        SeededLDA sweep; ``True`` / ``False`` force the default bar, and a
+        ``KeyboardInterrupt`` aborts the fit."""
         prior = self.document_topic_prior(doc_embeddings) if doc_embeddings is not None else None
         self._model.fit(
             data,
@@ -446,6 +452,7 @@ class EmbeddingLDA:
             doc_topic_prior=prior,
             convergence_tol=convergence_tol,
             check_every=check_every,
+            progress=progress,
         )
         return self
 

--- a/python/topica/gdmr.py
+++ b/python/topica/gdmr.py
@@ -352,6 +352,7 @@ class GDMR:
         check_every: int = 10,
         covariates=None,
         metadata=None,
+        progress=None,
     ) -> None:
         """Fit GDMR by collapsed Gibbs with the Legendre-basis DMR prior.
 
@@ -391,6 +392,11 @@ class GDMR:
             Alias for ``features`` (topica's DMR vocabulary).
         metadata:
             Alias for ``features`` (tomotopy ``GDMRModel`` vocabulary).
+        progress:
+            Optional ``(iteration, total, info)`` fit-progress callback, forwarded
+            to the underlying DMR engine (see :func:`topica.progress`). ``True`` /
+            ``False`` force the default bar on or off; a ``KeyboardInterrupt``
+            aborts the fit.
         """
         features = _resolve_covariates(
             features, covariates, metadata, where="GDMR.fit", required=True
@@ -502,6 +508,7 @@ class GDMR:
             convergence_tol=convergence_tol,
             check_every=check_every,
             offset=offset,
+            progress=progress,
         )
 
         # Recover true coefficients as lambda_j = dmr_lambda_j * c_j. c_0 == 1 by

--- a/python/topica/narrative.py
+++ b/python/topica/narrative.py
@@ -127,6 +127,7 @@ class NarrativeTM:
         keep_theta_draws: bool = True,
         convergence_tol: float = 0.0,
         check_every: int = 10,
+        progress=None,
     ) -> None:
         from ._topica import Corpus
         
@@ -211,6 +212,7 @@ class NarrativeTM:
             keep_theta_draws=keep_theta_draws,
             convergence_tol=convergence_tol,
             check_every=check_every,
+            progress=progress,
         )
 
         self._vocabulary = self._gdmr.vocabulary

--- a/src/author_topic.rs
+++ b/src/author_topic.rs
@@ -71,7 +71,7 @@ pub struct AuthorTopicModel {
 /// - `beta`: symmetric topic-word Dirichlet scalar.
 /// - `iters`: Gibbs sweeps.
 #[allow(clippy::too_many_arguments)]
-pub fn fit<R: Rng>(
+pub fn fit<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     doc_authors: &[Vec<u32>],
@@ -80,6 +80,7 @@ pub fn fit<R: Rng>(
     alpha: Vec<f64>,
     beta: f64,
     iters: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> AuthorTopicModel {
     let k = num_topics;
@@ -205,6 +206,10 @@ pub fn fit<R: Rng>(
                 k,
             );
             fit_history.push((it + 1, ll));
+        }
+
+        if !on_progress(it + 1, iters) {
+            break;
         }
     }
 
@@ -356,7 +361,18 @@ mod tests {
         let (docs, v, authors, k) = planted();
         let alpha = vec![50.0 / k as f64; k];
         let mut rng = ChaCha8Rng::seed_from_u64(13);
-        let m = fit(&docs, v, &authors, k, k, alpha, 0.01, 300, &mut rng);
+        let m = fit(
+            &docs,
+            v,
+            &authors,
+            k,
+            k,
+            alpha,
+            0.01,
+            300,
+            |_, _| true,
+            &mut rng,
+        );
         // Each author's dominant topic is distinct (authors map 1:1 to topics).
         let dom: Vec<usize> = m
             .author_topic
@@ -388,8 +404,30 @@ mod tests {
         let alpha = vec![50.0 / k as f64; k];
         let mut r1 = ChaCha8Rng::seed_from_u64(7);
         let mut r2 = ChaCha8Rng::seed_from_u64(7);
-        let a = fit(&docs, v, &authors, k, k, alpha.clone(), 0.01, 80, &mut r1);
-        let b = fit(&docs, v, &authors, k, k, alpha, 0.01, 80, &mut r2);
+        let a = fit(
+            &docs,
+            v,
+            &authors,
+            k,
+            k,
+            alpha.clone(),
+            0.01,
+            80,
+            |_, _| true,
+            &mut r1,
+        );
+        let b = fit(
+            &docs,
+            v,
+            &authors,
+            k,
+            k,
+            alpha,
+            0.01,
+            80,
+            |_, _| true,
+            &mut r2,
+        );
         assert_eq!(a.topic_word, b.topic_word);
         assert_eq!(a.author_topic, b.author_topic);
         assert_eq!(a.doc_topic, b.doc_topic);
@@ -400,7 +438,18 @@ mod tests {
         let (docs, v, authors, k) = planted();
         let alpha = vec![50.0 / k as f64; k];
         let mut rng = ChaCha8Rng::seed_from_u64(0);
-        let m = fit(&docs, v, &authors, k, k, alpha, 0.01, 20, &mut rng);
+        let m = fit(
+            &docs,
+            v,
+            &authors,
+            k,
+            k,
+            alpha,
+            0.01,
+            20,
+            |_, _| true,
+            &mut rng,
+        );
         assert!(crate::conformance::check_conformance(&m).is_empty());
     }
 
@@ -412,7 +461,18 @@ mod tests {
         let docs: Vec<Vec<u32>> = (0..10).map(|_| (0..8).map(|i| i % 6).collect()).collect();
         let authors: Vec<Vec<u32>> = (0..10).map(|d| vec![(d % 2) as u32]).collect();
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        let m = fit(&docs, 6, &authors, 2, 20, vec![2.5; 20], 0.01, 15, &mut rng);
+        let m = fit(
+            &docs,
+            6,
+            &authors,
+            2,
+            20,
+            vec![2.5; 20],
+            0.01,
+            15,
+            |_, _| true,
+            &mut rng,
+        );
         assert_eq!(m.author_topic.len(), 2);
         assert_eq!(m.author_topic[0].len(), 20);
         // K=2 topics, A=8 authors (co-authored docs).
@@ -430,6 +490,7 @@ mod tests {
             vec![25.0; 2],
             0.01,
             15,
+            |_, _| true,
             &mut rng2,
         );
         assert_eq!(m2.author_topic.len(), 8);
@@ -456,6 +517,7 @@ mod tests {
             alpha,
             0.01,
             200,
+            |_, _| true,
             &mut rng,
         );
         // Each document's empirical dominant topic and its (sole) author's dominant

--- a/src/disclda.rs
+++ b/src/disclda.rs
@@ -96,7 +96,7 @@ fn allowed_for(c: usize, num_classes: usize, k_class: usize, k_shared: usize) ->
 /// Fit fixed-transform DiscLDA by restricted collapsed Gibbs sampling. `docs[d]` is
 /// the token ids of document `d`; `labels[d]` is its class in `0..num_classes`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_disclda<R: Rng>(
+pub fn fit_disclda<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     labels: &[usize],
     num_classes: usize,
@@ -106,6 +106,7 @@ pub fn fit_disclda<R: Rng>(
     alpha: f64,
     beta: f64,
     iters: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> DiscLdaModel {
     let l = num_classes * k_class + k_shared;
@@ -137,7 +138,7 @@ pub fn fit_disclda<R: Rng>(
 
     let vbeta = v as f64 * beta;
     let mut scores: Vec<f64> = Vec::with_capacity(k_class + k_shared);
-    for _ in 0..iters {
+    for it in 0..iters {
         for di in 0..d {
             let allow = &allowed[labels[di]];
             for pos in 0..docs[di].len() {
@@ -169,6 +170,9 @@ pub fn fit_disclda<R: Rng>(
                 nwt[chosen][w] += 1;
                 nt[chosen] += 1;
             }
+        }
+        if !on_progress(it + 1, iters) {
+            break;
         }
     }
 
@@ -375,7 +379,19 @@ mod tests {
         let (docs, labels, v) = planted(nc, cbw, sbw, 240, 12, 42);
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         // k_class=1 per class, k_shared=2
-        let m = fit_disclda(&docs, &labels, nc, 1, 2, v, 0.1, 0.01, 300, &mut rng);
+        let m = fit_disclda(
+            &docs,
+            &labels,
+            nc,
+            1,
+            2,
+            v,
+            0.1,
+            0.01,
+            300,
+            |_, _| true,
+            &mut rng,
+        );
 
         assert_eq!(m.num_topics, nc + 2); // k_class=1 per class + k_shared=2
         for row in &m.topic_word {
@@ -411,7 +427,19 @@ mod tests {
         let (nc, cbw, sbw) = (3, 6, 6);
         let (docs, labels, v) = planted(nc, cbw, sbw, 240, 12, 1);
         let mut rng = ChaCha8Rng::seed_from_u64(7);
-        let m = fit_disclda(&docs, &labels, nc, 2, 2, v, 0.1, 0.01, 300, &mut rng);
+        let m = fit_disclda(
+            &docs,
+            &labels,
+            nc,
+            2,
+            2,
+            v,
+            0.1,
+            0.01,
+            300,
+            |_, _| true,
+            &mut rng,
+        );
         // Held-out docs of a known class should be predicted correctly a large
         // majority of the time.
         let (test, tlabels, _) = planted(nc, cbw, sbw, 60, 12, 999);
@@ -439,7 +467,19 @@ mod tests {
         let (docs, labels, v) = planted(nc, cbw, sbw, 80, 10, 123);
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(99);
-            fit_disclda(&docs, &labels, nc, 2, 2, v, 0.1, 0.01, 120, &mut rng)
+            fit_disclda(
+                &docs,
+                &labels,
+                nc,
+                2,
+                2,
+                v,
+                0.1,
+                0.01,
+                120,
+                |_, _| true,
+                &mut rng,
+            )
         };
         let a = run();
         let b = run();
@@ -455,7 +495,19 @@ mod tests {
         let (nc, cbw, sbw) = (2, 5, 5);
         let (docs, labels, v) = planted(nc, cbw, sbw, 80, 10, 5);
         let mut rng = ChaCha8Rng::seed_from_u64(1);
-        let mut m = fit_disclda(&docs, &labels, nc, 2, 2, v, 0.1, 0.01, 100, &mut rng);
+        let mut m = fit_disclda(
+            &docs,
+            &labels,
+            nc,
+            2,
+            2,
+            v,
+            0.1,
+            0.01,
+            100,
+            |_, _| true,
+            &mut rng,
+        );
         // A skewed empirical-style prior: p = [0.8, 0.2].
         m.class_log_prior = vec![0.8f64.ln(), 0.2f64.ln()];
         let mut prng = ChaCha8Rng::seed_from_u64(2);

--- a/src/factorial_lda.rs
+++ b/src/factorial_lda.rs
@@ -830,11 +830,12 @@ impl<'a> State<'a> {
 /// optional semi-supervised constraint: `observed[d][kf] = Some(label)` pins factor
 /// kf of document d to `label`; pass an empty slice (or all-empty rows) for the
 /// faithful fully-unsupervised fit.
-pub fn fit_flda<R: Rng>(
+pub fn fit_flda<R: Rng, F: FnMut(usize, usize) -> bool>(
     corpus: &Corpus,
     cfg: &FactorialLdaConfig,
     priors: &OmegaPriors,
     observed: &[Vec<Option<usize>>],
+    mut on_progress: F,
     rng: &mut R,
 ) -> FactorialLDAModel {
     let mut st = State::new(corpus, cfg, priors, observed);
@@ -875,6 +876,9 @@ pub fn fit_flda<R: Rng>(
         }
         if burned_in {
             st.collect_sample();
+        }
+        if !on_progress(iter, cfg.iters) {
+            break;
         }
     }
     let final_ll = st.log_likelihood();
@@ -990,8 +994,22 @@ mod tests {
         let c = tiny_corpus();
         let cfg = cfg();
         let priors = OmegaPriors::default();
-        let m1 = fit_flda(&c, &cfg, &priors, &[], &mut ChaCha8Rng::seed_from_u64(42));
-        let m2 = fit_flda(&c, &cfg, &priors, &[], &mut ChaCha8Rng::seed_from_u64(42));
+        let m1 = fit_flda(
+            &c,
+            &cfg,
+            &priors,
+            &[],
+            |_, _| true,
+            &mut ChaCha8Rng::seed_from_u64(42),
+        );
+        let m2 = fit_flda(
+            &c,
+            &cfg,
+            &priors,
+            &[],
+            |_, _| true,
+            &mut ChaCha8Rng::seed_from_u64(42),
+        );
         assert_eq!(m1.topic_word, m2.topic_word);
         assert_eq!(m1.doc_topic, m2.doc_topic);
     }
@@ -1004,6 +1022,7 @@ mod tests {
             &cfg(),
             &OmegaPriors::default(),
             &[],
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(0),
         );
         assert!(crate::conformance::check_conformance(&m).is_empty());
@@ -1025,6 +1044,7 @@ mod tests {
             &cfg(),
             &OmegaPriors::default(),
             &[],
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(7),
         );
         for row in &m.topic_word {
@@ -1048,6 +1068,7 @@ mod tests {
             &cfg,
             &OmegaPriors::default(),
             &[],
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(3),
         );
         assert!(m.tuple_activity.iter().all(|b| b.is_finite()));

--- a/src/gaussian_lda.rs
+++ b/src/gaussian_lda.rs
@@ -448,7 +448,7 @@ fn kmeans_words<R: Rng>(
 /// Cholesky sampler's behavior). Seeds every draw from `rng` for bit-for-bit
 /// reproducibility.
 #[allow(clippy::too_many_arguments)]
-pub fn fit<R: Rng>(
+pub fn fit<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     embeddings: &[Vec<f64>],
     num_topics: usize,
@@ -458,6 +458,7 @@ pub fn fit<R: Rng>(
     psi_scale: f64,
     iters: usize,
     use_kmeans: bool,
+    mut on_progress: F,
     rng: &mut R,
 ) -> GaussianLDAModel {
     let e = embeddings.first().map(|r| r.len()).unwrap_or(0);
@@ -582,10 +583,14 @@ pub fn fit<R: Rng>(
             ndk[doc * num_topics + newk] += 1;
             topic_add(&mut topics[newk], &emb_i, &prior);
         }
+        let ll = avg_ll(&topics, &token_emb, &token_topic, embeddings, &prior);
         fit_history.push((
             it + 2, // 1-based: point 1 is post-init, so sweep `it` (0-based) is point it+2
-            avg_ll(&topics, &token_emb, &token_topic, embeddings, &prior),
+            ll,
         ));
+        if !on_progress(it + 1, iters, ll) {
+            break;
+        }
     }
 
     // Derived topic_word: softmax over vocab of the Student-t density under each topic.
@@ -810,6 +815,7 @@ mod tests {
             3.0,
             60,
             true,
+            |_, _, _| true,
             &mut rng,
         );
         // Each doc's argmax topic should be consistent per planted label: build a
@@ -842,8 +848,32 @@ mod tests {
         let (docs, emb, _) = planted(3, 8, 12, 40, 5);
         let mut r1 = ChaCha8Rng::seed_from_u64(13);
         let mut r2 = ChaCha8Rng::seed_from_u64(13);
-        let m1 = fit(&docs, &emb, 3, 0.3, 0.1, 8.0, 3.0, 30, true, &mut r1);
-        let m2 = fit(&docs, &emb, 3, 0.3, 0.1, 8.0, 3.0, 30, true, &mut r2);
+        let m1 = fit(
+            &docs,
+            &emb,
+            3,
+            0.3,
+            0.1,
+            8.0,
+            3.0,
+            30,
+            true,
+            |_, _, _| true,
+            &mut r1,
+        );
+        let m2 = fit(
+            &docs,
+            &emb,
+            3,
+            0.3,
+            0.1,
+            8.0,
+            3.0,
+            30,
+            true,
+            |_, _, _| true,
+            &mut r2,
+        );
         assert_eq!(m1.topic_word, m2.topic_word);
         assert_eq!(m1.doc_topic, m2.doc_topic);
         assert_eq!(m1.topic_means, m2.topic_means);
@@ -862,6 +892,7 @@ mod tests {
             3.0,
             15,
             true,
+            |_, _, _| true,
             &mut ChaCha8Rng::seed_from_u64(0),
         );
         assert!(crate::conformance::check_conformance(&m).is_empty());

--- a/src/mg_lda.rs
+++ b/src/mg_lda.rs
@@ -78,7 +78,7 @@ pub struct MgLdaModel {
 ///   >= 1 non-empty sentence.
 /// - `num_types`: vocabulary size V.
 #[allow(clippy::too_many_arguments)]
-pub fn fit<R: Rng>(
+pub fn fit<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<Vec<u32>>],
     num_types: usize,
     k_gl: usize,
@@ -92,6 +92,7 @@ pub fn fit<R: Rng>(
     beta_loc: f64,
     gamma: f64,
     iters: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> MgLdaModel {
     let t = window;
@@ -319,6 +320,10 @@ pub fn fit<R: Rng>(
                 gamma,
             );
             fit_history.push((it + 1, ll));
+        }
+
+        if !on_progress(it + 1, iters) {
+            break;
         }
     }
 
@@ -567,7 +572,21 @@ mod tests {
         let (docs, v) = planted();
         let mut rng = ChaCha8Rng::seed_from_u64(13);
         let m = fit(
-            &docs, v, 2, 3, 3, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.1, 400, &mut rng,
+            &docs,
+            v,
+            2,
+            3,
+            3,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.01,
+            0.01,
+            0.1,
+            400,
+            |_, _| true,
+            &mut rng,
         );
         let argmax = |r: &[f64]| {
             (0..v)
@@ -602,10 +621,38 @@ mod tests {
         let mut r1 = ChaCha8Rng::seed_from_u64(7);
         let mut r2 = ChaCha8Rng::seed_from_u64(7);
         let a = fit(
-            &docs, v, 2, 3, 3, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.1, 60, &mut r1,
+            &docs,
+            v,
+            2,
+            3,
+            3,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.01,
+            0.01,
+            0.1,
+            60,
+            |_, _| true,
+            &mut r1,
         );
         let b = fit(
-            &docs, v, 2, 3, 3, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.1, 60, &mut r2,
+            &docs,
+            v,
+            2,
+            3,
+            3,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.01,
+            0.01,
+            0.1,
+            60,
+            |_, _| true,
+            &mut r2,
         );
         assert_eq!(a.global_topic_word, b.global_topic_word);
         assert_eq!(a.local_topic_word, b.local_topic_word);
@@ -618,7 +665,21 @@ mod tests {
         let (docs, v) = planted();
         let mut rng = ChaCha8Rng::seed_from_u64(0);
         let m = fit(
-            &docs, v, 2, 3, 3, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.1, 20, &mut rng,
+            &docs,
+            v,
+            2,
+            3,
+            3,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.01,
+            0.01,
+            0.1,
+            20,
+            |_, _| true,
+            &mut rng,
         );
         assert!(crate::conformance::check_conformance(&m).is_empty());
         // topic_word rows sum to 1; doc_topic rows sum to 1
@@ -640,7 +701,21 @@ mod tests {
         ];
         let mut rng = ChaCha8Rng::seed_from_u64(1);
         let m = fit(
-            &docs, 5, 2, 2, 3, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.1, 20, &mut rng,
+            &docs,
+            5,
+            2,
+            2,
+            3,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.01,
+            0.01,
+            0.1,
+            20,
+            |_, _| true,
+            &mut rng,
         );
         assert_eq!(m.topic_word.len(), 4);
         assert_eq!(m.doc_topic.len(), 3);
@@ -652,7 +727,21 @@ mod tests {
         let (docs, v) = planted();
         let mut rng = ChaCha8Rng::seed_from_u64(2);
         let m = fit(
-            &docs, v, 2, 3, 1, 0.1, 0.1, 0.1, 0.1, 0.01, 0.01, 0.1, 40, &mut rng,
+            &docs,
+            v,
+            2,
+            3,
+            1,
+            0.1,
+            0.1,
+            0.1,
+            0.1,
+            0.01,
+            0.01,
+            0.1,
+            40,
+            |_, _| true,
+            &mut rng,
         );
         assert_eq!(m.topic_word.len(), 5);
         assert!(m.global_fraction >= 0.0 && m.global_fraction <= 1.0);

--- a/src/pa.rs
+++ b/src/pa.rs
@@ -543,7 +543,7 @@ impl PamModel {
 /// super-topic label symmetry), are held fixed through a burn-in, then adapted to
 /// the data over the final quarter of the sweeps. Deterministic for a fixed `rng`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_pam<R: Rng>(
+pub fn fit_pam<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_super: usize,
@@ -551,6 +551,7 @@ pub fn fit_pam<R: Rng>(
     alpha: f64,
     beta: f64,
     iters: usize,
+    on_progress: F,
     rng: &mut R,
 ) -> PamModel {
     // Plain fit is the draw-collecting fit with collection disabled, so the
@@ -567,6 +568,7 @@ pub fn fit_pam<R: Rng>(
         0.0,
         0,
         1,
+        on_progress,
         rng,
     );
     model
@@ -583,7 +585,7 @@ pub fn fit_pam<R: Rng>(
 ///
 /// Returns `(model, ll_history, converged)`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_pam_with_draws<R: Rng>(
+pub fn fit_pam_with_draws<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_super: usize,
@@ -595,6 +597,7 @@ pub fn fit_pam_with_draws<R: Rng>(
     convergence_tol: f64,
     check_every: usize,
     num_threads: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> (PamModel, Vec<(usize, f64)>, bool) {
     let d = docs.len();
@@ -719,10 +722,14 @@ pub fn fit_pam_with_draws<R: Rng>(
                 let prev = ll_history[ll_history.len() - 2].1;
                 let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
                 if rel < convergence_tol {
+                    let _ = on_progress(iter, iter); // snap bar to 100% (#786)
                     converged = true;
                     break;
                 }
             }
+        }
+        if !on_progress(iter, iters) {
+            break;
         }
     }
 
@@ -771,7 +778,7 @@ mod tests {
     fn recovers_planted_blocks_and_grouping() {
         let (docs, blocks, groups, v) = planted_corpus();
         let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let model = fit_pam(&docs, v, 2, 4, 0.1, 0.01, 200, &mut rng);
+        let model = fit_pam(&docs, v, 2, 4, 0.1, 0.01, 200, |_, _| true, &mut rng);
 
         // (1) Each sub-topic's top words concentrate on a single planted block.
         // Map each sub-topic to the block its top-6 words fill.
@@ -836,8 +843,8 @@ mod tests {
             .collect();
         let mut r1 = ChaCha8Rng::seed_from_u64(7);
         let mut r2 = ChaCha8Rng::seed_from_u64(7);
-        let m1 = fit_pam(&docs, 12, 2, 4, 0.1, 0.01, 30, &mut r1);
-        let m2 = fit_pam(&docs, 12, 2, 4, 0.1, 0.01, 30, &mut r2);
+        let m1 = fit_pam(&docs, 12, 2, 4, 0.1, 0.01, 30, |_, _| true, &mut r1);
+        let m2 = fit_pam(&docs, 12, 2, 4, 0.1, 0.01, 30, |_, _| true, &mut r2);
         assert_eq!(m1.topic_word(), m2.topic_word());
     }
 
@@ -847,7 +854,7 @@ mod tests {
             .map(|d| (0..8).map(|i| ((i + d * 3) % 12) as u32).collect())
             .collect();
         let mut rng = ChaCha8Rng::seed_from_u64(11);
-        let m = fit_pam(&docs, 12, 2, 3, 0.1, 0.01, 20, &mut rng);
+        let m = fit_pam(&docs, 12, 2, 3, 0.1, 0.01, 20, |_, _| true, &mut rng);
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
         let dir = crate::conformance::check_dirichlet(&m);
@@ -862,7 +869,7 @@ mod tests {
         // the corpus into two groups aligned (up to label swap) with the planting.
         let (docs, _, _, v) = planted_corpus();
         let mut rng = ChaCha8Rng::seed_from_u64(42);
-        let model = fit_pam(&docs, v, 2, 4, 0.1, 0.01, 200, &mut rng);
+        let model = fit_pam(&docs, v, 2, 4, 0.1, 0.01, 200, |_, _| true, &mut rng);
         let ds = model.doc_super();
         assert_eq!(ds.len(), docs.len());
         for row in &ds {
@@ -896,8 +903,21 @@ mod tests {
             .collect();
         let opts = crate::keyatm::ThetaDrawOpts { cap: 0, thin: 1 };
         let mut rng = ChaCha8Rng::seed_from_u64(3);
-        let (model, _, _) =
-            fit_pam_with_draws(&docs, 12, 2, 3, 0.1, 0.01, 5, opts, 0.0, 0, 1, &mut rng);
+        let (model, _, _) = fit_pam_with_draws(
+            &docs,
+            12,
+            2,
+            3,
+            0.1,
+            0.01,
+            5,
+            opts,
+            0.0,
+            0,
+            1,
+            |_, _| true,
+            &mut rng,
+        );
         // Collection stays disabled: nothing pushed despite thin=1.
         assert!(model.theta_draws.is_empty());
     }
@@ -932,6 +952,7 @@ mod tests {
             0.0,
             0,
             num_threads,
+            |_, _| true,
             &mut rng,
         );
         m
@@ -943,7 +964,7 @@ mod tests {
         // pre-threading serial path exactly.
         let (docs, v) = threading_corpus();
         let mut r_serial = ChaCha8Rng::seed_from_u64(99);
-        let serial = fit_pam(&docs, v, 3, 4, 0.1, 0.01, 40, &mut r_serial);
+        let serial = fit_pam(&docs, v, 3, 4, 0.1, 0.01, 40, |_, _| true, &mut r_serial);
         let threaded1 = fit_threaded(&docs, v, 40, 1, 99);
         assert_eq!(serial.nkw, threaded1.nkw, "nkw differs at num_threads=1");
         assert_eq!(serial.nk, threaded1.nk, "nk differs at num_threads=1");

--- a/src/pltm.rs
+++ b/src/pltm.rs
@@ -214,7 +214,7 @@ pub fn infer_tuple<R: Rng>(
 /// number of tuples `D` (a tuple absent in a language is an empty inner vector).
 /// `vocab_sizes[l]` is V_l, `beta[l]` is that language's topic-word prior.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_pltm<R: Rng>(
+pub fn fit_pltm<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<Vec<u32>>],
     num_topics: usize,
     vocab_sizes: &[usize],
@@ -224,6 +224,7 @@ pub fn fit_pltm<R: Rng>(
     optimize_alpha: bool,
     optimize_interval: usize,
     optimize_burn_in: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> PltmModel {
     let k = num_topics;
@@ -300,6 +301,9 @@ pub fn fit_pltm<R: Rng>(
             && (it + 1) % optimize_interval == 0
         {
             optimize_alpha_step(&mut alpha, &mut alpha_sum, &n_dk, k);
+        }
+        if !on_progress(it + 1, iters) {
+            break;
         }
     }
 
@@ -383,7 +387,19 @@ mod tests {
         let (docs, vocab) = planted(k, block, langs, 180, 8, 42);
         let beta = vec![0.01; langs];
         let mut rng = ChaCha8Rng::seed_from_u64(7);
-        let m = fit_pltm(&docs, k, &vocab, 0.1, &beta, 300, true, 10, 50, &mut rng);
+        let m = fit_pltm(
+            &docs,
+            k,
+            &vocab,
+            0.1,
+            &beta,
+            300,
+            true,
+            10,
+            50,
+            |_, _| true,
+            &mut rng,
+        );
 
         assert_eq!(m.topic_word.len(), langs);
         for l in 0..langs {
@@ -431,7 +447,19 @@ mod tests {
         let beta = vec![0.01; langs];
         let run = || {
             let mut rng = ChaCha8Rng::seed_from_u64(99);
-            fit_pltm(&docs, k, &vocab, 0.1, &beta, 120, true, 10, 30, &mut rng)
+            fit_pltm(
+                &docs,
+                k,
+                &vocab,
+                0.1,
+                &beta,
+                120,
+                true,
+                10,
+                30,
+                |_, _| true,
+                &mut rng,
+            )
         };
         let a = run();
         let b = run();
@@ -448,7 +476,19 @@ mod tests {
         let (docs, vocab) = planted(k, block, 1, 120, 8, 1);
         let beta = vec![0.01];
         let mut rng = ChaCha8Rng::seed_from_u64(3);
-        let m = fit_pltm(&docs, k, &vocab, 0.1, &beta, 200, false, 10, 0, &mut rng);
+        let m = fit_pltm(
+            &docs,
+            k,
+            &vocab,
+            0.1,
+            &beta,
+            200,
+            false,
+            10,
+            0,
+            |_, _| true,
+            &mut rng,
+        );
         assert_eq!(m.topic_word.len(), 1);
         let mut covered = std::collections::HashSet::new();
         for row in &m.topic_word[0] {

--- a/src/pt.rs
+++ b/src/pt.rs
@@ -510,7 +510,7 @@ impl PtmModel {
 /// * `iters`      — number of Gibbs sweeps
 /// * `rng`        — random-number source (determines all randomness)
 #[allow(clippy::too_many_arguments)]
-pub fn fit_ptm<R: Rng>(
+pub fn fit_ptm<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -519,6 +519,7 @@ pub fn fit_ptm<R: Rng>(
     beta: f64,
     lambda: f64,
     iters: usize,
+    on_progress: F,
     rng: &mut R,
 ) -> PtmModel {
     // Plain fit is the draw-collecting fit with collection disabled, so the
@@ -536,6 +537,7 @@ pub fn fit_ptm<R: Rng>(
         0.0,
         0,
         1,
+        on_progress,
         rng,
     );
     model
@@ -551,7 +553,7 @@ pub fn fit_ptm<R: Rng>(
 ///
 /// Returns `(model, ll_history, converged)`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_ptm_with_draws<R: Rng>(
+pub fn fit_ptm_with_draws<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     num_topics: usize,
@@ -564,6 +566,7 @@ pub fn fit_ptm_with_draws<R: Rng>(
     convergence_tol: f64,
     check_every: usize,
     num_threads: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> (PtmModel, Vec<(usize, f64)>, bool) {
     let d_count = docs.len();
@@ -675,10 +678,14 @@ pub fn fit_ptm_with_draws<R: Rng>(
                 let prev = ll_history[ll_history.len() - 2].1;
                 let rel = (ll - prev).abs() / (prev.abs() + 1e-12);
                 if rel < convergence_tol {
+                    let _ = on_progress(iter, iter);
                     converged = true;
                     break;
                 }
             }
+        }
+        if !on_progress(iter, iters) {
+            break;
         }
     }
 
@@ -757,7 +764,18 @@ mod tests {
         let recovered = (1..=n_seeds)
             .filter(|&s| {
                 let mut rng = ChaCha8Rng::seed_from_u64(s);
-                let model = fit_ptm(&docs, v, num_topics, 50, 0.1, 0.01, 0.1, 1000, &mut rng);
+                let model = fit_ptm(
+                    &docs,
+                    v,
+                    num_topics,
+                    50,
+                    0.1,
+                    0.01,
+                    0.1,
+                    1000,
+                    |_, _| true,
+                    &mut rng,
+                );
                 recovers(&model)
             })
             .count();
@@ -777,8 +795,8 @@ mod tests {
             .collect();
         let mut r1 = ChaCha8Rng::seed_from_u64(7);
         let mut r2 = ChaCha8Rng::seed_from_u64(7);
-        let m1 = fit_ptm(&docs, v, 3, 5, 0.1, 0.01, 0.1, 30, &mut r1);
-        let m2 = fit_ptm(&docs, v, 3, 5, 0.1, 0.01, 0.1, 30, &mut r2);
+        let m1 = fit_ptm(&docs, v, 3, 5, 0.1, 0.01, 0.1, 30, |_, _| true, &mut r1);
+        let m2 = fit_ptm(&docs, v, 3, 5, 0.1, 0.01, 0.1, 30, |_, _| true, &mut r2);
         assert_eq!(m1.nk, m2.nk, "nk differs between two identical-seed runs");
         assert_eq!(
             m1.topic_word(),
@@ -794,7 +812,7 @@ mod tests {
             .map(|d| (0..3).map(|i| ((i + d) % v) as u32).collect())
             .collect();
         let mut rng = ChaCha8Rng::seed_from_u64(55);
-        let m = fit_ptm(&docs, v, 3, 5, 0.1, 0.01, 0.1, 20, &mut rng);
+        let m = fit_ptm(&docs, v, 3, 5, 0.1, 0.01, 0.1, 20, |_, _| true, &mut rng);
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
         let dir = crate::conformance::check_dirichlet(&m);
@@ -834,6 +852,7 @@ mod tests {
             0.0,
             0,
             num_threads,
+            |_, _| true,
             &mut rng,
         );
         m
@@ -846,7 +865,18 @@ mod tests {
         // assignments (both sweep phases).
         let (docs, v) = threading_corpus();
         let mut r_serial = ChaCha8Rng::seed_from_u64(42);
-        let serial = fit_ptm(&docs, v, 3, 8, 0.1, 0.01, 0.1, 40, &mut r_serial);
+        let serial = fit_ptm(
+            &docs,
+            v,
+            3,
+            8,
+            0.1,
+            0.01,
+            0.1,
+            40,
+            |_, _| true,
+            &mut r_serial,
+        );
         let threaded1 = fit_threaded(&docs, v, 40, 1, 42);
         assert_eq!(serial.nkw, threaded1.nkw, "nkw differs at num_threads=1");
         assert_eq!(serial.nk, threaded1.nk, "nk differs at num_threads=1");

--- a/src/python/author_topic.rs
+++ b/src/python/author_topic.rs
@@ -121,13 +121,18 @@ impl AuthorTopic {
     /// labels build a stable, sorted author vocabulary. `iters` is the number of
     /// collapsed-Gibbs sweeps (default 1000, a topica default — the paper uses
     /// problem-specific chain lengths).
-    #[pyo3(signature = (data, authors, *, iters=1000))]
+    ///
+    /// `progress` takes a ``(iteration, total, info)`` callback (see
+    /// ``topica.progress``); pass ``True``/``False`` to force the bar on or off, and a
+    /// ``KeyboardInterrupt`` raised from the callback aborts the fit.
+    #[pyo3(signature = (data, authors, *, iters=1000, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         authors: Vec<Vec<String>>,
         iters: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         // Build (or accept) the corpus; keep the surviving-document indices so the
         // author lists stay aligned when empty documents are pruned.
@@ -203,7 +208,9 @@ impl AuthorTopic {
         let beta = slf.beta;
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
+        let progress = resolve_progress(py, progress, "AuthorTopic")?;
         let (model, corpus) = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             let m = crate::author_topic::fit(
                 &corpus.docs,
                 num_types,
@@ -213,10 +220,12 @@ impl AuthorTopic {
                 alpha,
                 beta,
                 iters,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         slf.model = Some(model);
         slf.corpus = Some(corpus);

--- a/src/python/btm.rs
+++ b/src/python/btm.rs
@@ -227,12 +227,7 @@ impl BTM {
         let progress = resolve_progress(py, progress, "BTM")?;
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let mut on_progress = |it: usize, total: usize| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress_bare(py, cb, it, total)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_bare(&progress);
             let m = crate::btm::fit_btm(
                 &corpus.docs,
                 k,

--- a/src/python/disclda.rs
+++ b/src/python/disclda.rs
@@ -305,13 +305,18 @@ impl DiscLDA {
 
     /// Fit on documents with a per-document class label `y` (str or int, one per
     /// document). Classes are sorted to a fixed order.
-    #[pyo3(signature = (data, y, *, iters=None))]
+    ///
+    /// `progress` is an optional `(iteration, total, info)` callback fired once per
+    /// Gibbs sweep; `True`/`False` force or silence the default bar, and a
+    /// `KeyboardInterrupt` raised from it aborts the fit.
+    #[pyo3(signature = (data, y, *, iters=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         y: &Bound<'_, PyAny>,
         iters: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let labels_str = extract_labels(y)?;
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -382,8 +387,10 @@ impl DiscLDA {
             num_classes,
         )?;
 
+        let progress = resolve_progress(py, progress, "DiscLDA")?;
         let (mut model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut on_progress = on_progress_bare(&progress);
             let m = crate::disclda::fit_disclda(
                 &corpus.docs,
                 &labels,
@@ -394,10 +401,12 @@ impl DiscLDA {
                 alpha,
                 beta,
                 iters,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
         model.class_log_prior = class_log_prior;
         slf.class_counts = class_counts;
         slf.model = Some(model);

--- a/src/python/factorial_lda.rs
+++ b/src/python/factorial_lda.rs
@@ -372,7 +372,10 @@ impl FactorialLDA {
         })
     }
 
-    #[pyo3(signature = (data, *, iters=2000, samples=100, eval_every=0, omega_priors=None, observed_factors=None))]
+    /// `progress` is an optional `(iteration, total, info)` callback fired once per
+    /// Gibbs sweep; `True`/`False` force or silence the default bar, and a
+    /// `KeyboardInterrupt` raised from it aborts the fit.
+    #[pyo3(signature = (data, *, iters=2000, samples=100, eval_every=0, omega_priors=None, observed_factors=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -382,6 +385,7 @@ impl FactorialLDA {
         eval_every: usize,
         omega_priors: Option<&Bound<'_, PyAny>>,
         observed_factors: Option<&Bound<'_, PyAny>>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -430,10 +434,20 @@ impl FactorialLDA {
         };
         let cfg = slf.build_config(iters, samples, eval_every);
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
+        let progress = resolve_progress(py, progress, "FactorialLDA")?;
         let (model, corpus) = py.allow_threads(move || {
-            let model = crate::factorial_lda::fit_flda(&corpus, &cfg, &priors, &observed, &mut rng);
+            let mut on_progress = on_progress_bare(&progress);
+            let model = crate::factorial_lda::fit_flda(
+                &corpus,
+                &cfg,
+                &priors,
+                &observed,
+                &mut on_progress,
+                &mut rng,
+            );
             (model, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.model = Some(model);
         slf.corpus = Some(corpus);
         slf.fitted = true;

--- a/src/python/gaussian_lda.rs
+++ b/src/python/gaussian_lda.rs
@@ -162,8 +162,10 @@ impl GaussianLDA {
     /// Fit on `data` (a Corpus or list of token lists) with `word_embeddings`
     /// (`(len(vocabulary), E)`) and the aligned `vocabulary`, which defines the word
     /// ids. Tokens outside the vocabulary are dropped. `iters` sets the number of
-    /// Gibbs sweeps (default 100).
-    #[pyo3(signature = (data, word_embeddings, vocabulary, *, iters=None))]
+    /// Gibbs sweeps (default 100). `progress` is an optional per-sweep callback
+    /// `callback(iteration, total, {"ll": avg_ll})`; `True`/`False` force/suppress
+    /// the default `topica.progress()` bar (raising in it aborts the fit).
+    #[pyo3(signature = (data, word_embeddings, vocabulary, *, iters=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -171,6 +173,7 @@ impl GaussianLDA {
         word_embeddings: &Bound<'_, PyAny>,
         vocabulary: Vec<String>,
         iters: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let docs_str: Vec<Vec<String>> = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -224,11 +227,24 @@ impl GaussianLDA {
         let use_kmeans = slf.init == "kmeans";
         let it = iters.unwrap_or(100);
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
+        let progress = resolve_progress(py, progress, "GaussianLDA")?;
         let model = py.allow_threads(move || {
+            let mut on_progress = on_progress_ll(&progress);
             crate::gaussian_lda::fit(
-                &docs_ids, &rho, num_topics, alpha, kappa, nu0, psi_scale, it, use_kmeans, &mut rng,
+                &docs_ids,
+                &rho,
+                num_topics,
+                alpha,
+                kappa,
+                nu0,
+                psi_scale,
+                it,
+                use_kmeans,
+                &mut on_progress,
+                &mut rng,
             )
         });
+        reraise_if_interrupted(py)?;
 
         // Build a corpus aligned to `vocabulary` for coherence / top_words / vocabulary.
         let n = docs_str.len();

--- a/src/python/hierarchical.rs
+++ b/src/python/hierarchical.rs
@@ -221,8 +221,12 @@ impl PA {
     /// (`None` = constructor value); `>1` runs the collapsed-Gibbs sweep as
     /// approximate-parallel AD-LDA (deterministic for a fixed `num_threads`+`seed`),
     /// `1` is the exact serial path.
+    /// `progress` is an optional per-sweep callback `callback(iteration, total, {})`
+    /// (no per-sweep metric); `True`/`False` force/suppress the default
+    /// `topica.progress()` bar (raising in it aborts the fit).
     #[pyo3(signature = (data, *, iters=1000, keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None))]
+                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None,
+                        progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -233,6 +237,7 @@ impl PA {
         convergence_tol: f64,
         check_every: usize,
         num_threads: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -266,7 +271,9 @@ impl PA {
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
         let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
+        let progress = resolve_progress(py, progress, "PA")?;
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             let (m, hist, conv) = pa::fit_pam_with_draws(
                 &corpus.docs,
                 num_types,
@@ -279,10 +286,12 @@ impl PA {
                 convergence_tol,
                 check_every,
                 num_threads,
+                &mut on_progress,
                 &mut rng,
             );
             (m, hist, conv, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.theta_draws = draws_to_array3(&model.theta_draws, num_docs, k, None);
         slf.phi = Some(vecs_to_arr2(&model.topic_word()));
         slf.theta = Some(vecs_to_arr2(&model.doc_topic()));

--- a/src/python/mg_lda.rs
+++ b/src/python/mg_lda.rs
@@ -217,13 +217,17 @@ impl MGLDA {
     /// document positions are preserved: empty sentences and empty documents are kept,
     /// so the output rows (`doc_topic`, `global_doc_topic`) align 1:1 with the input
     /// documents (an empty document gets a uniform row). `iters` is the number of
-    /// collapsed-Gibbs sweeps (default 1000, a topica default).
-    #[pyo3(signature = (data, *, iters=1000))]
+    /// collapsed-Gibbs sweeps (default 1000, a topica default). `progress` is an
+    /// optional `(iteration, total, info)` callback fired once per sweep;
+    /// `True`/`False` force or silence the default bar, and a `KeyboardInterrupt`
+    /// raised from it aborts the fit.
+    #[pyo3(signature = (data, *, iters=1000, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let sent_docs = parse_sentence_docs(data)?;
         if sent_docs.is_empty() {
@@ -291,11 +295,28 @@ impl MGLDA {
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
         let n_docs = id_docs.len();
 
+        let progress = resolve_progress(py, progress, "MGLDA")?;
         let model = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             crate::mg_lda::fit(
-                &id_docs, num_types, kg, kl, t, ag, al, amg, aml, bg, bl, g, iters, &mut rng,
+                &id_docs,
+                num_types,
+                kg,
+                kl,
+                t,
+                ag,
+                al,
+                amg,
+                aml,
+                bg,
+                bl,
+                g,
+                iters,
+                &mut on_progress,
+                &mut rng,
             )
         });
+        reraise_if_interrupted(py)?;
 
         // Warn when the local grain barely fired: the grain switch routed almost every
         // token to the global grain, so `local_topic_word` is dominated by the prior and

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -1073,6 +1073,40 @@ fn reraise_if_interrupted(py: Python<'_>) -> PyResult<()> {
     }
 }
 
+/// Build the per-fit `on_progress` closure for a model core whose progress
+/// callback is `FnMut(iteration, total, ll) -> bool` (the common contract).
+/// Returns a closure that re-acquires the GIL and forwards to `emit_progress`,
+/// or is a no-op returning `true` (continue) when no `progress` was resolved.
+///
+/// Reused verbatim by every progress-enabled model binding so the GIL handshake
+/// and the abort contract live in one place (#786). Call it *inside* the
+/// `py.allow_threads(move || …)` block, after `progress` has been moved in:
+///
+/// ```ignore
+/// let progress = resolve_progress(py, progress, "MyModel")?;
+/// let model = py.allow_threads(move || {
+///     let mut on_progress = on_progress_ll(&progress);
+///     mymodel::fit(…, &mut on_progress, …)
+/// });
+/// reraise_if_interrupted(py)?;
+/// ```
+fn on_progress_ll(progress: &Option<PyObject>) -> impl FnMut(usize, usize, f64) -> bool + '_ {
+    move |it, total, ll| match progress {
+        Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
+        None => true,
+    }
+}
+
+/// Like [`on_progress_ll`] but for cores with no per-iteration metric: the
+/// callback is `FnMut(iteration, total) -> bool` and forwards to
+/// `emit_progress_bare` (bar/ETA only, no sparkline). (#786)
+fn on_progress_bare(progress: &Option<PyObject>) -> impl FnMut(usize, usize) -> bool + '_ {
+    move |it, total| match progress {
+        Some(cb) => Python::with_gil(|py| emit_progress_bare(py, cb, it, total)),
+        None => true,
+    }
+}
+
 /// SparseLDA topic model (the MALLET algorithm).
 ///
 /// Invoke a fit progress callback with the standard 3-arg contract
@@ -7570,12 +7604,7 @@ impl CTM {
 
         let progress = resolve_progress(py, progress, "CTM")?;
         let (model, corpus) = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             let m = run_with_threads(num_threads, || {
                 if svi {
                     // The stochastic (SVI) inference path is not yet wired for
@@ -8709,12 +8738,7 @@ impl STM {
         let (model, corpus) = py.allow_threads(move || {
             let prev_ref = prevalence_x.as_deref();
             let cont_ref = content_groups.as_ref().map(|(g, n)| (g.as_slice(), *n));
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             let m = run_with_threads(num_threads, || {
                 ctm::fit_ctm(
                     &corpus.docs,
@@ -11669,12 +11693,7 @@ impl DTM {
 
         let progress = resolve_progress(py, progress, "DTM")?;
         let (model, corpus) = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             let m = dtm::fit_dtm(
                 &corpus.docs,
                 &times_u,
@@ -14488,12 +14507,7 @@ impl SeededLDA {
 
         let progress = resolve_progress(py, progress, "SeededLDA")?;
         let (model, ll_history, converged, corpus) = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             let (m, ll, conv) = seeded::fit_seeded_lda(
                 &corpus.docs,
                 num_types,
@@ -15321,12 +15335,7 @@ impl FASTopic {
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
         let progress = resolve_progress(py, progress, "FASTopic")?;
         let model = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             fastopic::fit_fastopic(
                 &docs_ids,
                 &doc_emb,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -10069,11 +10069,13 @@ impl STS {
     /// tolerance for EM early stopping — the run stops when the relative change in
     /// the variational evidence bound falls below it. `keep_eta_cov` (default True)
     /// stores the full per-document logistic-normal covariances; set it False to
-    /// save memory.
+    /// save memory. `progress` takes an optional `(iteration, total, info)` fit
+    /// callback (see `topica.progress`) reporting the EM bound; `True`/`False`
+    /// force the default bar, and a KeyboardInterrupt aborts the fit.
     #[pyo3(signature = (data, sentiment_seed, prevalence=None, *,
                         prevalence_names=None, iters=30, convergence_tol=1e-5,
                         kappa_estimation=None, kappa_ridge=1e-3, em_tol=None, covariates=None,
-                        keep_eta_cov=true, reference="none"))]
+                        keep_eta_cov=true, reference="none", progress=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -10090,6 +10092,7 @@ impl STS {
         covariates: Option<&Bound<'_, PyAny>>,
         keep_eta_cov: bool,
         reference: &str,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let convergence_tol = if let Some(old_val) = em_tol {
             let warnings = py.import_bound("warnings")?;
@@ -10271,8 +10274,10 @@ impl STS {
         let spectral = slf.init_spectral;
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
+        let progress = resolve_progress(py, progress, "STS")?;
         let (model, corpus) = py.allow_threads(move || {
             let prev_ref = prevalence_x.as_deref();
+            let mut on_progress = on_progress_ll(&progress);
             let m = sts::fit_sts(
                 &corpus.docs,
                 k,
@@ -10286,10 +10291,12 @@ impl STS {
                 keep_eta_cov,
                 reference_init,
                 kappa_damping,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         let n = 2 * k - 1;
         // Baseline topic-word (α^(s)=0).
@@ -12185,10 +12192,13 @@ impl SupervisedLDA {
     /// `num_threads` caps the worker pool for the parallel per-document variational
     /// E-step (`None`/`0` = all cores). Output is deterministic regardless of the
     /// worker count, so this controls only resource use, not results; it has no
-    /// effect on the serial `inference="gibbs"` backend.
+    /// effect on the serial `inference="gibbs"` backend. `progress` takes an
+    /// optional `(iteration, total, info)` fit callback (see `topica.progress`);
+    /// `True`/`False` force the default bar, and a KeyboardInterrupt aborts the fit.
     #[pyo3(signature = (data, y, *, iters=25, var_iters=15,
                         keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=1_usize, num_threads=None))]
+                        convergence_tol=0.0_f64, check_every=1_usize, num_threads=None,
+                        progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -12201,6 +12211,7 @@ impl SupervisedLDA {
         convergence_tol: f64,
         check_every: usize,
         num_threads: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -12248,10 +12259,12 @@ impl SupervisedLDA {
         let draw_cap = if keep_theta_draws { num_theta_draws } else { 0 };
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
+        let progress = resolve_progress(py, progress, "SupervisedLDA")?;
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
         let use_gibbs = slf.inference == "gibbs";
 
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             let (m, hist, conv) = run_with_threads(num_threads, || {
                 if use_gibbs {
                     // Gibbs ignores var_iters (no per-document E-step) and never
@@ -12265,6 +12278,7 @@ impl SupervisedLDA {
                         alpha,
                         iters,
                         check_every,
+                        &mut on_progress,
                         &mut rng,
                     )
                 } else {
@@ -12278,12 +12292,14 @@ impl SupervisedLDA {
                         var_iters,
                         convergence_tol,
                         check_every,
+                        &mut on_progress,
                         &mut rng,
                     )
                 }
             });
             (m, hist, conv, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         let mut beta = Array2::<f64>::zeros((k, num_types));
         let tw = model.topic_word();
@@ -12877,9 +12893,12 @@ impl PT {
     /// `num_threads` overrides the constructor's worker count for this fit only
     /// (`None` = constructor value); `>1` runs the two-phase collapsed-Gibbs sweep
     /// as approximate-parallel AD-LDA (deterministic for a fixed `num_threads`+`seed`),
-    /// `1` is the exact serial path.
+    /// `1` is the exact serial path. `progress` takes an optional
+    /// `(iteration, total, info)` fit callback (see `topica.progress`);
+    /// `True`/`False` force the default bar, and a KeyboardInterrupt aborts the fit.
     #[pyo3(signature = (data, *, iters=1000, keep_theta_draws=true, num_theta_draws=25,
-                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None))]
+                        convergence_tol=0.0_f64, check_every=10_usize, num_threads=None,
+                        progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -12890,6 +12909,7 @@ impl PT {
         convergence_tol: f64,
         check_every: usize,
         num_threads: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -12945,8 +12965,10 @@ impl PT {
         let draws_opts = keyatm::ThetaDrawOpts::new(keep_theta_draws, num_theta_draws, iters);
         warn_theta_draw_memory(py, keep_theta_draws, num_theta_draws, num_docs, k)?;
 
+        let progress = resolve_progress(py, progress, "PT")?;
         let mut rng = Pcg64Mcg::seed_from_u64(slf.seed);
         let (model, ll_history, converged_flag, corpus) = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             let (m, hist, conv) = pt::fit_ptm_with_draws(
                 &corpus.docs,
                 num_types,
@@ -12960,10 +12982,12 @@ impl PT {
                 convergence_tol,
                 check_every,
                 num_threads,
+                &mut on_progress,
                 &mut rng,
             );
             (m, hist, conv, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.theta_draws = draws_to_array3(&model.theta_draws, num_docs, k, None);
         slf.topic_names = (0..k).map(|i| format!("topic_{i}")).collect();
         slf.phi = Some(vecs_to_arr2(&model.topic_word()));

--- a/src/python/neural.rs
+++ b/src/python/neural.rs
@@ -431,12 +431,7 @@ impl ETM {
             );
             let progress = resolve_progress(py, progress, "ETM")?;
             let model = py.allow_threads(move || {
-                let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                    match &progress {
-                        Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                        None => true,
-                    }
-                };
+                let mut on_progress = on_progress_ll(&progress);
                 etm::fit_etm(
                     &docs_ids,
                     k,
@@ -1188,12 +1183,7 @@ impl DETM {
         );
         let progress = resolve_progress(py, progress, "DETM")?;
         let model = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             detm::fit_detm(
                 &tokens,
                 &counts,
@@ -1863,12 +1853,7 @@ impl InfoCTM {
         let docs_b = corpus_b.docs.clone();
         let progress = resolve_progress(py, progress, "InfoCTM")?;
         let model = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             infoctm::fit_infoctm(
                 &docs_a,
                 &docs_b,
@@ -2414,12 +2399,7 @@ impl ProdLDA {
         let empty: Vec<Vec<f64>> = vec![Vec::new(); corpus.docs.len()];
         let progress = resolve_progress(py, progress, "ProdLDA")?;
         let (model, corpus) = py.allow_threads(move || {
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             let m = prodlda::fit_avitm(
                 &corpus.docs,
                 &empty,

--- a/src/python/pltm.rs
+++ b/src/python/pltm.rs
@@ -213,13 +213,17 @@ impl PolylingualLDA {
     /// Fit on aligned document tuples. `data` is a dict `{language: docs}` (or a
     /// list of per-language corpora); every language must have the same number of
     /// tuples `D`, aligned by index. A tuple absent in a language is an empty
-    /// document `[]` at that index.
-    #[pyo3(signature = (data, *, iters=None))]
+    /// document `[]` at that index. `progress` is an optional per-sweep callback
+    /// `callback(iteration, total, {})` (no per-sweep metric); `True`/`False`
+    /// force/suppress the default `topica.progress()` bar (raising in it aborts
+    /// the fit).
+    #[pyo3(signature = (data, *, iters=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let (languages, str_docs) = extract_languages(data)?;
 
@@ -273,8 +277,10 @@ impl PolylingualLDA {
             slf.num_topics,
         );
 
+        let progress = resolve_progress(py, progress, "PolylingualLDA")?;
         let model = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut on_progress = on_progress_bare(&progress);
             crate::pltm::fit_pltm(
                 &docs_by_lang,
                 k,
@@ -285,9 +291,11 @@ impl PolylingualLDA {
                 optimize_alpha,
                 optimize_interval,
                 optimize_burn_in,
+                &mut on_progress,
                 &mut rng,
             )
         });
+        reraise_if_interrupted(py)?;
 
         slf.model = Some(model);
         slf.corpora = corpora;

--- a/src/python/scholar.rs
+++ b/src/python/scholar.rs
@@ -505,12 +505,7 @@ impl Scholar {
         let progress = resolve_progress(py, progress, "Scholar")?;
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
-            let mut on_progress = |it: usize, total: usize, ll: f64| -> bool {
-                match &progress {
-                    Some(cb) => Python::with_gil(|py| emit_progress(py, cb, it, total, ll)),
-                    None => true,
-                }
-            };
+            let mut on_progress = on_progress_ll(&progress);
             let m = crate::scholar::fit_scholar(
                 &corpus.docs,
                 &pcs,

--- a/src/python/topical_ngrams.rs
+++ b/src/python/topical_ngrams.rs
@@ -152,12 +152,17 @@ impl TopicalNGrams {
     /// (so "New STOPWORD York" cannot form "New_York"). A pre-built `Corpus` has
     /// already discarded such gaps, so all surviving adjacent tokens are treated as
     /// phrase-eligible — pass raw token lists to preserve boundary breaks.
-    #[pyo3(signature = (data, *, iters=1000))]
+    ///
+    /// `progress` takes a ``(iteration, total, info)`` callback (see
+    /// ``topica.progress``); pass ``True``/``False`` to force the bar on or off, and a
+    /// ``KeyboardInterrupt`` raised from the callback aborts the fit.
+    #[pyo3(signature = (data, *, iters=1000, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         // Raw token lists (order preserved), and whether gaps are known.
         let (docs_str, doc_names): (Vec<Vec<String>>, Vec<String>) =
@@ -299,13 +304,26 @@ impl TopicalNGrams {
         let alpha = slf.alpha_sum / k as f64;
         let (beta, gamma, d1, d2) = (slf.beta, slf.gamma, slf.delta1, slf.delta2);
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
+        let progress = resolve_progress(py, progress, "TopicalNGrams")?;
         let (model, phrases) = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             let model = topical_ngrams::fit_tng(
-                &seqs, num_types, k, iters, alpha, beta, gamma, d1, d2, &mut rng,
+                &seqs,
+                num_types,
+                k,
+                iters,
+                alpha,
+                beta,
+                gamma,
+                d1,
+                d2,
+                &mut on_progress,
+                &mut rng,
             );
             let phrases = topical_ngrams::extract_phrases(&model, &seqs);
             (model, phrases)
         });
+        reraise_if_interrupted(py)?;
 
         slf.phrases = phrases
             .into_iter()

--- a/src/python/topics_over_time.rs
+++ b/src/python/topics_over_time.rs
@@ -137,7 +137,11 @@ impl TopicsOverTime {
     /// peaks/means in the input units). `iters` is the number of collapsed-Gibbs sweeps
     /// (default 1000, a topica default). A constant-timestamp corpus reduces to LDA (the
     /// per-topic Beta collapses to uniform).
-    #[pyo3(signature = (data, times=None, *, timestamps=None, iters=1000))]
+    ///
+    /// `progress` takes a ``(iteration, total, info)`` callback (see
+    /// ``topica.progress``); pass ``True``/``False`` to force the bar on or off, and a
+    /// ``KeyboardInterrupt`` raised from the callback aborts the fit.
+    #[pyo3(signature = (data, times=None, *, timestamps=None, iters=1000, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -145,6 +149,7 @@ impl TopicsOverTime {
         times: Option<Vec<f64>>,
         timestamps: Option<Vec<f64>>,
         iters: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let raw_times = match (times, timestamps) {
             (Some(t), None) | (None, Some(t)) => t,
@@ -233,7 +238,9 @@ impl TopicsOverTime {
         let beta = slf.beta;
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
 
+        let progress = resolve_progress(py, progress, "TopicsOverTime")?;
         let (model, corpus) = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             let m = crate::topics_over_time::fit(
                 &corpus.docs,
                 num_types,
@@ -242,10 +249,12 @@ impl TopicsOverTime {
                 alpha,
                 beta,
                 iters,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         slf.model = Some(model);
         slf.corpus = Some(corpus);

--- a/src/slda.rs
+++ b/src/slda.rs
@@ -255,7 +255,7 @@ fn response_log_likelihood(
 /// of `(em_iteration, response_log_likelihood)` pairs, one per EM iteration when
 /// `check_every > 0`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_slda<R: Rng>(
+pub fn fit_slda<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     y: &[f64],
     num_types: usize,
@@ -265,6 +265,7 @@ pub fn fit_slda<R: Rng>(
     var_iters: usize,
     convergence_tol: f64,
     check_every: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> (SldaModel, Vec<(usize, f64)>, bool) {
     let k = num_topics;
@@ -375,10 +376,14 @@ pub fn fit_slda<R: Rng>(
                 let prev = bound_history[bound_history.len() - 2].1;
                 let rel = (bnd - prev).abs() / (prev.abs() + 1e-12);
                 if rel < convergence_tol {
+                    let _ = on_progress(em_iter, em_iter);
                     converged = true;
                     break;
                 }
             }
+        }
+        if !on_progress(em_iter, em_iters) {
+            break;
         }
     }
 
@@ -422,7 +427,7 @@ pub fn fit_slda<R: Rng>(
 /// [`fit_slda`]'s shape; the history records `(sweep, response_log_likelihood)`
 /// every `check_every` sweeps (no early stopping — Gibbs runs the full `iters`).
 #[allow(clippy::too_many_arguments)]
-pub fn fit_slda_gibbs<R: Rng>(
+pub fn fit_slda_gibbs<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     y: &[f64],
     num_types: usize,
@@ -430,6 +435,7 @@ pub fn fit_slda_gibbs<R: Rng>(
     alpha: f64,
     iters: usize,
     check_every: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> (SldaModel, Vec<(usize, f64)>, bool) {
     let k = num_topics;
@@ -564,6 +570,9 @@ pub fn fit_slda_gibbs<R: Rng>(
             ll -= d as f64 * 0.5 * (2.0 * std::f64::consts::PI * sigma2).ln();
             bound_history.push((sweep, ll));
         }
+        if !on_progress(sweep, iters) {
+            break;
+        }
     }
 
     // Read out β from the final counts and γ = α + topic counts (for doc_topic).
@@ -682,7 +691,7 @@ mod tests {
     fn recovers_predictive_topics() {
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let (docs, y, v) = supervised_corpus(&mut rng);
-        let (model, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 25, 15, 0.0, 0, &mut rng);
+        let (model, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 25, 15, 0.0, 0, |_, _| true, &mut rng);
 
         // The two topics should separate the two vocabularies.
         let tw = model.topic_word();
@@ -718,7 +727,7 @@ mod tests {
     fn coefficient_se_and_predictive_variance() {
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let (docs, y, v) = supervised_corpus(&mut rng);
-        let (model, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 25, 15, 0.0, 0, &mut rng);
+        let (model, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 25, 15, 0.0, 0, |_, _| true, &mut rng);
 
         // Coefficient SEs: finite, positive, and the strong predictive topic's
         // coefficient is many SEs from zero on this well-separated corpus.
@@ -757,8 +766,8 @@ mod tests {
         let (docs, y, v) = supervised_corpus(&mut r0);
         let mut r1 = ChaCha8Rng::seed_from_u64(9);
         let mut r2 = ChaCha8Rng::seed_from_u64(9);
-        let (m1, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 10, 10, 0.0, 0, &mut r1);
-        let (m2, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 10, 10, 0.0, 0, &mut r2);
+        let (m1, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 10, 10, 0.0, 0, |_, _| true, &mut r1);
+        let (m2, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 10, 10, 0.0, 0, |_, _| true, &mut r2);
         assert_eq!(m1.eta, m2.eta);
         assert_eq!(m1.sigma2, m2.sigma2);
     }
@@ -782,7 +791,8 @@ mod tests {
     fn gibbs_recovers_predictive_topics() {
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let (docs, y, v) = supervised_corpus(&mut rng);
-        let (model, hist, conv) = fit_slda_gibbs(&docs, &y, v, 2, 0.1, 300, 50, &mut rng);
+        let (model, hist, conv) =
+            fit_slda_gibbs(&docs, &y, v, 2, 0.1, 300, 50, |_, _| true, &mut rng);
         assert!(!conv); // Gibbs runs the full sweep budget
         assert!(!hist.is_empty(), "expected a response-ll trace");
 
@@ -817,8 +827,8 @@ mod tests {
         let (docs, y, v) = supervised_corpus(&mut r0);
         let mut r1 = ChaCha8Rng::seed_from_u64(9);
         let mut r2 = ChaCha8Rng::seed_from_u64(9);
-        let (m1, _, _) = fit_slda_gibbs(&docs, &y, v, 2, 0.1, 50, 0, &mut r1);
-        let (m2, _, _) = fit_slda_gibbs(&docs, &y, v, 2, 0.1, 50, 0, &mut r2);
+        let (m1, _, _) = fit_slda_gibbs(&docs, &y, v, 2, 0.1, 50, 0, |_, _| true, &mut r1);
+        let (m2, _, _) = fit_slda_gibbs(&docs, &y, v, 2, 0.1, 50, 0, |_, _| true, &mut r2);
         assert_eq!(m1.eta, m2.eta);
         assert_eq!(m1.sigma2, m2.sigma2);
         assert_eq!(m1.log_beta, m2.log_beta);
@@ -828,7 +838,7 @@ mod tests {
     fn gibbs_conforms() {
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let (docs, y, v) = supervised_corpus(&mut rng);
-        let (m, _, _) = fit_slda_gibbs(&docs, &y, v, 2, 0.1, 100, 0, &mut rng);
+        let (m, _, _) = fit_slda_gibbs(&docs, &y, v, 2, 0.1, 100, 0, |_, _| true, &mut rng);
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
         let dir = crate::conformance::check_dirichlet(&m);
@@ -839,7 +849,7 @@ mod tests {
     fn slda_conforms() {
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let (docs, y, v) = supervised_corpus(&mut rng);
-        let (m, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 25, 15, 0.0, 0, &mut rng);
+        let (m, _, _) = fit_slda(&docs, &y, v, 2, 0.1, 25, 15, 0.0, 0, |_, _| true, &mut rng);
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
         let dir = crate::conformance::check_dirichlet(&m);

--- a/src/sts.rs
+++ b/src/sts.rs
@@ -870,7 +870,7 @@ fn damp_kappa_halfstep(new: &mut [Vec<f64>], prev: &[Vec<f64>]) {
 /// dims (`Sigma_Inv = diag(1/20)`). `kappa_damping` applies the CRAN half-step κ
 /// update `(κ_new + κ_old)/2` on every M-step and at initialization.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_sts<R: Rng>(
+pub fn fit_sts<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     num_topics: usize,
     num_types: usize,
@@ -883,6 +883,7 @@ pub fn fit_sts<R: Rng>(
     keep_nu: bool,
     reference_init: bool,
     kappa_damping: bool,
+    mut on_progress: F,
     rng: &mut R,
 ) -> StsModel {
     let k = num_topics;
@@ -1162,9 +1163,13 @@ pub fn fit_sts<R: Rng>(
             let prev = bound_history[bound_history.len() - 2];
             let rel = (total_bound - prev).abs() / (prev.abs() + 1e-12);
             if rel < em_tol {
+                let _ = on_progress(em + 1, em + 1, total_bound);
                 converged = true;
                 break;
             }
+        }
+        if !on_progress(em + 1, em_iters, total_bound) {
+            break;
         }
 
         // M-step: Γ (pooled ridge) or shared mean μ.
@@ -1440,6 +1445,7 @@ mod tests {
             true,
             false,
             false,
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -1494,6 +1500,7 @@ mod tests {
             true,
             false,
             false,
+            |_, _, _| true,
             &mut r1,
         );
         let m2 = fit_sts(
@@ -1509,6 +1516,7 @@ mod tests {
             true,
             false,
             false,
+            |_, _, _| true,
             &mut r2,
         );
         for (a, b) in m1.alpha.iter().flatten().zip(m2.alpha.iter().flatten()) {
@@ -1608,6 +1616,7 @@ mod tests {
             true,
             false,
             false,
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -1646,6 +1655,7 @@ mod tests {
             true,
             false,
             false,
+            |_, _, _| true,
             &mut rng,
         );
 
@@ -1734,6 +1744,7 @@ mod tests {
             true,
             false,
             false,
+            |_, _, _| true,
             &mut rng,
         );
         let ks_max = m
@@ -1791,6 +1802,7 @@ mod tests {
             true,
             true,
             true,
+            |_, _, _| true,
             &mut rng,
         );
         assert!(m.kappa_t.iter().flatten().all(|x| x.is_finite()));
@@ -1840,6 +1852,7 @@ mod tests {
             true,
             false,
             false,
+            |_, _, _| true,
             &mut rng,
         );
         let base = check_conformance(&m);

--- a/src/topical_ngrams.rs
+++ b/src/topical_ngrams.rs
@@ -70,7 +70,7 @@ pub struct TopicalNGramsModel {
 /// unigram topic-word prior; `gamma` the bigram topic-word prior; `delta1`/`delta2`
 /// the Beta pseudocounts for unigram/bigram status.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_tng<R: Rng>(
+pub fn fit_tng<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<Token>],
     num_types: usize,
     num_topics: usize,
@@ -80,6 +80,7 @@ pub fn fit_tng<R: Rng>(
     gamma: f64,
     delta1: f64,
     delta2: f64,
+    mut on_progress: F,
     rng: &mut R,
 ) -> TopicalNGramsModel {
     let k = num_topics;
@@ -250,6 +251,9 @@ pub fn fit_tng<R: Rng>(
         }
         let bi: usize = token_gram.iter().flatten().filter(|&&g| g == 1).count();
         fit_history.push((it + 1, bi as f64));
+        if !on_progress(it + 1, iters) {
+            break;
+        }
     }
 
     // Unigram topic-word phi (K, V): a proper simplex per topic.
@@ -443,6 +447,7 @@ mod tests {
             0.01,
             1.0,
             1.0,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(1),
         );
         let phrases = extract_phrases(&model, &docs);
@@ -475,6 +480,7 @@ mod tests {
             0.01,
             1.0,
             1.0,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(7),
         );
         let b = fit_tng(
@@ -487,6 +493,7 @@ mod tests {
             0.01,
             1.0,
             1.0,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(7),
         );
         assert_eq!(a.topic_word, b.topic_word);
@@ -507,6 +514,7 @@ mod tests {
             0.01,
             1.0,
             1.0,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(0),
         );
         for row in &m.topic_word {
@@ -534,6 +542,7 @@ mod tests {
             0.01,
             1.0,
             1.0,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(2),
         );
         for grams in &m.token_gram {

--- a/src/topics_over_time.rs
+++ b/src/topics_over_time.rs
@@ -133,7 +133,7 @@ fn beta_peak(a: f64, b: f64) -> f64 {
 ///   clipped away from the exact boundaries by the binding.
 /// - `alpha`: length-K doc-topic Dirichlet. `beta`: symmetric topic-word Dirichlet.
 #[allow(clippy::too_many_arguments)]
-pub fn fit<R: Rng>(
+pub fn fit<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     num_types: usize,
     times: &[f64],
@@ -141,6 +141,7 @@ pub fn fit<R: Rng>(
     alpha: Vec<f64>,
     beta: f64,
     iters: usize,
+    mut on_progress: F,
     rng: &mut R,
 ) -> TopicsOverTimeModel {
     let k = num_topics;
@@ -300,6 +301,10 @@ pub fn fit<R: Rng>(
                 docs, &wt, &n_dk, &psi, &ln_norm, &ln_t, &ln_1mt, &alpha, beta, beta_sum, k,
             );
             fit_history.push((it + 1, ll));
+        }
+
+        if !on_progress(it + 1, iters) {
+            break;
         }
     }
 
@@ -463,7 +468,7 @@ mod tests {
         let (docs, v, times) = planted(k);
         let alpha = vec![50.0 / k as f64; k];
         let mut rng = ChaCha8Rng::seed_from_u64(13);
-        let m = fit(&docs, v, &times, k, alpha, 0.1, 300, &mut rng);
+        let m = fit(&docs, v, &times, k, alpha, 0.1, 300, |_, _| true, &mut rng);
         // Each topic concentrates on its 5-word block.
         for row in &m.topic_word {
             let top5: f64 = {
@@ -501,6 +506,7 @@ mod tests {
             alpha.clone(),
             0.1,
             80,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(1),
         );
         let b = fit(
@@ -511,6 +517,7 @@ mod tests {
             alpha,
             0.1,
             80,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(1),
         );
         assert_eq!(a.topic_word, b.topic_word);
@@ -531,6 +538,7 @@ mod tests {
             alpha,
             0.1,
             20,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(0),
         );
         assert!(crate::conformance::check_conformance(&m).is_empty());
@@ -554,6 +562,7 @@ mod tests {
             alpha,
             0.1,
             40,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(0),
         );
         assert!(
@@ -682,6 +691,7 @@ mod tests {
             alpha.clone(),
             0.1,
             400,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(13),
         );
         // Time-blind: constant timestamp → Beta collapses to uniform → plain LDA.
@@ -694,6 +704,7 @@ mod tests {
             alpha,
             0.1,
             400,
+            |_, _| true,
             &mut ChaCha8Rng::seed_from_u64(13),
         );
 

--- a/tests/test_progress_786_modrs.py
+++ b/tests/test_progress_786_modrs.py
@@ -1,0 +1,71 @@
+"""progress= for the mod.rs-bound iterative models PT, STS, SupervisedLDA (#786).
+
+Same contract as the other progress-enabled models: an opt-in (iteration, total,
+info) callback, KeyboardInterrupt aborts, non-callable raises TypeError, and the
+fit is bit-identical with and without the callback.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+rng = np.random.default_rng(0)
+VOCAB = [f"w{i}" for i in range(40)]
+DOCS = [[VOCAB[i] for i in rng.integers(0, 40, 20)] for _ in range(200)]
+SENT = [i % 5 for i in range(200)]
+Y = [float(i % 2) for i in range(200)]
+
+
+def _corpus():
+    return topica.Corpus.from_documents(DOCS)
+
+
+def _fit(model, progress, iters):
+    c = _corpus()
+    if model == "PT":
+        return topica.PT(5, seed=13).fit(c, iters=iters, progress=progress)
+    if model == "STS":
+        return topica.STS(5, seed=13).fit(c, SENT, iters=iters, progress=progress)
+    if model == "SupervisedLDA":
+        return topica.SupervisedLDA(5, seed=13).fit(c, Y, iters=iters, progress=progress)
+    if model == "SupervisedLDA-gibbs":
+        return topica.SupervisedLDA(5, seed=13, inference="gibbs").fit(
+            c, Y, iters=iters, progress=progress
+        )
+    raise ValueError(model)
+
+
+MODELS = ["PT", "STS", "SupervisedLDA", "SupervisedLDA-gibbs"]
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_progress_callback_fires(model):
+    calls = []
+    _fit(model, lambda it, total, info: calls.append((it, total)), iters=30)
+    assert calls
+    # totals are the iter budget, except a convergence "snap" which pegs the bar
+    # to 100% by reporting (current, current).
+    assert all(total in (30, it) for it, total in calls)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_keyboardinterrupt_aborts(model):
+    def boom(*args):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit(model, boom, iters=500)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_non_callable_progress_raises(model):
+    with pytest.raises(TypeError):
+        _fit(model, 5, iters=20)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_progress_does_not_change_fit(model):
+    a = _fit(model, None, iters=40)
+    b = _fit(model, lambda *args: None, iters=40)
+    assert np.allclose(np.asarray(a.topic_word), np.asarray(b.topic_word))

--- a/tests/test_progress_author_topic.py
+++ b/tests/test_progress_author_topic.py
@@ -1,0 +1,83 @@
+"""Fit-progress callback for AuthorTopic, TopicalNGrams, TopicsOverTime (#786).
+
+Each model's ``fit(progress=cb)`` must call ``cb(iteration, total, info)`` once
+per sweep, drive iteration up to the ``iters`` budget, abort on a callback that
+raises ``KeyboardInterrupt``, reject a non-callable ``progress``, and leave the
+fit bit-identical to a ``progress=None`` run at the same seed.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+# ~200 short token lists over a ~40-word vocab, two planted themes.
+_RNG = np.random.RandomState(0)
+_BLOCK_A = [f"a{i}" for i in range(20)]
+_BLOCK_B = [f"b{i}" for i in range(20)]
+DOCS = []
+for d in range(200):
+    block = _BLOCK_A if d % 2 == 0 else _BLOCK_B
+    DOCS.append([block[_RNG.randint(0, len(block))] for _ in range(6)])
+
+AUTHORS = [[f"a{d % 8}"] for d in range(len(DOCS))]
+TIMES = [float(d % 5) for d in range(len(DOCS))]
+
+
+def _corpus():
+    return topica.Corpus.from_documents(DOCS)
+
+
+def _fit(model_name, iters, progress):
+    """Fit one of the three models with the given progress callback."""
+    c = _corpus()
+    if model_name == "AuthorTopic":
+        return topica.AuthorTopic(5).fit(c, AUTHORS, iters=iters, progress=progress)
+    if model_name == "TopicalNGrams":
+        return topica.TopicalNGrams(5).fit(c, iters=iters, progress=progress)
+    if model_name == "TopicsOverTime":
+        return topica.TopicsOverTime(5).fit(
+            c, timestamps=TIMES, iters=iters, progress=progress
+        )
+    raise AssertionError(model_name)
+
+
+MODELS = ["AuthorTopic", "TopicalNGrams", "TopicsOverTime"]
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_callback_fires(model_name):
+    iters = 30
+    calls = []
+    _fit(model_name, iters, lambda it, total, info: calls.append((it, total)))
+    assert calls, f"{model_name}: progress callback never fired"
+    assert all(total == iters for _, total in calls), (
+        f"{model_name}: every call must report total == iters ({iters}): {calls[:3]}"
+    )
+    # Iterations are 1-based and reach the budget.
+    assert calls[0][0] == 1
+    assert calls[-1][0] == iters
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_abort_raises(model_name):
+    def boom(it, total, info):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit(model_name, 40, boom)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_type_validation(model_name):
+    with pytest.raises(TypeError):
+        _fit(model_name, 20, 5)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_determinism(model_name):
+    a = _fit(model_name, 30, None)
+    b = _fit(model_name, 30, lambda *args: None)
+    assert np.array_equal(a.topic_word, b.topic_word), (
+        f"{model_name}: progress callback perturbed the fit"
+    )

--- a/tests/test_progress_gaussian_lda.py
+++ b/tests/test_progress_gaussian_lda.py
@@ -1,0 +1,95 @@
+"""Live fit-progress callback for GaussianLDA, PolylingualLDA, and PA (#786).
+
+Each model's fit(progress=cb) must call cb(iteration, total, info) once per
+sweep, drive iteration up to total, abort on KeyboardInterrupt, reject a
+non-callable/non-bool progress, and leave the fit bit-identical.
+"""
+
+import random
+
+import numpy as np
+import pytest
+
+import topica
+
+# ~200 short docs over a ~40-word vocab, two planted themes.
+_RNG = random.Random(13)
+_THEME_A = [f"a{i}" for i in range(20)]
+_THEME_B = [f"b{i}" for i in range(20)]
+# A second language for PolylingualLDA: disjoint token set, same tuple shape.
+_THEME_A2 = [f"x{i}" for i in range(20)]
+_THEME_B2 = [f"y{i}" for i in range(20)]
+
+
+def _make_docs(pool_a, pool_b, n=200):
+    docs = []
+    for d in range(n):
+        pool = pool_a if d % 2 == 0 else pool_b
+        docs.append([_RNG.choice(pool) for _ in range(8)])
+    return docs
+
+
+DOCS = _make_docs(_THEME_A, _THEME_B)
+DOCS2 = _make_docs(_THEME_A2, _THEME_B2)
+
+
+def _fit(model_name, progress, iters=30):
+    """Fit one model with progress=progress at a small iters; return the model."""
+    c = topica.Corpus.from_documents(DOCS)
+    if model_name == "GaussianLDA":
+        emb = np.random.default_rng(1).normal(size=(c.num_words, 16))
+        vocab = list(c.vocabulary)
+        return topica.GaussianLDA(5).fit(
+            c, emb, vocab, iters=iters, progress=progress
+        )
+    if model_name == "PolylingualLDA":
+        return topica.PolylingualLDA(5).fit(
+            {"en": DOCS, "fr": DOCS2}, iters=iters, progress=progress
+        )
+    if model_name == "PA":
+        return topica.PA(3, 5).fit(c, iters=iters, progress=progress)
+    raise AssertionError(model_name)
+
+
+def _fitted_array(model_name, progress, iters=30):
+    m = _fit(model_name, progress, iters=iters)
+    if model_name == "GaussianLDA":
+        return np.asarray(m.topic_word)
+    # PolylingualLDA.topic_word needs a language; doc_topic is a single matrix.
+    return np.asarray(m.doc_topic)
+
+
+MODELS = ["GaussianLDA", "PolylingualLDA", "PA"]
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_fires_with_total_equals_iters(model_name):
+    iters = 30
+    calls = []
+    _fit(model_name, lambda it, total, info: calls.append((it, total)), iters=iters)
+    assert calls, f"{model_name}: progress never fired"
+    # A model that runs its full budget hits (iters, iters) on the last call.
+    assert calls[-1] == (iters, iters), f"{model_name}: last call {calls[-1]}"
+    assert all(total == iters for _, total in calls)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_keyboardinterrupt_aborts(model_name):
+    def boom(it, total, info):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit(model_name, boom, iters=30)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_typeerror_on_non_callable(model_name):
+    with pytest.raises(TypeError):
+        _fit(model_name, 5, iters=30)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_does_not_change_fit(model_name):
+    baseline = _fitted_array(model_name, None, iters=30)
+    with_cb = _fitted_array(model_name, lambda *a: None, iters=30)
+    np.testing.assert_array_equal(baseline, with_cb)

--- a/tests/test_progress_mglda.py
+++ b/tests/test_progress_mglda.py
@@ -1,0 +1,86 @@
+"""Live fit-progress callback for MGLDA, DiscLDA, and FactorialLDA (#786).
+
+Each model's fit(progress=cb) must call cb(iteration, total, info) once per
+sweep, drive iteration up to total, abort on KeyboardInterrupt, reject a
+non-callable/non-bool progress, and leave the fit bit-identical.
+"""
+
+import random
+
+import numpy as np
+import pytest
+
+import topica
+
+# ~200 short docs over a ~40-word vocab, two planted themes.
+_RNG = random.Random(13)
+_THEME_A = [f"a{i}" for i in range(20)]
+_THEME_B = [f"b{i}" for i in range(20)]
+
+
+def _make_docs(n=200):
+    docs = []
+    for d in range(n):
+        pool = _THEME_A if d % 2 == 0 else _THEME_B
+        docs.append([_RNG.choice(pool) for _ in range(8)])
+    return docs
+
+
+DOCS = _make_docs()
+# Sentence-segmented view for MGLDA: split each doc into two sentences.
+SDOCS = [[d[: len(d) // 2], d[len(d) // 2 :]] for d in DOCS]
+Y = [d % 2 for d in range(len(DOCS))]
+
+
+def _fit(model_name, progress, iters=30):
+    """Fit one model with progress=progress at a small iters; return the model."""
+    c = topica.Corpus.from_documents(DOCS)
+    if model_name == "MGLDA":
+        return topica.MGLDA(5, 5).fit(SDOCS, iters=iters, progress=progress)
+    if model_name == "DiscLDA":
+        return topica.DiscLDA(2, 4).fit(c, Y, iters=iters, progress=progress)
+    if model_name == "FactorialLDA":
+        return topica.FactorialLDA([2, 3]).fit(
+            c, iters=iters, samples=10, progress=progress
+        )
+    raise AssertionError(model_name)
+
+
+def _fitted_array(model_name, progress, iters=30):
+    return np.asarray(_fit(model_name, progress, iters=iters).topic_word)
+
+
+MODELS = ["MGLDA", "DiscLDA", "FactorialLDA"]
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_fires_with_total_equals_iters(model_name):
+    iters = 30
+    calls = []
+    _fit(model_name, lambda it, total, info: calls.append((it, total)), iters=iters)
+    assert calls, f"{model_name}: progress never fired"
+    # A model that runs its full budget hits (iters, iters) on the last call.
+    assert calls[-1] == (iters, iters), f"{model_name}: last call {calls[-1]}"
+    assert all(total == iters for _, total in calls)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_keyboardinterrupt_aborts(model_name):
+    def boom(it, total, info):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit(model_name, boom, iters=30)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_typeerror_on_non_callable(model_name):
+    with pytest.raises(TypeError):
+        _fit(model_name, 5, iters=30)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_does_not_change_fit(model_name):
+    baseline = _fitted_array(model_name, None, iters=30)
+    with_cb = _fitted_array(model_name, lambda *a: None, iters=30)
+    np.testing.assert_array_equal(baseline, with_cb)

--- a/tests/test_progress_wrappers_786.py
+++ b/tests/test_progress_wrappers_786.py
@@ -1,0 +1,72 @@
+"""progress= forwarding for the pure-Python wrapper models (#786).
+
+GDMR, NarrativeTM, and EmbeddingLDA are Python wrappers over compiled cores
+(DMR / GDMR->DMR / SeededLDA) that already emit progress. These tests confirm
+the wrappers forward `progress=` so the shared bar, the interrupt abort, and the
+type validation all reach the user.
+"""
+
+import os
+import warnings
+
+import numpy as np
+import pytest
+
+import topica
+
+os.environ.setdefault("TOPICA_EXPERIMENTAL", "1")
+try:
+    topica.enable_experimental()
+except Exception:
+    pass
+
+rng = np.random.default_rng(0)
+VOCAB = [f"w{i}" for i in range(40)]
+DOCS = [[VOCAB[i] for i in rng.integers(0, 40, 20)] for _ in range(200)]
+COV = rng.normal(size=200)
+
+
+def _corpus():
+    return topica.Corpus.from_documents(DOCS)
+
+
+def _fit(model, progress, iters):
+    c = _corpus()
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        if model == "GDMR":
+            topica.GDMR(5, degrees=[3]).fit(c, COV, iters=iters, progress=progress)
+        elif model == "NarrativeTM":
+            topica.NarrativeTM(5).fit(c, iters=iters, progress=progress)
+        elif model == "EmbeddingLDA":
+            emb = rng.normal(size=(c.num_words, 16))
+            topica.EmbeddingLDA(5, embeddings=emb, vocabulary=list(c.vocabulary)).fit(
+                c, iters=iters, progress=progress
+            )
+        else:  # pragma: no cover
+            raise ValueError(model)
+
+
+MODELS = ["GDMR", "NarrativeTM", "EmbeddingLDA"]
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_wrapper_forwards_progress_callback(model):
+    calls = []
+    _fit(model, lambda it, total, info: calls.append(it), iters=30)
+    assert calls  # the underlying core's progress reached our callback
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_wrapper_keyboardinterrupt_aborts(model):
+    def boom(*args):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit(model, boom, iters=500)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_wrapper_non_callable_progress_raises(model):
+    with pytest.raises(TypeError):
+        _fit(model, 5, iters=20)


### PR DESCRIPTION
Part of #786 (phase-2 progress rollout). Adds the opt-in `progress=` fit callback to the iterative models a user realistically waits on, decided by benchmark: a big-corpus fit (10k docs, default iters) taking **>=5s** gets a bar; the sub-5s embedding/matrix-dominated models are deliberately skipped (see below).

## Shared reuse (no per-model rewrite)
- New `on_progress_ll` / `on_progress_bare` closure factories in `src/python/mod.rs` centralize the GIL handshake + abort contract; the existing progress-enabled bindings are refactored onto them (behavior-neutral). Each new model's binding is then ~2 lines.
- The interrupt/validation machinery from #794 (`resolve_progress`, `deliver_progress`, `reraise_if_interrupted`, `topica.progress()`) is reused as-is.

## Models wired (15)
**Rust cores (12):** AuthorTopic, DiscLDA, FactorialLDA (+FLDA alias), GaussianLDA, MGLDA, PolylingualLDA (+PLTM alias), PA, PT, STS, SupervisedLDA (both `variational` and `gibbs`), TopicalNGrams, TopicsOverTime. Each core fit loop gained an `FnMut(iteration, total[, ll]) -> bool` hook that breaks on abort; GaussianLDA and STS report a real per-iteration metric (avg log-likelihood / EM bound), the rest drive the bar/ETA only.

**Python wrappers (3):** GDMR, NarrativeTM, EmbeddingLDA forward `progress=` to their compiled cores (DMR / GDMR->DMR / SeededLDA), which already emit.

## Deliberately skipped (<5s at 10k docs, per benchmark)
HDP 2.1s, CorEx 1.1s, IdealPointTM 0.8s, KeyNMF 0.7s, SemanticSignalSeparation 0.4s, Wordshoal 0.4s, IdealPointSentenceTM 0.3s, NMF 0.3s, AnchorLDA 0.3s, GuidedNMF 0.3s.

## Guarantees / tests
- Opt-in, off by default, **bit-identical to a no-progress fit** (progress reads state only, never touches the RNG) — asserted per model.
- KeyboardInterrupt aborts and propagates; non-callable `progress=` raises `TypeError`; `True`/`False` toggle the bar.
- Per-model callback/abort/type/determinism tests (`tests/test_progress_*`). `.pyi` stubs updated.
- Local gate green: preflight (fmt + clippy + tables + stub + compat), full `pytest tests/` (**5139 passed, 38 skipped**), and a 15-model manual sweep.

Remaining phase-2 tail (OnlineLDA, RTM, Wordfish, TBIP, TensorLDA) will follow in a second PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)