### PR TITLE
feat(replytm): blend coupling (parent + root) for mixed discourse (#831)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -763,10 +763,29 @@ m = topica.ReplyTM(num_topics=25, seed=13, coupling="root")
 Root coupling fits the same logistic-normal field on a reparented depth-2 star (every node
 points at its thread root), so the same machinery runs for `kappa`, `transform`,
 `persistence`, and the readouts; only the coupling neighbor changes (their values differ,
-since they are now computed on the root-star topology). To let the data say which structure fits,
-fit both and compare them on held-out replies with the `"root"` baseline in
-`reply_completion` below: `delta["root"]` is parent-coupling minus root-coupling, positive
-where the reply edge matters more than the thread topic and negative where it does not.
+since they are now computed on the root-star topology).
+
+When discourse is neither purely edge-driven nor purely thread-driven, `coupling="blend"`
+shrinks each node toward BOTH its parent and its thread root:
+
+```python
+m = topica.ReplyTM(num_topics=25, seed=13, coupling="blend")
+m.fit(docs, parents=parents)
+m.blend_alpha, m.blend_beta   # fitted parent weight and root weight
+```
+
+The prior mean is `alpha * parent + beta * root + (1 - alpha - beta) * anchor`. The weights
+are estimated in the M-step (or pinned with `blend_alpha=`/`blend_beta=`). Estimation uses a
+reliability-corrected (errors-in-variables) regression, so the weights are de-attenuated for
+the η measurement error, but they remain conditional on the topic fit; use the held-out
+`reply_completion` delta for the model-versus-model comparison. Separating `alpha` from `beta` needs threads with depth-3 or more (where
+a node's parent is not its root); on shallower corpora the fit warns and you should pin the
+weights or use `coupling="parent"`/`"root"`. `kappa`/`kappa_ci` are `NaN` under blend, since
+the mix is described by the two weights instead of a single reversion. To let the data say which structure fits, fit
+these variants and compare them on held-out replies with the `"root"` and `"blend"` baselines
+in `reply_completion` below: `delta["root"]` is parent-coupling minus root-coupling, positive
+where the reply edge matters more than the thread topic and negative where it does not, and
+`delta["blend"]` is parent-coupling minus the estimated blend.
 
 **Inferring topics for a new thread.** `transform` maps a fresh reply forest to topic
 proportions, holding the fitted topics, reversion, step/root variances, and per-group

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3060,10 +3060,14 @@ class ReplyTM:
     validated by planted recovery + a held-out-beat gate (the parent's topics predict held-out
     leaf tokens better than the no-tree baseline on synthetic persistence-structured data).
     Experimental."""
-    def __init__(self, num_topics: int, *, em_iters: int = 150, seed: int = 13, coupling: str = "parent") -> None:
+    def __init__(self, num_topics: int, *, em_iters: int = 150, seed: int = 13, coupling: str = "parent", blend_alpha: float | None = None, blend_beta: float | None = None) -> None:
         """coupling is "parent" (default; a node's prior shrinks toward its immediate parent, the
-        reply-chain prior) or "root" (shrink toward the thread root, a broadcast / topic-around-the-
-        root prior for discourse where replies track the thread topic, not the specific parent)."""
+        reply-chain prior), "root" (shrink toward the thread root, a broadcast / topic-around-the-
+        root prior for discourse where replies track the thread topic, not the specific parent), or
+        "blend" (shrink toward both: alpha*parent + beta*root + (1-alpha-beta)*anchor). With
+        coupling="blend" the weights are estimated in the M-step unless pinned by blend_alpha and/or
+        blend_beta (each in [0, 1], with alpha+beta <= 1); blend_alpha/blend_beta are only valid
+        with coupling="blend"."""
         ...
     def fit(
         self,
@@ -3097,7 +3101,16 @@ class ReplyTM:
     def num_topics(self) -> int: ...
     @property
     def coupling(self) -> str:
-        """The reply coupling structure (``"parent"`` or ``"root"``)."""
+        """The reply coupling structure (``"parent"``, ``"root"``, or ``"blend"``)."""
+        ...
+    @property
+    def blend_alpha(self) -> float:
+        """Blend parent weight alpha (NaN unless fit with coupling="blend"). A reliability-corrected
+        (errors-in-variables) hard-EM estimate; use the reply_completion delta for the model test."""
+        ...
+    @property
+    def blend_beta(self) -> float:
+        """Blend root weight beta (NaN unless fit with coupling="blend"); the anchor takes 1-alpha-beta."""
         ...
     @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...

--- a/python/topica/evaluate.py
+++ b/python/topica/evaluate.py
@@ -800,7 +800,7 @@ class ReplyCompletionResult:
         # fold in the whole modeling stack (covariates, estimator), so a reader who saw
         # only the flattering tree-no_tree line could misattribute a covariate/tool gain
         # to the reply tree. Order no_tree/permuted (tree ablations) before lda/stm.
-        order = ["no_tree", "permuted", "root", "lda", "stm"]
+        order = ["no_tree", "permuted", "root", "blend", "lda", "stm"]
         parts = []
         for name in order:
             d = self.delta.get(name)
@@ -884,7 +884,7 @@ def reply_completion(
     This is the turnkey preference test for ReplyTM: does the reply tree add
     predictive information on real data, and does the gain come from the
     observed edge? It fits the matched models named in ``baselines`` (the tree
-    plus up to five comparators) on the SAME reduced corpus (identical
+    plus up to six comparators) on the SAME reduced corpus (identical
     vocabulary, ``num_topics``, ``min_count``, and ``seed``) and scores held-out
     tokens of short leaf comments under each.
 
@@ -918,6 +918,11 @@ def reply_completion(
       root structure). ``delta["root"]`` is parent-coupling minus root-coupling, so
       it is positive where the reply edge matters more than the thread topic and
       negative where the thread root is the operative structure (sports, fandom).
+    - ``blend`` (issue #831): ReplyTM that couples each node to BOTH its parent and
+      its thread root (``alpha*parent + beta*root + (1-alpha-beta)*anchor``), with
+      the mix estimated. ``delta["blend"]`` is parent-coupling minus blend-coupling;
+      a negative value means the blend of edge and thread structure predicts better
+      than the reply edge alone.
     - ``lda`` / ``stm`` (issue #828): off-the-shelf comparators — a plain
       ``LDA(K)``, and an ``STM(K)`` with the ``covariates`` one-hot encoded as
       prevalence — fit on the same reduced corpus (pinned to the tree model's
@@ -946,8 +951,8 @@ def reply_completion(
     eval_frac : float. Share of eligible leaves to evaluate (sampled with
         ``seed``); ``1.0`` uses them all.
     baselines : which comparators to fit, any of ``"no_tree"``, ``"permuted"``,
-        ``"root"``, ``"lda"``, ``"stm"``.
-    em_iters : EM iterations for the ReplyTM fits (tree, no_tree, permuted, root). Match
+        ``"root"``, ``"blend"``, ``"lda"``, ``"stm"``.
+    em_iters : EM iterations for the ReplyTM fits (tree, no_tree, permuted, root, blend). Match
         this to the analysis fit. The off-the-shelf ``lda`` / ``stm`` comparators
         run at their own default iteration counts, not ``em_iters``.
     min_count : words rarer than this are dropped (shared across models).
@@ -975,7 +980,7 @@ def reply_completion(
     if not (0.0 < eval_frac <= 1.0):
         raise ValueError("eval_frac must be in (0, 1]")
     baselines = tuple(baselines)
-    _known_baselines = ("no_tree", "permuted", "root", "lda", "stm")
+    _known_baselines = ("no_tree", "permuted", "root", "blend", "lda", "stm")
     for b in baselines:
         if b not in _known_baselines:
             raise ValueError(
@@ -1052,6 +1057,10 @@ def reply_completion(
         # and covariate; only the coupling neighbor differs. delta["root"] = parent-tree minus
         # root-tree, so it is positive where reply-edge structure beats thread-level structure.
         models["root"] = _fit(parents, coupling="root")
+    if "blend" in baselines:
+        # A matched ReplyTM that couples each node to BOTH its parent and its thread root (issue
+        # #831), with the parent/root mix estimated. delta["blend"] = parent-tree minus blend-tree.
+        models["blend"] = _fit(parents, coupling="blend")
     perm_changed_frac = None
     if "permuted" in baselines:
         perm = _permute_parents_within_depth(parents, depth, root, rng)

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -9580,6 +9580,7 @@ fn reply_tm_fit(
             em_iters,
             em_tol,
             false, // raw smoke-test entry point does not return kappa_ci
+            None,  // parent coupling
             |_, _, _| true,
             &mut rng,
         );

--- a/src/python/reply_tm.rs
+++ b/src/python/reply_tm.rs
@@ -26,8 +26,9 @@ use std::collections::HashMap;
 /// dominated). Reduces to a plain logistic-normal topic model when the reply tree is flat.
 /// `num_topics` is K; `em_iters` the variational-EM iteration cap; `seed` makes the fit deterministic.
 /// `coupling` chooses the prior structure: `"parent"` (default; shrink toward the immediate parent,
-/// the reply-chain prior) or `"root"` (shrink toward the thread root, a broadcast / topic-around-the-
-/// root prior for discourse where replies track the thread topic rather than the specific parent).
+/// the reply-chain prior), `"root"` (shrink toward the thread root, a broadcast / topic-around-the-
+/// root prior), or `"blend"` (shrink toward both, `α·parent + β·root + (1-α-β)·anchor`, with the
+/// weights estimated or pinned via `blend_alpha`/`blend_beta`).
 #[pyclass(module = "topica")]
 pub struct ReplyTM {
     num_topics: usize,
@@ -37,8 +38,17 @@ pub struct ReplyTM {
     // reply-chain prior) or "root" (a node shrinks toward its thread root, a broadcast /
     // topic-around-the-root prior). "root" is fit by running the SAME kernel on a reparented
     // depth-2 star topology (every non-root points at its thread root), so the whole field / kappa
-    // / transform / persistence stack is unchanged; only the coupling neighbor differs.
+    // / transform / persistence stack is unchanged; only the coupling neighbor differs. "blend"
+    // couples each node to BOTH its parent and its thread root (α·parent + β·root + rest·anchor);
+    // its weights are estimated (or pinned by blend_alpha_fixed/blend_beta_fixed).
     coupling: String,
+    // Fixed blend weights from the constructor (None = estimate in the M-step). Retained so
+    // `settings` round-trips and refits reproduce the same pinning.
+    blend_alpha_fixed: Option<f64>,
+    blend_beta_fixed: Option<f64>,
+    // Effective (fitted or pinned) blend weights after fit; NaN unless coupling="blend" and fitted.
+    blend_alpha: f64,
+    blend_beta: f64,
     fitted: bool,
     vocab: Vec<String>,
     group_names: Vec<String>,
@@ -75,6 +85,14 @@ struct ReplyTmState {
     // consistency with the other states (see mod.rs / neural.rs).
     #[serde(default = "default_coupling")]
     coupling: String,
+    #[serde(default = "default_none_f64")]
+    blend_alpha_fixed: Option<f64>,
+    #[serde(default = "default_none_f64")]
+    blend_beta_fixed: Option<f64>,
+    #[serde(default = "default_nan")]
+    blend_alpha: f64,
+    #[serde(default = "default_nan")]
+    blend_beta: f64,
     fitted: bool,
     vocab: Vec<String>,
     group_names: Vec<String>,
@@ -96,6 +114,27 @@ struct ReplyTmState {
 
 fn default_coupling() -> String {
     "parent".to_string()
+}
+
+fn default_none_f64() -> Option<f64> {
+    None
+}
+
+fn default_nan() -> f64 {
+    f64::NAN
+}
+
+/// Each node's thread root (itself for a root). Used to build the blend `BlendConfig`.
+fn thread_roots(parents: &[i64]) -> Vec<usize> {
+    (0..parents.len())
+        .map(|start| {
+            let mut cur = start as i64;
+            while parents[cur as usize] >= 0 {
+                cur = parents[cur as usize];
+            }
+            cur as usize
+        })
+        .collect()
 }
 
 /// Reparent a forest to its thread-root star: every non-root node points at its thread root, roots
@@ -129,25 +168,57 @@ impl ReplyTM {
 #[pymethods]
 impl ReplyTM {
     #[new]
-    #[pyo3(signature = (num_topics, *, em_iters=150, seed=13, coupling="parent".to_string()))]
-    fn new(num_topics: usize, em_iters: usize, seed: u64, coupling: String) -> PyResult<Self> {
+    #[pyo3(signature = (num_topics, *, em_iters=150, seed=13, coupling="parent".to_string(), blend_alpha=None, blend_beta=None))]
+    fn new(
+        num_topics: usize,
+        em_iters: usize,
+        seed: u64,
+        coupling: String,
+        blend_alpha: Option<f64>,
+        blend_beta: Option<f64>,
+    ) -> PyResult<Self> {
         if num_topics < 2 {
             return Err(PyValueError::new_err("num_topics must be >= 2"));
         }
         if em_iters == 0 {
             return Err(PyValueError::new_err("em_iters must be >= 1"));
         }
-        if coupling != "parent" && coupling != "root" {
+        if coupling != "parent" && coupling != "root" && coupling != "blend" {
             return Err(PyValueError::new_err(format!(
-                "coupling must be \"parent\" (shrink toward the immediate parent) or \"root\" \
-                 (shrink toward the thread root); got {coupling:?}"
+                "coupling must be \"parent\" (immediate parent), \"root\" (thread root), or \
+                 \"blend\" (both); got {coupling:?}"
             )));
+        }
+        // blend weights are only meaningful under blend coupling; a pinned weight must be a valid
+        // convex share (α, β ≥ 0 and α + β ≤ 1 so the anchor keeps the remainder).
+        if coupling != "blend" && (blend_alpha.is_some() || blend_beta.is_some()) {
+            return Err(PyValueError::new_err(
+                "blend_alpha/blend_beta are only valid with coupling=\"blend\"",
+            ));
+        }
+        for (name, w) in [("blend_alpha", blend_alpha), ("blend_beta", blend_beta)] {
+            if let Some(v) = w {
+                if !(0.0..=1.0).contains(&v) {
+                    return Err(PyValueError::new_err(format!("{name} must be in [0, 1]")));
+                }
+            }
+        }
+        if let (Some(a), Some(b)) = (blend_alpha, blend_beta) {
+            if a + b > 1.0 {
+                return Err(PyValueError::new_err(
+                    "blend_alpha + blend_beta must be <= 1 (the anchor takes the remaining weight)",
+                ));
+            }
         }
         Ok(ReplyTM {
             num_topics,
             em_iters,
             seed,
             coupling,
+            blend_alpha_fixed: blend_alpha,
+            blend_beta_fixed: blend_beta,
+            blend_alpha: f64::NAN,
+            blend_beta: f64::NAN,
             fitted: false,
             vocab: Vec::new(),
             group_names: Vec::new(),
@@ -377,14 +448,40 @@ impl ReplyTM {
             }
         };
 
-        // The coupling topology the kernel actually fits on: the reply tree itself for the default
-        // parent coupling, or the reparented thread-root star for root coupling. Everything
-        // downstream (field fit, kappa, persistence, transform) operates on this topology, so
-        // storing it as `fit_parents` keeps them consistent with how the model was fit.
+        // The coupling topology the kernel actually fits on. Parent coupling uses the reply tree
+        // itself; root coupling uses the reparented thread-root star; blend keeps the real tree
+        // (it couples to parent AND root via a BlendConfig, not a reparented topology). Everything
+        // downstream (field fit, kappa, persistence, transform) operates on `fit_parents`, so
+        // storing the right topology keeps them consistent with how the model was fit.
         let coupling_par = if slf.coupling == "root" {
             root_star_parents(&par)
         } else {
             par.clone()
+        };
+        // Blend configuration: the real tree's thread roots + any pinned weights. Warn when the tree
+        // lacks depth-3 structure, where a node's parent equals its root and α vs β is unidentified.
+        let blend_cfg = if slf.coupling == "blend" {
+            let n_deep = (0..n)
+                .filter(|&c| par[c] >= 0 && thread_roots(&par)[c] != par[c] as usize)
+                .count();
+            if slf.blend_alpha_fixed.is_none() && slf.blend_beta_fixed.is_none() && n_deep < 2 {
+                PyErr::warn_bound(
+                    py,
+                    &py.get_type_bound::<pyo3::exceptions::PyUserWarning>(),
+                    "coupling=\"blend\": the reply tree has almost no depth-3+ structure (a node's \
+                     parent is its thread root), so the parent weight α and root weight β are not \
+                     separately identified and the split is arbitrary. Pin blend_alpha/blend_beta, \
+                     or use coupling=\"parent\"/\"root\".",
+                    1,
+                )?;
+            }
+            Some(crate::reply_tm::BlendConfig {
+                root: thread_roots(&par),
+                fixed_alpha: slf.blend_alpha_fixed,
+                fixed_beta: slf.blend_beta_fixed,
+            })
+        } else {
+            None
         };
 
         // Retain the coupling topology + groups for persistence() before the move-closure consumes them.
@@ -407,6 +504,7 @@ impl ReplyTM {
                 iters,
                 1e-6,
                 false, // kappa_ci computed lazily by the getter, not in fit
+                blend_cfg.as_ref(),
                 |_, _, _| true,
                 &mut rng,
             )
@@ -424,6 +522,8 @@ impl ReplyTM {
         slf.prevalence_se = m.anchor_se;
         slf.kappa = m.kappa;
         slf.kappa_ci = m.kappa_ci;
+        slf.blend_alpha = m.blend_alpha;
+        slf.blend_beta = m.blend_beta;
         slf.sigma2 = m.sigma2;
         slf.p0 = m.p0;
         slf.bound_history = m.bound_history;
@@ -584,12 +684,15 @@ impl ReplyTM {
             }
         };
 
-        // Couple the new forest the same way the model was fit: toward the immediate parent, or
-        // (root coupling) toward each node's thread root via the reparented star topology.
-        let coupling_par = if self.coupling == "root" {
-            root_star_parents(&par)
+        // Couple the new forest the same way the model was fit: toward the immediate parent; (root)
+        // toward each node's thread root via the reparented star; or (blend) toward both, with the
+        // fitted weights passed through so transform_reply_tm builds α·parent + β·root + rest·anchor.
+        let (coupling_par, blend) = if self.coupling == "root" {
+            (root_star_parents(&par), None)
+        } else if self.coupling == "blend" {
+            (par, Some((self.blend_alpha, self.blend_beta)))
         } else {
-            par
+            (par, None)
         };
 
         let kappa = self.kappa;
@@ -606,6 +709,7 @@ impl ReplyTM {
                 kappa,
                 sigma2,
                 p0,
+                blend,
             )
         });
         Ok(vecs_to_arr2(&theta).to_pyarray_bound(py))
@@ -734,6 +838,10 @@ impl ReplyTM {
                 em_iters: self.em_iters,
                 seed: self.seed,
                 coupling: self.coupling.clone(),
+                blend_alpha_fixed: self.blend_alpha_fixed,
+                blend_beta_fixed: self.blend_beta_fixed,
+                blend_alpha: self.blend_alpha,
+                blend_beta: self.blend_beta,
                 fitted: self.fitted,
                 vocab: self.vocab.clone(),
                 group_names: self.group_names.clone(),
@@ -764,6 +872,10 @@ impl ReplyTM {
             em_iters: s.em_iters,
             seed: s.seed,
             coupling: s.coupling,
+            blend_alpha_fixed: s.blend_alpha_fixed,
+            blend_beta_fixed: s.blend_beta_fixed,
+            blend_alpha: s.blend_alpha,
+            blend_beta: s.blend_beta,
             fitted: s.fitted,
             vocab: s.vocab,
             group_names: s.group_names,
@@ -837,6 +949,7 @@ impl ReplyTM {
                 iters,
                 1e-6,
                 false, // uncoupled pass for persistence(); no kappa_ci needed
+                None,  // uncoupled: every doc a root, no blend
                 |_, _, _| true,
                 &mut rng,
             )
@@ -1013,10 +1126,28 @@ impl ReplyTM {
         }))
     }
 
-    /// Reversion strength `κ = 1 - a` (0 = pure persistence / parent-copy, 1 = no memory).
+    /// Reversion strength `κ = 1 - a` (0 = pure persistence / parent-copy, 1 = no memory). `NaN`
+    /// under `coupling="blend"`, where the mix is described by `blend_alpha`/`blend_beta` instead.
     #[getter]
     fn kappa(&self) -> f64 {
         self.kappa
+    }
+
+    /// Blend parent weight `α` (how much a node tracks its immediate parent), `NaN` unless the model
+    /// was fit with `coupling="blend"`. A reliability-corrected (errors-in-variables) hard-EM
+    /// estimate, so it is de-attenuated for the η measurement error but still conditional on the
+    /// topic fit; read the held-out `reply_completion` delta for the model-vs-model comparison.
+    #[getter]
+    fn blend_alpha(&self) -> f64 {
+        self.blend_alpha
+    }
+
+    /// Blend root weight `β` (how much a node tracks its thread root), `NaN` unless the model was fit
+    /// with `coupling="blend"`. The anchor takes the remaining `1 - α - β`. Same estimator caveat as
+    /// `blend_alpha`.
+    #[getter]
+    fn blend_beta(&self) -> f64 {
+        self.blend_beta
     }
 
     /// Per-edge diffusion variance `σ²` (floored at 0.1; a returned 0.1 may be the floor, not an
@@ -1049,6 +1180,8 @@ impl ReplyTM {
         d.set_item("em_iters", self.em_iters)?;
         d.set_item("seed", self.seed)?;
         d.set_item("coupling", self.coupling.clone())?;
+        d.set_item("blend_alpha", self.blend_alpha_fixed)?;
+        d.set_item("blend_beta", self.blend_beta_fixed)?;
         Ok(d)
     }
 
@@ -1058,13 +1191,20 @@ impl ReplyTM {
         self.seed
     }
 
-    /// The reply coupling structure (`"parent"` or `"root"`).
+    /// The reply coupling structure (`"parent"`, `"root"`, or `"blend"`).
     #[getter]
     fn coupling(&self) -> String {
         self.coupling.clone()
     }
 
     fn __repr__(&self) -> String {
+        if self.fitted && self.coupling == "blend" {
+            return format!(
+                "ReplyTM(num_topics={}, coupling=\"blend\", fitted, alpha={:.3}, beta={:.3}, \
+                 sigma2={:.3})",
+                self.num_topics, self.blend_alpha, self.blend_beta, self.sigma2
+            );
+        }
         if self.fitted {
             format!(
                 "ReplyTM(num_topics={}, coupling={:?}, fitted, kappa={:.3}, sigma2={:.3})",

--- a/src/python/reply_tm.rs
+++ b/src/python/reply_tm.rs
@@ -461,8 +461,9 @@ impl ReplyTM {
         // Blend configuration: the real tree's thread roots + any pinned weights. Warn when the tree
         // lacks depth-3 structure, where a node's parent equals its root and α vs β is unidentified.
         let blend_cfg = if slf.coupling == "blend" {
+            let roots = thread_roots(&par); // compute once, reused for the check and BlendConfig
             let n_deep = (0..n)
-                .filter(|&c| par[c] >= 0 && thread_roots(&par)[c] != par[c] as usize)
+                .filter(|&c| par[c] >= 0 && roots[c] != par[c] as usize)
                 .count();
             if slf.blend_alpha_fixed.is_none() && slf.blend_beta_fixed.is_none() && n_deep < 2 {
                 PyErr::warn_bound(
@@ -476,7 +477,7 @@ impl ReplyTM {
                 )?;
             }
             Some(crate::reply_tm::BlendConfig {
-                root: thread_roots(&par),
+                root: roots,
                 fixed_alpha: slf.blend_alpha_fixed,
                 fixed_beta: slf.blend_beta_fixed,
             })

--- a/src/reply_tm.rs
+++ b/src/reply_tm.rs
@@ -58,8 +58,15 @@ pub struct ReplyTmModel {
     /// each κ; `(NaN, NaN)` when there are no reply edges or the field was not fit (κ unidentified).
     /// Conditional on the topic fit; the point estimate is biased toward κ→0 (persistence).
     pub kappa_ci: (f64, f64),
-    /// Reversion strength `κ = 1 - a` toward the anchor.
+    /// Reversion strength `κ = 1 - a` toward the anchor. `NaN` under blend coupling (where the mix
+    /// is described by `alpha`/`beta` instead of a single reversion).
     pub kappa: f64,
+    /// Blend coupling parent weight `α` (`NaN` unless `coupling="blend"`): how much a node's prior
+    /// mean tracks its immediate parent.
+    pub blend_alpha: f64,
+    /// Blend coupling root weight `β` (`NaN` unless `coupling="blend"`): how much a node's prior mean
+    /// tracks its thread root. The anchor gets the remaining `1 - α - β`.
+    pub blend_beta: f64,
     /// Per-edge diffusion variance `σ²`.
     pub sigma2: f64,
     /// Root prior variance.
@@ -101,6 +108,17 @@ impl ReplyTmModel {
 /// parent in the reply forest (any negative value marks a root). `num_types` is the vocabulary
 /// size. Returns the fitted model; deterministic given `rng` (the E-step runs in parallel but
 /// folds sufficient statistics in document order, as in `fit_ctm`).
+/// Blend coupling configuration (issue #831). Under blend a non-root node's prior mean is
+/// `α·η_parent + β·η_root + (1-α-β)·anchor`, coupling each node to BOTH its immediate parent and its
+/// thread root. `root[c]` is node `c`'s thread root (itself for a root). `fixed_alpha`/`fixed_beta`
+/// pin the weights; when `None` they are estimated in the M-step by a ridge-regularized regression
+/// of each node's centered η on its parent's and root's centered η (a hard-EM point estimate).
+pub struct BlendConfig {
+    pub root: Vec<usize>,
+    pub fixed_alpha: Option<f64>,
+    pub fixed_beta: Option<f64>,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     docs: &[Vec<u32>],
@@ -112,6 +130,7 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     em_iters: usize,
     em_tol: f64,
     compute_ci: bool,
+    blend: Option<&BlendConfig>,
     mut on_progress: F,
     rng: &mut R,
 ) -> ReplyTmModel {
@@ -154,6 +173,10 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     let mut a = 0.7f64;
     let mut sigma2 = 1.0f64;
     let mut p0 = 1.0f64;
+    // Blend coupling weights (α = parent, β = root); seeded to a parent-leaning mix and updated in
+    // the M-step unless pinned. Unused (and returned as NaN) when `blend` is None.
+    let mut alpha = blend.and_then(|b| b.fixed_alpha).unwrap_or(0.5);
+    let mut beta_w = blend.and_then(|b| b.fixed_beta).unwrap_or(0.25);
 
     let mut bound_history: Vec<f64> = Vec::with_capacity(em_iters);
     let mut converged = false;
@@ -191,6 +214,16 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                 let ag = &anchor[groups[di]]; // the document's covariate-group anchor
                 let (mu_d, siginv, entropy) = if par < 0 {
                     (ag.clone(), &siginv_root, ent_root)
+                } else if let Some(bc) = blend {
+                    // Blend: couple to BOTH parent and thread root, reverting toward the anchor by
+                    // the residual weight. Reads the previous iteration's λ for both (structured
+                    // mean-field); parent and root are ancestors, so this is a directed coupling.
+                    let lp = &lambda[par as usize];
+                    let lr = &lambda[bc.root[di]];
+                    let mu: Vec<f64> = (0..km1)
+                        .map(|i| alpha * lp[i] + beta_w * lr[i] + (1.0 - alpha - beta_w) * ag[i])
+                        .collect();
+                    (mu, &siginv_edge, ent_edge)
                 } else {
                     let lp = &lambda[par as usize];
                     let mu: Vec<f64> = (0..km1)
@@ -288,46 +321,144 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         // keeps a reply's own tokens able to move it off the parent even once the field is fit.
         let warmup = 15;
         if em + 1 > warmup {
-            let obs: Vec<Vec<f64>> = (0..km1)
-                .map(|i| {
-                    lambda
-                        .iter()
-                        .enumerate()
-                        .map(|(di, l)| l[i] - anchor[groups[di]][i])
-                        .collect()
-                })
-                .collect();
-            // Empty nodes stay in the tree (so their children still couple through them) but
-            // carry NO observation: r = +inf makes them latent-only, so they never pin the field.
-            let r: Vec<f64> = (0..d)
-                .map(|di| {
-                    if !has_tokens[di] {
-                        return 1e12;
+            if let Some(bc) = blend {
+                // Blend M-step: estimate (α, β) by a ridge-regularized, errors-in-variables
+                // regression of each node's anchor-centered η on its parent's and root's
+                // anchor-centered η, pooled over topics and edges. The EIV term (below) subtracts the
+                // Laplace ν so the weights are reliability-corrected rather than attenuated (the
+                // two-regressor analogue of persistence()'s structural correction); still a hard-EM
+                // estimate conditional on the topic fit, so the held-out reply_completion delta is
+                // the model-vs-model readout. σ² is the residual variance; p0 the root variance.
+                let (mut spp, mut spr, mut srr, mut spy, mut sry, mut syy, mut ne) =
+                    (0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0f64);
+                // Measurement-error (Laplace ν) sums for the errors-in-variables correction below:
+                // the parent/root regressors are noisy estimates of the latent η, so their observed
+                // second moments are inflated by ν; subtracting it de-attenuates α/β (the same
+                // reliability correction persistence() applies, generalized to two regressors).
+                let (mut snu_p, mut snu_r, mut snu_pr) = (0.0, 0.0, 0.0f64);
+                for c in 0..d {
+                    let par = parents[c];
+                    if par < 0 || !has_tokens[c] {
+                        continue;
                     }
-                    let nd = &nu_diag_store[di];
-                    (nd.iter().sum::<f64>() / km1 as f64).max(1e-6)
-                })
-                .collect();
-            // fit with the anchor mean held at 0 (obs are anchor-centered): this keeps the fitted
-            // `a` consistent with the m=0 profile used for kappa_ci, and avoids double-counting the
-            // mean the anchor already removed.
-            let fit = tree_field::fit_fixed_mean(
-                parents,
-                &obs,
-                &r,
-                TreeFieldParams {
-                    a,
-                    q: sigma2,
-                    m: 0.0,
-                    p0,
-                },
-            );
-            // clamp a < 1 so the next iteration's logit init stays finite (a=1 → +inf → NaN in
-            // the Nelder-Mead simplex); floor σ²/p0 (a clamp, not an estimate — see kappa_ci).
-            a = fit.a.min(0.999);
-            sigma2 = fit.q.max(0.1);
-            p0 = fit.p0.max(0.1);
-            field_fit_ran = true;
+                    let (p, r) = (par as usize, bc.root[c]);
+                    if !has_tokens[p] || !has_tokens[r] {
+                        continue;
+                    }
+                    let ag = &anchor[groups[c]];
+                    for i in 0..km1 {
+                        let xp = lambda[p][i] - ag[i];
+                        let xr = lambda[r][i] - ag[i];
+                        let y = lambda[c][i] - ag[i];
+                        spp += xp * xp;
+                        spr += xp * xr;
+                        srr += xr * xr;
+                        spy += xp * y;
+                        sry += xr * y;
+                        syy += y * y;
+                        snu_p += nu_diag_store[p][i];
+                        snu_r += nu_diag_store[r][i];
+                        // When parent == root (depth-2 nodes) the two regressors are the SAME noisy
+                        // node, so their measurement errors are perfectly shared and inflate the
+                        // cross term too; otherwise the errors are independent (cross-correction 0).
+                        if p == r {
+                            snu_pr += nu_diag_store[p][i];
+                        }
+                        ne += 1.0;
+                    }
+                }
+                if ne > 0.0 {
+                    if bc.fixed_alpha.is_none() || bc.fixed_beta.is_none() {
+                        // De-attenuate: subtract the measurement-error second moments, then ridge
+                        // for stability / collinearity (depth-2 threads, where parent == root).
+                        let ridge = 1e-6 * (spp + srr) + 1e-9;
+                        let a11 = (spp - snu_p).max(0.0) + ridge;
+                        let a22 = (srr - snu_r).max(0.0) + ridge;
+                        let a12 = spr - snu_pr;
+                        let (b1, b2) = (spy, sry);
+                        let det = a11 * a22 - a12 * a12;
+                        if det.abs() > 1e-12 {
+                            let mut al = (a22 * b1 - a12 * b2) / det;
+                            let mut be = (a11 * b2 - a12 * b1) / det;
+                            // Project onto {α,β ≥ 0, α+β ≤ 1} so the prior mean stays a convex
+                            // blend of parent, root, and anchor.
+                            al = al.max(0.0);
+                            be = be.max(0.0);
+                            if al + be > 1.0 {
+                                let s = al + be;
+                                al /= s;
+                                be /= s;
+                            }
+                            alpha = bc.fixed_alpha.unwrap_or(al);
+                            beta_w = bc.fixed_beta.unwrap_or(be);
+                        }
+                    }
+                    // σ² = residual variance of y around α·xp + β·xr.
+                    let resid = (syy - 2.0 * (alpha * spy + beta_w * sry)
+                        + alpha * alpha * spp
+                        + 2.0 * alpha * beta_w * spr
+                        + beta_w * beta_w * srr)
+                        / ne;
+                    sigma2 = resid.max(0.1);
+                }
+                // p0 = root variance around the anchor.
+                let (mut rss, mut nr) = (0.0, 0.0f64);
+                for c in 0..d {
+                    if parents[c] < 0 && has_tokens[c] {
+                        let ag = &anchor[groups[c]];
+                        for i in 0..km1 {
+                            let e = lambda[c][i] - ag[i];
+                            rss += e * e;
+                            nr += 1.0;
+                        }
+                    }
+                }
+                if nr > 0.0 {
+                    p0 = (rss / nr).max(0.1);
+                }
+                field_fit_ran = true;
+            } else {
+                let obs: Vec<Vec<f64>> = (0..km1)
+                    .map(|i| {
+                        lambda
+                            .iter()
+                            .enumerate()
+                            .map(|(di, l)| l[i] - anchor[groups[di]][i])
+                            .collect()
+                    })
+                    .collect();
+                // Empty nodes stay in the tree (so their children still couple through them) but
+                // carry NO observation: r = +inf makes them latent-only, so they never pin the field.
+                let r: Vec<f64> = (0..d)
+                    .map(|di| {
+                        if !has_tokens[di] {
+                            return 1e12;
+                        }
+                        let nd = &nu_diag_store[di];
+                        (nd.iter().sum::<f64>() / km1 as f64).max(1e-6)
+                    })
+                    .collect();
+                // fit with the anchor mean held at 0 (obs are anchor-centered): this keeps the fitted
+                // `a` consistent with the m=0 profile used for kappa_ci, and avoids double-counting the
+                // mean the anchor already removed.
+                let fit = tree_field::fit_fixed_mean(
+                    parents,
+                    &obs,
+                    &r,
+                    TreeFieldParams {
+                        a,
+                        q: sigma2,
+                        m: 0.0,
+                        p0,
+                    },
+                );
+                // clamp a < 1 so the next iteration's logit init stays finite (a=1 → +inf → NaN in
+                // the Nelder-Mead simplex); floor σ²/p0 (a clamp, not an estimate — see kappa_ci).
+                a = fit.a.min(0.999);
+                sigma2 = fit.q.max(0.1);
+                p0 = fit.p0.max(0.1);
+                field_fit_ran = true;
+            }
         }
     }
 
@@ -339,6 +470,18 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         sigma2 = f64::NAN;
         p0 = f64::NAN;
     }
+    // Blend reports its mix via (alpha, beta), not a single reversion; kappa is undefined. When the
+    // field never ran (no edges / warm-up not reached) the weights are still the init constants, so
+    // report them as NaN like the other field params.
+    let (kappa_out, alpha_out, beta_out) = if blend.is_some() {
+        if n_edges == 0 || !field_fit_ran {
+            (f64::NAN, f64::NAN, f64::NAN)
+        } else {
+            (f64::NAN, alpha, beta_w)
+        }
+    } else {
+        (1.0 - a, f64::NAN, f64::NAN)
+    };
 
     // ---- uncertainty ----
     // Thread root of each document (walk parents to the root). The reply tree induces WITHIN-THREAD
@@ -396,7 +539,8 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     // κ CI is the dominant per-fit cost (a 99-point profile, each an inner Nelder-Mead), and it is
     // usually not read (persistence() supersedes it). Compute it here only when explicitly asked;
     // otherwise the binding computes it lazily from the stored fit via `kappa_profile_ci`.
-    let kappa_ci = if compute_ci {
+    // kappa_ci is a tree-field profile of the reversion; it has no meaning under blend coupling.
+    let kappa_ci = if compute_ci && blend.is_none() {
         kappa_profile_ci(
             parents,
             &lambda,
@@ -420,7 +564,9 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         anchor,
         anchor_se,
         kappa_ci,
-        kappa: 1.0 - a,
+        kappa: kappa_out,
+        blend_alpha: alpha_out,
+        blend_beta: beta_out,
         sigma2,
         p0,
         bound: bound_history.last().copied().unwrap_or(f64::NAN),
@@ -447,6 +593,7 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
 /// (θ uniform); transform's prior-mode is the principled value (it matches `ctm::infer_theta`), so on
 /// a tree with an empty interior or root node transform and the stored fit `doc_topic` diverge for
 /// that node and its subtree. Returns D×K proportions in `docs` order.
+#[allow(clippy::too_many_arguments)]
 pub fn transform_reply_tm(
     docs: &[Vec<u32>],
     parents: &[i64],
@@ -456,10 +603,22 @@ pub fn transform_reply_tm(
     kappa: f64,
     sigma2: f64,
     p0: f64,
+    blend: Option<(f64, f64)>,
 ) -> Vec<Vec<f64>> {
     let k = beta.len();
     let km1 = k - 1;
     let d = docs.len();
+    // Blend needs each node's thread root (parent and root are both ancestors, so the same
+    // topological pass still finalizes both before a node is inferred).
+    let root: Vec<usize> = (0..d)
+        .map(|start| {
+            let mut cur = start as i64;
+            while parents[cur as usize] >= 0 {
+                cur = parents[cur as usize];
+            }
+            cur as usize
+        })
+        .collect();
 
     // Diagonal inverse prior covariance for edges (σ²) and roots (p0).
     let siginv_diag = |var: f64| -> Vec<f64> {
@@ -499,6 +658,13 @@ pub fn transform_reply_tm(
         let par = parents[di];
         let (mu_d, siginv) = if par < 0 {
             (ag.clone(), &siginv_root)
+        } else if let Some((alpha, beta_w)) = blend {
+            let lp = &lambda[par as usize];
+            let lr = &lambda[root[di]];
+            let mu: Vec<f64> = (0..km1)
+                .map(|i| alpha * lp[i] + beta_w * lr[i] + (1.0 - alpha - beta_w) * ag[i])
+                .collect();
+            (mu, &siginv_edge)
         } else {
             let lp = &lambda[par as usize];
             let mu: Vec<f64> = (0..km1)
@@ -667,6 +833,7 @@ mod tests {
             150,
             1e-7,
             true, // exercise the eager kappa_ci path
+            None, // parent coupling
             |_, _, _| true,
             &mut fit_rng,
         );

--- a/src/reply_tm.rs
+++ b/src/reply_tm.rs
@@ -368,32 +368,45 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                     }
                 }
                 if ne > 0.0 {
-                    if bc.fixed_alpha.is_none() || bc.fixed_beta.is_none() {
-                        // De-attenuate: subtract the measurement-error second moments, then ridge
-                        // for stability / collinearity (depth-2 threads, where parent == root).
-                        let ridge = 1e-6 * (spp + srr) + 1e-9;
-                        let a11 = (spp - snu_p).max(0.0) + ridge;
-                        let a22 = (srr - snu_r).max(0.0) + ridge;
-                        let a12 = spr - snu_pr;
-                        let (b1, b2) = (spy, sry);
-                        let det = a11 * a22 - a12 * a12;
-                        if det.abs() > 1e-12 {
-                            let mut al = (a22 * b1 - a12 * b2) / det;
-                            let mut be = (a11 * b2 - a12 * b1) / det;
-                            // Project onto {α,β ≥ 0, α+β ≤ 1} so the prior mean stays a convex
-                            // blend of parent, root, and anchor.
-                            al = al.max(0.0);
-                            be = be.max(0.0);
-                            if al + be > 1.0 {
-                                let s = al + be;
-                                al /= s;
-                                be /= s;
+                    // Errors-in-variables normal equations (de-attenuated), with a ridge for
+                    // stability / collinearity (depth-2 threads, where parent == root).
+                    let ridge = 1e-6 * (spp + srr) + 1e-9;
+                    let a11 = (spp - snu_p).max(0.0) + ridge;
+                    let a22 = (srr - snu_r).max(0.0) + ridge;
+                    let a12 = spr - snu_pr;
+                    // The free (unpinned) weight's conditional 1-D EIV minimizer, clamped so it never
+                    // drives α+β past 1 (a negative anchor weight would break the convex blend).
+                    let free_a = |b: f64, hi: f64| ((spy - b * a12) / a11).clamp(0.0, hi);
+                    let free_b = |a: f64, hi: f64| ((sry - a * a12) / a22).clamp(0.0, hi);
+                    let (al, be) = match (bc.fixed_alpha, bc.fixed_beta) {
+                        (Some(fa), Some(fb)) => (fa, fb),
+                        // Pin one, estimate the other conditional on the pin (not the biased joint
+                        // value) and cap it at 1 - pin so the invariant always holds.
+                        (Some(fa), None) => (fa, free_b(fa, 1.0 - fa)),
+                        (None, Some(fb)) => (free_a(fb, 1.0 - fb), fb),
+                        // Both free: the joint solve, projected onto {α,β ≥ 0, α+β ≤ 1} (clamp then
+                        // rescale) so the prior mean stays a convex blend of parent, root, anchor.
+                        (None, None) => {
+                            let det = a11 * a22 - a12 * a12;
+                            if det.abs() <= 1e-12 {
+                                (alpha, beta_w) // keep the previous iterate if degenerate
+                            } else {
+                                let mut a = ((a22 * spy - a12 * sry) / det).max(0.0);
+                                let mut b = ((a11 * sry - a12 * spy) / det).max(0.0);
+                                if a + b > 1.0 {
+                                    let s = a + b;
+                                    a /= s;
+                                    b /= s;
+                                }
+                                (a, b)
                             }
-                            alpha = bc.fixed_alpha.unwrap_or(al);
-                            beta_w = bc.fixed_beta.unwrap_or(be);
                         }
-                    }
-                    // σ² = residual variance of y around α·xp + β·xr.
+                    };
+                    alpha = al;
+                    beta_w = be;
+                    // σ² = residual variance of y around α·xp + β·xr (floored). Left with the
+                    // measurement error folded in, as the σ² floor already bounds the edge prior;
+                    // de-convolving ν here destabilized the fit through the E-step feedback.
                     let resid = (syy - 2.0 * (alpha * spy + beta_w * sry)
                         + alpha * alpha * spp
                         + 2.0 * alpha * beta_w * spr

--- a/tests/test_reply_tm.py
+++ b/tests/test_reply_tm.py
@@ -785,6 +785,24 @@ def test_blend_fixed_weights_respected():
     assert m.settings["blend_alpha"] == 0.6 and m.settings["blend_beta"] == 0.3
 
 
+def test_blend_partial_pin_keeps_convexity():
+    """Pinning ONE weight must estimate the other conditionally and never push alpha+beta past 1
+    (a negative anchor weight would make the prior mean non-convex). Regression for the
+    three-reviewer finding on PR #833."""
+    docs, parents = _mixed_corpus()
+    for pin in (0.5, 0.7, 0.9):
+        ma = topica.ReplyTM(4, em_iters=60, seed=13, coupling="blend", blend_alpha=pin)
+        ma.fit(docs, parents=parents)
+        assert ma.blend_alpha == pin
+        assert 0.0 <= ma.blend_beta <= 1.0 - pin + 1e-9
+        assert ma.blend_alpha + ma.blend_beta <= 1.0 + 1e-9
+        mb = topica.ReplyTM(4, em_iters=60, seed=13, coupling="blend", blend_beta=pin)
+        mb.fit(docs, parents=parents)
+        assert mb.blend_beta == pin
+        assert 0.0 <= mb.blend_alpha <= 1.0 - pin + 1e-9
+        assert mb.blend_alpha + mb.blend_beta <= 1.0 + 1e-9
+
+
 def test_blend_transform_and_save(tmp_path):
     docs, parents = _mixed_corpus(n_threads=30)
     m = topica.ReplyTM(4, em_iters=50, seed=13, coupling="blend")

--- a/tests/test_reply_tm.py
+++ b/tests/test_reply_tm.py
@@ -713,3 +713,107 @@ def test_parent_coupling_wins_on_chain_persistence():
     res = topica.evaluate.reply_completion(
         docs, parents, num_topics=5, baselines=("root",), em_iters=60, seed=13, n_boot=300)
     assert res.delta["root"]["estimate"] > 0.0
+
+
+# ---------------------------------------------------------------------------
+# coupling="blend": parent + root mixture (issue #831)
+# ---------------------------------------------------------------------------
+
+def test_blend_validation():
+    # blend weights only valid with coupling="blend"
+    with pytest.raises(ValueError, match="only valid with"):
+        topica.ReplyTM(2, blend_alpha=0.5)
+    with pytest.raises(ValueError, match=r"\[0, 1\]"):
+        topica.ReplyTM(2, coupling="blend", blend_alpha=1.5)
+    with pytest.raises(ValueError, match="<= 1"):
+        topica.ReplyTM(2, coupling="blend", blend_alpha=0.7, blend_beta=0.6)
+    with pytest.raises(ValueError, match="coupling"):
+        topica.ReplyTM(2, coupling="bogus")
+
+
+def _mixed_corpus(seed=1, n_threads=140):
+    """Planted MIXED discourse: each thin leaf token is drawn 50/50 from its thread-root topic and
+    its parent topic, with root and parent topics both drawn from four equally-frequent blocks and
+    required to differ (so all topics are balanced, the two regressors are not collinear, and there
+    are no pure leaves). The optimal predictor of a held-out leaf token, not knowing which component
+    it came from, is the blend of parent and root, so blend coupling should beat both pure couplings."""
+    rng = np.random.default_rng(seed)
+    blocks = [[f"t{k}w{i}" for i in range(6)] for k in range(4)]
+    docs, parents = [], []
+    for _ in range(n_threads):
+        rk = int(rng.integers(4))
+        docs.append(list(rng.choice(blocks[rk], 10))); parents.append(-1)
+        r = len(docs) - 1
+        for _ in range(2):
+            pk = int(rng.integers(4))
+            while pk == rk:  # parent topic differs from the root topic
+                pk = int(rng.integers(4))
+            docs.append(list(rng.choice(blocks[pk], 10))); parents.append(r)
+            m = len(docs) - 1
+            for _ in range(3):  # thin leaves: each token a 50/50 draw from root vs parent topic
+                leaf = [rng.choice(blocks[rk if rng.random() < 0.5 else pk]) for _ in range(3)]
+                docs.append(leaf); parents.append(m)
+    return docs, parents
+
+
+def test_blend_fits_getters_and_repr():
+    docs, parents = _mixed_corpus()
+    m = topica.ReplyTM(4, em_iters=80, seed=13, coupling="blend")
+    m.fit(docs, parents=parents)
+    assert m.coupling == "blend"
+    assert np.isfinite(m.blend_alpha) and np.isfinite(m.blend_beta)
+    assert 0.0 <= m.blend_alpha <= 1.0 and 0.0 <= m.blend_beta <= 1.0
+    assert m.blend_alpha + m.blend_beta <= 1.0 + 1e-9
+    assert np.isnan(m.kappa)  # blend has no single reversion
+    assert "blend" in repr(m)
+    assert m.settings["coupling"] == "blend"
+
+
+def test_blend_estimates_both_weights_positive():
+    """On genuinely mixed discourse both the parent and the root weight are estimated positive."""
+    docs, parents = _mixed_corpus()
+    m = topica.ReplyTM(4, em_iters=80, seed=13, coupling="blend")
+    m.fit(docs, parents=parents)
+    assert m.blend_alpha > 0.01 and m.blend_beta > 0.01
+
+
+def test_blend_fixed_weights_respected():
+    docs, parents = _mixed_corpus(n_threads=30)
+    m = topica.ReplyTM(4, em_iters=40, seed=13, coupling="blend", blend_alpha=0.6, blend_beta=0.3)
+    m.fit(docs, parents=parents)
+    assert m.blend_alpha == 0.6 and m.blend_beta == 0.3
+    assert m.settings["blend_alpha"] == 0.6 and m.settings["blend_beta"] == 0.3
+
+
+def test_blend_transform_and_save(tmp_path):
+    docs, parents = _mixed_corpus(n_threads=30)
+    m = topica.ReplyTM(4, em_iters=50, seed=13, coupling="blend")
+    m.fit(docs, parents=parents)
+    th = m.transform(docs, parents=parents)
+    assert th.shape == (len(docs), 4) and np.allclose(th.sum(1), 1.0)
+    p = tmp_path / "blend.bin"
+    m.save(str(p))
+    m2 = topica.ReplyTM.load(str(p))
+    assert m2.coupling == "blend"
+    assert m2.blend_alpha == m.blend_alpha and m2.blend_beta == m.blend_beta
+    assert np.allclose(m2.transform(docs, parents=parents), th)
+
+
+def test_blend_identifiability_warning():
+    """A shallow (depth-2-only) corpus cannot separate alpha from beta; the fit warns."""
+    docs, parents, cov, vocab = _threaded_corpus(n_threads=20, depth=2)
+    m = topica.ReplyTM(2, em_iters=30, seed=13, coupling="blend")
+    with pytest.warns(UserWarning, match="not separately identified"):
+        m.fit(docs, parents=parents)
+
+
+def test_blend_beats_parent_and_root_on_mixed():
+    """The headline: on mixed discourse the estimated blend predicts held-out leaf tokens better
+    than either pure-parent or pure-root coupling."""
+    docs, parents = _mixed_corpus()
+    res = topica.evaluate.reply_completion(
+        docs, parents, num_topics=4, baselines=("root", "blend"),
+        em_iters=70, seed=13, n_boot=300)
+    assert res.per_token_ll["blend"] > res.per_token_ll["tree"]   # blend beats pure parent
+    assert res.per_token_ll["blend"] > res.per_token_ll["root"]   # blend beats pure root
+    assert res.delta["blend"]["estimate"] < 0.0                   # tree(parent) minus blend < 0


### PR DESCRIPTION
## Summary

The third coupling variant from #831 (the "most useful single knob"). `coupling="blend"` couples each node to **both** its immediate parent and its thread root:

`prior mean = alpha*parent + beta*root + (1 - alpha - beta)*anchor`

for discourse that is neither purely reply-chained (debate) nor purely broadcast (sports/fandom).

## Why no loopy-Gaussian kernel is needed

A node coupled to both parent and root is not a tree (per thread, root + chain forms cycles), which breaks the exact tree-field BP. Two observations sidestep that:

- **Inference (E-step + `transform`) is still a single directed pass.** Parent and root are both *ancestors*, so a topological (roots-first) sweep lets each node read its finalized parent and root eta. `transform` reparents nothing — it reads both.
- **Estimation of (alpha, beta, sigma2, p0) is a hard-EM M-step**: a ridge-regularized, **errors-in-variables** regression of each node's anchor-centered eta on its parent's and root's. The EIV term subtracts the Laplace nu (the two-regressor analogue of `persistence()`'s reliability correction), so the weights are **de-attenuated** rather than shrunk toward zero — without which blend loses to the tree-field-fit pure couplings. Weights are projected onto `{alpha,beta>=0, alpha+beta<=1}`; pin them with `blend_alpha=`/`blend_beta=`.

`kappa`/`kappa_ci` are `NaN` under blend (the mix is two weights, not one reversion); `.blend_alpha`/`.blend_beta` expose the fitted values. The fit **warns** when the tree lacks depth-3 structure (a node's parent == its root), where alpha vs beta is unidentified.

## reply_completion

Gains a `"blend"` baseline; `delta["blend"]` = parent-coupling minus blend-coupling.

```python
res = topica.evaluate.reply_completion(docs, parents, num_topics=25,
                                       baselines=("no_tree", "root", "blend"))
res.delta["blend"]   # negative where a parent+root blend beats the reply edge alone
```

## Validation (planted recovery)

On mixed discourse — each thin leaf token a 50/50 draw from its parent and root topics, four **balanced** blocks with parent != root (so all topics equally frequent, no pure leaves, alpha/beta identified) — the estimated blend predicts held-out leaf tokens better than **both** pure parent and pure root (`delta["blend"]` CI excludes zero, `per_token_ll["blend"] > tree > root`), with alpha and beta both estimated positive.

## Scope

Fixed/estimated weights per the accepted plan. A thread random-effect (#831 option 3) remains a tracked follow-up.

## Verification

49 `tests/test_reply_tm.py` pass (8 new: validation, fits/getters/repr, both-weights-positive, fixed override, transform + save roundtrip, identifiability warning, and the beats-both planted-recovery gate). `cargo test`/`fmt`/`clippy`, `preflight.sh` (stub + tables in sync), `mkdocs --strict`, and the cross-model settings roundtrip all pass. Save-state carries `coupling` + blend weights (`serde(default)` -> `parent`, inert under positional bincode as documented).

🤖 Generated with [Claude Code](https://claude.com/claude-code)