### PR TITLE
feat(progress): live fit progress for the phase-2 tail (OnlineLDA/RTM/Wordfish/TBIP/TensorLDA) (#786)

### DIFF
--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -2167,11 +2167,13 @@ class OnlineLDA:
         *,
         iters: int = 100,
         convergence_tol: float = 0.0,
+        progress: Callable[[int, int, dict], object] | bool | None = None,
     ) -> "OnlineLDA":
         """Fit by online VB: sweep the corpus for ``iters`` passes (gensim's
         ``passes``), one stochastic lambda update per minibatch.
         ``convergence_tol > 0`` early-stops on the relative change in the per-pass
-        evidence lower bound. Returns ``self``."""
+        evidence lower bound. ``progress`` opts into a fit progress callback
+        ``callback(pass, total, {"ll": elbo})``. Returns ``self``."""
         ...
 
     def partial_fit(
@@ -3398,9 +3400,12 @@ class RTM:
         iters: int = 50,
         e_sweeps: int = 3,
         e_inner: int = 5,
+        progress: Callable[[int, int, dict], object] | bool | None = None,
     ) -> "RTM":
         """Fit RTM on a document graph. ``links`` is a sequence of undirected
-        ``(i, j)`` document-index pairs (only observed links are modelled)."""
+        ``(i, j)`` document-index pairs (only observed links are modelled).
+        ``progress`` opts into a fit progress callback ``callback(iteration,
+        total, {})`` (one call per EM / Gibbs M-step)."""
         ...
     def predict_link(self, i: int, j: int) -> float:
         """Plug-in link probability between two training documents."""
@@ -6064,7 +6069,13 @@ class TensorLDA:
         pca_batch_size: int = 128,
         seed: int = 13,
     ) -> None: ...
