### PR TITLE
feat(replytm,stm): follow-up batch — posterior_doc_topic, content contrast/smooth, prevalence-CI FrameDict (#840, #843, #846)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -761,7 +761,7 @@ m = topica.ReplyTM(num_topics=25, seed=13)
 m.fit(docs, parents=parents, covariates=group)   # e.g. covariates=["cmv", "hn", "cmv", ...]
 
 m.group_prevalence        # (G, K) per-group baseline topic mix (probability scale)
-m.group_prevalence_ci()   # (G, K, 2) probability-scale CI aligned with group_prevalence
+topica.inspect.group_prevalence_ci(m)   # tidy prob-scale CI (labels + mean/ci_low/ci_high/sd)
 m.converged               # did EM converge before the em_iters cap? (else raise it)
 topica.inspect.topic_table(m)
 ```
@@ -900,10 +900,11 @@ which you should read as strong persistence, not a tight interval.
 
 ReplyTM's covariate story lives entirely in `group_prevalence` / `prevalence_se`; it is
 **not** wired into the `topica.effects` namespace, so reach for those two readouts
-rather than `effects.estimate_effect`. For a publication table, `m.group_prevalence_ci()`
-returns a probability-scale credible interval aligned cell-for-cell with
-`group_prevalence` (a Monte-Carlo transform of the η-space `prevalence_se`), so you get
-`prevalence ± CI` in one call without the η conversion by hand.
+rather than `effects.estimate_effect`. For a publication table,
+`topica.inspect.group_prevalence_ci(m)` returns a probability-scale credible interval (a
+Monte-Carlo transform of the η-space `prevalence_se`) as a tidy result carrying the group
+labels and `mean`/`ci_low`/`ci_high`/`sd`; call `.to_frame()` for one row per (group, topic),
+so you get `prevalence ± CI` without the η conversion by hand.
 
 ReplyTM is **experimental**, and the honest empirical picture is why. The core is
 validated by planted recovery, a degenerate-case reduction (a flat tree collapses it

--- a/python/topica/_compat.py
+++ b/python/topica/_compat.py
@@ -80,6 +80,7 @@ LAZY = {
     'find_thoughts_html': 'inspect',
     'flag_topics': 'evaluate',
     'frex': 'inspect',
+    'group_prevalence_ci': 'inspect',
     'interaction': 'design',
     'inverted_rbo': 'evaluate',
     'label_topics': 'inspect',

--- a/python/topica/_results.py
+++ b/python/topica/_results.py
@@ -99,3 +99,37 @@ class TimePrevalenceCI(FrameDict):
             for k in range(K)
         ]
         return pd.DataFrame(rows, columns=self._COLUMNS)
+
+
+class GroupPrevalenceCI(FrameDict):
+    """:func:`~topica.inspect.group_prevalence_ci` result: ``labels`` (the covariate group names)
+    plus ``(G, K)`` arrays ``mean``/``ci_low``/``ci_high``/``sd`` on the probability scale.
+    :meth:`to_frame` melts them to one row per (group, topic)."""
+
+    _COLUMNS = ["group", "topic", "mean", "ci_low", "ci_high", "sd"]
+
+    def to_frame(self):
+        """Long tidy frame, one row per (group, topic), with columns ``group``, ``topic``,
+        ``mean``, ``ci_low``, ``ci_high``, ``sd``."""
+        import numpy as np
+        import pandas as pd
+
+        labels = list(self["labels"])
+        mean = np.asarray(self["mean"])
+        lo = np.asarray(self["ci_low"])
+        hi = np.asarray(self["ci_high"])
+        sd = np.asarray(self["sd"])
+        G, K = mean.shape
+        rows = [
+            {
+                "group": labels[g],
+                "topic": k,
+                "mean": float(mean[g, k]),
+                "ci_low": float(lo[g, k]),
+                "ci_high": float(hi[g, k]),
+                "sd": float(sd[g, k]),
+            }
+            for g in range(G)
+            for k in range(K)
+        ]
+        return pd.DataFrame(rows, columns=self._COLUMNS)

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -630,6 +630,15 @@ class CTM:
         ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
+    def posterior_doc_topic(
+        self, *, n_samples: int = 400, seed: int = 13
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Posterior-predictive ``E[softmax(η)]`` per document (D×K): a Monte-Carlo average over the
+        full logistic-normal variational posterior, symmetric with ``ReplyTM.posterior_doc_topic``.
+        Unlike the plug-in ``doc_topic`` it integrates the posterior covariance ν (needs
+        ``keep_eta_cov=True``); the hedged θ to score held-out tokens with (#840). Deterministic
+        given ``seed``."""
+        ...
     @property
     def topic_correlation(self) -> numpy.typing.NDArray[numpy.float64]:
         """Topic-correlation matrix (num_topics, num_topics) from theta across docs."""
@@ -816,6 +825,15 @@ class STM:
         ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]: ...
+    def posterior_doc_topic(
+        self, *, n_samples: int = 400, seed: int = 13
+    ) -> numpy.typing.NDArray[numpy.float64]:
+        """Posterior-predictive ``E[softmax(η)]`` per document (D×K): a Monte-Carlo average over the
+        full logistic-normal variational posterior, symmetric with ``ReplyTM.posterior_doc_topic``.
+        Unlike the plug-in ``doc_topic`` it integrates the posterior covariance ν (needs
+        ``keep_eta_cov=True``); the hedged θ to score held-out tokens with (#840). Deterministic
+        given ``seed``."""
+        ...
     @property
     def topic_correlation(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
@@ -3081,6 +3099,7 @@ class ReplyTM:
         content_names: Sequence[str] | None = None,
         content_prior: str = "l2",
         content_prior_var: float = 0.5,
+        content_smooth: float = 0.0,
         depth_bins: Sequence[int] | None = None,
     ) -> "ReplyTM":
         """`data` is a ``topica.Corpus`` or a list of token lists. `parents[d]` is document
@@ -3169,14 +3188,13 @@ class ReplyTM:
         """Cluster-robust (on the thread) method-of-composition SE of the group prevalence anchor
         (η space); NaN for a group with fewer than two threads."""
         ...
-    def group_prevalence_ci(
+    def _group_prevalence_ci_mc(
         self, *, ci: float = 0.95, n_samples: int = 2000, seed: int = 13
     ) -> numpy.typing.NDArray[numpy.float64]:
-        """G×K×2 probability-scale credible interval ``[lower, upper]`` aligned cell-for-cell with
-        ``group_prevalence`` (pair with ``group_labels()`` for row names). Monte-Carlo: per group,
-        draw η from ``N(anchor, diag(prevalence_se²))``, softmax each draw, take the ``ci``
-        percentiles per topic (``ci`` is the coverage, matching ``time_prevalence_ci``). Uses only
-        the diagonal η SE; a group with fewer than two threads yields NaN bounds (#830)."""
+        """Monte-Carlo primitive backing :func:`topica.inspect.group_prevalence_ci`: a ``(G, K, 4)``
+        array whose last axis is ``[mean, ci_low, ci_high, sd]`` on the probability scale. Prefer the
+        public ``topica.inspect.group_prevalence_ci(model)`` wrapper, which attaches labels and a
+        ``to_frame()`` (#843)."""
         ...
     def group_labels(self) -> list[str]: ...
     @property
@@ -3231,6 +3249,14 @@ class ReplyTM:
         """The fitted SAGE content deviations κ as a dict of numpy arrays (``None`` without a content
         covariate), matching STM's ``content_kappa``: ``m`` (V), ``kappa_topic`` (K×V), ``kappa_cov``
         (G×V), ``kappa_interaction`` (K×G×V). Near-zero means that level does not shift the topic (#841)."""
+        ...
+    def content_word_contrast(
+        self, topic: int, level_a, level_b, n: int = 10
+    ) -> list[tuple[str, float]]:
+        """Top-``n`` ``(word, log_ratio)`` pairs separating one ``topic``'s language between two
+        content levels, by descending ``ln(beta[level_a] / beta[level_b])`` (STM's ``word_contrast``
+        on content levels). ``level_a``/``level_b`` are level indices or labels; the natural threaded
+        readout is ``content_word_contrast(k, "deep", "root")``. Requires a content fit (#841)."""
         ...
     def content_top_words(self, topic: int, n: int = 10) -> dict:
         """Top-``n`` words per content level for one ``topic``: ``{level_label: [word, ...]}`` — the

--- a/python/topica/inspect.py
+++ b/python/topica/inspect.py
@@ -28,6 +28,7 @@ __all__ = [
     'find_thoughts',
     'find_thoughts_html',
     'frex',
+    'group_prevalence_ci',
     'label_topics',
     'mmr',
     'prepare_pyldavis',
@@ -37,6 +38,37 @@ __all__ = [
     'topic_table',
     'topics_for_term',
 ]
+
+
+def group_prevalence_ci(model, *, ci=0.95, n_samples=2000, seed=13):
+    """Probability-scale credible intervals for a :class:`~topica.ReplyTM`'s per-group topic
+    prevalence, as a tidy :class:`~topica._results.GroupPrevalenceCI`.
+
+    ``group_prevalence`` is a softmax and ``prevalence_se`` is a standard error in the η (logit)
+    space, so you cannot combine them into an interval by hand (different scale AND different width,
+    ``(G, K)`` vs ``(G, K-1)``). This does the transform by Monte-Carlo: per group it draws η from
+    ``N(anchor, diag(prevalence_se**2))``, softmaxes each draw, and takes the ``ci`` percentiles per
+    topic. It only uses the diagonal (marginal) η SE. A group with fewer than two threads (NaN
+    ``prevalence_se``) yields NaN bounds. ``ci`` is the coverage (0.95 gives a 95% interval),
+    matching :func:`topica.time_prevalence_ci` / :func:`topica.effects.prevalence_ci`.
+
+    Returns a :class:`~topica._results.GroupPrevalenceCI` (a ``dict``) with keys ``labels`` (the
+    group names), and ``(G, K)`` arrays ``mean`` (the point ``group_prevalence``), ``ci_low``,
+    ``ci_high``, ``sd``. Call ``.to_frame()`` for a long tidy DataFrame, one row per (group, topic).
+    """
+    from ._results import GroupPrevalenceCI
+
+    raw = np.asarray(
+        model._group_prevalence_ci_mc(ci=ci, n_samples=n_samples, seed=seed), dtype=np.float64
+    )
+    labels = list(model.group_labels())
+    return GroupPrevalenceCI(
+        labels=labels,
+        mean=raw[:, :, 0],
+        ci_low=raw[:, :, 1],
+        ci_high=raw[:, :, 2],
+        sd=raw[:, :, 3],
+    )
 
 
 

--- a/python/topica/inspect.py
+++ b/python/topica/inspect.py
@@ -55,6 +55,8 @@ def group_prevalence_ci(model, *, ci=0.95, n_samples=2000, seed=13):
     Returns a :class:`~topica._results.GroupPrevalenceCI` (a ``dict``) with keys ``labels`` (the
     group names), and ``(G, K)`` arrays ``mean`` (the point ``group_prevalence``), ``ci_low``,
     ``ci_high``, ``sd``. Call ``.to_frame()`` for a long tidy DataFrame, one row per (group, topic).
+    ``labels`` follow ``model.group_labels()`` (the fitted first-appearance order of the covariate,
+    which ``covariate_names`` renamed in place), not alphabetical order.
     """
     from ._results import GroupPrevalenceCI
 

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7888,12 +7888,12 @@ impl CTM {
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
     }
 
-    /// Posterior-predictive `E[softmax(η)]` per document (D × K): a Monte-Carlo average over the full
-    /// logistic-normal variational posterior, symmetric with `ReplyTM.posterior_doc_topic`. Unlike the
-    /// plug-in `doc_topic` (= `softmax(mean η)`) it integrates the posterior covariance ν, so it hedges
-    /// rather than overcommitting — the θ to score held-out tokens with when comparing to a sample-
-    /// averaged model like LDA (#840). Needs the variational covariance; refit with `keep_eta_cov=True`
-    /// if it was dropped. Deterministic given `seed`.
+    /// Posterior-predictive `E[softmax(η)]` per document (D × K): a Monte-Carlo average of `n_samples`
+    /// draws over the full logistic-normal variational posterior, symmetric with
+    /// `ReplyTM.posterior_doc_topic`. Unlike the plug-in `doc_topic` (= `softmax(mean η)`) it integrates
+    /// the posterior covariance ν, so it hedges rather than overcommitting — the θ to score held-out
+    /// tokens with when comparing to a sample-averaged model like LDA (#840). Needs the variational
+    /// covariance; refit with `keep_eta_cov=True` if it was dropped. Deterministic given `seed`.
     #[pyo3(signature = (*, n_samples=400, seed=13))]
     fn posterior_doc_topic<'py>(
         &self,
@@ -9051,12 +9051,12 @@ impl STM {
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
     }
 
-    /// Posterior-predictive `E[softmax(η)]` per document (D × K): a Monte-Carlo average over the full
-    /// logistic-normal variational posterior, symmetric with `ReplyTM.posterior_doc_topic`. Unlike the
-    /// plug-in `doc_topic` (= `softmax(mean η)`) it integrates the posterior covariance ν, so it hedges
-    /// rather than overcommitting — the θ to score held-out tokens with when comparing to a sample-
-    /// averaged model like LDA (#840). Needs the variational covariance; refit with `keep_eta_cov=True`
-    /// if it was dropped. Deterministic given `seed`.
+    /// Posterior-predictive `E[softmax(η)]` per document (D × K): a Monte-Carlo average of `n_samples`
+    /// draws over the full logistic-normal variational posterior, symmetric with
+    /// `ReplyTM.posterior_doc_topic`. Unlike the plug-in `doc_topic` (= `softmax(mean η)`) it integrates
+    /// the posterior covariance ν, so it hedges rather than overcommitting — the θ to score held-out
+    /// tokens with when comparing to a sample-averaged model like LDA (#840). Needs the variational
+    /// covariance; refit with `keep_eta_cov=True` if it was dropped. Deterministic given `seed`.
     #[pyo3(signature = (*, n_samples=400, seed=13))]
     fn posterior_doc_topic<'py>(
         &self,

--- a/src/python/mod.rs
+++ b/src/python/mod.rs
@@ -7350,6 +7350,67 @@ fn infer_theta_batch_per_doc(
     out
 }
 
+/// Posterior-predictive `E[softmax([η, 0])]` per document (D × K), a Monte-Carlo average over the
+/// full logistic-normal variational posterior `N(eta_mean_d, eta_cov_d)` — the hedged, sample-
+/// averaged θ that a proper held-out predictive should use, rather than the plug-in `softmax(mean η)`
+/// (issue #840, symmetric with `ReplyTM.posterior_doc_topic`, which uses a diagonal ν; STM/CTM retain
+/// the full ν here). Deterministic given `seed`.
+fn posterior_doc_topic_mc(
+    eta_mean: &Array2<f64>,
+    eta_cov: &Array3<f32>,
+    num_topics: usize,
+    n_samples: usize,
+    seed: u64,
+) -> Array2<f64> {
+    let d = eta_mean.nrows();
+    let km1 = eta_mean.ncols();
+    let k = num_topics;
+    let mut out = Array2::<f64>::zeros((d, k));
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+    let gauss = |rng: &mut ChaCha8Rng| -> f64 {
+        let u1: f64 = rng.gen::<f64>().max(1e-12);
+        let u2: f64 = rng.gen::<f64>();
+        (-2.0 * u1.ln()).sqrt() * (2.0 * std::f64::consts::PI * u2).cos()
+    };
+    let inv_s = 1.0 / n_samples as f64;
+    for di in 0..d {
+        // Cholesky (jittered for PD safety) of the document's full variational covariance.
+        let mut cov = vec![0.0f64; km1 * km1];
+        for i in 0..km1 {
+            for j in 0..km1 {
+                cov[i * km1 + j] = eta_cov[[di, i, j]] as f64;
+            }
+        }
+        let l = crate::linalg::cholesky_jitter(&cov, km1); // lower-triangular, row-major
+        let mean = eta_mean.row(di);
+        for _ in 0..n_samples {
+            let z: Vec<f64> = (0..km1).map(|_| gauss(&mut rng)).collect();
+            // η = mean + L z, then softmax([η, 0]) with reference topic K-1 held at 0.
+            let mut logits = vec![0.0f64; k];
+            let mut mx = 0.0f64;
+            for i in 0..km1 {
+                let mut e = mean[i];
+                for j in 0..=i {
+                    e += l[i * km1 + j] * z[j];
+                }
+                logits[i] = e;
+                if e > mx {
+                    mx = e;
+                }
+            }
+            let mut zsum = 0.0f64;
+            for lg in logits.iter_mut() {
+                *lg = (*lg - mx).exp();
+                zsum += *lg;
+            }
+            for i in 0..k {
+                out[[di, i]] += logits[i] / zsum * inv_s;
+            }
+        }
+    }
+    out
+}
+
 /// Correlated Topic Model (Blei & Lafferty; the STM core). Topics are drawn
 /// from a logistic-normal prior with a full covariance, so they can correlate —
 /// unlike LDA's Dirichlet. Fit by variational EM (STM's Laplace E-step).
@@ -7825,6 +7886,36 @@ impl CTM {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+
+    /// Posterior-predictive `E[softmax(η)]` per document (D × K): a Monte-Carlo average over the full
+    /// logistic-normal variational posterior, symmetric with `ReplyTM.posterior_doc_topic`. Unlike the
+    /// plug-in `doc_topic` (= `softmax(mean η)`) it integrates the posterior covariance ν, so it hedges
+    /// rather than overcommitting — the θ to score held-out tokens with when comparing to a sample-
+    /// averaged model like LDA (#840). Needs the variational covariance; refit with `keep_eta_cov=True`
+    /// if it was dropped. Deterministic given `seed`.
+    #[pyo3(signature = (*, n_samples=400, seed=13))]
+    fn posterior_doc_topic<'py>(
+        &self,
+        py: Python<'py>,
+        n_samples: usize,
+        seed: u64,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        if n_samples == 0 {
+            return Err(PyValueError::new_err("n_samples must be >= 1"));
+        }
+        let mean = self
+            .eta_mean
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("no variational eta_mean retained; refit"))?;
+        let cov = self.eta_cov.as_ref().ok_or_else(|| {
+            PyValueError::new_err(
+                "posterior_doc_topic needs the variational covariance ν; refit with keep_eta_cov=True",
+            )
+        })?;
+        let arr = posterior_doc_topic_mc(mean, cov, self.num_topics, n_samples, seed);
+        Ok(arr.to_pyarray_bound(py))
     }
 
     /// Topic-correlation matrix from the logistic-normal Σ, shape
@@ -8958,6 +9049,36 @@ impl STM {
     fn doc_topic<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyArray2<f64>>> {
         self.require_fitted()?;
         Ok(self.theta.as_ref().unwrap().to_pyarray_bound(py))
+    }
+
+    /// Posterior-predictive `E[softmax(η)]` per document (D × K): a Monte-Carlo average over the full
+    /// logistic-normal variational posterior, symmetric with `ReplyTM.posterior_doc_topic`. Unlike the
+    /// plug-in `doc_topic` (= `softmax(mean η)`) it integrates the posterior covariance ν, so it hedges
+    /// rather than overcommitting — the θ to score held-out tokens with when comparing to a sample-
+    /// averaged model like LDA (#840). Needs the variational covariance; refit with `keep_eta_cov=True`
+    /// if it was dropped. Deterministic given `seed`.
+    #[pyo3(signature = (*, n_samples=400, seed=13))]
+    fn posterior_doc_topic<'py>(
+        &self,
+        py: Python<'py>,
+        n_samples: usize,
+        seed: u64,
+    ) -> PyResult<Bound<'py, PyArray2<f64>>> {
+        self.require_fitted()?;
+        if n_samples == 0 {
+            return Err(PyValueError::new_err("n_samples must be >= 1"));
+        }
+        let mean = self
+            .eta_mean
+            .as_ref()
+            .ok_or_else(|| PyRuntimeError::new_err("no variational eta_mean retained; refit"))?;
+        let cov = self.eta_cov.as_ref().ok_or_else(|| {
+            PyValueError::new_err(
+                "posterior_doc_topic needs the variational covariance ν; refit with keep_eta_cov=True",
+            )
+        })?;
+        let arr = posterior_doc_topic_mc(mean, cov, self.num_topics, n_samples, seed);
+        Ok(arr.to_pyarray_bound(py))
     }
 
     /// Topic-correlation matrix, shape ``(num_topics, num_topics)``.

--- a/src/python/reply_tm.rs
+++ b/src/python/reply_tm.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2, PyArray3, ToPyArray};
-use pyo3::types::{PyDict, PyType};
+use pyo3::types::{PyDict, PyList, PyType};
 use rand::Rng;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -365,6 +365,31 @@ impl ReplyTM {
             ))
         }
     }
+
+    /// Resolve a content level given either its integer index or its string label.
+    fn resolve_content_level(&self, level: &Bound<'_, PyAny>) -> PyResult<usize> {
+        if let Ok(i) = level.extract::<usize>() {
+            if i >= self.num_content_groups {
+                return Err(PyValueError::new_err(format!(
+                    "content level {i} out of range; the model has {} level(s)",
+                    self.num_content_groups
+                )));
+            }
+            return Ok(i);
+        }
+        if let Ok(s) = level.extract::<String>() {
+            if let Some(i) = self.content_names.iter().position(|n| n == &s) {
+                return Ok(i);
+            }
+            return Err(PyValueError::new_err(format!(
+                "content level {s:?} is not one of the fitted levels {:?}",
+                self.content_names
+            )));
+        }
+        Err(PyValueError::new_err(
+            "content level must be an integer index or a string label",
+        ))
+    }
 }
 
 #[pymethods]
@@ -463,7 +488,7 @@ impl ReplyTM {
     /// `min_count` drops words rarer than it. Experimental: requires `topica.enable_experimental()`.
     #[pyo3(signature = (data, parents=None, covariates=None, covariate_names=None, *, min_count=1,
                         content=None, content_names=None, content_prior="l2".to_string(),
-                        content_prior_var=0.5, depth_bins=None))]
+                        content_prior_var=0.5, content_smooth=0.0, depth_bins=None))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -477,6 +502,7 @@ impl ReplyTM {
         content_names: Option<Vec<String>>,
         content_prior: String,
         content_prior_var: f64,
+        content_smooth: f64,
         depth_bins: Option<Vec<usize>>,
     ) -> PyResult<Py<Self>> {
         require_experimental("ReplyTM")?;
@@ -736,6 +762,11 @@ impl ReplyTM {
                 "content_prior_var must be finite and > 0",
             ));
         }
+        if !(content_smooth.is_finite() && content_smooth >= 0.0) {
+            return Err(PyValueError::new_err(
+                "content_smooth must be finite and >= 0 (0 disables adjacent-level smoothing)",
+            ));
+        }
         let mut content_depth_edges_used: Vec<usize> = Vec::new();
         let (content_groups, n_content, content_group_names): (
             Option<Vec<usize>>,
@@ -807,6 +838,7 @@ impl ReplyTM {
                     num_groups: n_content,
                     prior_var: content_prior_var,
                     l1: content_l1,
+                    smooth: content_smooth,
                 });
             crate::reply_tm::fit_reply_tm(
                 &docs_id,
@@ -1242,18 +1274,14 @@ impl ReplyTM {
         Ok(vecs_to_arr2(&self.prevalence_se).to_pyarray_bound(py))
     }
 
-    /// G×K×2 probability-scale credible interval `[lower, upper]` for `group_prevalence`, aligned
-    /// cell-for-cell with it (pair with `group_labels()` for the row names). Because
-    /// `group_prevalence` is a softmax and `prevalence_se` is a standard error in η space, you cannot
-    /// combine them by hand (different scale AND different width, `(G, K)` vs `(G, K-1)`); this does
-    /// the transform for you by Monte-Carlo, drawing η from `N(anchor, diag(prevalence_se²))` per
-    /// group, softmaxing each draw, and taking the `ci` percentiles per topic. `ci` is the coverage
-    /// (0.95 gives a 95% interval), matching `time_prevalence_ci`/`prevalence_ci`. Uses only the
-    /// diagonal (marginal) η SE, so it ignores cross-topic anchor covariance. A group with fewer than
-    /// two threads (its `prevalence_se` is NaN) yields NaN bounds. Build a tidy table with, e.g.,
-    /// `lo, hi = m.group_prevalence_ci().transpose(2, 0, 1)`.
+    /// Monte-Carlo primitive backing `topica.inspect.group_prevalence_ci`: returns a `G×K×4` array
+    /// whose last axis is `[mean, ci_low, ci_high, sd]` on the probability scale. Per group it draws
+    /// η from `N(anchor, diag(prevalence_se²))` (the anchor reconstructed from `group_prevalence` by
+    /// inverse softmax), softmaxes each draw, and summarizes per topic; `ci` is the coverage. Uses
+    /// only the diagonal (marginal) η SE. A group with fewer than two threads (NaN `prevalence_se`)
+    /// yields NaN. The Python wrapper attaches labels and a `to_frame()` (issue #843).
     #[pyo3(signature = (*, ci=0.95, n_samples=2000, seed=13))]
-    fn group_prevalence_ci<'py>(
+    fn _group_prevalence_ci_mc<'py>(
         &self,
         py: Python<'py>,
         ci: f64,
@@ -1282,22 +1310,21 @@ impl ReplyTM {
         };
         let lo_q = 0.5 * (1.0 - ci);
         let hi_q = 0.5 * (1.0 + ci);
-        let mut out = numpy::ndarray::Array3::<f64>::zeros((ng, k, 2));
+        let mut out = numpy::ndarray::Array3::<f64>::zeros((ng, k, 4));
         for g in 0..ng {
-            // Reconstruct the η anchor from the stored softmax prevalence (inverse softmax).
             let gp = &self.group_prevalence[g];
             let ref_p = gp[km1].max(1e-12);
             let anchor: Vec<f64> = (0..km1).map(|i| (gp[i].max(1e-12) / ref_p).ln()).collect();
             let se = &self.prevalence_se[g];
-            // A NaN SE (fewer than two threads) leaves the group's CI undefined.
             if se.iter().any(|v| !v.is_finite()) {
                 for kk in 0..k {
-                    out[[g, kk, 0]] = f64::NAN;
+                    out[[g, kk, 0]] = gp[kk]; // mean is still the plug-in point estimate
                     out[[g, kk, 1]] = f64::NAN;
+                    out[[g, kk, 2]] = f64::NAN;
+                    out[[g, kk, 3]] = f64::NAN;
                 }
                 continue;
             }
-            // Draw η ~ N(anchor, diag(se²)), softmax([η, 0]) per draw, collect per-topic samples.
             let mut cols: Vec<Vec<f64>> = vec![Vec::with_capacity(n_samples); k];
             for _ in 0..n_samples {
                 let mut logits = vec![0.0f64; k];
@@ -1319,9 +1346,14 @@ impl ReplyTM {
                 }
             }
             for (kk, col) in cols.iter_mut().enumerate() {
+                let mean = col.iter().sum::<f64>() / col.len() as f64;
+                let var = col.iter().map(|x| (x - mean) * (x - mean)).sum::<f64>()
+                    / col.len().max(1) as f64;
                 col.sort_by(|a, b| a.partial_cmp(b).unwrap());
-                out[[g, kk, 0]] = percentile_sorted(col, lo_q);
-                out[[g, kk, 1]] = percentile_sorted(col, hi_q);
+                out[[g, kk, 0]] = gp[kk]; // report the exact plug-in mean as the point estimate
+                out[[g, kk, 1]] = percentile_sorted(col, lo_q);
+                out[[g, kk, 2]] = percentile_sorted(col, hi_q);
+                out[[g, kk, 3]] = var.sqrt();
             }
         }
         Ok(out.to_pyarray_bound(py))
@@ -1502,6 +1534,54 @@ impl ReplyTM {
             out.set_item(label, words)?;
         }
         Ok(out)
+    }
+
+    /// The words that most separate one topic's language between two content levels: the top-`n`
+    /// `(word, log_ratio)` pairs by descending `ln(β[level_a] / β[level_b])` for `topic` (STM's
+    /// `word_contrast`, on content levels). `level_a`/`level_b` are level indices or labels (e.g.
+    /// `"deep"`, `"root"`). Positive log-ratio = more characteristic of `level_a`. The natural
+    /// threaded readout is `content_word_contrast(k, "deep", "root")`. Requires a content fit.
+    #[pyo3(signature = (topic, level_a, level_b, n=10))]
+    fn content_word_contrast<'py>(
+        &self,
+        py: Python<'py>,
+        topic: usize,
+        level_a: &Bound<'py, PyAny>,
+        level_b: &Bound<'py, PyAny>,
+        n: usize,
+    ) -> PyResult<Bound<'py, PyList>> {
+        self.require_fitted()?;
+        if self.content_beta.is_empty() {
+            return Err(PyValueError::new_err(
+                "no content covariate was fit; pass content= to fit for the level contrast",
+            ));
+        }
+        if topic >= self.num_topics {
+            return Err(PyValueError::new_err(format!(
+                "topic {topic} out of range 0..{}",
+                self.num_topics
+            )));
+        }
+        let la = self.resolve_content_level(level_a)?;
+        let lb = self.resolve_content_level(level_b)?;
+        let a = &self.content_beta[la][topic];
+        let b = &self.content_beta[lb][topic];
+        let ratio: Vec<f64> = (0..self.vocab.len())
+            .map(|v| (a[v].max(1e-300) / b[v].max(1e-300)).ln())
+            .collect();
+        let mut idx: Vec<usize> = (0..self.vocab.len()).collect();
+        idx.sort_by(|&x, &y| f64::total_cmp(&ratio[y], &ratio[x]));
+        let items: Vec<Bound<'py, pyo3::types::PyTuple>> = idx
+            .iter()
+            .take(n)
+            .map(|&v| {
+                pyo3::types::PyTuple::new_bound(
+                    py,
+                    &[self.vocab[v].clone().into_py(py), ratio[v].into_py(py)],
+                )
+            })
+            .collect();
+        Ok(PyList::new_bound(py, items))
     }
 
     /// Topic coherence (one score per topic). `coherence_type` is `"u_mass"` (default, uses the

--- a/src/reply_tm.rs
+++ b/src/reply_tm.rs
@@ -115,6 +115,10 @@ pub struct ContentConfig<'a> {
     pub num_groups: usize,
     pub prior_var: f64,
     pub l1: f64,
+    /// First-order random-walk precision (`1/τ²`) tying ADJACENT content levels, for ordered levels
+    /// like depth bins. `0` disables it (levels treated as unordered categories). Only applied when
+    /// there are at least two levels.
+    pub smooth: f64,
 }
 
 /// Numerically-stable softmax of `[eta, 0]` (reference topic K-1 fixed at 0). Subtracts the max
@@ -411,6 +415,13 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
 
         // M-step (β): a SAGE content update per level (content covariate), else plain normalization.
         if let Some(c) = content {
+            // Optional first-order random walk over the (ordered) content levels: one base group,
+            // n_content ordered periods, precision c.smooth. Off (None) when smooth<=0 or <2 levels.
+            let rw = if c.smooth > 0.0 && n_content >= 2 {
+                Some((1usize, n_content, c.smooth))
+            } else {
+                None
+            };
             content_beta = crate::ctm::optimize_content(
                 &m_bg,
                 &mut kappa_t,
@@ -422,7 +433,7 @@ pub fn fit_reply_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                 num_types,
                 c.prior_var,
                 c.l1,
-                None, // no ordered random-walk over content levels in v1
+                rw,
                 20,
             );
         } else {

--- a/tests/test_posterior_doc_topic.py
+++ b/tests/test_posterior_doc_topic.py
@@ -1,0 +1,52 @@
+"""STM/CTM posterior_doc_topic — the hedged E[softmax(eta)] readout, symmetric with
+ReplyTM.posterior_doc_topic (issue #840)."""
+import numpy as np
+import pytest
+
+import topica
+
+
+def _corpus(seed=0, n=120):
+    rng = np.random.default_rng(seed)
+    A = [f"a{i}" for i in range(6)]
+    B = [f"b{i}" for i in range(6)]
+    docs, grp = [], []
+    for t in range(n):
+        g = t % 2
+        pool = A if g == 0 else B
+        docs.append([pool[rng.integers(6)] for _ in range(8)])  # short docs -> non-trivial nu
+        grp.append(g)
+    prevalence = np.array(grp, dtype=float).reshape(-1, 1)  # STM needs a covariate; CTM ignores it
+    return docs, prevalence
+
+
+def _fit(Model, docs, prevalence, **kw):
+    # STM requires prevalence/content; CTM takes neither.
+    if Model is topica.STM:
+        return Model(3, seed=13).fit(docs, prevalence=prevalence, **kw)
+    return Model(3, seed=13).fit(docs, **kw)
+
+
+@pytest.mark.parametrize("Model", [topica.CTM, topica.STM])
+def test_posterior_doc_topic(Model):
+    docs, prevalence = _corpus()
+    m = _fit(Model, docs, prevalence)
+    plug = np.asarray(m.doc_topic)
+    pdt = np.asarray(m.posterior_doc_topic(n_samples=400, seed=13))
+    assert pdt.shape == plug.shape
+    assert np.allclose(pdt.sum(axis=1), 1.0) and (pdt >= 0).all()
+    # deterministic given seed; integrates nu, so it is not the plug-in softmax(mean eta)
+    assert np.array_equal(pdt, np.asarray(m.posterior_doc_topic(n_samples=400, seed=13)))
+    assert not np.allclose(pdt, plug)
+    # posterior-predictive hedges: on average flatter (higher entropy) than the plug-in
+    ent = lambda p: -(p * np.log(np.clip(p, 1e-12, None))).sum(axis=1)
+    assert ent(pdt).mean() > ent(plug).mean()
+    with pytest.raises(ValueError):
+        m.posterior_doc_topic(n_samples=0)
+
+
+def test_posterior_doc_topic_needs_eta_cov():
+    docs, prevalence = _corpus(n=60)
+    m = topica.STM(3, seed=13).fit(docs, prevalence=prevalence, keep_eta_cov=False)
+    with pytest.raises(ValueError, match="keep_eta_cov"):
+        m.posterior_doc_topic()

--- a/tests/test_reply_tm.py
+++ b/tests/test_reply_tm.py
@@ -66,6 +66,47 @@ def test_content_depth_recovers_planted_shift():
     assert not (overlap(top10, AR) >= 4 and overlap(top10, AD) <= 1)
 
 
+def test_content_word_contrast():
+    """#846: content_word_contrast(topic, "deep", "root") surfaces the words that separate a topic's
+    language between two levels — for the planted shift, deep-over-root favors AD, root-over-deep AR."""
+    docs, parents, AR, AD, B = _content_shift_corpus()
+    m = topica.ReplyTM(2, em_iters=80, seed=13).fit(docs, parents=parents, content="depth")
+    a = max(range(2), key=lambda t: len(set(m.content_top_words(t, n=5)["root"]) & set(AR)))
+    deep_over_root = m.content_word_contrast(a, "deep", "root", n=5)
+    assert all(isinstance(w, str) and isinstance(r, float) for w, r in deep_over_root)
+    assert [r for _, r in deep_over_root] == sorted((r for _, r in deep_over_root), reverse=True)
+    top_deep = [w for w, _ in deep_over_root]
+    assert len(set(top_deep) & set(AD)) >= 4  # deep-characteristic words are the AD vocabulary
+    # the reverse contrast surfaces the root (AR) vocabulary
+    top_root = [w for w, _ in m.content_word_contrast(a, "root", "deep", n=5)]
+    assert len(set(top_root) & set(AR)) >= 4
+    # accepts integer levels too, and errors on an unknown level
+    assert m.content_word_contrast(a, 2, 0, n=3)  # deep vs root by index
+    with pytest.raises(ValueError):
+        m.content_word_contrast(a, "nope", "root")
+
+
+def test_content_smooth_ordered_levels():
+    """#846: content_smooth ties adjacent (ordered) depth levels; the fit stays valid and the
+    smoothed per-level topic-word distributions are closer between adjacent levels than unsmoothed."""
+    docs, parents, *_ = _content_shift_corpus(n_threads=60)
+    m0 = topica.ReplyTM(2, em_iters=60, seed=13).fit(docs, parents=parents, content="depth")
+    ms = topica.ReplyTM(2, em_iters=60, seed=13).fit(
+        docs, parents=parents, content="depth", content_smooth=5.0
+    )
+    tw0 = np.asarray(m0.topic_word_by_group)  # (K, G, V)
+    tws = np.asarray(ms.topic_word_by_group)
+    assert tws.shape == tw0.shape and np.allclose(tws.sum(axis=2), 1.0)
+    # adjacent-level L1 distance (root vs shallow) should shrink under smoothing
+    adj0 = np.abs(tw0[:, 0] - tw0[:, 1]).sum(axis=1).mean()
+    adjs = np.abs(tws[:, 0] - tws[:, 1]).sum(axis=1).mean()
+    assert adjs <= adj0 + 1e-9
+    with pytest.raises(ValueError):
+        topica.ReplyTM(2, em_iters=5, seed=13).fit(
+            docs, parents=parents, content="depth", content_smooth=-1.0
+        )
+
+
 def test_content_readouts_and_labels():
     """#841: content readouts have the right shapes (STM-compatible), plug into topica.content, and
     are None without a content covariate."""
@@ -642,21 +683,28 @@ def test_kappa_ci_boundary_flag():
 
 
 def test_group_prevalence_ci():
-    """#830 T3a: a one-call prob-scale CI aligned with group_prevalence (G,K,2), bracketing the
-    point estimate; a group with fewer than two threads yields NaN bounds."""
+    """#830 T3a / #843: topica.inspect.group_prevalence_ci returns a FrameDict (labels + mean/ci/sd)
+    matching the house CI-helper convention, with valid prob-scale intervals and a tidy to_frame."""
     docs, parents, cov, _ = _threaded_corpus(n_threads=30, depth=4)
-    m = topica.ReplyTM(3, em_iters=40, seed=13).fit(docs, parents=parents, covariates=cov)
+    m = topica.ReplyTM(3, em_iters=40, seed=13).fit(
+        docs, parents=parents, covariates=cov, covariate_names=["A", "B"]
+    )
+    res = topica.inspect.group_prevalence_ci(m, ci=0.9, n_samples=1500, seed=1)
+    assert set(res) == {"labels", "mean", "ci_low", "ci_high", "sd"}
+    assert res["labels"] == ["A", "B"]
     gp = np.asarray(m.group_prevalence)
-    ci = np.asarray(m.group_prevalence_ci(ci=0.9, n_samples=1500, seed=1))
-    assert ci.shape == gp.shape + (2,)
-    # valid probability-scale interval, correctly ordered (the plug-in point need not sit strictly
-    # inside a narrow MC interval by Jensen, so we don't assert bracketing)
-    assert np.all(ci[:, :, 0] <= ci[:, :, 1])
-    assert np.all((ci >= 0.0) & (ci <= 1.0))
+    assert np.allclose(np.asarray(res["mean"]), gp)  # point estimate is the exact group_prevalence
+    lo, hi = np.asarray(res["ci_low"]), np.asarray(res["ci_high"])
+    assert lo.shape == gp.shape and np.all(lo <= hi) and np.all((lo >= 0) & (hi <= 1))
+    # tidy long frame: one row per (group, topic)
+    df = res.to_frame()
+    assert list(df.columns) == ["group", "topic", "mean", "ci_low", "ci_high", "sd"]
+    assert len(df) == gp.size
     # deterministic given seed
-    assert np.array_equal(ci, np.asarray(m.group_prevalence_ci(ci=0.9, n_samples=1500, seed=1)))
+    res2 = topica.inspect.group_prevalence_ci(m, ci=0.9, n_samples=1500, seed=1)
+    assert np.array_equal(np.asarray(res["ci_low"]), np.asarray(res2["ci_low"]))
     with pytest.raises(ValueError):
-        m.group_prevalence_ci(ci=1.5)
+        topica.inspect.group_prevalence_ci(m, ci=1.5)
 
 
 def test_topic_table_pretty_print():


### PR DESCRIPTION
Bundles three tracked follow-ups from the ReplyTM work.

## #840 — `posterior_doc_topic` on STM and CTM
The hedged posterior-predictive `E[softmax(η)]` (full-covariance Monte-Carlo over the variational posterior), symmetric with `ReplyTM.posterior_doc_topic`. Unlike the plug-in `doc_topic` (= `softmax(mean η)`) it integrates the posterior covariance ν, so it's the θ to score held-out tokens with when comparing to a sample-averaged model like LDA. Needs `keep_eta_cov=True` (clear error otherwise). Shared `posterior_doc_topic_mc` helper (Box-Muller + `linalg::cholesky_jitter`).

## #846 — ReplyTM content follow-ups
- **`content_word_contrast(topic, level_a, level_b, n=10)`** — STM's `word_contrast` on content levels: the top-n `(word, log_ratio)` pairs separating a topic's language between two levels. The natural threaded readout is `content_word_contrast(k, "deep", "root")`.
- **`content_smooth=`** — a first-order random walk tying **adjacent** (ordered) content levels, wired to the CTM core's `optimize_content` `rw_time` (`num_base=1`, `num_times=n_levels`). `0` (default) treats levels as unordered.

## #843 — `group_prevalence_ci` follows the house CI-helper convention
The Rust method is now the primitive `_group_prevalence_ci_mc` (returns `(G,K,4)` = `[mean, ci_low, ci_high, sd]`); the public entry point is **`topica.inspect.group_prevalence_ci(model, ci=, n_samples=, seed=)`** returning a `GroupPrevalenceCI(FrameDict)` with `labels` + `mean`/`ci_low`/`ci_high`/`sd` and a `to_frame()` melting to one row per (group, topic) — matching `time_prevalence_ci`/`prevalence_ci`.

## Tests / gate
New: STM/CTM `posterior_doc_topic` (simplex, determinism, hedging vs plug-in, `keep_eta_cov` guard); `content_word_contrast` (deep-vs-root recovers AD/AR vocab); `content_smooth` (adjacent-level distance shrinks); `group_prevalence_ci` FrameDict shape + `to_frame`. fmt/clippy/preflight (stub sync)/mkdocs --strict clean.

Closes #840, #843, #846.

🤖 Generated with [Claude Code](https://claude.com/claude-code)