### PR TITLE
perf(replytm): full edge covariance so tree and no-tree share the base (completes #834)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -667,15 +667,16 @@ that vector's prior mean comes from. A thread root is drawn around its
 covariate-group baseline with a **full covariance** (the same correlated logistic-normal
 prior CTM/STM fit, so with no reply tree ReplyTM's base matches CTM up to empty-document
 handling, not a weaker isotropic model); a reply is drawn around a blend of its parent
-comment's vector and that same group baseline, with an isotropic per-edge variance. The blend is `(1 - kappa) * parent + kappa *
+comment's vector and that same group baseline, with its own full edge covariance (so a reply
+leaf is on the same covariance footing as a root, and the tree-vs-no_tree comparison reflects
+the reply coupling, not a covariance downgrade). The blend is `(1 - kappa) * parent + kappa *
 baseline`, so `kappa` is a **reversion** knob: `kappa = 0` copies the parent (pure
 persistence along the reply edge), `kappa = 1` ignores the parent and falls back to
-the group baseline (a plain covariate topic model). The reply-edge parameters (persistence
-`kappa`, per-edge variance `sigma2`) are fit by maximum likelihood on a Gaussian
-belief-propagation pass over the tree; `sigma2` is floored at 0.1 to keep the diffusion from
-collapsing, so a reported `sigma2` of exactly 0.1 may be the floor rather than an estimate.
-The root prior is a full covariance fit CTM-style (see above), and `p0` reports its mean
-marginal variance (defined even in the no-tree case, where it is not floored).
+the group baseline (a plain covariate topic model). The persistence `kappa` is fit by maximum
+likelihood on a Gaussian belief-propagation pass over the tree. The root and edge priors are
+both full covariances fit CTM-style (see above); `p0` and `sigma2` report their respective mean
+marginal variances (the root's and the reply edge's), each defined once the corpus has roots or
+edges.
 
 The point of the prior is out-of-sample: a comment's parent tells you something about
 what the comment is about, on top of its own words. ReplyTM ships a committed

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3181,7 +3181,8 @@ class ReplyTM:
         ...
     @property
     def sigma2(self) -> float:
-        """Per-edge diffusion variance (floored at 0.1); NaN when the field was not fit."""
+        """Per-edge (OU step) variance: the mean marginal variance of the fitted full edge
+        covariance Sigma_edge (a scalar summary; the edge prior is the full Sigma_edge). NaN with no edges."""
         ...
     @property
     def p0(self) -> float:

