### PR TITLE
perf(replytm): parallelize tree-field loglik over the K observation dims (#824, lever 1)

### DIFF
--- a/src/tree_field.rs
+++ b/src/tree_field.rs
@@ -26,6 +26,7 @@
 //! tests.
 #![allow(dead_code)]
 
+use rayon::prelude::*;
 use std::f64::consts::PI;
 
 const LOG_2PI: f64 = 1.837_877_066_409_345_5; // ln(2π)
@@ -168,13 +169,23 @@ pub(crate) fn solve(parents: &[i64], y: &[f64], r: &[f64], p: TreeFieldParams) -
 
 /// Summed marginal log-likelihood across the K observation dimensions that share the field
 /// params — used to profile a (hence kappa) for a confidence interval.
+///
+/// The K solves are independent, so they run in parallel — this is the serial per-iteration cost
+/// (`fit_fixed_mean`'s Nelder–Mead evaluates it hundreds of times per M-step) that the E-step's own
+/// `par_iter` was contending with (see issue #824). To keep the fit bit-for-bit reproducible the
+/// per-dimension log-liks are collected in dimension order and summed serially (float `+` is not
+/// associative), rather than reduced in rayon's nondeterministic order.
 pub(crate) fn loglik_multi(
     parents: &[i64],
     obs: &[Vec<f64>],
     r: &[f64],
     p: TreeFieldParams,
 ) -> f64 {
-    obs.iter().map(|yk| solve(parents, yk, r, p).loglik).sum()
+    obs.par_iter()
+        .map(|yk| solve(parents, yk, r, p).loglik)
+        .collect::<Vec<f64>>()
+        .iter()
+        .sum()
 }
 
 /// PROFILE log-likelihood at a fixed `a` (hence fixed κ): the max of [`loglik_multi`] over the
@@ -237,11 +248,7 @@ pub(crate) fn fit(
         if !(p.a.is_finite() && p.q > 1e-12 && p.p0 > 1e-12) {
             return f64::INFINITY;
         }
-        let mut ll = 0.0;
-        for yk in obs {
-            ll += solve(parents, yk, r, p).loglik;
-        }
-        -ll
+        -loglik_multi(parents, obs, r, p)
     };
     let x0 = vec![
         (init.a / (1.0 - init.a)).ln(),


### PR DESCRIPTION
Closes the first lever of #824.

## What

`ReplyTM`'s per-EM-iteration M-step field fit (`tree_field::fit_fixed_mean`, a Nelder–Mead) evaluates `loglik_multi` hundreds of times, and each evaluation looped **serially** over the K topic dimensions. The #824 profiling identified this serial term as the dominator of long fits and the reason the whole fit sat at ~one core despite the E-step's `par_iter`.

The K solves are independent, so this parallelizes them with rayon. To keep the fit bit-for-bit reproducible, the per-dimension log-liks are collected in dimension order and summed serially (float `+` is not associative) rather than reduced in rayon's nondeterministic order. `fit()`'s inline serial loop is routed through `loglik_multi` so it shares the parallelism.

## Measured speedup

Synthetic threaded corpus (4,200 docs, 140 threads × depth 30, K=15, 40 EM iters), 14-core M-series:

| RAYON_NUM_THREADS | main (serial) | this branch |
|---|---|---|
| 1 | 13.84s | 13.90s |
| 8 | 12.55s | **2.99s** |
| 14 | 13.02s | **2.96s** |

`main` is essentially flat across cores (reproducing the issue's 73.8s@1 vs 70.2s@14 observation — the E-step `par_iter` alone gives ~10%). This branch is **~4.2× faster at 8 threads** and scales.

## Correctness

- Bit-identical output: the `topica.ReplyTM` fingerprint (`|doc_eta|.sum()`) is `10690.16028317` on both `main` and this branch at 8 threads — the order-preserving collect makes the parallel sum equal the old serial sum exactly, at any thread count.
- Rust `tree_field` + `reply_tm` unit tests pass; `pytest -k reply` (26 tests) passes; `preflight.sh` clean.

## Not in this PR

Levers 2–8 of #824 remain open (E-step `par_iter` diagnosis, GEMM E-step, cheaper Laplace ν, adaptive inner L-BFGS, `num_threads` knob, sweep-level trims). This is the cheap, high-confidence one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)