### PR TITLE
feat(dx): topica.guide() cheat sheet + task recipes for agents and newcomers

### DIFF
--- a/.claude/skills/topica-analysis/SKILL.md
+++ b/.claude/skills/topica-analysis/SKILL.md
@@ -49,8 +49,8 @@ roster. `guide()` ships in the wheel, so it works from a bare `pip install topic
 with no repository checkout. For task-shaped starting points you can transplant
 onto the researcher's data (explore with LDA and justify K, seed named concepts
 with keyATM, short text with GSDMM, embedding clusters with BERTopic, compare
-prevalence or wording across groups, track a topic over time), copy from
-`examples/recipes/` in the
+prevalence or wording across groups, track a topic over time, bootstrap topic
+robustness, record provenance), copy from `examples/recipes/` in the
 [repository](https://github.com/nealcaren/topica/tree/main/examples/recipes),
 which has one recipe per common task.
 

--- a/.claude/skills/topica-analysis/SKILL.md
+++ b/.claude/skills/topica-analysis/SKILL.md
@@ -40,6 +40,20 @@ Because the count-based variational models (`CTM`, `STM`, `DTM`,
 seed-reproducible, "run it again and see if the topics hold" is a real test here,
 not a hope. Use that.
 
+**First move at the REPL: `topica.guide()`.** It prints a one-screen cheat sheet
+built live from the installed build — the canonical workflow, a goal-to-model
+chooser, the read surface above, and the helper namespaces — so you do not have to
+guess signatures or grep the type stub. `topica.guide("STM")` prints one model's
+constructor and `fit` signatures; `topica.guide(full=True)` prints the whole
+roster. `guide()` ships in the wheel, so it works from a bare `pip install topica`
+with no repository checkout. For task-shaped starting points you can transplant
+onto the researcher's data (explore with LDA and justify K, seed named concepts
+with keyATM, short text with GSDMM, embedding clusters with BERTopic, compare
+prevalence or wording across groups, track a topic over time), copy from
+`examples/recipes/` in the
+[repository](https://github.com/nealcaren/topica/tree/main/examples/recipes),
+which has one recipe per common task.
+
 ## How topica changes the standard advice
 
 If you have internalized the usual computational-text-analysis guidance ("STM is

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,8 +48,8 @@ roster. `guide()` ships in the wheel, so it works from a bare `pip install topic
 with no repository checkout. For task-shaped starting points you can transplant
 onto the researcher's data (explore with LDA and justify K, seed named concepts
 with keyATM, short text with GSDMM, embedding clusters with BERTopic, compare
