### PR TITLE
chore(ci): pin the Rust toolchain to one source of truth

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,6 +32,14 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
+# Pin the Rust toolchain so a new stable release cannot move CI ahead of a
+# contributor's local clippy (which twice landed red-lint pushes in 2026-08).
+# Keep this in lockstep with `rust-toolchain.toml` (which drives local dev);
+# `scripts/preflight.sh` fails if the two disagree. Bumping is a deliberate,
+# reviewed edit to both, not a silent `@stable` upgrade.
+env:
+  RUST_TOOLCHAIN: "1.98.0"
+
 # ---------------------------------------------------------------------------
 # Job: test
 # Builds the extension in-place with `maturin develop` and runs pytest.
@@ -64,9 +72,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust (pinned)
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           components: rustfmt, clippy
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
@@ -86,8 +95,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust (pinned)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
       # `--workspace` so the extracted `topica-core` member is tested too, not
@@ -113,9 +124,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Install stable Rust toolchain (required for maturin/pyo3 compilation).
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+      # Install the pinned Rust toolchain (required for maturin/pyo3 compilation).
+      - name: Install Rust (pinned)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       # Cache the cargo registry and target/ across runs so the release compile
       # is paid once and reused, not rebuilt cold every time.
@@ -179,8 +192,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust (pinned)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Cache Rust build
         uses: Swatinem/rust-cache@v2
@@ -307,8 +322,10 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Install Rust (stable)
-        uses: dtolnay/rust-toolchain@stable
+      - name: Install Rust (pinned)
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -417,8 +434,9 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
         with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
           targets: ${{ matrix.target }}
 
       - name: Install musl tools (Linux)

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,6 +14,10 @@ on:
 permissions:
   contents: write
 
+# Pinned to match rust-toolchain.toml (and CI.yml); preflight fails on drift.
+env:
+  RUST_TOOLCHAIN: "1.98.0"
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
@@ -25,7 +29,9 @@ jobs:
           python-version: "3.11"
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ env.RUST_TOOLCHAIN }}
 
       - name: Build the extension and deploy the docs
         shell: bash

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,12 @@
+# Single source of truth for the Rust toolchain, so local dev and GitHub CI use
+# the *same* clippy/rustfmt and a new stable release cannot silently move CI ahead
+# of a contributor's local toolchain (which twice landed red-lint pushes in
+# 2026-08). rustup auto-installs this version on any cargo/clippy/rustc call in the
+# repo; CI reads this file via `dtolnay/rust-toolchain@master`.
+#
+# To adopt a newer stable: bump `channel` here in its own small PR (that is the
+# deliberate, reviewed upgrade), then `rustup update` locally. Nothing else pins a
+# version — the workflows all read this file.
+[toolchain]
+channel = "1.98.0"
+components = ["rustfmt", "clippy"]

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -9,9 +9,10 @@
 #
 # It runs the EXACT commands CI runs, in order of cheapest-first:
 #   1. cargo fmt --all --check
-#   2. cargo clippy --workspace --all-targets --all-features -- -D warnings
-#   3. generated model tables are in sync (scripts/gen_model_tables.py --check)
-#   4. the .pyi type stub is in sync with the compiled extension (test_stub_sync.py)
+#   2. the Rust toolchain pin agrees (rust-toolchain.toml == the workflow env)
+#   3. cargo clippy --workspace --all-targets --all-features -- -D warnings
+#   4. generated model tables are in sync (scripts/gen_model_tables.py --check)
+#   5. the .pyi type stub is in sync with the compiled extension (test_stub_sync.py)
 #
 # Steps 3-4 need `topica` importable; they use $VIRTUAL_ENV or .venv-dev, and are
 # skipped with a warning (not a hard failure) if no dev venv is present, so the
@@ -27,6 +28,42 @@ step "cargo fmt --all --check"
 if ! cargo fmt --all --check; then
     echo "  -> run 'cargo fmt --all' to fix" >&2
     fail=1
+fi
+
+# The Rust toolchain is pinned in one place, `rust-toolchain.toml`, which drives
+# local dev (rustup auto-selects it) AND CI (the workflows pass it via a
+# RUST_TOOLCHAIN env). If those drift, CI's clippy differs from local clippy and a
+# new stable can land a red-lint push (as happened twice in 2026-08). Fail on any
+# mismatch so the pin stays a single source of truth. Bump by editing
+# rust-toolchain.toml *and* the workflow env together, then `rustup update`.
+step "rust toolchain pin agrees across rust-toolchain.toml and the workflows"
+pin="$(sed -n 's/^channel *= *"\([^"]*\)".*/\1/p' rust-toolchain.toml | head -1)"
+if [ -z "$pin" ]; then
+    echo "  -> could not read channel from rust-toolchain.toml" >&2
+    fail=1
+else
+    ok=1
+    for wf in .github/workflows/CI.yml .github/workflows/docs.yml; do
+        wf_pin="$(sed -n 's/.*RUST_TOOLCHAIN: *"\([^"]*\)".*/\1/p' "$wf" | head -1)"
+        if [ "$wf_pin" != "$pin" ]; then
+            echo "  -> $wf pins RUST_TOOLCHAIN='$wf_pin' but rust-toolchain.toml pins '$pin'" >&2
+            ok=0
+        fi
+    done
+    if command -v rustc >/dev/null 2>&1; then
+        active="$(rustc --version 2>/dev/null | awk '{print $2}')"
+        if [ "$active" != "$pin" ]; then
+            echo "  -> active rustc is $active but the repo pins $pin; run 'rustup update'" >&2
+            echo "     (rustup honors rust-toolchain.toml, so this usually just needs the" >&2
+            echo "     pinned toolchain installed)." >&2
+            ok=0
+        fi
+    fi
+    if [ "$ok" = 1 ]; then
+        echo "pinned at $pin, local and CI agree"
+    else
+        fail=1
+    fi
 fi
 
 step "cargo clippy --workspace --all-targets --all-features -- -D warnings"


### PR DESCRIPTION
## Problem

CI installed Rust with `dtolnay/rust-toolchain@stable` — the *latest* stable at run time. When a new stable released, CI's clippy moved ahead of a contributor's local clippy, and preflight (running the older local clippy) could not catch lints CI would enforce. This landed red-lint pushes twice in August 2026, most recently a `needless_late_init` in `src/tbip.rs` (local clippy 1.96, CI clippy 1.98).

## Fix: pin to a single source of truth

- **`rust-toolchain.toml`** (new) pins the version. rustup auto-selects it for every local `cargo`/`clippy`/`rustc` call, so local dev matches CI by construction.
- **Both workflows** read a `RUST_TOOLCHAIN` env (the same version) and pass it to every `dtolnay/rust-toolchain@master` step. (`@master` + explicit `toolchain:` input is dtolnay's documented pinned-version usage; the action does **not** read `rust-toolchain.toml` itself, hence the env.)
- **`scripts/preflight.sh`** now fails if `rust-toolchain.toml`, the workflow env, and the active `rustc` disagree — so the pin cannot silently drift.

A new stable can no longer move CI underneath us. Upgrading is a deliberate, reviewed bump of `rust-toolchain.toml` + the workflow env together, then `rustup update` locally.

## Validation

This PR's own CI run is the test that `@master` + `toolchain: 1.98.0` resolves correctly across the lint, rust-test, build, docs, and wheel jobs. Locally: preflight passes (pin agrees at 1.98.0), clippy clean on the pinned toolchain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)