-    def fit(self, data: Corpus | Sequence[Sequence[str]], *, iters: int | None = None) -> "TensorLDA": ...
+    def fit(
+        self,
+        data: Corpus | Sequence[Sequence[str]],
+        *,
+        iters: int | None = None,
+        progress: Callable[[int, int, dict], object] | bool | None = None,
+    ) -> "TensorLDA": ...
     def partial_fit(
         self,
         data: Corpus | Sequence[Sequence[str]],
@@ -6811,6 +6822,7 @@ class Wordfish:
         anchors: dict[str, float] | None = None,
         iters: int | None = None,
         convergence_tol: float | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "Wordfish":
         """group pools documents sharing a label into one unit with one position;
         control is an optional categorical confound (constant within each author)
@@ -7087,6 +7099,7 @@ class TBIP:
         iters: int | None = None,
         batch_size: int | None = None,
         learning_rate: float | None = None,
+        progress: Callable[[int, int, dict], object] | None = None,
     ) -> "TBIP":
         """data is a Corpus or list of token lists; group (length num_docs) gives the
         author of each document (documents sharing a label share one ideal point)."""

--- a/src/online_lda.rs
+++ b/src/online_lda.rs
@@ -427,7 +427,7 @@ impl OnlineLDAModel {
 /// the bound (`convergence_tol > 0`). A final full E-step gives every document a
 /// θ row and the reported topic-word matrix its normalised `λ`.
 #[allow(clippy::too_many_arguments)]
-pub fn fit<R: Rng>(
+pub fn fit<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     corpus: &Corpus,
     num_topics: usize,
     alpha: Vec<f64>,
@@ -440,6 +440,7 @@ pub fn fit<R: Rng>(
     iters: usize,
     convergence_tol: f64,
     total_docs_override: Option<f64>,
+    mut on_progress: F,
     rng: &mut R,
 ) -> OnlineLDAModel {
     let num_types = corpus.num_types();
@@ -479,15 +480,26 @@ pub fn fit<R: Rng>(
         let (elogbeta, _) = dirichlet_expectation(&model.lambda);
         pass_bound += beta_bound(&model.lambda, &elogbeta, eta, num_types);
 
+        let mut converged_now = false;
         if let Some(&(_, prev)) = model.fit_history.last() {
             let rel = (pass_bound - prev).abs() / prev.abs().max(1e-10);
             model.fit_history.push((pass + 1, pass_bound));
             if convergence_tol > 0.0 && rel < convergence_tol {
                 model.converged = true;
-                break;
+                converged_now = true;
             }
         } else {
             model.fit_history.push((pass + 1, pass_bound));
+        }
+
+        // Per-pass ELBO drives the live progress bar. On an early-stop, snap the
+        // bar to 100% by reporting (pass, pass) (mirrors fastopic, #786).
+        if converged_now {
+            let _ = on_progress(pass + 1, pass + 1, pass_bound);
+            break;
+        }
+        if !on_progress(pass + 1, iters, pass_bound) {
+            break;
         }
     }
 
@@ -608,6 +620,7 @@ mod tests {
             100,
             0.0,
             None,
+            |_, _, _| true,
             &mut rng,
         )
     }

--- a/src/python/online_lda.rs
+++ b/src/python/online_lda.rs
@@ -253,13 +253,18 @@ impl OnlineLDA {
     /// update per minibatch. `data` is a :class:`Corpus` or a list of token
     /// lists. `convergence_tol` (default 0.0, disabled) early-stops on the
     /// relative change in the per-pass evidence lower bound. Returns `self`.
-    #[pyo3(signature = (data, *, iters=100, convergence_tol=0.0))]
+    ///
+    /// `progress` opts into a fit progress callback `callback(pass, total,
+    /// {"ll": elbo})` (per-pass ELBO); pass `True` to force the default
+    /// :func:`topica.progress` bar, a callable for a custom sink, or leave `None`.
+    #[pyo3(signature = (data, *, iters=100, convergence_tol=0.0, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: usize,
         convergence_tol: f64,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         ensure_finite_nonneg("convergence_tol", convergence_tol)?;
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
@@ -297,8 +302,10 @@ impl OnlineLDA {
         );
         let total_docs_override = slf.total_docs;
 
+        let progress = resolve_progress(py, progress, "OnlineLDA")?;
         let (model, corpus) = py.allow_threads(move || {
             let mut rng = Pcg64Mcg::seed_from_u64(seed);
+            let mut on_progress = on_progress_ll(&progress);
             // A user-declared streaming corpus size scales the natural gradient for
             // BOTH the batch fit and later partial_fit; otherwise D = fit-corpus size.
             let m = online_lda::fit(
@@ -314,10 +321,12 @@ impl OnlineLDA {
                 iters,
                 convergence_tol,
                 total_docs_override,
+                &mut on_progress,
                 &mut rng,
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         slf.model = Some(model);
         slf.corpus = Some(corpus);

--- a/src/python/rtm.rs
+++ b/src/python/rtm.rs
@@ -236,7 +236,12 @@ impl RTM {
 
     /// Fit RTM on a document graph. ``data`` is a ``Corpus`` or ``list[list[str]]``;
     /// ``links`` is a sequence of undirected ``(i, j)`` document-index pairs.
-    #[pyo3(signature = (data, links, *, iters=50, e_sweeps=3, e_inner=5))]
+    ///
+    /// `progress` opts into a fit progress callback `callback(iteration, total,
+    /// {})` (one call per EM / Gibbs M-step, no per-iteration metric); pass `True`
+    /// to force the default :func:`topica.progress` bar, a callable for a custom
+    /// sink, or leave `None`.
+    #[pyo3(signature = (data, links, *, iters=50, e_sweeps=3, e_inner=5, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -245,6 +250,7 @@ impl RTM {
         iters: usize,
         e_sweeps: usize,
         e_inner: usize,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -293,14 +299,17 @@ impl RTM {
         };
         let gibbs = slf.inference == "gibbs";
         let mut rng = ChaCha8Rng::seed_from_u64(slf.seed);
+        let progress = resolve_progress(py, progress, "RTM")?;
         let (model, corpus) = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             let model = if gibbs {
-                crate::rtm::fit_rtm_gibbs(&corpus.docs, &edges, &params, &mut rng)
+                crate::rtm::fit_rtm_gibbs(&corpus.docs, &edges, &params, &mut on_progress, &mut rng)
             } else {
-                crate::rtm::fit_rtm(&corpus.docs, &edges, &params, &mut rng)
+                crate::rtm::fit_rtm(&corpus.docs, &edges, &params, &mut on_progress, &mut rng)
             };
             (model, corpus)
         });
+        reraise_if_interrupted(py)?;
         slf.model = Some(model);
         slf.corpus = Some(corpus);
         slf.fitted = true;

--- a/src/python/tbip.rs
+++ b/src/python/tbip.rs
@@ -145,8 +145,10 @@ impl TBIP {
     /// of author labels (length num_docs): documents sharing a label share one latent
     /// ideal point; if omitted, each document is its own author. `iters`,
     /// `batch_size`, and `learning_rate` override the constructor values when given.
+    /// `progress` opts into a per-step fit callback (or `True` for a progress bar);
+    /// it receives `(step, total, elbo)` and may return `False` to stop early.
     #[pyo3(signature = (data, *, group=None, iters=None, batch_size=None,
-                        learning_rate=None))]
+                        learning_rate=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -155,6 +157,7 @@ impl TBIP {
         iters: Option<usize>,
         batch_size: Option<usize>,
         learning_rate: Option<f64>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let (docs_str, doc_names): (Vec<Vec<String>>, Vec<String>) =
             if let Ok(c) = data.extract::<Corpus>() {
@@ -272,8 +275,10 @@ impl TBIP {
             learning_rate: learning_rate.unwrap_or(slf.learning_rate),
         };
         let (k, seed) = (slf.num_topics, slf.seed);
+        let progress = resolve_progress(py, progress, "TBIP")?;
         let model = py.allow_threads(move || {
             let mut rng = ChaCha8Rng::seed_from_u64(seed);
+            let mut on_progress = on_progress_ll(&progress);
             tbip::fit_tbip(
                 &docs_ids,
                 &group_idx,
@@ -281,9 +286,11 @@ impl TBIP {
                 k,
                 num_types,
                 &cfg,
+                &mut on_progress,
                 &mut rng,
             )
         });
+        reraise_if_interrupted(py)?;
 
         slf.model = Some(model);
         slf.corpus = Some(coherence_corpus);

--- a/src/python/tlda.rs
+++ b/src/python/tlda.rs
@@ -211,12 +211,18 @@ impl TensorLDA {
     }
 
     /// Fit the model on the given corpus or token lists.
-    #[pyo3(signature = (data, *, iters=None))]
+    ///
+    /// `progress` opts into a fit progress callback `callback(iteration, total,
+    /// {})` (one call per training iteration, no per-iteration metric); pass `True`
+    /// to force the default :func:`topica.progress` bar, a callable for a custom
+    /// sink, or leave `None`.
+    #[pyo3(signature = (data, *, iters=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
         data: &Bound<'_, PyAny>,
         iters: Option<usize>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let corpus: corpus::Corpus = if let Ok(c) = data.extract::<Corpus>() {
             c.inner
@@ -272,7 +278,9 @@ impl TensorLDA {
             slf.seed,
         );
 
+        let progress = resolve_progress(py, progress, "TensorLDA")?;
         let (model, corpus) = py.allow_threads(move || {
+            let mut on_progress = on_progress_bare(&progress);
             let m = crate::tlda::fit_tlda(
                 &corpus.docs,
                 k,
@@ -286,9 +294,11 @@ impl TensorLDA {
                 theta,
                 n_eigen,
                 seed,
+                &mut on_progress,
             );
             (m, corpus)
         });
+        reraise_if_interrupted(py)?;
 
         slf.model = Some(model);
         slf.corpus = Some(corpus);

--- a/src/python/wordfish.rs
+++ b/src/python/wordfish.rs
@@ -135,9 +135,11 @@ impl Wordfish {
     /// word offsets so it does not contaminate the latent position. `anchors` is an
     /// optional `{author_label: value}` mapping used to orient the sign of the axis so
     /// positions align with the supplied direction. `iters` sets the EM iteration cap
-    /// (default 100).
+    /// (default 100). `progress` opts into a per-iteration fit callback (or `True`
+    /// for a progress bar); it receives `(iter, total, log_likelihood)` and may
+    /// return `False` to stop early.
     #[pyo3(signature = (data, *, group=None, control=None, anchors=None, iters=None,
-                        convergence_tol=None))]
+                        convergence_tol=None, progress=None))]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
         py: Python<'_>,
@@ -147,6 +149,7 @@ impl Wordfish {
         anchors: Option<HashMap<String, f64>>,
         iters: Option<usize>,
         convergence_tol: Option<f64>,
+        progress: Option<PyObject>,
     ) -> PyResult<Py<Self>> {
         let (docs_str, doc_names): (Vec<Vec<String>>, Vec<String>) =
             if let Ok(c) = data.extract::<Corpus>() {
@@ -317,7 +320,9 @@ impl Wordfish {
         let tol = convergence_tol.unwrap_or(slf.convergence_tol);
         let it = iters.unwrap_or(100);
         let (bsd, tsd) = (slf.beta_prior_sd, slf.theta_prior_sd);
+        let progress = resolve_progress(py, progress, "Wordfish")?;
         let model = py.allow_threads(move || {
+            let mut on_progress = on_progress_ll(&progress);
             wordfish::fit_wordfish_controlled(
                 &counts,
                 num_types,
@@ -328,8 +333,10 @@ impl Wordfish {
                 tol,
                 bsd,
                 tsd,
+                &mut on_progress,
             )
         });
+        reraise_if_interrupted(py)?;
 
         slf.model = Some(model);
         slf.id_to_word = id_to_word;

--- a/src/rtm.rs
+++ b/src/rtm.rs
@@ -274,10 +274,11 @@ pub struct RtmParams {
 /// Fit RTM by variational EM. `docs` are token-id lists; `edges` are undirected
 /// observed links between document indices. Deterministic given `rng` and a
 /// serial (Gauss-Seidel) E-step.
-pub fn fit_rtm<R: Rng>(
+pub fn fit_rtm<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     edges: &[(usize, usize)],
     p: &RtmParams,
+    mut on_progress: F,
     rng: &mut R,
 ) -> RTMModel {
     let k = p.num_topics;
@@ -464,9 +465,13 @@ pub fn fit_rtm<R: Rng>(
         history.push((it, obj));
         if (obj - prev_obj).abs() < p.convergence_tol * prev_obj.abs().max(1.0) && it > 0 {
             converged = true;
+            let _ = on_progress(it + 1, it + 1); // snap bar to 100% (#786)
             break;
         }
         prev_obj = obj;
+        if !on_progress(it + 1, p.em_iters) {
+            break;
+        }
     }
 
     let topic_word: Vec<Vec<f64>> = log_beta
@@ -571,10 +576,11 @@ fn rtm_gibbs_estimate_beta(
 ///   computed once per document per sweep from neighbours' raw topic counts and the
 ///   fixed document token lengths. The exponential link's coefficient is stored as
 ///   `eta` (with `nu = 0`, matching R's intercept-free link).
-pub fn fit_rtm_gibbs<R: Rng>(
+pub fn fit_rtm_gibbs<R: Rng, F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     edges: &[(usize, usize)],
     p: &RtmParams,
+    mut on_progress: F,
     rng: &mut R,
 ) -> RTMModel {
     use std::collections::BTreeMap;
@@ -709,6 +715,9 @@ pub fn fit_rtm_gibbs<R: Rng>(
         // M-step: re-estimate the link coefficient from the final counts.
         link_beta = rtm_gibbs_estimate_beta(&ndk, &adj, alpha, lambda, k);
         history.push((m + 1, link_beta.iter().sum::<f64>()));
+        if !on_progress(m + 1, m_steps) {
+            break;
+        }
     }
 
     // Fitted surface (same shape as the variational backend).
@@ -994,7 +1003,7 @@ mod tests {
             let mut rng = ChaCha8Rng::seed_from_u64(7);
             let (docs, edges, groups, v) = planted(&mut rng, 60, 3, 6, 40);
             let mut frng = ChaCha8Rng::seed_from_u64(0);
-            let m = fit_rtm(&docs, &edges, &params(3, v, link), &mut frng);
+            let m = fit_rtm(&docs, &edges, &params(3, v, link), |_, _| true, &mut frng);
             // each topic concentrates on a distinct 6-word block
             let owned: Vec<usize> = (0..3)
                 .map(|kk| {
@@ -1047,7 +1056,13 @@ mod tests {
         let (docs, edges, _g, v) = planted(&mut rng, 30, 2, 5, 30);
         let fit = || {
             let mut r = ChaCha8Rng::seed_from_u64(3);
-            fit_rtm(&docs, &edges, &params(2, v, Link::Logistic), &mut r)
+            fit_rtm(
+                &docs,
+                &edges,
+                &params(2, v, Link::Logistic),
+                |_, _| true,
+                &mut r,
+            )
         };
         let a = fit();
         let b = fit();
@@ -1056,7 +1071,13 @@ mod tests {
         assert_eq!(a.phi_bar, b.phi_bar);
         // a different seed gives a different fit (so the test can't pass trivially)
         let mut r2 = ChaCha8Rng::seed_from_u64(99);
-        let c = fit_rtm(&docs, &edges, &params(2, v, Link::Logistic), &mut r2);
+        let c = fit_rtm(
+            &docs,
+            &edges,
+            &params(2, v, Link::Logistic),
+            |_, _| true,
+            &mut r2,
+        );
         assert_ne!(a.topic_word, c.topic_word);
     }
 
@@ -1065,7 +1086,13 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(2);
         let (docs, edges, _g, v) = planted(&mut rng, 20, 2, 5, 25);
         let mut frng = ChaCha8Rng::seed_from_u64(0);
-        let m = fit_rtm(&docs, &edges, &params(2, v, Link::Logistic), &mut frng);
+        let m = fit_rtm(
+            &docs,
+            &edges,
+            &params(2, v, Link::Logistic),
+            |_, _| true,
+            &mut frng,
+        );
         assert!(crate::conformance::check_conformance(&m).is_empty());
     }
 
@@ -1076,7 +1103,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(7);
         let (docs, edges, _groups, v) = planted(&mut rng, 60, 3, 6, 40);
         let mut frng = ChaCha8Rng::seed_from_u64(0);
-        let m = fit_rtm_gibbs(&docs, &edges, &gibbs_params(3, v), &mut frng);
+        let m = fit_rtm_gibbs(&docs, &edges, &gibbs_params(3, v), |_, _| true, &mut frng);
 
         // rows are valid simplices
         for row in &m.topic_word {
@@ -1114,7 +1141,7 @@ mod tests {
         let (docs, edges, _g, v) = planted(&mut rng, 30, 2, 5, 30);
         let fit = || {
             let mut r = ChaCha8Rng::seed_from_u64(3);
-            fit_rtm_gibbs(&docs, &edges, &gibbs_params(2, v), &mut r)
+            fit_rtm_gibbs(&docs, &edges, &gibbs_params(2, v), |_, _| true, &mut r)
         };
         let a = fit();
         let b = fit();
@@ -1122,7 +1149,7 @@ mod tests {
         assert_eq!(a.eta, b.eta);
         assert_eq!(a.doc_topic, b.doc_topic);
         let mut r2 = ChaCha8Rng::seed_from_u64(99);
-        let c = fit_rtm_gibbs(&docs, &edges, &gibbs_params(2, v), &mut r2);
+        let c = fit_rtm_gibbs(&docs, &edges, &gibbs_params(2, v), |_, _| true, &mut r2);
         assert_ne!(a.topic_word, c.topic_word);
     }
 
@@ -1131,7 +1158,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(2);
         let (docs, edges, _g, v) = planted(&mut rng, 20, 2, 5, 25);
         let mut frng = ChaCha8Rng::seed_from_u64(0);
-        let m = fit_rtm_gibbs(&docs, &edges, &gibbs_params(2, v), &mut frng);
+        let m = fit_rtm_gibbs(&docs, &edges, &gibbs_params(2, v), |_, _| true, &mut frng);
         assert!(crate::conformance::check_conformance(&m).is_empty());
     }
 
@@ -1143,7 +1170,7 @@ mod tests {
         let mut rng = ChaCha8Rng::seed_from_u64(5);
         let (docs, edges, _g, v) = planted(&mut rng, 60, 3, 6, 40);
         let mut frng = ChaCha8Rng::seed_from_u64(0);
-        let m = fit_rtm_gibbs(&docs, &edges, &gibbs_params(3, v), &mut frng);
+        let m = fit_rtm_gibbs(&docs, &edges, &gibbs_params(3, v), |_, _| true, &mut frng);
         assert!(
             m.eta.iter().all(|&b| b < 0.0),
             "expected all-negative link β (R quirk), got {:?}",

--- a/src/tbip.rs
+++ b/src/tbip.rs
@@ -637,13 +637,15 @@ fn ln_gamma(x: f64) -> f64 {
 
 /// Fit TBIP by reparameterized SVI (Adam). Deterministic for a fixed `rng` seed:
 /// one RNG drives both the minibatch sampling and the reparam noise.
-pub fn fit_tbip<R: Rng>(
+#[allow(clippy::too_many_arguments)]
+pub fn fit_tbip<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
     group: &[usize],
     num_authors: usize,
     num_topics: usize,
     num_types: usize,
     cfg: &TbipConfig,
+    mut on_progress: F,
     rng: &mut R,
 ) -> TbipModel {
     let k = num_topics;
@@ -668,8 +670,10 @@ pub fn fit_tbip<R: Rng>(
     let m2 = (steps * 4) / 5; // halve at 80%
     let mut elbo_history: Vec<f64> = Vec::new();
     let mut counts_buf = vec![0.0f64; v];
+    let mut steps_run = 0usize;
 
     for step in 0..steps {
+        steps_run = step + 1;
         // LR schedule (halve at 50% and 80%).
         let lr = cfg.learning_rate
             * if step >= m2 {
@@ -740,7 +744,10 @@ pub fn fit_tbip<R: Rng>(
         step_sparse(&mut ad_rs_theta, &mut p.rs_theta, &full_rs, &touched, k);
 
         elbo_history.push(g.elbo);
-        let _ = step;
+        // Report the ELBO (higher is better) as the per-step metric (#786).
+        if !on_progress(step + 1, steps, g.elbo) {
+            break;
+        }
     }
 
     TbipModel {
@@ -750,7 +757,7 @@ pub fn fit_tbip<R: Rng>(
         params: p,
         group: group.to_vec(),
         elbo_history,
-        iters_run: steps,
+        iters_run: steps_run,
     }
 }
 
@@ -1246,7 +1253,7 @@ mod tests {
             learning_rate: 0.05,
         };
         let mut fit_rng = ChaCha8Rng::seed_from_u64(7);
-        let m = fit_tbip(&docs, &group, a_n, k, v, &cfg, &mut fit_rng);
+        let m = fit_tbip(&docs, &group, a_n, k, v, &cfg, |_, _, _| true, &mut fit_rng);
         let xhat = m.ideal_points();
         let r = pearson(&xhat, &x_true).abs();
         println!("synthetic recovery Pearson r = {r:.4}");
@@ -1274,7 +1281,7 @@ mod tests {
             batch_size: docs.len(),
             ..Default::default()
         };
-        let m = fit_tbip(&docs, &group, 6, k, v, &cfg, &mut rng);
+        let m = fit_tbip(&docs, &group, 6, k, v, &cfg, |_, _, _| true, &mut rng);
         let se = m.position_se();
         assert_eq!(se.len(), 6);
         for (s, &sd) in se.iter().enumerate() {
@@ -1303,7 +1310,7 @@ mod tests {
             batch_size: docs.len(),
             ..Default::default()
         };
-        let m = fit_tbip(&docs, &group, 8, k, v, &cfg, &mut rng);
+        let m = fit_tbip(&docs, &group, 8, k, v, &cfg, |_, _, _| true, &mut rng);
         let base = crate::conformance::check_conformance(&m);
         assert!(base.is_empty(), "check_conformance: {:?}", base);
     }

--- a/src/tlda.rs
+++ b/src/tlda.rs
@@ -761,7 +761,7 @@ fn recover_params(
 }
 
 /// Fit Online Tensor LDA on the given document-term counts.
-pub fn fit_tlda(
+pub fn fit_tlda<F: FnMut(usize, usize) -> bool>(
     docs: &[Vec<u32>],
     num_topics: usize,
     num_types: usize,
@@ -774,6 +774,7 @@ pub fn fit_tlda(
     theta: f64,
     n_eigenvec: Option<usize>,
     seed: u64,
+    mut on_progress: F,
 ) -> TensorLdaModel {
     let d = docs.len();
     let v = num_types;
@@ -875,6 +876,11 @@ pub fn fit_tlda(
         fit_history.push((i, max_diff));
         if max_diff < tol && i >= 10 {
             converged = true;
+            let _ = on_progress(i, i); // snap bar to 100% on early convergence (#786)
+            break;
+        }
+        if !on_progress(i, n_iter_train) {
+            break;
         }
         i += 1;
     }
@@ -946,7 +952,21 @@ mod tests {
         let block = 6;
         let (docs, v) = planted_corpus(k, block, 60, 10, 42);
 
-        let m = fit_tlda(&docs, k, v, 1.0, 50, 20, 0.01, 10, 0.01, 1.0, None, 42);
+        let m = fit_tlda(
+            &docs,
+            k,
+            v,
+            1.0,
+            50,
+            20,
+            0.01,
+            10,
+            0.01,
+            1.0,
+            None,
+            42,
+            |_, _| true,
+        );
         assert_eq!(m.num_topics(), k);
         assert_eq!(m.topic_word.len(), k);
         assert_eq!(m.topic_word[0].len(), v);
@@ -1067,8 +1087,36 @@ mod tests {
         let block = 5;
         let (docs, v) = planted_corpus(k, block, 40, 8, 123);
 
-        let m1 = fit_tlda(&docs, k, v, 0.5, 30, 15, 0.05, 5, 0.05, 1.0, None, 999);
-        let m2 = fit_tlda(&docs, k, v, 0.5, 30, 15, 0.05, 5, 0.05, 1.0, None, 999);
+        let m1 = fit_tlda(
+            &docs,
+            k,
+            v,
+            0.5,
+            30,
+            15,
+            0.05,
+            5,
+            0.05,
+            1.0,
+            None,
+            999,
+            |_, _| true,
+        );
+        let m2 = fit_tlda(
+            &docs,
+            k,
+            v,
+            0.5,
+            30,
+            15,
+            0.05,
+            5,
+            0.05,
+            1.0,
+            None,
+            999,
+            |_, _| true,
+        );
 
         assert_eq!(m1.topic_word, m2.topic_word);
         assert_eq!(m1.doc_topic, m2.doc_topic);

--- a/src/wordfish.rs
+++ b/src/wordfish.rs
@@ -112,6 +112,7 @@ pub fn fit_wordfish(
         tol,
         beta_prior_sd,
         theta_prior_sd,
+        |_, _, _| true,
     )
 }
 
@@ -124,7 +125,7 @@ pub fn fit_wordfish(
 /// latent position `theta`. With `num_levels == 1` the offsets are all zero and the
 /// fit is exactly plain Wordfish.
 #[allow(clippy::too_many_arguments)]
-pub fn fit_wordfish_controlled(
+pub fn fit_wordfish_controlled<F: FnMut(usize, usize, f64) -> bool>(
     counts: &[Vec<(u32, f64)>],
     num_types: usize,
     level: &[usize],
@@ -134,6 +135,7 @@ pub fn fit_wordfish_controlled(
     tol: f64,
     beta_prior_sd: f64,
     theta_prior_sd: f64,
+    mut on_progress: F,
 ) -> WordfishModel {
     let a = counts.len();
     let v = num_types;
@@ -286,10 +288,14 @@ pub fn fit_wordfish_controlled(
             if (ll - prev_ll).abs() / denom < tol {
                 converged = true;
                 prev_ll = ll;
+                let _ = on_progress(it + 1, it + 1, ll); // snap bar to 100% (#786)
                 break;
             }
         }
         prev_ll = ll;
+        if !on_progress(it + 1, iters, ll) {
+            break;
+        }
     }
 
     orient(&mut theta, &mut beta, anchors);
@@ -684,7 +690,18 @@ mod tests {
             );
         }
         let no_control = fit_wordfish(&counts, v, &[], 120, 1e-8, 3.0, 1.0);
-        let with_control = fit_wordfish_controlled(&counts, v, &level, 2, &[], 120, 1e-8, 3.0, 1.0);
+        let with_control = fit_wordfish_controlled(
+            &counts,
+            v,
+            &level,
+            2,
+            &[],
+            120,
+            1e-8,
+            3.0,
+            1.0,
+            |_, _, _| true,
+        );
         let r_plain = pearson(&no_control.theta, &ideo).abs();
         let r_ctrl = pearson(&with_control.theta, &ideo).abs();
         assert!(
@@ -715,7 +732,10 @@ mod tests {
         }
         let plain = fit_wordfish(&counts, v, &[], 50, 1e-8, 3.0, 1.0);
         let level = vec![0usize; a];
-        let ctrl = fit_wordfish_controlled(&counts, v, &level, 1, &[], 50, 1e-8, 3.0, 1.0);
+        let ctrl =
+            fit_wordfish_controlled(&counts, v, &level, 1, &[], 50, 1e-8, 3.0, 1.0, |_, _, _| {
+                true
+            });
         assert_eq!(plain.theta, ctrl.theta);
         assert_eq!(plain.beta, ctrl.beta);
         assert_eq!(plain.psi, ctrl.psi);

--- a/tests/test_progress_online_lda.py
+++ b/tests/test_progress_online_lda.py
@@ -1,0 +1,103 @@
+"""Fit progress callback (`progress=`) for OnlineLDA, RTM, and TensorLDA (#786).
+
+Each model gets the same four checks:
+  1. a valid callback fires with the 3-arg contract (iter, total, info), the
+     recorded totals are the iteration budget (except a convergence snap, which
+     reports ``(n, n)``);
+  2. a callback raising ``KeyboardInterrupt`` aborts the fit with
+     ``KeyboardInterrupt``;
+  3. a non-callable, non-bool ``progress`` (here ``5``) is a ``TypeError``;
+  4. determinism: ``progress=lambda *a: None`` gives the same fitted topic-word
+     matrix as ``progress=None`` for the same seed.
+"""
+
+import os
+
+import numpy as np
+import pytest
+
+import topica
+
+# TensorLDA is experimental-gated; enable it so the sweep can construct it.
+os.environ.setdefault("TOPICA_EXPERIMENTAL", "1")
+try:
+    topica.enable_experimental()
+except Exception:
+    pass
+
+
+def _planted_docs(n_docs=200, n_blocks=4, words_per_block=10, doc_len=12, seed=0):
+    """A small planted-block corpus: each doc draws mostly from one word block."""
+    rng = np.random.default_rng(seed)
+    vocab = [f"w{i}" for i in range(n_blocks * words_per_block)]
+    docs = []
+    for d in range(n_docs):
+        b = d % n_blocks
+        toks = []
+        for _ in range(doc_len):
+            if rng.random() < 0.85:
+                w = b * words_per_block + rng.integers(0, words_per_block)
+            else:
+                w = rng.integers(0, len(vocab))
+            toks.append(vocab[int(w)])
+        docs.append(toks)
+    return docs
+
+
+DOCS = _planted_docs()
+LINKS = [(i, i + 1) for i in range(0, 100, 2)]
+ITERS = 12
+
+
+def _fit(model_name, progress):
+    """Fit one of the three models with the given `progress` value; return it."""
+    if model_name == "OnlineLDA":
+        return topica.OnlineLDA(4, seed=13).fit(DOCS, iters=ITERS, progress=progress)
+    if model_name == "RTM":
+        return topica.RTM(4, seed=13).fit(DOCS, LINKS, iters=ITERS, progress=progress)
+    if model_name == "TensorLDA":
+        return topica.TensorLDA(4, seed=13).fit(DOCS, iters=ITERS, progress=progress)
+    raise AssertionError(model_name)
+
+
+MODELS = ["OnlineLDA", "RTM", "TensorLDA"]
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_callback_fires(model_name):
+    calls = []
+
+    def cb(it, total, info):
+        calls.append((it, total, info))
+
+    _fit(model_name, cb)
+
+    assert calls, f"{model_name}: progress callback never fired"
+    for it, total, info in calls:
+        assert isinstance(info, dict)
+        assert 1 <= it <= total
+        # Every call reports the iteration budget as the total, except a
+        # convergence snap, which reports (n, n).
+        assert total == ITERS or it == total, (it, total)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_keyboardinterrupt_aborts(model_name):
+    def cb(it, total, info):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit(model_name, cb)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_non_callable_is_typeerror(model_name):
+    with pytest.raises(TypeError):
+        _fit(model_name, 5)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_is_deterministic(model_name):
+    noop = _fit(model_name, lambda *a: None)
+    none = _fit(model_name, None)
+    np.testing.assert_array_equal(noop.topic_word, none.topic_word)

--- a/tests/test_progress_wordfish.py
+++ b/tests/test_progress_wordfish.py
@@ -1,0 +1,83 @@
+"""Fit-progress callback for Wordfish and TBIP (#786).
+
+Each model's ``fit(progress=cb)`` must call ``cb(iteration, total, metric)`` once
+per main-loop iteration, drive iteration up to the ``iters`` budget (a Wordfish
+convergence snap may report ``(n, n)``), abort on a callback that raises
+``KeyboardInterrupt``, reject a non-callable ``progress``, and leave the fit
+bit-identical to a ``progress=None`` run at the same seed.
+"""
+
+import numpy as np
+import pytest
+
+import topica
+
+# ~200 short token lists over a ~40-word vocab, two planted themes so the
+# Poisson scaling has a real axis to find.
+_RNG = np.random.RandomState(0)
+_BLOCK_A = [f"a{i}" for i in range(20)]
+_BLOCK_B = [f"b{i}" for i in range(20)]
+DOCS = []
+for d in range(200):
+    # Mix the two blocks with a doc-specific tilt so authors differ.
+    tilt = (d % 10) / 10.0
+    doc = []
+    for _ in range(8):
+        block = _BLOCK_A if _RNG.rand() < tilt else _BLOCK_B
+        doc.append(block[_RNG.randint(0, len(block))])
+    DOCS.append(doc)
+
+GROUPS = [f"g{i % 4}" for i in range(len(DOCS))]
+
+
+def _fit(model_name, iters, progress):
+    if model_name == "Wordfish":
+        return topica.Wordfish().fit(DOCS, iters=iters, progress=progress)
+    if model_name == "TBIP":
+        return topica.TBIP(5).fit(DOCS, group=GROUPS, iters=iters, progress=progress)
+    raise AssertionError(model_name)
+
+
+def _array(model_name, model):
+    if model_name == "Wordfish":
+        return model.author_positions
+    return model.topic_word
+
+
+MODELS = ["Wordfish", "TBIP"]
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_callback_fires(model_name):
+    iters = 12
+    calls = []
+    _fit(model_name, iters, lambda it, total, metric: calls.append((it, total)))
+    assert calls, f"{model_name}: progress callback never fired"
+    # Every reported total is the iter budget, except a convergence snap that
+    # reports (n, n).
+    assert all(total == iters or it == total for it, total in calls), (
+        f"{model_name}: unexpected totals: {calls[:5]}"
+    )
+    assert calls[0][0] == 1
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_abort_raises(model_name):
+    def boom(it, total, metric):
+        raise KeyboardInterrupt
+
+    with pytest.raises(KeyboardInterrupt):
+        _fit(model_name, 40, boom)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_type_validation(model_name):
+    with pytest.raises(TypeError):
+        _fit(model_name, 20, 5)
+
+
+@pytest.mark.parametrize("model_name", MODELS)
+def test_progress_determinism(model_name):
+    a = _array(model_name, _fit(model_name, 12, None))
+    b = _array(model_name, _fit(model_name, 12, lambda *args: None))
+    assert np.array_equal(a, b), f"{model_name}: progress callback perturbed the fit"


### PR DESCRIPTION
Completes the phase-2 progress rollout (#786), following #797 (15 models). Adds the opt-in `progress=` fit callback to the last iterative models whose big-corpus fit (10k docs, default iters) exceeds ~5s:

| model | benchmark | metric |
|---|--:|---|
| TBIP | 74s | VAE ELBO (ll) |
| OnlineLDA | 12s | per-pass ELBO (ll) |
| RTM | 6.7s | bar/ETA (variational + gibbs) |
| Wordfish | 6.5s | Poisson log-likelihood (ll) |
| TensorLDA | 5.5s | bar/ETA (experimental) |

All reuse the shared `on_progress_ll` / `on_progress_bare` factories and the `resolve_progress` / `reraise_if_interrupted` contract from #794/#797. Same guarantees: opt-in, off by default, **bit-identical to a no-progress fit**, KeyboardInterrupt aborts and propagates, non-callable `progress=` raises `TypeError`, `True`/`False` toggle the bar.

Notes:
- RTM wires both inference backends (`variational` and `gibbs`); bar-only since the Gibbs backend has no cheap per-sweep bound.
- Wordfish/TensorLDA are deterministic (no RNG), so `on_progress` is threaded as the last core arg.
- TensorLDA is experimental-gated; its test enables experimental.

This closes out #786's phase-2 model rollout. Per-model callback/abort/type/determinism tests added; `.pyi` stubs updated.

Local gate: preflight (fmt + clippy + tables + stub + compat) green; full `pytest tests/` **5160 passed, 38 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)