-prevalence or wording across groups, track a topic over time), copy from
-`examples/recipes/` in the
+prevalence or wording across groups, track a topic over time, bootstrap topic
+robustness, record provenance), copy from `examples/recipes/` in the
 [repository](https://github.com/nealcaren/topica/tree/main/examples/recipes),
 which has one recipe per common task.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,20 @@ Because the count-based variational models (`CTM`, `STM`, `DTM`,
 seed-reproducible, "run it again and see if the topics hold" is a real test here,
 not a hope. Use that.
 
+**First move at the REPL: `topica.guide()`.** It prints a one-screen cheat sheet
+built live from the installed build — the canonical workflow, a goal-to-model
+chooser, the read surface above, and the helper namespaces — so you do not have to
+guess signatures or grep the type stub. `topica.guide("STM")` prints one model's
+constructor and `fit` signatures; `topica.guide(full=True)` prints the whole
+roster. `guide()` ships in the wheel, so it works from a bare `pip install topica`
+with no repository checkout. For task-shaped starting points you can transplant
+onto the researcher's data (explore with LDA and justify K, seed named concepts
+with keyATM, short text with GSDMM, embedding clusters with BERTopic, compare
+prevalence or wording across groups, track a topic over time), copy from
+`examples/recipes/` in the
+[repository](https://github.com/nealcaren/topica/tree/main/examples/recipes),
+which has one recipe per common task.
+
 ## How topica changes the standard advice
 
 If you have internalized the usual computational-text-analysis guidance ("STM is

--- a/docs/guides/agent-cheatsheet.md
+++ b/docs/guides/agent-cheatsheet.md
@@ -1,0 +1,318 @@
+# Agent cheat sheet
+
+A one-screen reference for an LLM agent or a first-time user who has just run
+`import topica` and needs the canonical patterns without reading the whole
+documentation set. Everything below is also available at the REPL:
+
+```python
+import topica
+
+topica.guide()            # the one-screen essentials, printed
+topica.guide("STM")       # one model: purpose, signatures, first calls
+topica.guide(full=True)   # every validated model, grouped
+```
+
+`topica.guide()` renders live from the model registry and each model's real
+signature, so it always matches the installed build. It ships in the wheel, so it
+is available from a plain `pip install topica` with no repository checkout. The
+page below is generated from the same builder; do not edit it by hand. Edit
+`python/topica/_guide.py` and run `scripts/gen_guide.py`.
+
+For task-shaped starting points you can transplant onto your own data (compare
+prevalence across groups, compare how groups word a topic, track topics over
+time), see the [task recipes](https://github.com/nealcaren/topica/tree/main/examples/recipes)
+in `examples/recipes/`.
+
+<!-- BEGIN GUIDE (generated from topica.guide via scripts/gen_guide.py; edit _guide.py, not this block) -->
+
+## The one-screen guide
+
+```text
+topica - quick guide for agents and first-time users
+
+THE WORKFLOW (a full LDA analysis in five lines)
+    import topica
+    corpus = topica.from_dataframe(df, text_col="text")      # build + prune vocab
+    res    = topica.select.search_k(corpus, ks=[10, 20, 30])  # choose K; res.best_k()
+    model  = topica.LDA(num_topics=res.best_k()).fit(corpus)
+    topica.inspect.topic_table(model)                         # labelled topics
+    # with metadata:
+    topica.effects.estimate_effect(model, X=X, corpus=corpus) # covariate effects + CIs
+
+EVERY FITTED MODEL EXPOSES THE SAME SURFACE
+    model.topic_word                           (K, V) topic-word matrix; rows sum to 1 (generative models)
+    model.doc_topic                            (D, K) document-topic matrix; rows sum to 1
+    model.vocabulary                           V words, aligned to topic_word columns
+    model.top_words(n)                         list[list[str]] top n per topic; weights=True for (word, prob)
+    model.num_topics / .doc_names / .settings  K, row labels, and the fit config as a dict
+    model.save(path) / Model.load(path)        round-trip a fitted model to disk
+
+PICK A MODEL BY GOAL
+  Common openings:
+    Explore themes with no prior structure
+        -> LDA (or NMF): `search_k()`, `topic_table()`
+    Relate topics to metadata (author, date, party)
+        -> STM (or DMR): `estimate_effect()`, `one_hot()`, `spline()`
+    Measure concepts you can name in advance
+        -> KeyATM (or SeededLDA): `KeyATM(keywords=…)`, `.keyword_rate`
+    Very short documents: tweets, headlines, survey answers
+        -> GSDMM (or PT): `fit()`
+    Cluster by meaning using embeddings
+        -> BERTopic (or ETM): `fit(docs, doc_embeddings=…)`
+  Specialized (start here when your design calls for it):
+    Topics shift over time slices
+        -> DTM (or DETM): `fit(docs, times=…)`
+    Documents linked in a network (citations, replies)
+        -> RTM: `fit(docs, links=…)`
+    Documents in more than one language
+        -> PolylingualLDA: `fit(doc_tuples)`
+    Place authors or actors on an ideological scale
+        -> Wordfish (or TBIP): `fit(docs)`
+    How tone or sentiment varies with metadata
+        -> STS: `estimate_effect()`
+
+HELPER NAMESPACES (topica.<stage>.*)
+    select                             choosing K (search_k, select_model)
+    inspect                            reading topics (label_topics, topic_table, frex, find_thoughts)
+    evaluate                           validation (coherence, exclusivity, topic_stability, perplexity)
+    effects                            covariate effects (estimate_effect, predicted_prevalence)
+    design                             design matrices (one_hot, design_matrix, spline)
+    data                               corpus + bundled datasets (from_dataframe, tokenize, datasets)
+    compare / provenance / embeddings  two-fit drift, analysis manifest, embedding I/O
+
+GO DEEPER
+    topica.guide("STM")      one model: signatures + first calls
+    topica.guide(full=True)  every model, grouped
+    help(topica.STM)         full constructor / fit docstrings
+    topica.list_models()     the roster (list_models(group=...) to filter)
+    docs: https://nealcaren.github.io/topica/
+```
+
+## Every validated model
+
+```text
+topica model reference (validated roster)
+
+### General-purpose
+
+LDA(num_topics, *, alpha_sum=None, beta=0.01, optimize_interval=50, burn_in=200, seed=13, num_threads=1, sampler='sparse', mh_steps=2, use_symmetric_alpha=False, init='random')
+    Classic latent Dirichlet allocation via a fast SparseLDA collapsed-Gibbs sampler.
+    .fit(data, *, iters=1000, num_samples=5, sample_interval=25, progress=None, progress_interval=50, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, check_every=10, num_threads=None, turbo_merge_every=1)
+
+OnlineLDA(num_topics, *, alpha_sum=None, beta=0.01, tau=1.0, kappa=0.7, batch_size=256, inner_iters=100, mean_change_tol=0.001, total_docs=None, seed=13)
+    Online (streaming) variational-Bayes LDA (Hoffman et al. 2010): minibatch stochastic VB with a decaying learning rate and a streaming partial_fit; the gensim LdaModel analogue for very large or streaming corpora.
+    .fit(data, *, iters=100, convergence_tol=0.0, progress=None)
+
+CTM(num_topics, *, sigma_shrink=0.0, seed=13, init='spectral', variational='laplace')
+    Correlated topic model: a logistic-normal prior that lets topics co-occur.
+    .fit(data, *, iters=500, convergence_tol=1e-05, inference='batch', batch_size=256, tau=64.0, kappa=0.7, beta_init=None, em_tol=None, keep_eta_cov=True, num_threads=None, spectral_projection_threshold=Ellipsis, progress=None)
+
+ProdLDA(num_topics, *, alpha=1.0, hidden_size=100, dropout=0.2, batch_size=200, lr=0.002, convergence_tol=0.0, seed=13, prior=Ellipsis, contrastive=False, contrastive_weight=0.5, contrastive_temp=0.5, em_tol=None)
+    Product-of-experts LDA (AVITM) for sharper, more coherent topics; hand-coded VAE.
+    .fit(data, *, iters=None, convergence_tol=None, progress=None)
+
+HDP(*, alpha=0.1, gamma=0.1, beta=0.01, seed=13, resample_conc=True, concentration_max=1000000.0, eta=None)
+    Hierarchical Dirichlet process: infers the number of topics from the data.
+    .fit(data, *, iters=150, progress_interval=0, keep_theta_draws=True, num_theta_draws=25, report_interval=None)
+
+NMF(num_topics, *, beta_loss='frobenius', init='nndsvd', weighting='tfidf', convergence_tol=0.0001, seed=13)
+    Non-negative matrix factorization of the document-term matrix via multiplicative updates.
+    .fit(data, *, iters=None, convergence_tol=None, num_threads=None)
+
+LSA(num_topics, *, weighting='tfidf', seed=13)
+    Latent semantic analysis: a truncated SVD of the weighted document-term matrix.
+    .fit(data, *, num_threads=None)
+
+AnchorLDA(num_topics: 'int', *, recover: 'str' = 'kl', min_count: 'int' = 5, seed: 'int' = 13, eta: 'float' = 1.0, convergence_tol: 'float' = 1e-05, frex_w: 'float' = 0.5, frequency_temper: 'float' = 0.5, anchor_min_doc_freq: 'float' = 0.01)
+    Anchor-words spectral recovery (Arora et al. 2013): deterministic, Gibbs-free topics from the word co-occurrence matrix.
+    .fit(data, *, iters=None, min_count=None)
+
+PolylingualLDA(num_topics, *, alpha=None, beta=0.01, iters=1000, optimize_alpha=True, optimize_interval=10, optimize_burn_in=200, seed=13)
+    Polylingual topic model (Mimno et al. 2009): aligned topics across languages from document tuples that share one topic distribution.
+    .fit(data, *, iters=None, progress=None)
+
+CorEx(num_topics=2, *, anchor_words=None, anchor_strength=1.0, count='binarize', convergence_tol=1e-05, seed_match='fixed', case_insensitive=False, seed=13)
+    Correlation Explanation: information-theoretic topic model that maximizes total correlation; supports anchor words.
+    .fit(data, *, iters=None, convergence_tol=None, num_threads=None)
+
+MGLDA(num_global_topics, num_local_topics, *, window=3, alpha_global=0.1, alpha_local=0.1, alpha_mix_global=0.1, alpha_mix_local=0.1, beta_global=0.01, beta_local=0.01, gamma=0.1, seed=13)
+    Multi-Grain LDA: global (document-level) + local (sliding-window aspect) topics with a per-token grain switch. For reviews / aspect extraction.
+    .fit(data, *, iters=1000, progress=None)
+
+TopicalNGrams(num_topics, *, alpha_sum=50.0, beta=0.01, gamma=0.01, delta1=1.0, delta2=1.0, min_count=1, seed=13)
+    Topical N-Grams (Wang, McCallum & Wei 2007): an LDA extension that jointly discovers topics and topic-specific multiword phrases. A per-token bigram-status indicator, sampled with the topic, decides whether a token continues a phrase from the previous word given its topic, so phrase structure is learned during fitting rather than fixed beforehand. Exposes top_phrases alongside top_words.
+    .fit(data, *, iters=1000, progress=None)
+
+### Covariates & structure
+
+STM(num_topics, *, sigma_shrink=0.0, seed=13, init='spectral', variational='laplace')
+    Structural topic model: relate topic prevalence and content to covariates.
+    .fit(data, prevalence=None, *, prevalence_names=None, content=None, content_names=None, content_time=None, content_smooth=1.0, content_prior_var=0.5, content_prior='l2', iters=500, convergence_tol=1e-05, gamma_prior='pooled', gamma_enet=1.0, beta_init=None, em_tol=None, covariates=None, keep_eta_cov=True, num_threads=None, spectral_projection_threshold=Ellipsis, progress=None)
+
+STS(num_topics, *, seed=13, init='spectral')
+    Structural topic-and-sentiment model over document metadata.
+    .fit(data, sentiment_seed, prevalence=None, *, prevalence_names=None, iters=30, convergence_tol=1e-05, kappa_estimation=None, kappa_ridge=0.001, em_tol=None, covariates=None, keep_eta_cov=True, reference='none', progress=None)
+
+SAGE(num_topics, *, alpha=0.1, prior='laplace', prior_variance=1.0, optimize_interval=50, burn_in=200, seed=13, lbfgs_iters=20)
+    Sparse additive generative model: the same topic worded differently across groups.
+    .fit(data, groups, *, group_names=None, iters=1000, num_samples=5, sample_interval=25, progress=None, progress_interval=50, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, check_every=10)
+
+DMR(num_topics, *, beta=0.01, optimize_interval=50, burn_in=200, seed=13, alpha=0.1, prior_variance=1.0, alpha_epsilon=1e-10, lbfgs_iters=20, sampler='sparse', num_threads=1)
+    Dirichlet-multinomial regression: a document-metadata prior on topic proportions.
+    .fit(data, features=None, *, feature_names=None, iters=1000, num_samples=5, sample_interval=25, progress=None, progress_interval=50, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, check_every=10, covariates=None, offset=None, num_threads=None)
+
+GDMR(num_topics: 'int', *, degrees: 'list[int]', beta: 'float' = 0.01, optimize_interval: 'int' = 50, burn_in: 'int' = 200, seed: 'int' = 13, sigma: 'float' = 1.0, sigma0: 'float' = 3.0, decay: 'float' = 0.0, alpha: 'float' = 0.1, metadata_range: 'list[tuple[float, float]] | None' = None, lbfgs_iters: 'int' = 20, sampler: 'str' = 'sparse', num_threads: 'int' = 1) -> 'None'
+    Generalized DMR with a smooth (Legendre-basis) prior over continuous covariates.
+    .fit(data: "'Corpus | Sequence[Sequence[str]]'", features=None, *, metadata_names=None, iters: 'int' = 1000, num_samples: 'int' = 5, sample_interval: 'int' = 25, keep_theta_draws: 'bool' = True, convergence_tol: 'float' = 0.0, check_every: 'int' = 10, covariates=None, metadata=None, progress=None) -> 'None'
+
+Scholar(num_topics, *, covariates=None, covariate_names=None, content=None, content_names=None, interactions=False, alpha=1.0, hidden_size=100, dropout=0.2, batch_size=200, lr=0.002, l2_prior_reg=0.0, l1_content_reg=0.0, convergence_tol=0.0, seed=13)
+    SCHOLAR (Card et al. 2018): a ProdLDA VAE with a covariate-shifted prevalence prior, an optional supervised label head, and optional content (topic-covariate) word deviations — neural STM prevalence + sLDA + SAGE.
+    .fit(data, *, covariates=None, labels=None, content=None, iters=None, convergence_tol=None, progress=None)
+
+RTM(num_topics, *, link=None, inference='variational', alpha=None, beta=0.1, rho=None, negative_ratio=1.0, ridge=1.0, seed=13)
+    Relational topic model (Chang & Blei 2010): jointly models document text and a link graph (citations, hyperlinks, adjacency); predicts links from words and words from links.
+    .fit(data, links, *, iters=50, e_sweeps=3, e_inner=5, progress=None)
+
+FactorialLDA(factor_sizes, *, sigma_alpha=1.0, sigma_alpha_bias=1.0, sigma_omega=0.5, sigma_omega_bias=10.0, delta0=0.1, delta1=0.1, alpha_bias_init=Ellipsis, omega_bias_init=Ellipsis, step_alpha_doc=0.01, step_alpha_corpus=None, step_alpha_bias=None, step_omega=0.001, step_omega_bias=None, step_beta=0.001, block_freq=1, weight_burnin=100, word_priors=True, sparsity=True, symmetric_word_prior=False, seed=13)
+    Factorial LDA (Paul & Dredze 2012): each token is a K-tuple of latent factors (e.g. topic x sentiment); structured word priors tie tuples sharing a component and a sparsity prior deactivates unsupported tuples.
+    .fit(data, *, iters=2000, samples=100, eval_every=0, omega_priors=None, observed_factors=None, progress=None)
+
+AuthorTopic(num_topics, *, alpha=None, beta=0.01, seed=13)
+    Author-Topic Model: each author has a topic distribution; documents mix their authors. Answers what an author writes about.
+    .fit(data, authors, *, iters=1000, progress=None)
+
+AuthorRecipientTopic(num_topics: 'int', *, alpha: 'float | None' = None, beta: 'float | None' = 0.1, seed: 'int' = 13)
+    Author-Recipient-Topic (McCallum et al. 2007): topics conditioned on the (sender, recipient) pair, for the language of a directed social network (who talks to whom about what). Realized over the AuthorTopic engine.
+    .fit(docs: 'Sequence[Sequence[str]]', *, authors: 'Sequence', recipients: 'Sequence[Sequence]', iters: 'int' = 1000, progress=None)
+
+### Guided & supervised
+
+KeyATM(keywords, *, num_topics=None, alpha=None, beta=0.01, beta_keyword=0.1, gamma1=1.0, gamma2=1.0, seed=13, estimate_alpha=True, sampler='sparse', num_threads=1)
+    Keyword-assisted topics: anchor named topics with a few seed words each.
+    .fit(data, *, iters=1500, covariates=None, feature_names=None, times=None, timestamps=None, num_states=5, weights='information-theory', num_threads=None, optimize_interval=50, burn_in=200, prior_variance=1.0, lbfgs_iters=20, progress_interval=0, prior_offset=None, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, report_interval=None, turbo_alpha_stride=1, progress=None)
+
+SeededLDA(seed_words, *, residual=0, alpha=0.5, beta=0.1, weight=0.01, seed=13, seed_prior='frequency', sampler='sparse', seed_match='fixed', case_insensitive=False, num_threads=1)
+    Seeded LDA: steer named topics toward supplied seed words.
+    .fit(data, *, iters=2000, doc_topic_prior=None, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, check_every=10, num_threads=None, progress=None)
+
+GuidedNMF(num_topics, seed_words, *, guidance=3.0, lam=None, seed_weight=1.0, init='random', weighting='tfidf', convergence_tol=0.0, seed_match='fixed', case_insensitive=False, init_a=None, init_s=None, init_b=None, seed=13)
+    Guided NMF: seed-word-guided semi-supervised NMF; the matrix-factorization analogue of SeededLDA.
+    .fit(data, *, iters=None, convergence_tol=None, num_threads=None)
+
+LabeledLDA(*, alpha=0.1, beta=0.01, seed=13, sampler='sparse', num_threads=1)
+    Labeled LDA: each document label is a topic; tokens are restricted to its labels.
+    .fit(data, labels, *, label_names=None, iters=1000, num_samples=5, sample_interval=25, progress=None, progress_interval=50, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, check_every=10, num_threads=None)
+
+SupervisedLDA(num_topics, *, alpha=0.1, seed=13, inference='variational')
+    Supervised LDA: topics shaped to predict a per-document real-valued response.
+    .fit(data, y, *, iters=25, var_iters=15, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, check_every=1, num_threads=None, progress=None)
+
+DiscLDA(k_class, k_shared, *, alpha=None, beta=0.01, iters=1000, infer_sweeps=100, class_prior=None, seed=13)
+    Discriminative LDA (Lacoste-Julien et al. 2008): topics split into per-class and shared blocks; reads how classes talk differently.
+    .fit(data, y, *, iters=None, progress=None)
+
+### Short text
+
+GSDMM(num_topics, *, alpha=0.1, beta=0.1, seed=13, num_threads=1)
+    Gibbs-sampling Dirichlet mixture: one topic per short document.
+    .fit(data, *, iters=30, progress_interval=0, report_interval=None, num_threads=1, verbose=False, progress=None)
+
+PT(num_topics, *, num_pseudo=100, alpha=0.1, beta=0.01, pseudo_doc_prior=0.1, seed=13, num_threads=1)
+    Pseudo-document topic model: pool short texts into pseudo-documents.
+    .fit(data, *, iters=1000, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, check_every=10, num_threads=None, progress=None)
+
+BTM(num_topics, *, alpha=None, beta=0.01, iters=1000, window=15, background=False, seed=13, num_threads=1)
+    Biterm topic model: learns topics from corpus-level word co-occurrence (biterms).
+    .fit(data, *, iters=None, num_threads=None, progress=None)
+
+### Dynamic & hierarchical
+
+DTM(num_topics, *, alpha=0.01, chain_variance=0.005, obs_variance=0.5, seed=13, init='random')
+    Dynamic topic model: a fixed topic set whose word distributions drift across time slices.
+    .fit(data, times, *, iters=20, progress=None)
+
+DETM(num_topics, *, delta=0.005, hidden_size=800, eta_hidden_size=200, eta_nlayers=3, batch_size=1000, lr=0.005, wdecay=1.2e-06, grad_clip=None, convergence_tol=0.0, seed=13)
+    Dynamic embedded topic model: embedding-factored topics that drift across time slices, fit as an amortized VAE.
+    .fit(data, word_embeddings, vocabulary, *, times=None, timestamps=None, iters=100, convergence_tol=None, progress=None)
+
+TopicsOverTime(num_topics, *, alpha=None, beta=0.1, seed=13)
+    Topics over Time: LDA with a per-topic Beta density over continuous timestamps; each topic has a temporal peak. Descriptive continuous-time prevalence (not vocabulary drift).
+    .fit(data, times=None, *, timestamps=None, iters=1000, progress=None)
+
+HLDA(*, depth=3, gamma=1.0, beta=0.01, alpha=None, level_prior='dirichlet', gem_mean=0.5, gem_scale=100.0, seed=13, eta=None)
+    Hierarchical LDA (nested CRP): a learned tree of super- and sub-topics.
+    .fit(data, *, iters=500, num_threads=1, progress=None)
+
+PA(num_super, num_sub, *, alpha=0.1, beta=0.01, seed=13, num_threads=1)
+    Pachinko allocation: a DAG of super- and sub-topics.
+    .fit(data, *, iters=1000, keep_theta_draws=True, num_theta_draws=25, convergence_tol=0.0, check_every=10, num_threads=None, progress=None)
+
+### Embedding-based
+
+KeyNMF(num_topics, *, top_n=25, metric=Ellipsis, seed=13)
+    KeyNMF (Kristensen-McLachlan et al. 2024): NMF over an embedding-derived keyword-importance matrix. For each document it scores its words by the similarity between the document embedding and the word embedding, keeps the top-N positive, and factors that sparse doc-word matrix. The bridge between the count-based NMF family and the embedding backend; sparse, readable topics robust to short/noisy text.
+    .fit(data, doc_embeddings, *, word_embeddings, vocabulary, iters=None, convergence_tol=None)
+
+BERTopic(*, n_components=5, min_cluster_size=15, min_samples=None, nr_topics=None, window=4, stride=1, reducer='umap', n_neighbors=15, bm25=False, reduce_frequent=False, weighting='c-tf-idf', min_similarity=0.0, clusterer='hdbscan', num_clusters=None, resolution=1.0, knn_neighbors=15, diagnostics=True, min_dist=0.0, spread=1.0, n_epochs=0, negative_sample_rate=5, repulsion_strength=1.0, metric='cosine', seed=13)
+    Cluster document embeddings; label topics by class-based TF-IDF.
+    .fit(data, doc_embeddings)
+
+Top2Vec(*, n_components=5, min_cluster_size=15, min_samples=None, reducer='umap', n_neighbors=15, clusterer='hdbscan', num_clusters=None, resolution=1.0, knn_neighbors=15, diagnostics=True, min_dist=0.0, spread=1.0, n_epochs=0, negative_sample_rate=5, repulsion_strength=1.0, metric='cosine', seed=13)
+    Topics as dense regions in a joint document-word embedding space.
+    .fit(data, doc_embeddings, *, word_embeddings=None, vocabulary=None)
+
+SemanticSignalSeparation(num_topics, *, feature_importance=Ellipsis, iters=200, convergence_tol=0.0001, seed=13)
+    Topics as independent axes of semantic space (S3, Kardos et al. 2025): FastICA over the document embeddings, with each word's importance read off by projecting the vocabulary embeddings onto each axis. Signed poles.
+    .fit(data, doc_embeddings, vocab_embeddings, *, vocabulary=None)
+
+ETM(num_topics, *, inference='em', convergence_tol=0.0001, sigma_shrink=0.0, prior_variance=1000000.0, max_inner=25, hidden_size=800, batch_size=1000, lr=0.005, wdecay=1.2e-06, seed=13, prior=Ellipsis, contrastive=False, contrastive_weight=0.5, contrastive_temp=0.5, em_tol=None)
+    Embedded topic model: topic-word distributions factored through word embeddings.
+    .fit(data, word_embeddings, vocabulary, *, iters=None, convergence_tol=None, progress=None)
+
+GaussianLDA(num_topics, *, alpha=None, kappa=0.1, nu=None, psi_scale=3.0, init=Ellipsis, seed=13)
+    Gaussian LDA (Das, Zaheer & Dyer 2015): each topic is a Gaussian over the word-embedding space (Normal-Inverse-Wishart prior), so topics generalize over semantically similar words. Collapsed Gibbs with a Student-t posterior predictive and rank-1 Cholesky up/downdates.
+    .fit(data, word_embeddings, vocabulary, *, iters=None, progress=None)
+
+FASTopic(num_topics, *, lr=0.002, dt_alpha=3.0, tw_alpha=2.0, theta_temp=1.0, convergence_tol=1e-06, sinkhorn_iters=5000, sinkhorn_tol=0.005, seed=13, em_tol=None)
+    Topics from optimal-transport plans between document, topic, and word embeddings.
+    .fit(data, doc_embeddings, *, iters=None, convergence_tol=None, progress=None)
+
+CombinedTM(num_topics, *, alpha=1.0, hidden_size=100, dropout=0.2, batch_size=200, lr=0.002, convergence_tol=0.0, seed=13, prior=Ellipsis, contrastive=False, contrastive_weight=0.5, contrastive_temp=0.5)
+    Contextualized ProdLDA: encoder reads the bag of words plus a document embedding.
+    .fit(data, doc_embeddings, *, iters=None, convergence_tol=None)
+
+ZeroShotTM(num_topics, *, alpha=1.0, hidden_size=100, dropout=0.2, batch_size=200, lr=0.002, convergence_tol=0.0, seed=13, prior=Ellipsis, contrastive=False, contrastive_weight=0.5, contrastive_temp=0.5)
+    Contextualized ProdLDA: encoder reads the document embedding alone, enabling cross-lingual transfer.
+    .fit(data, doc_embeddings, *, iters=None, convergence_tol=None)
+
+InfoCTM(num_topics, *, mi_weight=30.0, mi_temperature=0.2, pos_threshold=0.4, hidden_size=100, dropout=0.0, lr=0.002, convergence_tol=0.0, seed=13, languages=None)
+    Cross-lingual: two ProdLDA models aligned by a bilingual dictionary through a mutual-information term.
+    .fit(data_a, data_b, *, dictionary, embeddings_a=None, embeddings_b=None, iters=None, batch_size=128, progress=None)
+
+### Ideal point
+
+Wordfish(*, beta_prior_sd=3.0, theta_prior_sd=1.0, min_count=1, convergence_tol=1e-06, seed=13)
+    Poisson scaling (Slapin & Proksch 2008): an unsupervised one-dimensional ideal-point estimate from word frequencies alone, no topics. The word-frequency baseline companion to IdealPointTM.
+    .fit(data, *, group=None, control=None, anchors=None, iters=None, convergence_tol=None, progress=None)
+
+Wordshoal(*, theta_prior_sd=1.0, loading_prior_sd=0.5, intercept_prior_sd=0.5, tau_prior=1.0, min_count=1, convergence_tol=0.001, seed=13)
+    Multi-domain scaling (Lauderdale & Herzog 2016): scales each debate/domain with Wordfish, then combines the within-domain positions into one cross-domain actor scale via a linear factor model. The multi-domain extension of Wordfish, for speeches carrying trusted debate labels.
+    .fit(data, *, speakers, domains, anchors=None, iters=None, convergence_tol=None)
+
+TBIP(num_topics, *, a_gamma=0.3, b_gamma=0.3, iters=7000, batch_size=512, learning_rate=0.05, min_count=1, seed=13)
+    Text-Based Ideal Points (Vafa, Naidu & Blei 2020): a Poisson factorization whose neutral topic-word intensities are rescaled by a per-word ideological factor exp(x_s * eta_kv), with the author position x_s latent. Fit by the paper's mean-field variational inference (reparameterized SVI). Recovers ideological scales from unlabeled text.
+    .fit(data, *, group=None, iters=None, batch_size=None, learning_rate=None, progress=None)
+
+PartyEmbeddings(num_dims=2, *, vector_size=200, window=20, min_count=5, negative=5, sample=0.0001, learning_rate=0.025, seed=13)
+    Party embeddings (Rheault & Cochrane 2020): a PV-DM paragraph-vector model trained by negative sampling with party-period metadata tags; the leading principal components of the learned party vectors give the ideological scale, and words share the space so a party's language can be read off by proximity. The corpus-trained word-embedding member of the ideal-point family.
+    .fit(data, *, group, control=None, anchors=None, iters=5)
+
+### LLM-based
+
+TopicGPT(*, backend: 'Optional[Callable[[str], str]]' = None, model: 'Optional[str]' = None, hierarchical: 'bool' = False, assignment: 'str' = 'hard', sample: 'Optional[int]' = None, max_topics: 'Optional[int]' = None, min_topic_count: 'int' = 1, temperature: 'float' = 0.0, seed: 'int' = 13, prompts: 'Optional[dict]' = None) -> 'None'
+    LLM-driven topic discovery: prompt a model to propose, refine, and assign a topic taxonomy with descriptions.
+    .fit(data, *, metadata=None) -> "'TopicGPT'"
+
+Experimental models are omitted; enable_experimental() then list_models(experimental=True) to see them.
+```
+<!-- END GUIDE -->

--- a/docs/guides/agent-cheatsheet.md
+++ b/docs/guides/agent-cheatsheet.md
@@ -79,12 +79,14 @@ HELPER NAMESPACES (topica.<stage>.*)
     design                             design matrices (one_hot, design_matrix, spline)
     data                               corpus + bundled datasets (from_dataframe, tokenize, datasets)
     compare / provenance / embeddings  two-fit drift, analysis manifest, embedding I/O
+    -> guide("<name>") prints any helper's signature (e.g. guide("estimate_effect"))
 
 GO DEEPER
-    topica.guide("STM")      one model: signatures + first calls
-    topica.guide(full=True)  every model, grouped
-    help(topica.STM)         full constructor / fit docstrings
-    topica.list_models()     the roster (list_models(group=...) to filter)
+    topica.guide("STM")            one model: signatures + first calls
+    topica.guide("topic_stability") one helper: signature + purpose
+    topica.guide(full=True)        every model, grouped
+    help(topica.STM)               full constructor / fit docstrings
+    topica.list_models()           the roster (list_models(group=...) to filter)
     docs: https://nealcaren.github.io/topica/
 ```
 

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -1,0 +1,27 @@
+# Task recipes
+
+Small, self-contained scripts organized by the **task** you were handed, not by
+the corpus they happen to use. Each is ~60 lines, runs on data that ships with
+topica (so it works with no download beyond the one noted), and is written to be
+transplanted: swap the load + column names at the top for your own DataFrame and
+the rest carries over. Each is smoke-tested in `tests/test_recipes.py`.
+
+| If your task is... | Recipe | Model |
+|---|---|---|
+| Explore themes with no prior structure, and justify K | [`lda_explore.py`](lda_explore.py) | LDA + search_k |
+| Measure concepts you can name in advance (seed words) | [`keyatm_seeded.py`](keyatm_seeded.py) | keyATM |
+| Topics for very short documents (tweets, survey answers) | [`gsdmm_short_text.py`](gsdmm_short_text.py) | GSDMM |
+| Cluster documents by meaning using embeddings | [`bertopic_embeddings.py`](bertopic_embeddings.py) | BERTopic |
+| Do two groups talk about different things? (treatment vs control, party A vs B) | [`stm_prevalence_groups.py`](stm_prevalence_groups.py) | STM prevalence covariate |
+| Do two groups word the same topics differently? | [`stm_content_groups.py`](stm_content_groups.py) | STM content covariate |
+| How does a topic's wording drift over time? | [`dtm_over_time.py`](dtm_over_time.py) | Dynamic Topic Model |
+
+Run any of them directly:
+
+```bash
+python examples/recipes/stm_prevalence_groups.py
+```
+
+For the canonical end-to-end STM walkthrough (labelling, FREX, topic correlation,
+representative documents), see [`../stm_vignette.py`](../stm_vignette.py). For the
+one-screen API cheat sheet, run `topica.guide()`.

--- a/examples/recipes/README.md
+++ b/examples/recipes/README.md
@@ -15,6 +15,8 @@ the rest carries over. Each is smoke-tested in `tests/test_recipes.py`.
 | Do two groups talk about different things? (treatment vs control, party A vs B) | [`stm_prevalence_groups.py`](stm_prevalence_groups.py) | STM prevalence covariate |
 | Do two groups word the same topics differently? | [`stm_content_groups.py`](stm_content_groups.py) | STM content covariate |
 | How does a topic's wording drift over time? | [`dtm_over_time.py`](dtm_over_time.py) | Dynamic Topic Model |
+| Are my topics real, or seed/sample noise? | [`robustness.py`](robustness.py) | bootstrap_stability |
+| Record provenance so the analysis reproduces | [`provenance.py`](provenance.py) | record_fit → AnalysisManifest |
 
 Run any of them directly:
 

--- a/examples/recipes/bertopic_embeddings.py
+++ b/examples/recipes/bertopic_embeddings.py
@@ -1,0 +1,47 @@
+"""Recipe: cluster documents by meaning using embeddings.
+
+Task shape: "I have sentence embeddings for my documents (from a transformer) and
+want topics that group by meaning, not by shared words." BERTopic reduces the
+embeddings, clusters them, and labels each cluster with c-TF-IDF words. topica
+takes the embeddings you supply, so there is no PyTorch in the wheel.
+
+Watch out: this is clustering, not a fitted posterior. There is no doc-topic
+distribution to compose, so covariate-effect estimation and topic-proportion
+uncertainty behave differently than for LDA/STM. Some documents fall in no
+cluster (an outlier "topic"); that is expected.
+
+Data here is the bundled `ng20_minilm` sample: 20-Newsgroups documents with
+precomputed MiniLM embeddings, fetched on first use. REPLACE it with your own
+texts + doc_embeddings (one row per document, aligned) and the rest transfers.
+
+Run:  python examples/recipes/bertopic_embeddings.py
+"""
+import numpy as np
+
+import topica
+
+# --- your data: texts + aligned embeddings ---------------------------------
+data = topica.datasets.load_ng20_minilm()
+texts = data.texts                 # list[str], one per document
+embeddings = data.doc_embeddings   # (n_docs, dim) float array, same order
+
+# The embeddings drive the clustering; the tokens only supply the c-TF-IDF topic
+# labels. Tokenize in place (no pruning) so docs stay aligned to embedding rows.
+docs = [topica.tokenize(t, stopwords=topica.stopwords("english"), min_length=3)
+        for t in texts]
+
+# --- fit: reduce -> cluster -> label ---------------------------------------
+# min_cluster_size is the main knob: larger = fewer, bigger topics. reducer="pca"
+# is used here for a stable, seed-reproducible layout; the default "umap" can
+# collapse to very few topics on some corpora (widen min_cluster_size or switch
+# reducer if that happens). For a fixed number of topics, pass
+# clusterer="kmeans", num_clusters=K instead of density clustering.
+model = topica.BERTopic(reducer="pca", min_cluster_size=25, seed=13).fit(docs, embeddings)
+
+# --- read the discovered topics --------------------------------------------
+# doc_topic is a soft assignment; column mass approximates each topic's size.
+sizes = np.asarray(model.doc_topic).sum(axis=0)
+order = np.argsort(sizes)[::-1]
+print(f"BERTopic on {len(texts)} documents -> {model.num_topics} topics discovered.\n")
+for t in order:
+    print(f"  topic {t}  (~{sizes[t]:.0f} docs): {', '.join(model.top_words(8, topic=t))}")

--- a/examples/recipes/dtm_over_time.py
+++ b/examples/recipes/dtm_over_time.py
@@ -1,0 +1,62 @@
+"""Recipe: track how topics evolve over time.
+
+Task shape: "The same topics run through the whole corpus, but their wording
+shifts across years. What did topic 3 sound like in the first period vs the
+last?" A Dynamic Topic Model (DTM) ties each period's topics to the previous
+period's, so you can read a topic's drift instead of refitting per year.
+
+Data here is the bundled `load_congress` press releases (2013-2024), fetched on
+first use and cached. The time slice is the calendar year. REPLACE the load +
+column names with your own DataFrame and the rest transfers unchanged.
+
+Kept deliberately small (subsampled, few EM iters) so it runs in under a minute;
+raise SAMPLE / ITERS / K for a real analysis.
+
+Run:  python examples/recipes/dtm_over_time.py
+"""
+import numpy as np
+
+import topica
+
+# --- your data -------------------------------------------------------------
+df = topica.datasets.load_congress()
+TEXT_COL = "text"
+TIME_COL = "year"       # any orderable period column: year, month index, wave
+K = 6
+SAMPLE = 800            # subsample for a quick demo; None uses all rows
+ITERS = 15
+
+if SAMPLE is not None and len(df) > SAMPLE:
+    df = df.sample(n=SAMPLE, random_state=13).reset_index(drop=True)
+
+# --- corpus + 0-based contiguous time-slice index --------------------------
+corpus = topica.from_dataframe(
+    df, text_col=TEXT_COL, metadata_cols=[TIME_COL], strip_html=True,
+    stopwords=topica.stopwords("english"), min_length=4, min_doc_freq=5,
+)
+years = corpus.metadata[TIME_COL].to_numpy(dtype=int)
+slices = sorted(set(years))
+slice_of = {y: i for i, y in enumerate(slices)}       # year -> 0-based slice
+times = np.array([slice_of[y] for y in years])
+
+# --- fit -------------------------------------------------------------------
+model = topica.DTM(num_topics=K, seed=13).fit(corpus, times, iters=ITERS)
+first, last = 0, len(slices) - 1
+print(f"DTM with K={K} over {len(slices)} yearly slices "
+      f"({slices[first]}-{slices[last]}), {corpus.num_docs} docs\n")
+
+# --- read a topic's wording at the first vs last period --------------------
+# model.top_words(topic, time, n) reads that period's topic-word distribution;
+# model.word_evolution(topic, word) returns the word's probability per slice.
+for t in range(K):
+    early = ", ".join(model.top_words(t, first, 6))
+    late = ", ".join(model.top_words(t, last, 6))
+    print(f"Topic {t}")
+    print(f"    {slices[first]}: {early}")
+    print(f"    {slices[last]}: {late}")
+
+# --- track one word's trajectory inside a topic ----------------------------
+topic, word = 0, model.top_words(0, last, 1)[0]
+traj = model.word_evolution(topic, word)
+line = "  ".join(f"{slices[i]}:{p:.3f}" for i, p in enumerate(traj))
+print(f"\nWord '{word}' in topic {topic} over time:\n    {line}")

--- a/examples/recipes/gsdmm_short_text.py
+++ b/examples/recipes/gsdmm_short_text.py
@@ -1,0 +1,40 @@
+"""Recipe: topics for very short documents (tweets, headlines, survey answers).
+
+Task shape: "My documents are one or two sentences each. Standard LDA gives mushy,
+over-fragmented topics." Short text breaks the LDA assumption that a document
+mixes several topics. GSDMM (a Dirichlet mixture) assigns ONE topic per document,
+which fits short text. You set an upper bound on the number of clusters; where the
+data supports fewer, GSDMM leaves clusters empty, so the retained count is a rough
+read on how many topics the corpus supports (widen the bound and refit to check).
+
+Data here is the bundled `gadarian` survey (short open-ended answers). REPLACE the
+load + text column with your own short documents; the rest transfers.
+
+Run:  python examples/recipes/gsdmm_short_text.py
+"""
+import numpy as np
+
+import topica
+
+# --- your (short) data -----------------------------------------------------
+df = topica.datasets.load_gadarian()
+TEXT_COL = "open.ended.response"
+K_MAX = 12       # an UPPER bound; GSDMM collapses unused clusters below this
+
+# --- corpus ----------------------------------------------------------------
+corpus = topica.from_dataframe(
+    df, text_col=TEXT_COL,
+    stopwords=topica.stopwords("english"), min_length=3, min_doc_freq=2,
+)
+
+# --- fit: one topic per document -------------------------------------------
+model = topica.GSDMM(num_topics=K_MAX, seed=13).fit(corpus, iters=40)
+
+# --- read the clusters the data actually supported -------------------------
+# doc_topic is one-hot here (each doc in one cluster), so column sums are the
+# cluster sizes; print only the populated clusters, largest first.
+sizes = np.asarray(model.doc_topic).sum(axis=0)
+populated = [t for t in np.argsort(sizes)[::-1] if sizes[t] >= 1]
+print(f"GSDMM started from K_MAX={K_MAX}; {len(populated)} clusters retained.\n")
+for t in populated:
+    print(f"  cluster {t}  (n={int(sizes[t])} docs): {', '.join(model.top_words(8, topic=t))}")

--- a/examples/recipes/keyatm_seeded.py
+++ b/examples/recipes/keyatm_seeded.py
@@ -1,0 +1,49 @@
+"""Recipe: measure concepts you can name in advance (seeded topics).
+
+Task shape: "I already know the themes I care about (say, economy, security,
+culture). Anchor topics to those concepts with a few seed words each, and tell me
+how much each anchored topic actually shows up." keyATM keeps your named topics
+(seeded by keywords) and can add unseeded topics for whatever else is there.
+
+Data here is the bundled `gadarian` immigration survey. REPLACE the load, the
+text column, and the KEYWORDS with your own concepts; the rest transfers.
+
+Run:  python examples/recipes/keyatm_seeded.py
+"""
+import topica
+
+# --- your data + your named concepts ---------------------------------------
+df = topica.datasets.load_gadarian()
+TEXT_COL = "open.ended.response"
+
+# One entry per concept: a label -> a few seed words that name it. Seed words
+# that are too rare to matter are dropped with a warning, so over-supply is safe.
+KEYWORDS = {
+    "economy_jobs": ["jobs", "taxes", "welfare", "money", "pay"],
+    "crime_security": ["crime", "border", "security", "illegal", "laws"],
+    "language_culture": ["english", "language", "learn", "speak", "assimilate"],
+}
+
+# --- corpus ----------------------------------------------------------------
+corpus = topica.from_dataframe(
+    df, text_col=TEXT_COL,
+    stopwords=topica.stopwords("english"), min_length=3, min_doc_freq=3,
+)
+
+# --- fit keyATM (named topics + a couple of unseeded ones) -----------------
+# num_topics >= len(KEYWORDS) adds unseeded topics for themes you did not name.
+model = topica.KeyATM(KEYWORDS, num_topics=5, seed=13).fit(corpus, iters=500)
+
+# --- read each named topic + how present it is -----------------------------
+# keyword_rate[t] is the share of topic t's mass carried by its seed words:
+# high = the anchor held; low = the concept is weak or the seeds were off.
+names = list(KEYWORDS)
+rate = model.keyword_rate
+print("Seeded topics (top words; keyword_rate = share of mass on seed words):\n")
+for t, name in enumerate(names):
+    words = ", ".join(model.top_words(8, topic=t))
+    print(f"  [{name}]  keyword_rate={rate[t]:.2f}")
+    print(f"      {words}")
+print("\nUnseeded topics (whatever else the corpus contains):")
+for t in range(len(names), model.num_topics):
+    print(f"  topic {t}: {', '.join(model.top_words(8, topic=t))}")

--- a/examples/recipes/lda_explore.py
+++ b/examples/recipes/lda_explore.py
@@ -1,0 +1,48 @@
+"""Recipe: explore themes with no prior structure, and justify K.
+
+Task shape: "Here is a corpus. What is it about, and how many topics should I
+use?" This is the default first pass. Scan a few values of K, let the metrics
+inform (not decide) the choice, fit LDA at that K, and read labelled topics.
+Choosing K is a judgment call the researcher owns; the scan makes it defensible.
+
+Data here is the bundled `gadarian` survey; it ships with topica. REPLACE the
+load + text column with your own DataFrame and the rest transfers unchanged.
+
+Run:  python examples/recipes/lda_explore.py
+"""
+import numpy as np
+
+import topica
+
+# --- your data -------------------------------------------------------------
+df = topica.datasets.load_gadarian()
+TEXT_COL = "open.ended.response"
+KS = [3, 4, 5, 6, 8]        # the candidate topic counts to scan
+
+# --- corpus ----------------------------------------------------------------
+corpus = topica.from_dataframe(
+    df, text_col=TEXT_COL,
+    stopwords=topica.stopwords("english"), min_length=3, min_doc_freq=3,
+)
+
+# --- scan K (stm's searchK): coherence + exclusivity per candidate ---------
+scan = topica.select.search_k(corpus, ks=KS, seed=13)
+K = scan.best_k()
+print(f"Scanned K in {KS}; frontier-suggested K = {K}")
+print("(A suggestion, not a verdict: read the topics at a couple of K before committing.)\n")
+
+# --- fit LDA at the chosen K -----------------------------------------------
+model = topica.LDA(num_topics=K, seed=13).fit(corpus)
+
+# --- read the topics -------------------------------------------------------
+# topic_table gives publication-ready prob + FREX labels; here we print the top
+# words per topic so the terminal output stays readable.
+print(f"LDA topics at K={K}:")
+for t, words in enumerate(model.top_words(8)):
+    print(f"  topic {t}: {', '.join(words)}")
+
+# --- how coherent are they? (a validation check, not a K selector) ---------
+topics = model.top_words(10)
+texts = [" ".join(doc) for doc in corpus.documents()]
+per_topic = topica.evaluate.coherence(topics, texts, coherence_type="c_v")
+print(f"\nMean c_v coherence: {float(np.mean(per_topic)):.3f}  (0-1; higher = more coherent)")

--- a/examples/recipes/provenance.py
+++ b/examples/recipes/provenance.py
@@ -1,0 +1,41 @@
+"""Recipe: record provenance so the analysis is reproducible.
+
+Task shape: "The reviewers (and future me) need to know exactly how this model was
+fit — the data fingerprint, the settings, the seed — to reproduce the numbers in
+the table." `record_fit` captures a fitted model plus its corpus and settings as
+an AnalysisManifest, which you then serialize (JSON for the replication archive,
+Markdown for the appendix).
+
+Note the shape: `record_fit(model, corpus, ...)` — the second argument is the
+CORPUS you fit on, not a path. It RETURNS a manifest object; you write it out
+yourself. Data here is the bundled `gadarian` survey.
+
+Run:  python examples/recipes/provenance.py
+"""
+import numpy as np
+
+import topica
+
+# --- fit something worth recording -----------------------------------------
+df = topica.datasets.load_gadarian()
+corpus = topica.from_dataframe(
+    df, text_col="open.ended.response", metadata_cols=["treatment", "pid_rep"],
+    stopwords=topica.stopwords("english"), min_length=3, min_doc_freq=3,
+)
+X = np.column_stack([corpus.metadata[c].to_numpy(dtype=float) for c in ["treatment", "pid_rep"]])
+model = topica.STM(num_topics=5, seed=13).fit(
+    corpus, prevalence=X, prevalence_names=["treatment", "pid_rep"], iters=80,
+)
+
+# --- record it -------------------------------------------------------------
+# Pass the same covariate design you fit with so the manifest records it too.
+manifest = topica.provenance.record_fit(
+    model, corpus, prevalence=X, prevalence_names=["treatment", "pid_rep"],
+)
+
+# --- serialize -------------------------------------------------------------
+# JSON for the replication archive; Markdown for the paper's appendix.
+manifest.save("gadarian_manifest.json")               # -> a JSON file on disk
+print("Wrote gadarian_manifest.json")
+print("\nProvenance card (Markdown, paste into an appendix):\n")
+print(manifest.to_markdown())

--- a/examples/recipes/robustness.py
+++ b/examples/recipes/robustness.py
@@ -1,0 +1,52 @@
+"""Recipe: are my topics real, or seed/sample noise?
+
+Task shape: "Before I put this K-topic model in a paper, how do I know the topics
+would survive a rerun or a slightly different sample?" Refit on bootstrap
+resamples of the corpus and score how stably each topic reappears. Fragile topics
+(low stability) are a signal that K is too high or the topic is an artifact.
+
+This is the step a first-time user often can't find: for a covariate model like
+STM you pass a `model_factory` (seed -> a fresh model) and thread the covariate
+design through `fit_kwargs`; `bootstrap_stability` resamples the documents AND the
+per-document covariates together, so the prevalence rows stay aligned.
+
+Data here is the bundled `gadarian` survey. REPLACE the load + columns with your
+own; the rest transfers.
+
+Run:  python examples/recipes/robustness.py
+"""
+import numpy as np
+
+import topica
+
+# --- your data -------------------------------------------------------------
+df = topica.datasets.load_gadarian()
+TEXT_COL = "open.ended.response"
+GROUP_COLS = ["treatment", "pid_rep"]
+K = 5
+
+corpus = topica.from_dataframe(
+    df, text_col=TEXT_COL, metadata_cols=GROUP_COLS,
+    stopwords=topica.stopwords("english"), min_length=3, min_doc_freq=3,
+)
+X = np.column_stack([corpus.metadata[c].to_numpy(dtype=float) for c in GROUP_COLS])
+
+# --- bootstrap stability of an STM at K -----------------------------------
+# model_factory(seed) returns a fresh model; fit_kwargs carries the covariate
+# design (resampled in tandem with the documents on each bootstrap draw).
+result = topica.evaluate.bootstrap_stability(
+    corpus,
+    n_boot=8,
+    seed=13,
+    model_factory=lambda seed: topica.STM(num_topics=K, seed=seed),
+    fit_kwargs=dict(prevalence=X, prevalence_names=GROUP_COLS, iters=80),
+)
+
+print(f"Bootstrap topic stability (STM, K={K}, 8 resamples):")
+print(f"  mean stability = {result['mean']:.2f}  (1.0 = topic reappears every resample)\n")
+stab = result["stability"]
+ref = result["reference"]
+for t in np.argsort(stab):        # least stable first — the ones to worry about
+    flag = "  <- fragile" if stab[t] < 0.5 else ""
+    print(f"  topic {t}: stability {stab[t]:.2f}  [{', '.join(ref.top_words(5, topic=t))}]{flag}")
+print("\nLow-stability topics argue for a smaller K or merging; report this, don't hide it.")

--- a/examples/recipes/stm_content_groups.py
+++ b/examples/recipes/stm_content_groups.py
@@ -1,0 +1,53 @@
+"""Recipe: compare how two groups word the same topics.
+
+Task shape: "Both groups discuss the same themes, but do they describe them
+differently?" That is a *content* covariate, not a prevalence one: the STM keeps
+one shared set of topics and learns a per-group word distribution for each, so
+you can read topic 3 "in group A's words" vs "in group B's words".
+
+Data here is the bundled `gadarian` survey; the content group is party id
+(`pid_rep`). REPLACE the load + column names with your own DataFrame and the rest
+transfers unchanged.
+
+Run:  python examples/recipes/stm_content_groups.py
+"""
+import numpy as np
+
+import topica
+
+# --- your data -------------------------------------------------------------
+df = topica.datasets.load_gadarian()
+TEXT_COL = "open.ended.response"
+GROUP_COL = "pid_rep"           # the content group; any string/int labels work
+LABEL = {0: "non-Rep", 1: "Republican"}   # 0/1 codes -> readable group names
+K = 4
+
+# --- corpus ----------------------------------------------------------------
+corpus = topica.from_dataframe(
+    df, text_col=TEXT_COL, metadata_cols=[GROUP_COL],
+    stopwords=topica.stopwords("english"), min_length=3, min_doc_freq=3,
+)
+# Content groups are self-naming: pass readable string labels, one per document.
+group = np.array([LABEL[v] for v in corpus.metadata[GROUP_COL].to_numpy(dtype=int)])
+
+# --- fit with a content covariate ------------------------------------------
+# `content=` makes the group shift word choice within shared topics (SAGE-style).
+model = topica.STM(num_topics=K, seed=13).fit(corpus, content=group, iters=100)
+
+# --- read each group's wording of each topic -------------------------------
+# topic_word_by_group is (num_topics, num_groups, vocab); model.groups gives the
+# group order. topic_polarization ranks topics by how much the groups diverge.
+vocab = np.asarray(model.vocabulary)
+by_group = model.topic_word_by_group
+groups = list(model.groups)
+polar = topica.content.topic_polarization(model)
+order = np.argsort(polar)[::-1]       # most group-divergent topics first
+
+print(f"STM with K={K}, content = ~{GROUP_COL}")
+print("Topics ordered by how differently the groups word them.\n")
+for t in order:
+    print(f"Topic {t}  (group divergence {polar[t]:.3f})")
+    for gi, g in enumerate(groups):
+        top = vocab[np.argsort(by_group[t, gi])[::-1][:7]]
+        print(f"    {str(g):>11}: {', '.join(top)}")
+    print()

--- a/examples/recipes/stm_prevalence_groups.py
+++ b/examples/recipes/stm_prevalence_groups.py
@@ -1,0 +1,56 @@
+"""Recipe: compare topic prevalence across two groups.
+
+Task shape: "Do these two groups (treatment vs control, party A vs B, before vs
+after) talk about different things?" Fit an STM with the group as a prevalence
+covariate, then read the per-topic effect with uncertainty. Positive effect =
+the group uses that topic more.
+
+Data here is the bundled `gadarian` survey (immigration open-ends, with an
+experimental `treatment` and party id `pid_rep`); it ships with topica so this
+runs with no download. REPLACE the load + column names with your own DataFrame
+and the rest transfers unchanged.
+
+Run:  python examples/recipes/stm_prevalence_groups.py
+"""
+import numpy as np
+
+import topica
+
+# --- your data -------------------------------------------------------------
+# One row per document; a text column and one or more group/covariate columns.
+df = topica.datasets.load_gadarian()
+TEXT_COL = "open.ended.response"
+GROUP_COLS = ["treatment", "pid_rep"]   # numeric 0/1 here; the effect is read for each
+FOCUS = "treatment"                     # the group contrast you want to report
+K = 5
+
+# --- corpus (metadata stays aligned to surviving documents) ----------------
+corpus = topica.from_dataframe(
+    df, text_col=TEXT_COL, metadata_cols=GROUP_COLS,
+    stopwords=topica.stopwords("english"), min_length=3, min_doc_freq=3,
+)
+meta = corpus.metadata
+# Prevalence design: the covariates, one column each. For a categorical group
+# use topica.design.one_hot(meta["col"]); for a nonlinear trend, design.spline().
+X = np.column_stack([meta[c].to_numpy(dtype=float) for c in GROUP_COLS])
+
+# --- fit -------------------------------------------------------------------
+model = topica.STM(num_topics=K, seed=13).fit(
+    corpus, prevalence=X, prevalence_names=GROUP_COLS, iters=80,
+)
+
+# --- read topics + the group effect ---------------------------------------
+print(f"STM with K={K}, prevalence = ~{' + '.join(GROUP_COLS)}\n")
+labels = topica.inspect.label_topics(model.topic_word, model.vocabulary, n=7)
+effects = topica.effects.estimate_effect(
+    model.doc_topic, X, feature_names=GROUP_COLS,
+)
+fi = effects[0].feature_names.index(FOCUS)
+print(f"Effect of '{FOCUS}' on each topic's prevalence (95% CI):")
+for t in range(K):
+    e = effects[t]
+    lo, hi = e.ci_low[fi], e.ci_high[fi]
+    flag = "*" if lo > 0 or hi < 0 else " "   # CI excludes zero
+    top = ", ".join(w for w, _ in labels[t]["prob"][:5])
+    print(f"{flag} topic {t} [{e.coef[fi]:+.3f}  ({lo:+.3f}, {hi:+.3f})]  {top}")
+print(f"\n* = 95% CI excludes zero. Positive = higher '{FOCUS}' raises the topic.")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -85,6 +85,7 @@ nav:
       - Installation: getting-started/installation.md
       - Quickstart: getting-started/quickstart.md
       - Choose an approach: can-do/index.md
+      - Agent cheat sheet: guides/agent-cheatsheet.md
   - From corpus to credible result:
       - Overview: publishing/index.md
       - 1. Build a defensible corpus: publishing/corpus.md

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -12,6 +12,11 @@ choosing K, ``inspect`` for reading topics, ``evaluate`` for validation, ``effec
 for covariate effects, ``data`` / ``design`` for corpus and design-matrix prep,
 ``compare`` / ``provenance`` for the rest.
 
+New here? Run ``topica.guide()`` for a one-screen cheat sheet — the workflow, the
+goal-to-model chooser, and the read surface every fitted model shares —
+``topica.guide("STM")`` for one model, or ``topica.guide(full=True)`` for the
+whole roster. It is rendered live, so it always matches the installed build.
+
 Start here (a full LDA workflow is only a few lines)::
 
     import topica
@@ -21,6 +26,11 @@ Start here (a full LDA workflow is only a few lines)::
     model = topica.LDA(num_topics=res.best_k()).fit(corpus)
     topica.inspect.topic_table(model)                       # publication-ready labels
     topica.effects.estimate_effect(model, X=X, corpus=corpus)  # covariate effects + CIs
+
+For metadata-aware topics, swap ``LDA`` for ``STM`` and pass a prevalence design::
+
+    model = topica.STM(num_topics=20).fit(corpus, prevalence=X)
+    topica.effects.estimate_effect(model, X=X, corpus=corpus)
 
 The main entry points, by task:
 
@@ -184,6 +194,32 @@ def summary(model, topn=8):
     except Exception:
         pass
     return "\n".join(lines)
+
+
+def guide(topic=None, *, full=False):
+    """Print the topica cheat sheet: the workflow, the goal-to-model chooser, and
+    the read surface every fitted model shares.
+
+    The entry point for an agent or a first-time user who has ``import topica``
+    and needs the canonical patterns without reading the docs. Unlike
+    :func:`summary`, which describes a *fitted* model, ``guide`` is static: it
+    needs no model and no corpus.
+
+    Parameters
+    ----------
+    topic : a model name (case-insensitive, e.g. ``"STM"``) for that model's card
+        — its purpose, constructor and ``fit`` signatures, and first calls — or
+        ``None`` for the one-screen essentials.
+    full : print every validated model, grouped by purpose, with signatures.
+        Ignored when ``topic`` is given.
+
+    The sheet is rendered live from :mod:`topica.registry` and each model's real
+    signature, so it always matches the installed build. Returns ``None`` and
+    prints; use :func:`topica._guide.build_guide` for the string.
+    """
+    from ._guide import build_guide
+
+    print(build_guide(topic, full=full))
 
 
 from .gdmr import GDMR  # noqa: E402  (pure-Python Legendre-basis DMR wrapper)
@@ -428,7 +464,7 @@ __all__ = [
     # flagship models (the newcomer starting set; the rest stay importable)
     "LDA", "STM", "NMF", "KeyATM", "GSDMM", "BERTopic",
     # discovery / experimental gate / identity
-    "list_models", "enable_experimental",
+    "list_models", "guide", "enable_experimental",
     "__version__", "__citation__",
 ]
 # The flat helper callables (search_k, topic_table, estimate_effect, perplexity,

--- a/python/topica/__init__.py
+++ b/python/topica/__init__.py
@@ -36,7 +36,7 @@ The main entry points, by task:
 
 - **Corpus** (``topica.data``): :func:`from_dataframe`, :class:`Corpus`,
   :func:`tokenize` (also at the top level); bundled example corpora in
-  :mod:`topica.data.datasets`.
+  :mod:`topica.datasets` (``topica.datasets.load_gadarian()``).
 - **Models** (top level): :class:`LDA` and the wider family (:class:`STM`,
   :class:`CTM`, :class:`DMR`, :class:`KeyATM`, :class:`SAGE`, :class:`HDP`,
   :class:`BERTopic`, …); ``model.fit(corpus)`` then read ``model.topic_word`` /

--- a/python/topica/_guide.py
+++ b/python/topica/_guide.py
@@ -50,6 +50,13 @@ NAMESPACES = [
 ]
 
 
+# The workflow namespaces whose helper functions guide("<name>") can resolve.
+_HELPER_NAMESPACES = (
+    "data", "design", "select", "inspect", "evaluate",
+    "effects", "compare", "provenance", "embeddings",
+)
+
+
 def _model_class(name: str):
     """Resolve a registry name to its class on the ``topica`` namespace.
 
@@ -61,6 +68,46 @@ def _model_class(name: str):
     import topica
 
     return getattr(topica, name, None)
+
+
+def _helper_index() -> dict:
+    """Map every helper-function name to its ``(namespace, function)``.
+
+    Walks the workflow namespaces (:data:`_HELPER_NAMESPACES`) and indexes the
+    topica-owned callables they expose — the helpers the essentials sheet lists by
+    name so ``guide("estimate_effect")`` can print a signature the same way
+    ``guide("STM")`` prints a model's. Third-party re-exports (numpy, etc.) are
+    skipped by the ``__module__`` filter; the first namespace to define a name
+    wins, matching the display order.
+    """
+    import topica
+
+    index: dict = {}
+    for ns in _HELPER_NAMESPACES:
+        mod = getattr(topica, ns, None)
+        if mod is None:
+            continue
+        for name in dir(mod):
+            if name.startswith("_"):
+                continue
+            obj = getattr(mod, name, None)
+            if not callable(obj) or isinstance(obj, type):
+                continue
+            if not getattr(obj, "__module__", "").startswith("topica"):
+                continue
+            index.setdefault(name, (ns, obj))
+    return index
+
+
+def _helper_card(name: str, ns: str, func) -> list[str]:
+    """One helper function's card: where it lives, its purpose, its signature."""
+    out = [f"{ns}.{name}   (topica.{ns}.{name})", ""]
+    doc = (inspect.getdoc(func) or "").strip()
+    if doc:
+        out.append(f"  {doc.split(chr(10) + chr(10))[0].replace(chr(10), ' ')}")
+        out.append("")
+    out.append(f"  {name}{_sig(func) or '(...)'}")
+    return out
 
 
 def _sig(obj) -> str | None:
@@ -130,13 +177,15 @@ def _essentials(show_version: bool = True) -> list[str]:
     width = max(len(name) for name, _ in NAMESPACES)
     for name, desc in NAMESPACES:
         out.append(f"    {name.ljust(width)}  {desc}")
+    out.append('    -> guide("<name>") prints any helper\'s signature (e.g. guide("estimate_effect"))')
     out += [
         "",
         "GO DEEPER",
-        '    topica.guide("STM")      one model: signatures + first calls',
-        "    topica.guide(full=True)  every model, grouped",
-        "    help(topica.STM)         full constructor / fit docstrings",
-        "    topica.list_models()     the roster (list_models(group=...) to filter)",
+        '    topica.guide("STM")            one model: signatures + first calls',
+        '    topica.guide("topic_stability") one helper: signature + purpose',
+        "    topica.guide(full=True)        every model, grouped",
+        "    help(topica.STM)               full constructor / fit docstrings",
+        "    topica.list_models()           the roster (list_models(group=...) to filter)",
         f"    docs: {DOCS_BASE}",
     ]
     return out
@@ -213,14 +262,19 @@ def build_guide(topic: str | None = None, *, full: bool = False, show_version: b
     """
     if topic is not None:
         match = _resolve_name(topic)
-        if match is None:
-            near = _did_you_mean(topic)
-            hint = f" Did you mean: {', '.join(near)}?" if near else ""
-            return (
-                f"No model named {topic!r} in the roster.{hint}\n"
-                "Run topica.list_models() for the full list."
-            )
-        return "\n".join(_card(match))
+        if match is not None:
+            return "\n".join(_card(match))
+        # Not a model: try the helper functions the namespaces expose, so
+        # guide("estimate_effect") / guide("topic_stability") print a signature.
+        helper = _resolve_helper(topic)
+        if helper is not None:
+            return "\n".join(_helper_card(*helper))
+        near = _did_you_mean(topic)
+        hint = f" Did you mean: {', '.join(near)}?" if near else ""
+        return (
+            f"No model or helper named {topic!r}.{hint}\n"
+            "Run topica.list_models() for the roster, or topica.guide() for the helpers."
+        )
     if full:
         return "\n".join(_full())
     return "\n".join(_essentials(show_version=show_version))
@@ -235,9 +289,19 @@ def _resolve_name(topic: str) -> str | None:
     return None
 
 
-def _did_you_mean(topic: str) -> list[str]:
-    """Up to three registry names whose lowercase form contains, or is contained
-    by, the query — a cheap substring suggestion, no fuzzy-match dependency."""
+def _resolve_helper(topic: str):
+    """Case-insensitive match of ``topic`` to a helper; returns ``(name, ns, func)``."""
     lowered = topic.lower()
-    hits = [n for n in REGISTRY if lowered in n.lower() or n.lower() in lowered]
+    for name, (ns, func) in _helper_index().items():
+        if name.lower() == lowered:
+            return name, ns, func
+    return None
+
+
+def _did_you_mean(topic: str) -> list[str]:
+    """Up to three model or helper names whose lowercase form contains, or is
+    contained by, the query — a cheap substring suggestion, no fuzzy dependency."""
+    lowered = topic.lower()
+    names = list(REGISTRY) + list(_helper_index())
+    hits = [n for n in names if lowered in n.lower() or n.lower() in lowered]
     return hits[:3]

--- a/python/topica/_guide.py
+++ b/python/topica/_guide.py
@@ -1,0 +1,243 @@
+"""The agent/first-timer cheat sheet, rendered live so it cannot drift.
+
+``topica.guide()`` compresses the three artifacts a newcomer (human or LLM) has
+to find on their own — the canonical workflow, the goal-to-model chooser, and the
+uniform read surface every fitted model exposes — into one screen. It is built at
+call time from :mod:`topica.registry` (the roster + the front-door chooser) and
+from live ``inspect.signature`` on each model class, so it reflects the compiled
+extension exactly and needs no regeneration when a signature changes.
+
+Three views:
+
+* ``build_guide()`` — the one-screen essentials.
+* ``build_guide("STM")`` — one model's card (summary, signatures, first calls).
+* ``build_guide(full=True)`` — every validated model, grouped, with signatures.
+
+``scripts/gen_guide.py`` renders the same builder into
+``docs/guides/agent-cheatsheet.md`` for readers who are not at a REPL; a preflight
+``--check`` keeps that page in sync. Because the runtime view is generated on the
+fly, only the committed Markdown can go stale, and the check guards it.
+"""
+from __future__ import annotations
+
+import inspect
+
+from .registry import CHOOSER, GROUPS, REGISTRY
+
+DOCS_BASE = "https://nealcaren.github.io/topica/"
+
+# The uniform read surface (docs/contributing/estimator-contract.md): the same
+# attribute names carry the same meaning on every fitted model, so this is one
+# block, not a per-model column.
+READ_SURFACE = [
+    ("model.topic_word", "(K, V) topic-word matrix; rows sum to 1 (generative models)"),
+    ("model.doc_topic", "(D, K) document-topic matrix; rows sum to 1"),
+    ("model.vocabulary", "V words, aligned to topic_word columns"),
+    ("model.top_words(n)", "list[list[str]] top n per topic; weights=True for (word, prob)"),
+    ("model.num_topics / .doc_names / .settings", "K, row labels, and the fit config as a dict"),
+    ("model.save(path) / Model.load(path)", "round-trip a fitted model to disk"),
+]
+
+# The workflow namespaces (issue #757): the taught home of every helper.
+NAMESPACES = [
+    ("select", "choosing K (search_k, select_model)"),
+    ("inspect", "reading topics (label_topics, topic_table, frex, find_thoughts)"),
+    ("evaluate", "validation (coherence, exclusivity, topic_stability, perplexity)"),
+    ("effects", "covariate effects (estimate_effect, predicted_prevalence)"),
+    ("design", "design matrices (one_hot, design_matrix, spline)"),
+    ("data", "corpus + bundled datasets (from_dataframe, tokenize, datasets)"),
+    ("compare / provenance / embeddings", "two-fit drift, analysis manifest, embedding I/O"),
+]
+
+
+def _model_class(name: str):
+    """Resolve a registry name to its class on the ``topica`` namespace.
+
+    Imported lazily: this module is imported while ``topica.__init__`` is still
+    executing, so ``topica`` is only fully populated by call time. Returns
+    ``None`` if the name does not resolve (e.g. an experimental model behind the
+    gate), so the caller can degrade to a bare signature-less line.
+    """
+    import topica
+
+    return getattr(topica, name, None)
+
+
+def _sig(obj) -> str | None:
+    """A one-line ``inspect.signature`` string, or ``None`` if unavailable.
+
+    PyO3 sets ``text_signature`` on the Rust-backed models, so this works for the
+    whole roster; the pure-Python wrappers introspect natively. Anything without a
+    signature (a class the interpreter cannot introspect) degrades to ``None``.
+    """
+    try:
+        return str(inspect.signature(obj))
+    except (TypeError, ValueError):
+        return None
+
+
+def _fit_sig(cls) -> str | None:
+    """The ``fit`` signature with the leading ``self`` dropped, if introspectable."""
+    fit = getattr(cls, "fit", None)
+    if fit is None:
+        return None
+    s = _sig(fit)
+    if s is None:
+        return None
+    # Drop the bound-method receiver so the rendered call reads as `.fit(data, ...)`.
+    return s.replace("(self, /, ", "(").replace("(self, ", "(").replace("(self)", "()")
+
+
+def _chooser_lines() -> list[str]:
+    """The goal-to-model matrix (:data:`CHOOSER`) as aligned plain-text rows."""
+    lines = []
+    for section, header in (("common", "Common openings"), ("specialized", "Specialized (start here when your design calls for it)")):
+        rows = [r for r in CHOOSER if r.section == section]
+        if not rows:
+            continue
+        lines.append(f"  {header}:")
+        for r in rows:
+            also = f" (or {r.also})" if r.also else ""
+            lines.append(f"    {r.goal}")
+            lines.append(f"        -> {r.primary}{also}: {r.calls}")
+    return lines
+
+
+def _essentials(show_version: bool = True) -> list[str]:
+    import topica
+
+    version = f" {topica.__version__}" if show_version else ""
+    out = [
+        f"topica{version} - quick guide for agents and first-time users",
+        "",
+        "THE WORKFLOW (a full LDA analysis in five lines)",
+        "    import topica",
+        '    corpus = topica.from_dataframe(df, text_col="text")      # build + prune vocab',
+        "    res    = topica.select.search_k(corpus, ks=[10, 20, 30])  # choose K; res.best_k()",
+        "    model  = topica.LDA(num_topics=res.best_k()).fit(corpus)",
+        "    topica.inspect.topic_table(model)                         # labelled topics",
+        "    # with metadata:",
+        "    topica.effects.estimate_effect(model, X=X, corpus=corpus) # covariate effects + CIs",
+        "",
+        "EVERY FITTED MODEL EXPOSES THE SAME SURFACE",
+    ]
+    width = max(len(name) for name, _ in READ_SURFACE)
+    for name, desc in READ_SURFACE:
+        out.append(f"    {name.ljust(width)}  {desc}")
+    out += ["", "PICK A MODEL BY GOAL"]
+    out += _chooser_lines()
+    out += ["", "HELPER NAMESPACES (topica.<stage>.*)"]
+    width = max(len(name) for name, _ in NAMESPACES)
+    for name, desc in NAMESPACES:
+        out.append(f"    {name.ljust(width)}  {desc}")
+    out += [
+        "",
+        "GO DEEPER",
+        '    topica.guide("STM")      one model: signatures + first calls',
+        "    topica.guide(full=True)  every model, grouped",
+        "    help(topica.STM)         full constructor / fit docstrings",
+        "    topica.list_models()     the roster (list_models(group=...) to filter)",
+        f"    docs: {DOCS_BASE}",
+    ]
+    return out
+
+
+def _card(name: str) -> list[str]:
+    """One model's card: taxonomy line, constructor + fit signatures, first calls."""
+    info = REGISTRY[name]
+    cls = _model_class(name)
+    group = GROUPS.get(info.group, info.group)
+    out = [f"{name} - {group}   (topica.{name})", "", f"  {info.summary}", ""]
+    out.append(
+        f"  brings: {', '.join(info.brings) or 'text'}"
+        f"    inference: {info.inference}    determinism: {info.determinism}"
+    )
+    if cls is not None:
+        csig = _sig(cls)
+        fsig = _fit_sig(cls)
+        if csig:
+            out.append(f"  {name}{csig}")
+        if fsig:
+            out.append(f"  model.fit{fsig}")
+    # The chooser rows that name this model, so the reader gets the first calls.
+    for r in CHOOSER:
+        if name in (r.primary, r.also):
+            role = "start" if name == r.primary else "alternative"
+            out += ["", f'  goal ({role}): "{r.goal}"', f"    first calls: {r.calls}", f"    note: {r.note}"]
+    out += ["", f"  docs: {DOCS_BASE}{info.doc}"]
+    return out
+
+
+def _full() -> list[str]:
+    """Every validated model, grouped by purpose, with signatures."""
+    out = ["topica model reference (validated roster)", ""]
+    by_group: dict[str, list[str]] = {}
+    for name, info in REGISTRY.items():
+        if info.experimental:
+            continue
+        by_group.setdefault(info.group, []).append(name)
+    for key, label in GROUPS.items():
+        names = by_group.get(key)
+        if not names:
+            continue
+        out += [f"### {label}", ""]
+        for name in names:
+            info = REGISTRY[name]
+            cls = _model_class(name)
+            csig = _sig(cls) if cls is not None else None
+            out.append(f"{name}{csig or '(...)'}")
+            out.append(f"    {info.summary}")
+            fsig = _fit_sig(cls) if cls is not None else None
+            if fsig:
+                out.append(f"    .fit{fsig}")
+            out.append("")
+    out += [
+        "Experimental models are omitted; enable_experimental() then "
+        'list_models(experimental=True) to see them.',
+    ]
+    return out
+
+
+def build_guide(topic: str | None = None, *, full: bool = False, show_version: bool = True) -> str:
+    """Render the cheat sheet as a string (see :func:`topica.guide`).
+
+    Parameters
+    ----------
+    topic : a model name (case-insensitive) for that model's card, or ``None``
+        for the one-screen essentials.
+    full : render every validated model with signatures, grouped by purpose.
+        Ignored when ``topic`` is given.
+    show_version : include the running version in the essentials header. The docs
+        generator passes ``False`` so the committed page does not churn on a
+        version bump.
+    """
+    if topic is not None:
+        match = _resolve_name(topic)
+        if match is None:
+            near = _did_you_mean(topic)
+            hint = f" Did you mean: {', '.join(near)}?" if near else ""
+            return (
+                f"No model named {topic!r} in the roster.{hint}\n"
+                "Run topica.list_models() for the full list."
+            )
+        return "\n".join(_card(match))
+    if full:
+        return "\n".join(_full())
+    return "\n".join(_essentials(show_version=show_version))
+
+
+def _resolve_name(topic: str) -> str | None:
+    """Case-insensitive exact match of ``topic`` to a registry key."""
+    lowered = topic.lower()
+    for name in REGISTRY:
+        if name.lower() == lowered:
+            return name
+    return None
+
+
+def _did_you_mean(topic: str) -> list[str]:
+    """Up to three registry names whose lowercase form contains, or is contained
+    by, the query — a cheap substring suggestion, no fuzzy-match dependency."""
+    lowered = topic.lower()
+    hits = [n for n in REGISTRY if lowered in n.lower() or n.lower() in lowered]
+    return hits[:3]

--- a/scripts/gen_guide.py
+++ b/scripts/gen_guide.py
@@ -1,0 +1,63 @@
+#!/usr/bin/env python
+"""Render ``topica.guide()`` into the agent cheat-sheet docs page.
+
+``topica._guide.build_guide`` is the single source: the same builder that
+``topica.guide()`` prints live. This script injects its one-screen essentials and
+its full model reference between the marker comments in
+``docs/guides/agent-cheatsheet.md`` so the page cannot drift from the installed
+build. ``tests/test_guide.py`` fails if the page is out of sync.
+
+    python scripts/gen_guide.py           # rewrite the page in place
+    python scripts/gen_guide.py --check    # exit 1 if the page is stale
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(ROOT / "python"))
+
+from topica._guide import build_guide  # noqa: E402
+
+BEGIN = "<!-- BEGIN GUIDE (generated from topica.guide via scripts/gen_guide.py; edit _guide.py, not this block) -->"
+END = "<!-- END GUIDE -->"
+TARGET = ROOT / "docs" / "guides" / "agent-cheatsheet.md"
+
+
+def rendered_block() -> str:
+    essentials = build_guide(show_version=False)
+    reference = build_guide(full=True)
+    return (
+        f"{BEGIN}\n\n"
+        "## The one-screen guide\n\n"
+        f"```text\n{essentials}\n```\n\n"
+        "## Every validated model\n\n"
+        f"```text\n{reference}\n```\n"
+        f"{END}"
+    )
+
+
+def inject(text: str) -> str:
+    i, j = text.find(BEGIN), text.find(END)
+    if i == -1 or j == -1:
+        raise SystemExit(f"marker comments not found in {TARGET.name}")
+    return text[:i] + rendered_block() + text[j + len(END):]
+
+
+def main() -> None:
+    check = "--check" in sys.argv
+    old = TARGET.read_text(encoding="utf-8")
+    new = inject(old)
+    if old == new:
+        print("up to date" if check else f"{TARGET.name}: no change")
+        return
+    if check:
+        print(f"stale (run scripts/gen_guide.py): {TARGET.name}")
+        raise SystemExit(1)
+    TARGET.write_text(new, encoding="utf-8")
+    print(f"wrote {TARGET.name}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -13,6 +13,8 @@
 #   3. cargo clippy --workspace --all-targets --all-features -- -D warnings
 #   4. generated model tables are in sync (scripts/gen_model_tables.py --check)
 #   5. the .pyi type stub is in sync with the compiled extension (test_stub_sync.py)
+#   6. the compat map and the agent cheat sheet are in sync (gen_compat.py /
+#      gen_guide.py --check)
 #
 # Steps 3-4 need `topica` importable; they use $VIRTUAL_ENV or .venv-dev, and are
 # skipped with a warning (not a hard failure) if no dev venv is present, so the
@@ -111,6 +113,12 @@ if [ -x "$PY" ]; then
     step "compat map in sync with the namespaces (scripts/gen_compat.py --check)"
     if ! VIRTUAL_ENV="$VENV" "$PY" scripts/gen_compat.py --check; then
         echo "  -> run 'python scripts/gen_compat.py' to regenerate" >&2
+        fail=1
+    fi
+
+    step "agent cheat sheet in sync with topica.guide (scripts/gen_guide.py --check)"
+    if ! VIRTUAL_ENV="$VENV" "$PY" scripts/gen_guide.py --check; then
+        echo "  -> run 'python scripts/gen_guide.py' to regenerate" >&2
         fail=1
     fi
 else

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -43,10 +43,31 @@ def test_model_card_is_case_insensitive_and_carries_signatures():
         assert "guides/models.md#stm" in card
 
 
-def test_unknown_model_suggests_and_does_not_raise():
+def test_helper_card_resolves_signatures():
+    # The essentials sheet lists helper names without signatures; guide("<name>")
+    # must resolve them (the two a sample-user audit crashed on). See #816 audit.
+    for name, ns, needle in [
+        ("topic_stability", "evaluate", "topic_stability(runs"),
+        ("record_fit", "provenance", "record_fit(model, corpus"),
+        ("estimate_effect", "effects", "estimate_effect(doc_topic"),
+    ]:
+        card = build_guide(name)
+        assert card.startswith(f"{ns}.{name} "), card[:60]
+        assert needle in card
+
+
+def test_essentials_points_to_helper_guide():
+    text = build_guide()
+    assert 'guide("<name>")' in text  # closes the name -> signature loop
+
+
+def test_unknown_name_suggests_across_models_and_helpers():
     card = build_guide("STMX")
-    assert "No model named 'STMX'" in card
+    assert "No model or helper named 'STMX'" in card
     assert "STM" in card  # substring suggestion
+    # a helper-side miss suggests helper names too
+    card2 = build_guide("stability")
+    assert "topic_stability" in card2 or "bootstrap_stability" in card2
 
 
 def test_full_covers_every_validated_model():

--- a/tests/test_guide.py
+++ b/tests/test_guide.py
@@ -1,0 +1,72 @@
+"""``topica.guide()`` renders from the live registry + signatures, and the
+generated docs page stays in sync with it.
+
+The cheat sheet is the entry point an agent or first-time user hits after
+``import topica``, so it must (a) stay correct as models change (it is built from
+introspection, not a hand list) and (b) not drift from its committed docs page.
+"""
+import pathlib
+
+import pytest
+
+import topica
+from topica._guide import build_guide
+from topica.registry import REGISTRY
+
+
+def test_essentials_has_the_load_bearing_sections():
+    text = build_guide()
+    for marker in (
+        "THE WORKFLOW",
+        "EVERY FITTED MODEL EXPOSES THE SAME SURFACE",
+        "PICK A MODEL BY GOAL",
+        "HELPER NAMESPACES",
+        "model.topic_word",
+        "model.top_words(n)",
+        "topica.guide(",
+    ):
+        assert marker in text, marker
+
+
+def test_guide_prints_and_returns_none(capsys):
+    assert topica.guide() is None
+    out = capsys.readouterr().out
+    assert "quick guide" in out
+
+
+def test_model_card_is_case_insensitive_and_carries_signatures():
+    for query in ("STM", "stm"):
+        card = build_guide(query)
+        assert card.startswith("STM ")
+        assert "STM(num_topics" in card  # constructor signature, live
+        assert "model.fit(" in card      # fit signature, live
+        assert "guides/models.md#stm" in card
+
+
+def test_unknown_model_suggests_and_does_not_raise():
+    card = build_guide("STMX")
+    assert "No model named 'STMX'" in card
+    assert "STM" in card  # substring suggestion
+
+
+def test_full_covers_every_validated_model():
+    text = build_guide(full=True)
+    validated = [n for n, info in REGISTRY.items() if not info.experimental]
+    missing = [n for n in validated if f"\n{n}(" not in text and f"\n{n} " not in text]
+    assert not missing, f"full guide omits validated models: {missing}"
+
+
+def test_docs_page_in_sync_with_guide():
+    # The generated block in docs/guides/agent-cheatsheet.md must match the
+    # gen_guide render; regenerate with scripts/gen_guide.py if this fails.
+    import sys
+
+    root = pathlib.Path(__file__).resolve().parent.parent
+    sys.path.insert(0, str(root / "scripts"))
+    import gen_guide  # noqa: E402
+
+    text = gen_guide.TARGET.read_text(encoding="utf-8")
+    i, j = text.find(gen_guide.BEGIN), text.find(gen_guide.END)
+    assert i != -1 and j != -1, "agent-cheatsheet.md marker comments missing"
+    assert text[i:j + len(gen_guide.END)] == gen_guide.rendered_block(), (
+        "docs/guides/agent-cheatsheet.md is stale; run scripts/gen_guide.py")

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -1,0 +1,80 @@
+"""Smoke tests: every task recipe in examples/recipes/ runs end to end.
+
+The recipes are meant to be transplanted onto a user's own data, so "it runs on
+the bundled data" is the contract that keeps them trustworthy. Each is executed
+as a script (``runpy.run_path``) and must complete without error and print its
+header. The gadarian recipes use bundled data and always run; the DTM recipe
+fetches ``load_congress`` and is skipped when that dataset is unavailable
+(offline CI), mirroring ``test_dubois_tutorial``.
+"""
+import io
+import os
+import runpy
+from contextlib import redirect_stdout
+
+import pytest
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+RECIPES = os.path.join(os.path.dirname(HERE), "examples", "recipes")
+
+
+def _run(name: str) -> str:
+    path = os.path.join(RECIPES, name)
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        runpy.run_path(path, run_name="__main__")
+    return buf.getvalue()
+
+
+def _dataset_available(loader: str) -> bool:
+    try:
+        import topica
+
+        getattr(topica.datasets, loader)()
+        return True
+    except Exception:
+        return False
+
+
+def test_lda_explore_runs():
+    out = _run("lda_explore.py")
+    assert "frontier-suggested K" in out
+    assert "coherence" in out
+
+
+def test_keyatm_seeded_runs():
+    out = _run("keyatm_seeded.py")
+    assert "keyword_rate" in out
+    assert "Unseeded topics" in out
+
+
+def test_gsdmm_short_text_runs():
+    out = _run("gsdmm_short_text.py")
+    assert "clusters retained" in out
+
+
+@pytest.mark.skipif(not _dataset_available("load_ng20_minilm"),
+                    reason="load_ng20_minilm unavailable (offline)")
+def test_bertopic_embeddings_runs():
+    out = _run("bertopic_embeddings.py")
+    assert "topics discovered" in out
+
+
+def test_stm_prevalence_groups_runs():
+    out = _run("stm_prevalence_groups.py")
+    assert "prevalence" in out
+    assert "CI excludes zero" in out
+
+
+def test_stm_content_groups_runs():
+    out = _run("stm_content_groups.py")
+    assert "content = ~" in out
+    assert "divergence" in out
+
+
+@pytest.mark.skipif(not _dataset_available("load_congress"),
+                    reason="load_congress unavailable (offline)")
+def test_dtm_over_time_runs():
+    out = _run("dtm_over_time.py")
+    assert "DTM with K=" in out
+    assert "over time:" in out

--- a/tests/test_recipes.py
+++ b/tests/test_recipes.py
@@ -53,6 +53,21 @@ def test_gsdmm_short_text_runs():
     assert "clusters retained" in out
 
 
+def test_robustness_runs():
+    out = _run("robustness.py")
+    assert "Bootstrap topic stability" in out
+    assert "mean stability" in out
+
+
+def test_provenance_runs(tmp_path, monkeypatch):
+    # provenance.py writes a manifest JSON to the cwd; run it in a temp dir so it
+    # does not litter the repo.
+    monkeypatch.chdir(tmp_path)
+    out = _run("provenance.py")
+    assert "Analysis card" in out
+    assert (tmp_path / "gadarian_manifest.json").exists()
+
+
 @pytest.mark.skipif(not _dataset_available("load_ng20_minilm"),
                     reason="load_ng20_minilm unavailable (offline)")
 def test_bertopic_embeddings_runs():

--- a/tests/test_toplevel_compat.py
+++ b/tests/test_toplevel_compat.py
@@ -23,14 +23,14 @@ _CURATED = {
     "effects", "compare", "embeddings", "provenance",
     "Corpus", "tokenize", "from_dataframe", "progress",
     "LDA", "STM", "NMF", "KeyATM", "GSDMM", "BERTopic",
-    "list_models", "enable_experimental",
+    "list_models", "guide", "enable_experimental",
     "__version__", "__citation__",
 }
 
 
 def test_curated_all_is_exactly_the_surface():
     assert set(topica.__all__) == _CURATED
-    assert len(topica.__all__) == 23
+    assert len(topica.__all__) == 24
 
 
 def test_flagship_models_match_common_start_set():


### PR DESCRIPTION
## Why

A first-time agent session working with topica reported that the material is all there and high quality (AGENTS.md, the `.pyi` stub, the examples) but **the gap is compression and discoverability, not content**: the STM `fit()` signature lives in a 7,000-line stub, examples are named by corpus rather than task, and none of it reaches a bare `pip install topica` (AGENTS.md only exists in a repo checkout). This PR closes that gap.

## What

**`topica.guide()` — a live cheat sheet that ships in the wheel.** Rendered at call time from `topica.registry` and each model's real `inspect.signature`, so it always matches the installed build and cannot drift.
- `guide()` — one-screen essentials: the canonical workflow, the goal→model chooser, the read surface every fitted model shares, the helper namespaces.
- `guide("STM")` — one model's card: purpose, constructor + `fit` signatures, first calls.
- `guide(full=True)` — every validated model, grouped, with signatures.

Because it is code, a bare `pip install topica` gets it. `__init__.__doc__` now points at it and teaches the STM path alongside LDA.

**Generated docs page.** `scripts/gen_guide.py` renders the same builder into `docs/guides/agent-cheatsheet.md`, wired into `preflight.sh` (`--check`) and `tests/test_guide.py` so the committed page can't go stale. Added to the mkdocs "Start here" nav.

**Task recipes (`examples/recipes/`).** One transplantable ~60-line recipe per common task, self-contained on bundled/cached data, each with a smoke test:

| Task | Recipe |
|---|---|
| Explore + justify K | `lda_explore.py` |
| Named concepts (seed words) | `keyatm_seeded.py` |
| Very short docs | `gsdmm_short_text.py` |
| Cluster by meaning (embeddings) | `bertopic_embeddings.py` |
| Prevalence across groups | `stm_prevalence_groups.py` |
| Wording across groups | `stm_content_groups.py` |
| Topics over time | `dtm_over_time.py` |

Every "common opening" in `guide()`'s chooser now has a matching file. Indexed by task in `examples/recipes/README.md`.

**The agent guide knows about it.** The `topica-analysis` skill (and regenerated `AGENTS.md`) teach `topica.guide()` as the first REPL move and point at the recipes.

## Notes

- BERTopic recipe uses `reducer="pca"` for a stable multi-topic demo (the default umap can collapse to ~2 topics, #555); documented inline with the kmeans alternative.
- No new models: the roster is already comprehensive, and the reported gap was discoverability, not coverage.

## Testing

- `tests/test_guide.py` (6), `tests/test_recipes.py` (7) — all pass; recipes that need fetched data skip cleanly offline.
- Full suite: 5193 passed, 38 skipped.
- `scripts/preflight.sh` clean (incl. the new `gen_guide.py --check`); `mkdocs build --strict` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)