### PR TITLE
release: 0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,19 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.56.0] - 2026-08-31
+
 ### Changed
 
+- **The workflow namespaces are now the taught default** (#757, #763–#773). Helpers
+  live under `topica.<stage>` — `select` (choosing K), `inspect` (reading topics),
+  `evaluate` (validation), `effects` (covariate effects), `data` / `design`,
+  `compare` / `provenance` / `embeddings` / `robustness`. Docs, docstrings, and error
+  messages now teach the namespaced form (`topica.select.search_k`,
+  `topica.inspect.topic_table`, …). Model constructors and `Corpus` stay at the top
+  level. The flat helper names still resolve as legacy compatibility aliases.
+- **Default random seed is 13, not 42** (#673). Every model's default `seed` changed;
+  runs pinned to the old default reproduce by passing `seed=42` explicitly.
 - **Coherence is consistent across the model method and the standalone function**
   (#686). Every model's `m.coherence(n=10)` now accepts `coherence_type=` (`"u_mass"`
   default, plus `"c_v"` / `"c_uci"` / `"c_npmi"`) and an optional `texts=` reference
@@ -63,6 +74,44 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ### Added
 
+- **`ThreadTM` — the threaded topic model** (#823, #849). A CTM whose per-document
+  logistic-normal prior is coupled along a conversation's reply tree: a child
+  comment's topic mean reverts toward its parent (or root, or a blend) instead of
+  toward a shared corpus mean, so topics persist and drift down a thread the way real
+  discussion does. `fit(docs, parents=)` on a reply forest; `coupling=` selects
+  parent-anchored, root-anchored, or blended persistence. Adds soft `seed_words` (β)
+  and `prevalence_anchor` (θ) priors (#855) and a `thread_stability` robustness table
+  (#857). Paired with `topica.evaluate.reply_completion`, a held-out leaf-token
+  predictive test that scores whether the reply tree buys anything over a tree-free
+  baseline (#826, #853). **Experimental** (`enable_experimental()`); validation lives
+  in a separate repo.
+- **`ART` — the Author-Recipient-Topic model** (Rosen-Zvi / McCallum et al.; #813).
+  Author-Topic extended to directed messages: each token's topic is drawn from an
+  author-recipient pair, so topics condition on who is talking to whom. Fits from
+  `(author, recipients)` metadata alongside the documents.
+- **Live fit progress across the roster** (#785–#798). `topica.progress()` renders a
+  fit bar with an ETA and a metric sparkline; every iterative model takes a
+  `progress=` (or `verbose=`) callback on the standard 3-argument contract
+  (`iter, total, metric`), and interactive terminals show a progress bar by default.
+  `KeyboardInterrupt` propagates cleanly out of the Rust loops.
+- **Cross-validation framework** (#701–#707). A model-agnostic fold engine with a
+  topic path (held-out coherence / perplexity per fold) and a supervised
+  out-of-fold path, plus `plot_cv` and keyATM covariate-effect fold-stability. Reuses
+  the held-out and manifest machinery so a CV run records its own provenance.
+- **More evaluation metrics** (#805, #844). OCTIS/TopMost-style topic-quality metrics
+  and document-based topic alignment (#805), and a FREX-ranked `topic_diversity` with
+  a companion exclusivity measure (#844).
+- **`embedding_regression` — a validated conText replacement** (Rodriguez, Spirling &
+  Stewart 2023; #669). À-la-carte embedding regression with the group-and-bootstrap
+  inference conText users expect.
+- **LLM-assisted topic reading** (#583; #675–#678). `topica.llm.judge` (pairwise
+  topic-document Elo ranking), `topica.llm.refine` (LLM-cleaned top words per topic),
+  and `topica.llm.human_agreement` (coherence/intrusion agreement with human labels).
+- **Two new bundled datasets** (#736, #851). `load_congress()` — House press releases
+  2013–2024, the STM party+time example — and `load_threads()` — the two-subreddit
+  reply-tree vignette for `ThreadTM`.
+- **`topica.guide()` — an in-REPL cheat sheet** (#816) of task recipes for agents and
+  newcomers.
 - **`CSATM` — Conversational Structure Aware Topic Model** (Sun, Loparo &
   Kolacinski 2020; #811). A collapsed-Gibbs LDA for threaded forum discussions that
   weights each comment's tokens by a reply-tree "popularity" score and, after

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.55.0
+version: 0.56.0
 date-released: 2026-07-29
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.55.0"
+version = "0.56.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.55.0"
+version = "0.56.0"
 edition = "2021"
 description = "Fast, all-purpose topic modeling for Python, with a Rust core"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.55.0"
+version = "0.56.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Bump `0.55.0 -> 0.56.0` across `Cargo.toml`, `pyproject.toml`, `CITATION.cff`, and `Cargo.lock`, and cut the `CHANGELOG [0.56.0]` section from `Unreleased`.

This is a metadata + changelog PR only — no code changes. Merging this and then pushing the `v0.56.0` tag is what publishes the wheel to PyPI.

## Highlights since 0.55.0

**Added**
- `ThreadTM` — the threaded topic model (CTM + reply-tree persistence prior), with `topica.evaluate.reply_completion` held-out evaluation, seed/anchor priors, and a `thread_stability` table (#823, #849, #855, #857). Experimental.
- `ART` — the Author-Recipient-Topic model (#813)
- `CSATM` (#811), `KeyNMF` (#590), `TopicalNGrams` (#696), `Wordshoal` (#695), `GaussianLDA` (#689), `TopicsOverTime` (#694), `MGLDA` (#693), `AuthorTopic` (#692), `CorEx` (#688), `GuidedNMF` (#683)
- `embedding_regression` — a validated conText replacement (#669)
- A cross-validation framework (#701) and live fit progress across the roster (#785)
- LLM-assisted topic reading — `judge` / `refine` / `human_agreement` (#583)
- `load_congress` and `load_threads` datasets (#736, #851); `topica.guide()` (#816)

**Changed**
- The workflow namespaces (`topica.select` / `inspect` / `evaluate` / `effects` / …) are the taught default (#757)
- Default random seed `42 -> 13` (#673)
- Coherence is consistent across the model method and the standalone function (#686)

🤖 Generated with [Claude Code](https://claude.com/claude-code)