--- a/src/python/reply_tm.rs
+++ b/src/python/reply_tm.rs
@@ -65,6 +65,9 @@ pub struct ReplyTM {
     // Full root-prior covariance Σ_root (K-1 × K-1, row-major); the base logistic-normal prior for
     // root documents and for `transform`'s root nodes (#834).
     sigma_root: Vec<f64>,
+    // Full edge (OU step) covariance Σ_edge; the reply edges' prior covariance, on the same footing
+    // as sigma_root so tree and no-tree share the base covariance.
+    sigma_edge: Vec<f64>,
     bound_history: Vec<f64>,
     // Training reply tree + covariate groups (document-aligned), retained so `persistence()` can
     // re-fit an uncoupled pass and regress child η on parent η.
@@ -111,6 +114,8 @@ struct ReplyTmState {
     p0: f64,
     #[serde(default)]
     sigma_root: Vec<f64>,
+    #[serde(default)]
+    sigma_edge: Vec<f64>,
     bound_history: Vec<f64>,
     fit_parents: Vec<i64>,
     fit_groups: Vec<usize>,
@@ -238,6 +243,7 @@ impl ReplyTM {
             sigma2: f64::NAN,
             p0: f64::NAN,
             sigma_root: Vec::new(),
+            sigma_edge: Vec::new(),
             bound_history: Vec::new(),
             fit_parents: Vec::new(),
             fit_groups: Vec::new(),
@@ -534,6 +540,7 @@ impl ReplyTM {
         slf.sigma2 = m.sigma2;
         slf.p0 = m.p0;
         slf.sigma_root = m.sigma_root;
+        slf.sigma_edge = m.sigma_edge;
         slf.bound_history = m.bound_history;
         slf.corpus = Some(corpus_snapshot);
         slf.fitted = true;
@@ -704,20 +711,23 @@ impl ReplyTM {
         };
 
         let kappa = self.kappa;
-        let sigma2 = self.sigma2;
-        // Full root precision Σ_root⁻¹ for the root nodes. The isotropic p0·I fallback covers a
-        // freshly-constructed/degenerate model with no Σ_root; note it does NOT rescue genuinely
-        // old saves — the positional-bincode format cannot load a pre-Σ_root file at all (see the
-        // serde-default note on the state struct), consistent with the pre-v1.0 save-compat policy.
-        let root_siginv: Vec<f64> = if self.sigma_root.len() == km1 * km1 {
-            crate::linalg::spd_inverse_and_half_logdet(&self.sigma_root, km1).0
-        } else {
-            let mut s = vec![0.0f64; km1 * km1];
-            for i in 0..km1 {
-                s[i * km1 + i] = 1.0 / self.p0;
+        // Full precisions for roots (Σ_root⁻¹) and edges (Σ_edge⁻¹). The isotropic diagonal fallback
+        // covers a freshly-constructed/degenerate model with an empty covariance; note it does NOT
+        // rescue genuinely old saves — the positional-bincode format cannot load a pre-covariance
+        // file at all (see the serde-default note on the state struct), per the pre-v1.0 policy.
+        let full_or_iso = |sig: &[f64], var: f64| -> Vec<f64> {
+            if sig.len() == km1 * km1 {
+                crate::linalg::spd_inverse_and_half_logdet(sig, km1).0
+            } else {
+                let mut s = vec![0.0f64; km1 * km1];
+                for i in 0..km1 {
+                    s[i * km1 + i] = 1.0 / var;
+                }
+                s
             }
-            s
         };
+        let root_siginv = full_or_iso(&self.sigma_root, self.p0);
+        let edge_siginv = full_or_iso(&self.sigma_edge, self.sigma2);
         let beta = self.beta.clone();
         let theta = py.allow_threads(move || {
             crate::reply_tm::transform_reply_tm(
@@ -727,7 +737,7 @@ impl ReplyTM {
                 &beta,
                 &anchor_rows,
                 kappa,
-                sigma2,
+                &edge_siginv,
                 &root_siginv,
                 blend,
             )
@@ -876,6 +886,7 @@ impl ReplyTM {
                 sigma2: self.sigma2,
                 p0: self.p0,
                 sigma_root: self.sigma_root.clone(),
+                sigma_edge: self.sigma_edge.clone(),
                 bound_history: self.bound_history.clone(),
                 fit_parents: self.fit_parents.clone(),
                 fit_groups: self.fit_groups.clone(),
@@ -911,6 +922,7 @@ impl ReplyTM {
             sigma2: s.sigma2,
             p0: s.p0,
             sigma_root: s.sigma_root,
+            sigma_edge: s.sigma_edge,
             bound_history: s.bound_history,
             fit_parents: s.fit_parents,
             fit_groups: s.fit_groups,
@@ -1172,8 +1184,9 @@ impl ReplyTM {
         self.blend_beta
     }
 
-    /// Per-edge diffusion variance `σ²` (floored at 0.1; a returned 0.1 may be the floor, not an
-    /// estimate). `NaN` when the reply field was not identified/fit.
+    /// Per-edge (OU step) variance: the mean marginal variance of the fitted full edge covariance
+    /// Σ_edge (a scalar summary; the edge prior is the full Σ_edge, on the same footing as the root
+    /// Σ_root). `NaN` when there are no reply edges / the field was not fit.
     #[getter]
     fn sigma2(&self) -> f64 {
         self.sigma2

--- a/src/python/reply_tm.rs
+++ b/src/python/reply_tm.rs
@@ -1117,7 +1117,9 @@ impl ReplyTM {
     /// edges or the field was not fit. Conditional on the topic fit; the point estimate is biased
     /// toward κ→0 (persistence) by topic-model shrinkage and the interval does not correct that.
     /// Computed lazily on access (it is the dominant per-fit cost and usually not needed —
-    /// `persistence()` supersedes it), from the stored fit; expect ~1s per call.
+    /// `persistence()` supersedes it), from the stored fit; expect ~1s per call. The profile uses
+    /// the isotropic scalar (σ², p0) tree-field, an approximation to the full Σ_edge/Σ_root the fit
+    /// actually estimates — the CI reflects the reversion ridge, not the anisotropy of the priors.
     #[getter]
     fn kappa_ci<'py>(&self, py: Python<'py>) -> PyResult<(f64, f64)> {
         self.require_fitted()?;

--- a/src/reply_tm.rs
+++ b/src/reply_tm.rs
@@ -72,7 +72,8 @@ pub struct ReplyTmModel {
     /// Blend coupling root weight `β` (`NaN` unless `coupling="blend"`): how much a node's prior mean
     /// tracks its thread root. The anchor gets the remaining `1 - α - β`.
     pub blend_beta: f64,
-    /// Per-edge diffusion variance `σ²`.
+    /// Reported per-edge variance: the mean marginal variance of the fitted full edge covariance
+    /// `sigma_edge` (a scalar summary; the edge prior is the full `sigma_edge`).
     pub sigma2: f64,
     /// Root prior variance (mean marginal variance of `sigma_root`, a scalar summary of the full
     /// root covariance).
@@ -223,6 +224,9 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     let mut bound_history: Vec<f64> = Vec::with_capacity(em_iters);
     let mut converged = false;
     let mut em_iters_run = 0usize;
+    // Whether Σ_edge was ever estimated from at least one token-bearing edge (so the reported sigma2
+    // is a real estimate, not the identity init on a degenerate tree whose non-roots are all empty).
+    let mut edge_cov_fit = false;
     // Whether the tree field (a, σ², p0) was ever actually fit. It is gated behind a warm-up, so a
     // corpus that converges inside the warm-up window would otherwise return the INIT constants
     // (κ=0.3, σ²=1, p0=1) dressed up as estimates. We refuse to break before it has run once, and
@@ -540,6 +544,8 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                 );
                 // clamp a < 1 so the next iteration's logit init stays finite (a=1 → +inf → NaN in
                 // the Nelder-Mead simplex); floor σ²/p0 (a clamp, not an estimate — see kappa_ci).
+                // This scalar isotropic σ² seeds only the tree-field BP that estimates the reversion
+                // `a` (κ); the REPORTED sigma2 is reassigned from mean-diag Σ_edge after the loop.
                 a = fit.a.min(0.999);
                 sigma2 = fit.q.max(0.1);
                 p0 = fit.p0.max(0.1);
@@ -595,6 +601,7 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                     ss[i * km1 + i] += 1e-6; // PD ridge
                 }
                 sigma_edge = ss;
+                edge_cov_fit = true;
             }
         }
     }
@@ -604,11 +611,15 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     // are still the init constants; report NaN (unidentified) rather than dress them up as fitted.
     if n_edges == 0 || !field_fit_ran {
         a = f64::NAN;
-        sigma2 = f64::NAN;
-    } else {
-        // sigma2 now summarizes the fitted full edge covariance (mean marginal variance).
-        sigma2 = (0..km1).map(|i| sigma_edge[i * km1 + i]).sum::<f64>() / km1 as f64;
     }
+    // sigma2 summarizes the fitted full edge covariance (mean marginal variance) — but only once
+    // Σ_edge was actually estimated from a token-bearing edge; otherwise it is the identity init on a
+    // degenerate tree (all non-roots empty), so report NaN rather than a spurious 1.0.
+    sigma2 = if edge_cov_fit {
+        (0..km1).map(|i| sigma_edge[i * km1 + i]).sum::<f64>() / km1 as f64
+    } else {
+        f64::NAN
+    };
     // p0 now summarizes the fitted full root covariance (mean marginal variance), so it is defined
     // whenever there are token-bearing roots — including the no-tree (CTM-equivalent) case — rather
     // than the old scalar root variance. NaN only if Σ_root was never estimated (no roots).

--- a/src/reply_tm.rs
+++ b/src/reply_tm.rs
@@ -6,15 +6,16 @@
 //!
 //! ```text
 //! root d:      η_d ~ N(anchor_g, Σ_root)                        (full covariance, CTM-style; #834)
-//! non-root d:  η_d ~ N((1-κ)·η_{parent} + κ·anchor_g, σ²·I)     (κ = reversion, σ² = step variance)
+//! non-root d:  η_d ~ N((1-κ)·η_{parent} + κ·anchor_g, Σ_edge)   (κ = reversion; Σ_edge full covariance)
 //! tokens:      w ~ softmax([η_d, 0]) · β                        (CTM logistic-normal likelihood)
 //! ```
 //!
-//! The root prior carries a FULL covariance Σ_root (the same correlated logistic-normal prior CTM/STM
-//! fit), so with no reply tree ReplyTM reduces to CTM — up to empty-document handling and a small
-//! Σ_root ridge — rather than a weaker isotropic model (#834); the reply edges keep the isotropic OU
-//! step variance σ². It reduces to a plain (correlated) logistic-normal topic model when the tree is
-//! flat. On real corpora the
+//! Both the root prior (Σ_root) and the reply-edge step (Σ_edge) carry a FULL covariance (the same
+//! correlated logistic-normal prior CTM/STM fit). Roots get it so with no reply tree ReplyTM reduces
+//! to CTM — up to empty-document handling and a small ridge — rather than a weaker isotropic model
+//! (#834); edges get it so a reply leaf is on the SAME covariance footing as a root, so
+//! `reply_completion`'s tree-vs-no_tree comparison reflects the reply coupling and not a covariance
+//! downgrade. It reduces to a plain (correlated) logistic-normal topic model when the tree is flat. On real corpora the
 //! fit drives κ toward 0, i.e. **persistence** (a reply ≈ its parent), so the "reversion" reading
 //! is usually vacuous — κ is reported with a profile-likelihood CI that reflects this.
 //!
@@ -80,6 +81,10 @@ pub struct ReplyTmModel {
     /// logistic-normal model captures topic correlation (#834). Used as the root prior in the E-step
     /// and in `transform`.
     pub sigma_root: Vec<f64>,
+    /// Edge (OU step) FULL covariance Σ_edge (K-1 × K-1, row-major): the reply edges' prior
+    /// covariance, on the same full-covariance footing as `sigma_root` so tree and no-tree share the
+    /// base. Identity (unfit) when there are no reply edges.
+    pub sigma_edge: Vec<f64>,
     pub bound: f64,
     pub bound_history: Vec<f64>,
     pub converged: bool,
@@ -197,12 +202,18 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     let mut p0 = 1.0f64;
     // Root prior FULL covariance Σ_root (K-1 × K-1), estimated CTM-style from the root documents so
     // the base logistic-normal model captures topic correlation (issue #834: an isotropic root prior
-    // left the base ~0.1-0.26 nats/token behind STM at scale). Edges keep the isotropic OU σ². With
-    // no reply tree every document is a root, so this makes ReplyTM's base equivalent to CTM. Init
-    // to the identity (≡ the old p0 = 1 root prior).
+    // left the base ~0.1-0.26 nats/token behind STM at scale). With no reply tree every document is a
+    // root, so this makes ReplyTM's base equivalent to CTM. Init to the identity (≡ the old p0 = 1).
     let mut sigma_root = vec![0.0f64; km1 * km1];
+    // Edge (OU step) FULL covariance Σ_edge, the analogue of Σ_root for reply edges. Keeping edges
+    // isotropic while roots were full made a thin leaf's prior RICHER with the tree off than on, so
+    // `reply_completion`'s tree-vs-no_tree delta conflated the reply coupling with a covariance
+    // downgrade. A full Σ_edge (both sides full) restores a fair comparison. Warm-up-gated (identity
+    // until the topics separate) to avoid the collapse trap the isotropic σ² field also guarded.
+    let mut sigma_edge = vec![0.0f64; km1 * km1];
     for i in 0..km1 {
         sigma_root[i * km1 + i] = 1.0;
+        sigma_edge[i * km1 + i] = 1.0;
     }
     // Blend coupling weights (α = parent, β = root); seeded to a parent-leaning mix and updated in
     // the M-step unless pinned. Unused (and returned as NaN) when `blend` is None.
@@ -222,16 +233,9 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         em_iters_run = em + 1;
         let kappa = 1.0 - a;
 
-        // per-document-type inverse prior covariance (diagonal) and its half-logdet
-        let siginv_diag = |var: f64| -> (Vec<f64>, f64) {
-            let mut s = vec![0.0f64; km1 * km1];
-            for i in 0..km1 {
-                s[i * km1 + i] = 1.0 / var;
-            }
-            (s, 0.5 * km1 as f64 * var.ln())
-        };
-        let (siginv_edge, ent_edge) = siginv_diag(sigma2);
-        // Root prior uses the FULL Σ_root (its inverse + half-logdet), like CTM; edges stay isotropic.
+        // Both root and edge priors use their FULL covariance (inverse + half-logdet), like CTM, so
+        // roots and reply edges are on the same covariance footing.
+        let (siginv_edge, ent_edge) = crate::linalg::spd_inverse_and_half_logdet(&sigma_edge, km1);
         let (siginv_root, ent_root) = crate::linalg::spd_inverse_and_half_logdet(&sigma_root, km1);
 
         // E-step: per-document logistic-normal inference with a tree-coupled prior mean.
@@ -270,10 +274,9 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                     7,
                     1e-5,
                 );
-                // Roots need the FULL Laplace covariance ν to re-estimate Σ_root (diagonal=false);
-                // edges only use the diagonal for the isotropic σ² field, so keep them cheap.
-                let is_root = par < 0;
-                let res = ctm_hpb(&opt, &beta, words, counts, &mu_d, siginv, entropy, !is_root);
+                // Both roots and edges now re-estimate a FULL covariance, so every document needs the
+                // full Laplace covariance ν (diagonal=false).
+                let res = ctm_hpb(&opt, &beta, words, counts, &mu_d, siginv, entropy, false);
                 (di, opt, res.nu, res.phi, res.bound)
             })
             .collect();
@@ -287,15 +290,13 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         // fold sufficient statistics in document order
         let mut beta_ss = vec![vec![1e-8f64; num_types]; k];
         let mut nu_diag_store = vec![vec![0.0f64; km1]; d];
-        // Full ν for the root documents only (needed for the Σ_root M-step); empty for edges.
-        let mut nu_full_root: Vec<Vec<f64>> = vec![Vec::new(); d];
+        // Full ν for every token-bearing document (Σ_root uses the roots' ν, Σ_edge the edges').
+        let mut nu_full: Vec<Vec<f64>> = vec![Vec::new(); d];
         for (di, opt, nu, phi, _) in &results {
             let di = *di;
             lambda[di] = opt.clone();
             nu_diag_store[di] = (0..km1).map(|i| nu[i * km1 + i]).collect();
-            if parents[di] < 0 {
-                nu_full_root[di] = nu.clone();
-            }
+            nu_full[di] = nu.clone();
             let words = &sparse[di].0;
             for (wi, &w) in words.iter().enumerate() {
                 for (t, brow) in beta_ss.iter_mut().enumerate() {
@@ -362,7 +363,7 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                     continue;
                 }
                 let ag = &anchor[groups[di]];
-                let nu = &nu_full_root[di];
+                let nu = &nu_full[di];
                 for i in 0..km1 {
                     let ci = lambda[di][i] - ag[i];
                     for j in 0..km1 {
@@ -545,6 +546,57 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                 field_fit_ran = true;
             }
         }
+
+        // M-step (Σ_edge): full edge (OU step) covariance, CTM's update over the reply edges around
+        // the coupled mean μ_c = (1-κ)·parent + κ·anchor (or the blend mean). Warm-up-gated: held at
+        // identity until the topics separate, since (as with the isotropic σ² field) estimating the
+        // edge covariance too early can collapse it and pin children to their parents. This puts the
+        // tree edges on the same full-covariance footing as the roots, so `reply_completion`'s
+        // tree-vs-no_tree delta reflects the reply coupling, not a covariance downgrade.
+        if em + 1 > warmup {
+            let mut ss = vec![0.0f64; km1 * km1];
+            let mut n_edge = 0usize;
+            for di in 0..d {
+                let par = parents[di];
+                if par < 0 || !has_tokens[di] {
+                    continue;
+                }
+                let ag = &anchor[groups[di]];
+                let p = par as usize;
+                // The prior mean used for this edge (matches the E-step coupling with the updated κ).
+                let mu: Vec<f64> = if let Some(bc) = blend {
+                    let lr = &lambda[bc.root[di]];
+                    (0..km1)
+                        .map(|i| {
+                            alpha * lambda[p][i] + beta_w * lr[i] + (1.0 - alpha - beta_w) * ag[i]
+                        })
+                        .collect()
+                } else {
+                    let kappa = 1.0 - a;
+                    (0..km1)
+                        .map(|i| (1.0 - kappa) * lambda[p][i] + kappa * ag[i])
+                        .collect()
+                };
+                let nu = &nu_full[di];
+                for i in 0..km1 {
+                    let ci = lambda[di][i] - mu[i];
+                    for j in 0..km1 {
+                        let cj = lambda[di][j] - mu[j];
+                        ss[i * km1 + j] += nu[i * km1 + j] + ci * cj;
+                    }
+                }
+                n_edge += 1;
+            }
+            if n_edge > 0 {
+                for v in ss.iter_mut() {
+                    *v /= n_edge as f64;
+                }
+                for i in 0..km1 {
+                    ss[i * km1 + i] += 1e-6; // PD ridge
+                }
+                sigma_edge = ss;
+            }
+        }
     }
 
     // The field params are only real estimates when there ARE reply edges AND the field was
@@ -553,6 +605,9 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     if n_edges == 0 || !field_fit_ran {
         a = f64::NAN;
         sigma2 = f64::NAN;
+    } else {
+        // sigma2 now summarizes the fitted full edge covariance (mean marginal variance).
+        sigma2 = (0..km1).map(|i| sigma_edge[i * km1 + i]).sum::<f64>() / km1 as f64;
     }
     // p0 now summarizes the fitted full root covariance (mean marginal variance), so it is defined
     // whenever there are token-bearing roots — including the no-tree (CTM-equivalent) case — rather
@@ -665,6 +720,7 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         sigma2,
         p0,
         sigma_root,
+        sigma_edge,
         bound: bound_history.last().copied().unwrap_or(f64::NAN),
         bound_history,
         converged,
@@ -674,8 +730,8 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
 }
 
 /// Infer topic proportions θ for a NEW reply forest under a fitted model, holding the topics `beta`,
-/// the reversion `kappa`, the per-edge variance `sigma2`, the full root precision `root_siginv`
-/// (= Σ_root⁻¹), and the per-group `anchor` all fixed. This is `transform` for ReplyTM.
+/// the reversion `kappa`, the full edge and root precisions `edge_siginv` (= Σ_edge⁻¹) and
+/// `root_siginv` (= Σ_root⁻¹), and the per-group `anchor` all fixed. This is `transform` for ReplyTM.
 ///
 /// The E-step coupling is directed — a document's prior mean depends only on its PARENT's η, never on
 /// its children (see `fit_reply_tm`). So a single sweep in topological order (every parent before its
@@ -697,7 +753,7 @@ pub fn transform_reply_tm(
     beta: &[Vec<f64>],
     anchor: &[Vec<f64>],
     kappa: f64,
-    sigma2: f64,
+    edge_siginv: &[f64],
     root_siginv: &[f64],
     blend: Option<(f64, f64)>,
 ) -> Vec<Vec<f64>> {
@@ -716,14 +772,8 @@ pub fn transform_reply_tm(
         })
         .collect();
 
-    // Edges use the isotropic OU precision (1/σ²·I); roots use the FULL fitted root precision Σ_root⁻¹.
-    let siginv_edge = {
-        let mut s = vec![0.0f64; km1 * km1];
-        for i in 0..km1 {
-            s[i * km1 + i] = 1.0 / sigma2;
-        }
-        s
-    };
+    // Both edges (Σ_edge⁻¹) and roots (Σ_root⁻¹) use their FULL fitted precision.
+    let siginv_edge = edge_siginv;
     let siginv_root = root_siginv;
 
     // Topological order (roots first, every parent before its children). The tree is acyclic (the
@@ -759,13 +809,13 @@ pub fn transform_reply_tm(
             let mu: Vec<f64> = (0..km1)
                 .map(|i| alpha * lp[i] + beta_w * lr[i] + (1.0 - alpha - beta_w) * ag[i])
                 .collect();
-            (mu, &siginv_edge)
+            (mu, siginv_edge)
         } else {
             let lp = &lambda[par as usize];
             let mu: Vec<f64> = (0..km1)
                 .map(|i| (1.0 - kappa) * lp[i] + kappa * ag[i])
                 .collect();
-            (mu, &siginv_edge)
+            (mu, siginv_edge)
         };
         let (words, counts) = &sparse[di];
         lambda[di] = if words.is_empty() {

--- a/tests/test_reply_tm.py
+++ b/tests/test_reply_tm.py
@@ -330,6 +330,13 @@ def test_save_load_roundtrip(tmp_path):
     assert np.array_equal(m.topic_word, m2.topic_word)
     assert np.array_equal(m.group_prevalence, m2.group_prevalence)
     assert m.kappa == m2.kappa and m.kappa_ci == m2.kappa_ci
+    # the full Σ_edge/Σ_root priors round-trip: their scalar summaries and a tree-aware transform
+    # must be bit-identical after load (a diagonal-only save would silently change predictions).
+    assert m.sigma2 == m2.sigma2 and m.p0 == m2.p0
+    assert np.array_equal(
+        m.transform(docs, parents=parents, covariates=cov),
+        m2.transform(docs, parents=parents, covariates=cov),
+    )
     assert m.group_labels() == m2.group_labels()
     # coherence still works after load (the corpus snapshot round-tripped)
     assert np.allclose(m.coherence(10), m2.coherence(10))

--- a/tests/test_reply_tm.py
+++ b/tests/test_reply_tm.py
@@ -443,16 +443,18 @@ def test_transform_recovers_training_theta():
 
 def test_transform_tree_couples_reply_to_parent():
     """The reply coupling must act at transform time: a reply's inferred mix tracks its parent's
-    more under the tree than under the tree-blind (parents=None) pass."""
+    more under the tree than under the tree-blind (parents=None) pass. Fit without covariates so the
+    tree-blind baseline anchors at the global mean, isolating the reply coupling from a group anchor
+    that would otherwise already pull same-group parents and children together."""
     docs, parents, cov, vocab = _threaded_corpus(n_threads=40, depth=6)
     m = topica.ReplyTM(2, em_iters=80, seed=13)
-    m.fit(docs, parents=parents, covariates=cov, covariate_names=["A", "B"])
-    tree = m.transform(docs, parents=parents, covariates=cov)
-    flat = m.transform(docs, covariates=cov)  # every doc a root
-    # child-parent agreement in topic-0 proportion, over real edges
+    m.fit(docs, parents=parents)
+    tree = m.transform(docs, parents=parents)
+    flat = m.transform(docs)  # every doc a root (tree-blind)
+    # child-parent agreement (full topic mix) over real edges
     edges = [(d, p) for d, p in enumerate(parents) if p >= 0]
-    tree_gap = np.mean([abs(tree[d, 0] - tree[p, 0]) for d, p in edges])
-    flat_gap = np.mean([abs(flat[d, 0] - flat[p, 0]) for d, p in edges])
+    tree_gap = np.mean([np.abs(tree[d] - tree[p]).sum() for d, p in edges])
+    flat_gap = np.mean([np.abs(flat[d] - flat[p]).sum() for d, p in edges])
     assert tree_gap < flat_gap
 
 


### PR DESCRIPTION
## The problem (spotted in review)

#834 gave the **root** prior a full covariance Σ_root but explicitly left reply **edges** on the isotropic OU variance σ²·I. That created an asymmetry:

- **no-tree leaf:** `η ~ N(anchor, Σ_root)` — full covariance
- **tree leaf:** `η ~ N((1−κ)·parent + κ·anchor, σ²·I)` — isotropic

So a thin leaf's prior was **richer with the tree off than on**, and `reply_completion`'s `delta["no_tree"]` conflated the reply coupling with a **covariance downgrade** that only the tree side paid — biasing the comparison against the tree, which is the whole point of the model.

## The fix

Give the edge (OU step) its own **full covariance Σ_edge**, estimated CTM-style over the reply edges around the coupled mean `(1−κ)·parent + κ·anchor` (or the blend mean), warm-up-gated like the old σ² field. Roots and edges are now on the same covariance footing, so the delta reflects the reply coupling alone. The E-step computes the full Laplace ν for every document; κ is still fit by the tree-field BP pass; `transform` uses Σ_edge⁻¹ for edges; `sigma2` now reports the mean marginal variance of Σ_edge.

## Result (poliblog, K=20, topic-coherent threads)

| delta (tree − baseline) | #834 (isotropic edges) | now (full Σ_edge) |
|---|---|---|
| `no_tree` | −0.125 | **−0.028** |
| `stm` | −0.121 | **−0.024** |
| `lda` | −0.145 | **−0.048** |

The ~0.10 nats/token covariance-asymmetry handicap is removed; the tree model's own held-out per-token ll rose −7.103 → −7.006. `no_tree` is unchanged (it has no edges), so #834's base parity with STM is preserved.

## Notes

- Coupling verified intact (the tree still pulls children toward parents on persistence-structured corpora, κ≈0). The `transform` coupling test now fits without covariates so the tree-blind baseline is the global anchor, isolating the reply coupling from the group anchor.
- 50 ReplyTM tests pass; `cargo test`/`fmt`/`clippy`, `preflight.sh`, `mkdocs --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)