### PR TITLE
fix(results): uniform result-container surface (#817)

### DIFF
--- a/examples/recipes/lda_explore.py
+++ b/examples/recipes/lda_explore.py
@@ -42,7 +42,6 @@ for t, words in enumerate(model.top_words(8)):
     print(f"  topic {t}: {', '.join(words)}")
 
 # --- how coherent are they? (a validation check, not a K selector) ---------
-topics = model.top_words(10)
-texts = [" ".join(doc) for doc in corpus.documents()]
-per_topic = topica.evaluate.coherence(topics, texts, coherence_type="c_v")
+# coherence scores each topic against a reference corpus; pass the Corpus directly.
+per_topic = topica.evaluate.coherence(model.top_words(10), corpus, coherence_type="c_v")
 print(f"\nMean c_v coherence: {float(np.mean(per_topic)):.3f}  (0-1; higher = more coherent)")

--- a/python/topica/select.py
+++ b/python/topica/select.py
@@ -202,6 +202,37 @@ class SearchKResult(list):
     maximum) to avoid that, and to the held-out metric when one is supplied.
     """
 
+    def __repr__(self) -> str:
+        """A compact adjudicating summary: the chosen K and a per-K
+        coherence/exclusivity table, so printing the result answers "which K?"
+        instead of dumping the raw per-K dicts. ``.to_frame()`` gives every
+        column; ``.best_k(explain=True)`` gives the selection rule."""
+        if not self:
+            return "SearchKResult([])"
+        import warnings
+
+        ks = [r.get("k") for r in self]
+        try:
+            with warnings.catch_warnings():  # a boundary pick warns; don't emit on display
+                warnings.simplefilter("ignore")
+                chosen = self.best_k()
+        except Exception:
+            chosen = None
+        metric = self[0].get("coherence_metric", "coherence")
+        head = f"SearchKResult: scanned K={ks}"
+        if chosen is not None:
+            head += f"; best_k()={chosen}"
+        lines = [head, f"  {'K':>4}  {('coherence(' + metric + ')'):>20}  {'exclusivity':>11}"]
+        for r in self:
+            mark = " *" if r.get("k") == chosen else "  "
+            coh = r.get("coherence")
+            exc = r.get("exclusivity")
+            coh_s = f"{coh:.2f}" if isinstance(coh, (int, float)) else "-"
+            exc_s = f"{exc:.2f}" if isinstance(exc, (int, float)) else "-"
+            lines.append(f"{mark}{r.get('k'):>4}  {coh_s:>20}  {exc_s:>11}")
+        lines.append("  (* = best_k(); .to_frame() for all columns, .best_k(explain=True) for the rule)")
+        return "\n".join(lines)
+
     @property
     def directions(self) -> dict:
         """``{metric: "maximize"|"minimize"}`` for the metrics actually present."""

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -200,6 +200,13 @@ class EffectList(list):
             return pd.DataFrame()
         return pd.concat([e.to_frame() for e in self], ignore_index=True)
 
+    def __repr__(self) -> str:
+        if not self:
+            return "EffectList([])"
+        nfeat = len(getattr(self[0], "feature_names", []) or [])
+        return (f"EffectList: {len(self)} topics × {nfeat} features; "
+                ".to_frame() for the tidy table")
+
 
 def _coerce_design(X, feature_names):
     """Coerce a design-matrix argument to a float64 ``(n, p)`` array.
