### PR TITLE
feat(evaluate): FREX-ranked topic_diversity + exclusivity (#844)

### DIFF
--- a/docs/guides/diagnostics.md
+++ b/docs/guides/diagnostics.md
@@ -39,6 +39,21 @@ One gotcha when you compare them side by side: `inverted_rbo` defaults to
 default to `topn=25`. On a small vocabulary the wider window forces overlap and
 reads as a misleadingly low diversity, so set `topn` explicitly when comparing.
 
+A second gotcha bites shrinkage models (STM, CTM, ThreadTM) specifically. Ranking
+each topic's top words by raw probability floats the corpus's shared high-frequency
+words into every topic's list, so `topic_diversity` and `exclusivity` penalize the
+model for a measurement artifact rather than a topic-quality defect. Pass
+`rank="frex"` to rank by FREX (frequency-exclusivity, STM's own word ranking)
+instead, which measures diversity over each topic's *distinctive* vocabulary:
+
+```python
+topica.evaluate.topic_diversity(model, topn=25, rank="frex")   # over distinctive words
+topica.evaluate.exclusivity(model, n=10, rank="frex")          # sum each topic's top FREX words
+```
+
+Both readings use the identical FREX scores, so `rank="prob"` (the default,
+STM-faithful) and `rank="frex"` are on the same scale and directly comparable.
+
 `embedding_coherence` scores a topic by how close its top words sit in a
 word-embedding space — the intrinsic middle ground between corpus-based
 `coherence` and LLM-based `topica.llm.coherence`. Bring your own embedding (it is

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -566,21 +566,47 @@ def coherence_ci(
     return CoherenceCI(np.asarray(estimate, dtype=float), se, ci_low, ci_high)
 
 
-def topic_diversity(topics, topn=25):
+def topic_diversity(topics, topn=25, *, rank="prob", w=0.5):
     """Fraction of unique words across all topics' top-`topn` words (Dieng,
     Ruiz & Blei 2020). 1.0 means every top word is unique to its topic; low
     values indicate topics that recycle the same words.
 
     `topics` is a fitted model or a list of word lists.
+
+    `rank` selects each topic's top-`topn` words: ``"prob"`` (raw ``P(w | topic)``,
+    the default) or ``"frex"`` (FREX = frequency-exclusivity, STM's word ranking).
+    Ranking by probability floats the corpus's shared high-frequency words into
+    every topic's list, so it penalizes shrinkage models (ReplyTM/CTM/STM) for a
+    measurement artifact rather than a topic-quality defect; FREX ranking measures
+    diversity over each topic's *distinctive* vocabulary instead (issue #844, and
+    STM's own coherence/exclusivity-frontier framing, Roberts et al. 2014). ``w``
+    is the FREX frequency weight in ``[0, 1]`` (used only when ``rank="frex"``).
+    ``rank="frex"`` needs a fitted model or a ``(K, V)`` topic_word matrix (its
+    ranking is model-derived), not a pre-extracted list of word lists.
     """
     if not isinstance(topn, (int, np.integer)) or topn < 1:
         raise ValueError(f"topn must be a positive integer, got {topn!r}")
-    tops = _extract_topics(topics, topn)
+    if rank not in ("prob", "frex"):
+        raise ValueError(f'rank must be "prob" or "frex", got {rank!r}')
+    if rank == "frex":
+        from .inspect import frex as _frex_words
+        try:
+            rows = _frex_words(topics, w=w, n=topn)
+        except (AttributeError, TypeError, ValueError) as e:
+            raise ValueError(
+                'topic_diversity(rank="frex") needs a fitted model whose FREX ranking '
+                "is derived from its topic_word matrix, not a pre-extracted list of word "
+                "lists; for a raw (K, V) matrix call topica.inspect.frex(matrix, vocabulary) "
+                "and pass its word lists with rank=\"prob\""
+            ) from e
+        tops = [[wd for wd, _ in row] for row in rows]
+    else:
+        tops = _extract_topics(topics, topn)
     seen = set()
     total = 0
     for t in tops:
-        for w in t[:topn]:
-            seen.add(w)
+        for w_ in t[:topn]:
+            seen.add(w_)
             total += 1
     return len(seen) / total if total else float("nan")
 
@@ -855,30 +881,46 @@ def _vocabulary_of(obj, vocabulary):
     raise ValueError("vocabulary is required when the model/array carries none")
 
 
-def exclusivity(model_or_phi, *, n=10, w=0.7):
+def exclusivity(model_or_phi, *, n=10, w=0.7, rank="prob"):
     """Per-topic exclusivity, shape ``(num_topics,)`` — stm's ``exclusivity``.
 
-    For each topic, the **FREX summary** over its top-``n`` words (by probability):
-    the sum of each word's frequency–exclusivity score (the rank harmonic mean of
-    probability and exclusivity ``φ_{t,v} / Σ_k φ_{k,v}``, weighted by ``w``, stm's
-    default 0.7). Higher means the topic's top words are more distinctive. Pair with
-    per-topic coherence to make stm's coherence-vs-exclusivity quality plot: good
-    topics sit toward the upper-right (coherent *and* distinctive).
+    For each topic, the **FREX summary** over its top-``n`` words: the sum of each
+    word's frequency–exclusivity score (the rank harmonic mean of probability and
+    exclusivity ``φ_{t,v} / Σ_k φ_{k,v}``, weighted by ``w``, stm's default 0.7).
+    Higher means the topic's top words are more distinctive. Pair with per-topic
+    coherence to make stm's coherence-vs-exclusivity quality plot: good topics sit
+    toward the upper-right (coherent *and* distinctive).
+
+    `rank` chooses which top-``n`` words are summed: ``"prob"`` (top-``n`` by raw
+    ``P(w | topic)``, stm's exact ``exclusivity``, the default) or ``"frex"`` (top-``n``
+    by FREX score). Selecting by probability lets the corpus's shared high-frequency
+    words — which every topic's top-probability list carries under a shrinkage prior —
+    drag the summary down, penalizing shrinkage models (ReplyTM/CTM/STM) for a
+    measurement artifact; ``rank="frex"`` sums each topic's genuinely most distinctive
+    words instead (issue #844). Both use the identical FREX scores, so they are on the
+    same scale (a sum over ``n`` words, roughly ``[0, n]``) and directly comparable.
 
     The scores come from the single stm-faithful implementation in topica's Rust
     core (``topica-core``'s ``inspect``), shared with faSTM and the Stata plugin.
 
-    .. note::
-       This is stm's exclusivity (a sum of FREX scores over the top ``n`` words,
-       roughly in ``[0, n]``), not a mean exclusivity in ``[0, 1]``. The scale
-       changed in the move to the shared stm-faithful core.
-
-    `model_or_phi` is a fitted model (uses its ``topic_word``) or a ``(K, V)``
-    array.
+    `model_or_phi` is a fitted model (uses its ``topic_word``) or a ``(K, V)`` array.
     """
+    if rank not in ("prob", "frex"):
+        raise ValueError(f'rank must be "prob" or "frex", got {rank!r}')
+    phi = _as_topic_word(model_or_phi)
+    if rank == "frex":
+        # Sum each topic's top-n FREX scores (select by FREX, not probability). Same
+        # frex scores stm's `exclusivity` sums, only the word selection differs.
+        from ._topica import inspect_frex_scores
+
+        scores = np.asarray(inspect_frex_scores(phi.tolist(), [], float(w)), dtype=np.float64)
+        n = int(n)
+        return np.array(
+            [np.sort(scores[t])[::-1][:n].sum() for t in range(scores.shape[0])],
+            dtype=np.float64,
+        )
     from ._topica import inspect_exclusivity
 
-    phi = _as_topic_word(model_or_phi)
     return np.asarray(
         inspect_exclusivity(phi.tolist(), int(n), float(w)), dtype=np.float64
     )

--- a/python/topica/coherence.py
+++ b/python/topica/coherence.py
@@ -589,6 +589,10 @@ def topic_diversity(topics, topn=25, *, rank="prob", w=0.5):
     if rank not in ("prob", "frex"):
         raise ValueError(f'rank must be "prob" or "frex", got {rank!r}')
     if rank == "frex":
+        # Validate w up front so a bad-weight error is not masked by the
+        # "needs a fitted model" message the try/except below reports.
+        if not (0.0 <= w <= 1.0):
+            raise ValueError(f"w (frequency weight) must be in [0, 1], got {w!r}")
         from .inspect import frex as _frex_words
         try:
             rows = _frex_words(topics, w=w, n=topn)
@@ -911,9 +915,18 @@ def exclusivity(model_or_phi, *, n=10, w=0.7, rank="prob"):
     if rank == "frex":
         # Sum each topic's top-n FREX scores (select by FREX, not probability). Same
         # frex scores stm's `exclusivity` sums, only the word selection differs.
+        #
+        # stm's two functions weight the harmonic mean with OPPOSITE conventions:
+        # `exclusivity`'s `w` weights exclusivity (0.7 = mostly exclusivity), while
+        # `frex_scores` (calcfrex)'s `w` weights *frequency*. To sum the identical
+        # per-word FREX scores the prob path uses, we pass `1 - w` here so the
+        # exclusivity weight lines up (their frequency/exclusivity ranks already
+        # match: log is monotone, so beta/colsum and logbeta-lse rank the same).
         from ._topica import inspect_frex_scores
 
-        scores = np.asarray(inspect_frex_scores(phi.tolist(), [], float(w)), dtype=np.float64)
+        scores = np.asarray(
+            inspect_frex_scores(phi.tolist(), [], 1.0 - float(w)), dtype=np.float64
+        )
         n = int(n)
         return np.array(
             [np.sort(scores[t])[::-1][:n].sum() for t in range(scores.shape[0])],

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -188,6 +188,91 @@ class TestDiversity:
         assert 0.0 < d <= 1.0
 
 
+class _Model:
+    """Minimal duck-typed model carrying a static ``(K, V)`` topic_word and a
+    vocabulary — enough for the FREX-ranked diversity/exclusivity path."""
+
+    def __init__(self, topic_word, vocabulary):
+        self.topic_word = np.asarray(topic_word, dtype=np.float64)
+        self.vocabulary = list(vocabulary)
+
+
+class TestFrexRankedDiversity:
+    """`rank="frex"` neutralizes the shrinkage penalty (issue #844): two topics
+    that share their highest-*probability* words but differ in their *distinctive*
+    words score low on probability-ranked diversity (a measurement artifact) and
+    high on FREX-ranked diversity."""
+
+    # sh* are shared background (equal, high prob in both topics); a*/b* are each
+    # topic's exclusive, lower-probability but highly distinctive words.
+    VOCAB = ["sh0", "sh1", "a0", "a1", "b0", "b1"]
+    PHI = np.array(
+        [[0.35, 0.35, 0.14, 0.14, 0.01, 0.01],
+         [0.35, 0.35, 0.01, 0.01, 0.14, 0.14]]
+    )
+
+    @property
+    def model(self):
+        return _Model(self.PHI, self.VOCAB)
+
+    def test_prob_ranking_penalizes_shared_words(self):
+        # Top-2 by probability is {sh0, sh1} for BOTH topics → 2 unique / 4 = 0.5.
+        assert topica.topic_diversity(self.model, topn=2, rank="prob") == 0.5
+
+    def test_frex_ranking_recovers_distinctive_words(self):
+        # Top-2 by FREX is {a0, a1} vs {b0, b1} → all 4 unique → 1.0.
+        assert topica.topic_diversity(self.model, topn=2, rank="frex") == 1.0
+        # And it beats the probability-ranked artifact.
+        assert topica.topic_diversity(self.model, topn=2, rank="frex") > \
+            topica.topic_diversity(self.model, topn=2, rank="prob")
+
+    def test_default_rank_is_prob(self):
+        assert topica.topic_diversity(self.model, topn=2) == \
+            topica.topic_diversity(self.model, topn=2, rank="prob")
+
+    def test_bad_rank_raises(self):
+        with pytest.raises(ValueError, match="prob.*frex"):
+            topica.topic_diversity(self.model, rank="nope")
+
+    def test_frex_on_word_lists_raises_clearly(self):
+        # rank="frex" needs a model-derived ranking, not pre-extracted word lists.
+        with pytest.raises(ValueError, match="fitted model"):
+            topica.topic_diversity([["a", "b"], ["c", "d"]], rank="frex")
+
+
+class TestFrexRankedExclusivity:
+    """`exclusivity(rank="frex")` sums each topic's genuinely most distinctive
+    words rather than its top-probability words (issue #844). Both use the same
+    FREX scores, so they are on the same scale and directly comparable."""
+
+    VOCAB = TestFrexRankedDiversity.VOCAB
+    PHI = TestFrexRankedDiversity.PHI
+
+    def test_frex_selection_beats_prob_selection(self):
+        # Selecting by probability sums the shared words' (low) FREX; selecting by
+        # FREX sums the distinctive words' (high) FREX. frex >= prob per topic.
+        prob = topica.exclusivity(self.PHI, n=2, rank="prob")
+        frex = topica.exclusivity(self.PHI, n=2, rank="frex")
+        assert np.all(frex >= prob)
+        assert np.any(frex > prob)
+
+    def test_symmetric_topics_score_equally(self):
+        # The two topics are mirror images, so both readings are symmetric.
+        for rank in ("prob", "frex"):
+            e = topica.exclusivity(self.PHI, n=2, rank=rank)
+            assert e[0] == pytest.approx(e[1])
+
+    def test_default_rank_is_prob(self):
+        np.testing.assert_allclose(
+            topica.exclusivity(self.PHI, n=2),
+            topica.exclusivity(self.PHI, n=2, rank="prob"),
+        )
+
+    def test_bad_rank_raises(self):
+        with pytest.raises(ValueError, match="prob.*frex"):
+            topica.exclusivity(self.PHI, rank="nope")
+
+
 class TestSemanticDiversity:
     """topic_semantic_diversity (Wu, Nguyen & Luu 2024, Eq. 18): fraction of
     top-word *pairs* that are unique to a single topic."""

--- a/tests/test_coherence.py
+++ b/tests/test_coherence.py
@@ -256,6 +256,20 @@ class TestFrexRankedExclusivity:
         assert np.all(frex >= prob)
         assert np.any(frex > prob)
 
+    def test_same_frex_scale_at_default_weight(self):
+        # Regression guard for the weight-convention fix: stm's `exclusivity` weights
+        # `w` on exclusivity while `frex_scores` (calcfrex) weights it on frequency,
+        # so the frex path must pass `1 - w`. Then both paths sum the *identical*
+        # per-word FREX scores and differ only in word selection — so frex-selection
+        # (the n largest) is >= prob-selection (any other n-subset) elementwise, even
+        # at the asymmetric default w=0.7. Under the un-flipped weight this ordering
+        # does not hold because the two paths score words differently.
+        rng = np.random.default_rng(0)
+        phi = rng.dirichlet(np.ones(30) * 0.3, size=4)
+        prob = topica.exclusivity(phi, n=10, rank="prob", w=0.7)
+        frex = topica.exclusivity(phi, n=10, rank="frex", w=0.7)
+        assert np.all(frex >= prob - 1e-9)
+
     def test_symmetric_topics_score_equally(self):
         # The two topics are mirror images, so both readings are symmetric.
         for rank in ("prob", "frex"):


### PR DESCRIPTION
Closes #844.

## Problem

Ranking each topic's top words by raw probability floats the corpus's shared high-frequency words into every topic's list. So `topic_diversity` and `exclusivity` penalize shrinkage models (STM / CTM / ThreadTM) for a measurement artifact rather than a topic-quality defect — exactly the failure `replytm-paper` worked around with an ad-hoc `frex_diversity` in `runs/multimetric.py`.

## Change

Add `rank="prob"|"frex"` to `topica.evaluate.topic_diversity` and `topica.evaluate.exclusivity`:

- `rank="prob"` (default) — unchanged, STM-faithful (top words by `P(w|topic)`).
- `rank="frex"` — rank by FREX (STM's own frequency-exclusivity ranking), so diversity/exclusivity are measured over each topic's *distinctive* vocabulary.

Both readings use the identical FREX scores (topica-core's single STM-faithful `inspect` implementation, `inspect_frex_scores` with no James-Stein shrinkage — matching what `exclusivity()` already sums), so `prob` and `frex` are on the same scale and directly comparable. `topic_diversity(rank="frex")` requires a fitted model / `(K,V)` matrix (the ranking is model-derived) and raises a clear error if handed pre-extracted word lists.

This promotes the interim `frex_diversity` workaround into the public API; `topica.inspect.frex` was already public.

## Tests

- `TestFrexRankedDiversity` — a hand-built φ where two topics share their top-probability words but differ in distinctive words: `rank="prob"` reads 0.5 (artifact), `rank="frex"` reads 1.0; default is `prob`; bad rank and word-lists-with-frex raise.
- `TestFrexRankedExclusivity` — FREX selection ≥ probability selection per topic, symmetric topics score equally, default is `prob`.

## Gate

- `cargo fmt --all --check`, `cargo clippy` (via preflight): clean
- `./scripts/preflight.sh`: all checks passed (stub/table/compat/guide in sync)
- `mkdocs build --strict`: clean (added a `rank="frex"` note to the diagnostics guide)
- Full `pytest tests/`: running

🤖 Generated with [Claude Code](https://claude.com/claude-code)