@@ -1503,6 +1510,35 @@ def _build_reference_rows(
     raise ValueError("One of at=, contrast=, or continuous= must be supplied.")
 
 
+class PredictedPrevalenceList(list):
+    """The result of :func:`predicted_prevalence`: a ``list`` of per-topic
+    :class:`PredictedPrevalence` objects.
+
+    It *is* a plain ``list`` (index, iterate, ``len()``), with the same two
+    conveniences its sibling :class:`EffectList` gives so the return-type zoo
+    (#742) stays uniform: a container-level :meth:`to_frame` (no
+    ``pd.concat([p.to_frame() for p in result])`` boilerplate), and a summary
+    ``repr`` instead of dumping every :class:`PredictedPrevalence`.
+    """
+
+    def to_frame(self):
+        """One tidy DataFrame for the whole call: every element's per-point
+        :meth:`PredictedPrevalence.to_frame` concatenated. Empty when there are
+        no rows."""
+        import pandas as pd
+
+        if not self:
+            return pd.DataFrame()
+        return pd.concat([p.to_frame() for p in self], ignore_index=True)
+
+    def __repr__(self) -> str:
+        if not self:
+            return "PredictedPrevalenceList([])"
+        mode = getattr(self[0], "mode", "?")
+        return (f"PredictedPrevalenceList: {len(self)} topics, mode={mode!r}; "
+                ".to_frame() for the tidy per-point table")
+
+
 def predicted_prevalence(
     model,
     *,
@@ -1728,7 +1764,7 @@ def predicted_prevalence(
             ci_high=ci_hi,
             covariate=cov_name,
         ))
-    return out
+    return PredictedPrevalenceList(out)
 
 
 def posterior_theta_samples(model, nsims=25, seed=0, *, uncertainty="local"):

--- a/tests/test_result_containers.py
+++ b/tests/test_result_containers.py
@@ -1,0 +1,67 @@
+"""Conformance for the diagnostic result containers.
+
+Every helper that returns a *container* of results should present itself the same
+way: a ``.to_frame()`` a pandas user reaches for, and — for the ``list``-backed
+ones — a ``__repr__`` that summarizes instead of dumping raw rows. Two of these
+(``predicted_prevalence`` returning a bare list, ``SearchKResult`` printing raw
+per-K dicts) slipped because nothing enforced the contract; this test is that
+enforcement (issue #817, from the #816 sample-user audit).
+"""
+import numpy as np
+import pytest
+
+import topica
+from topica._results import FrameDict
+from topica.select import SearchKResult
+from topica.stm import EffectList, PredictedPrevalenceList
+
+# The list-backed result containers. A bare `list` return (predicted_prevalence's
+# old shape) or an un-overridden repr (SearchKResult's old shape) is the bug.
+LIST_CONTAINERS = [EffectList, SearchKResult, PredictedPrevalenceList]
+
+
+def _all_subclasses(cls):
+    out = set(cls.__subclasses__())
+    for c in list(out):
+        out |= _all_subclasses(c)
+    return out
+
+
+@pytest.mark.parametrize("cls", LIST_CONTAINERS, ids=lambda c: c.__name__)
+def test_list_container_has_to_frame_and_custom_repr(cls):
+    assert callable(getattr(cls, "to_frame", None)), f"{cls.__name__} needs .to_frame()"
+    assert cls.__repr__ is not list.__repr__, (
+        f"{cls.__name__} must override __repr__ — the raw list dump is unreadable")
+
+
+def test_framedict_containers_all_tabulate():
+    subs = _all_subclasses(FrameDict)
+    assert subs, "expected FrameDict result containers"
+    for cls in subs:
+        assert callable(getattr(cls, "to_frame", None)), f"{cls.__name__} needs .to_frame()"
+
+
+def test_containers_render_and_tabulate_end_to_end():
+    # A real fit: the containers must summarize (not dump) and tabulate.
+    df = topica.datasets.load_gadarian()
+    c = topica.from_dataframe(
+        df, text_col="open.ended.response", metadata_cols=["treatment", "pid_rep"],
+        stopwords=topica.stopwords("english"), min_length=3, min_doc_freq=3,
+    )
+    X = np.column_stack([c.metadata[k].to_numpy(float) for k in ["treatment", "pid_rep"]])
+
+    res = topica.select.search_k(c, ks=[3, 4], seed=13)
+    assert isinstance(res, SearchKResult)
+    r = repr(res)
+    assert r.startswith("SearchKResult:") and "best_k()" in r  # adjudicates, not a dict dump
+    assert not r.lstrip().startswith("[{")
+    assert res.to_frame().shape[0] == 2
+
+    m = topica.STM(num_topics=3, seed=13).fit(
+        c, prevalence=X, prevalence_names=["treatment", "pid_rep"], iters=40)
+    pp = topica.effects.predicted_prevalence(
+        m, X=X, feature_names=["treatment", "pid_rep"], contrast={"treatment": [0, 1]}, corpus=c)
+    assert isinstance(pp, PredictedPrevalenceList)
+    assert repr(pp).startswith("PredictedPrevalenceList:")
+    assert pp.to_frame().shape[0] == 3  # one row per topic (single contrast point)
+    assert isinstance(pp, list) and pp[0].topic == 0  # still a plain list underneath


### PR DESCRIPTION
Fixes #817 (B3, B4, + the root-cause guard), surfaced by the #816 sample-user audit.

## What

Two result containers didn't present themselves like their siblings, and nothing enforced the contract:

- **B3** — `effects.predicted_prevalence` returned a **bare `list`** with no `.to_frame()`, so it couldn't be dropped into a journal table like `estimate_effect` (which returns `EffectList`). Now returns a `PredictedPrevalenceList` (a `list` subclass) with a container-level `.to_frame()` (long: one row per topic×grid-point) and a summary `repr`.
- **B4** — `SearchKResult.__repr__` **dumped the raw per-K dicts**. It already had `.best_k()` / `.to_frame()`; only the default display was unhelpful. Now it adjudicates:

  ```
  SearchKResult: scanned K=[3, 4, 5]; best_k()=5
       K     coherence(u_mass)  exclusivity
       3                -89.23         9.44
       4                -90.46         9.32
   *   5                -89.94         9.61
    (* = best_k(); .to_frame() for all columns, .best_k(explain=True) for the rule)
  ```
  (The boundary-pick warning is suppressed on display so printing doesn't emit warnings.)
- `EffectList` gains a matching summary `repr` so all three list-backed containers are consistent.
- **Root cause** — `tests/test_result_containers.py` enforces the contract going forward: every list-backed container has `.to_frame()` and a custom `__repr__`; every `FrameDict` tabulates; plus an end-to-end check on a real fit.

## B2 — reframed, no API change

The audit's "`corpus.documents` is a method, not a property" is **correct as-is**: `documents()` is the only accessor that reconstructs the whole corpus (O(total_tokens)); the cheap ones (`vocabulary`, `word_counts`, `doc_lengths`, …) are properties. Making it a property would be a silent large-allocation footgun. And `coherence` already accepts a `Corpus` directly, so the fix is just to pass the corpus — the `lda_explore` recipe now does `coherence(model.top_words(10), corpus)` instead of `corpus.documents()`.

A separately reported Tier-1 (`bootstrap_stability` "misaligns covariates") was investigated and **dismissed** as a false positive — it resamples per-document covariates in tandem (`evaluate.py:1776`, #751).

## Testing

- `tests/test_result_containers.py` (new) + the touched suites (`test_predicted_prevalence`, `test_results_to_frame`, `test_issue_fixes`, sample-user regressions): 177+ pass.
- Containers still behave as plain lists (indexing, iteration, `isinstance(..., list)`).
- `scripts/preflight.sh` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)