### PR TITLE
feat(threadtm): seed-word API parity with SeededLDA (#854)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -908,14 +908,17 @@ about, supervise the fit with keyword seeds. Both knobs are orthogonal to the re
 (the tree shapes prevalence; these shape the topic-word content and the group baseline), so
 they compose with coupling and covariates.
 
-`seed_words={topic_index: [keywords]}` biases those topics' word distributions toward the
+`seed_words` biases seeded topics' word distributions toward the
 keywords (SeededLDA-style Dirichlet seeding) and pins each seeded topic to a **fixed slot**,
-which removes the arbitrary permutation an unsupervised fit lands in. Unseeded topic indices
-are still learned freely, so you can seed a few themes and let the rest emerge. The seed is
+which removes the arbitrary permutation an unsupervised fit lands in. Its keys are either int
+topic indices (`{0: [...]}`) or string topic names (`{"space": [...]}`, which name the seeded
+topics and take the leading slots, as SeededLDA/keyATM do, and populate `topic_names`); unseeded
+topics are still learned freely, so you can seed a few themes and let the rest emerge. The seed is
 a **soft** prior: with the default frequency scaling (`seed_prior="frequency"`, each matched
-seed word getting a pseudocount of `corpus_count(word) * seed_weight`, scale-robust) a
+seed word getting a pseudocount of `corpus_count(word) * weight * 100`, scale-robust) a
 seeded topic keeps learning the rest of its vocabulary rather than collapsing onto the seeds.
-`seed_strength` overrides the scheme with a flat per-word pseudocount; `seed_match` is
+`weight` matches SeededLDA's `weight` (a `[0, 1]` fraction, default `0.01`).
+`seed_strength` overrides the scheme with a flat raw per-word pseudocount; `seed_match` is
 `"fixed"` (default), `"glob"` (`tax*`), or `"regex"`, with `case_insensitive`. Seeding the
 word channel is not supported together with a `content` covariate (raise otherwise).
 
@@ -937,7 +940,7 @@ rob.prevalence[("askscience", 3)]   # {'mean', 'ci'} of that (group, topic) prev
 ```
 
 `prevalence_anchor={group: [K-length mix]}` shrinks a covariate group's baseline topic mix toward
-a supplied target by `anchor_strength` (0..1), steering *prevalence*; it works with `content`. The
+a supplied target by `prevalence_strength` (0..1), steering *prevalence*; it works with `content`. The
 key is either the encoded integer group index (first-seen order) or the string group label you
 passed to `covariates=`.
 

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3126,9 +3126,12 @@ class ThreadTM:
         `content_prior_var` (default 0.5) is the deviation-prior scale. Read the shift with
         `content_topic_word` / `content_top_words` / `content_kappa`.
 
-        User supervision (issue #854), both orthogonal to the reply tree. `seed_words` biases
-        seeded topics' word distributions toward the keywords (SeededLDA-style Dirichlet seeding)
-        and pins them to fixed slots; unseeded topics are learned freely. Keys are EITHER int topic
+        User supervision (issue #854): two INDEPENDENT axes, both orthogonal to the reply tree —
+        (A) word seeding (`seed_words` + `weight`/`seed_strength`, `seed_prior`, `seed_match`) shapes
+        what seeded topics MEAN; (B) prevalence anchoring (`prevalence_anchor` + `prevalence_strength`)
+        steers a covariate group's topic MIX. They compose and never share a knob.
+        (A) `seed_words` biases seeded topics' word distributions toward the keywords (SeededLDA-style
+        Dirichlet seeding) and pins them to fixed slots; unseeded topics are learned freely. Keys are EITHER int topic
         indices (explicit slots) OR string topic names (which name the seeded topics and take the
         leading slots in insertion order, as SeededLDA/KeyATM do, and populate `topic_names`); keys
         must be all-int or all-string, not mixed. `weight` matches SeededLDA's `weight` (a ``[0, 1]`` fraction,

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3101,14 +3101,14 @@ class ThreadTM:
         content_prior_var: float = 0.5,
         content_smooth: float = 0.0,
         depth_bins: Sequence[int] | None = None,
-        seed_words: dict[int, Sequence[str]] | None = None,
+        seed_words: dict[int, Sequence[str]] | dict[str, Sequence[str]] | None = None,
         seed_prior: str = "frequency",
-        seed_weight: float = 1.0,
+        weight: float = 0.01,
         seed_strength: float | None = None,
         seed_match: str = "fixed",
         case_insensitive: bool = False,
         prevalence_anchor: dict[int | str, Sequence[float]] | None = None,
-        anchor_strength: float = 0.5,
+        prevalence_strength: float = 0.5,
     ) -> "ThreadTM":
         """`data` is a ``topica.Corpus`` or a list of token lists. `parents[d]` is document
         ``d``'s parent index in the reply tree (``-1`` for a thread root), in the SAME order as
@@ -3126,18 +3126,21 @@ class ThreadTM:
         `content_prior_var` (default 0.5) is the deviation-prior scale. Read the shift with
         `content_topic_word` / `content_top_words` / `content_kappa`.
 
-        User supervision (issue #854), both orthogonal to the reply tree. `seed_words` maps a
-        topic index to keyword strings, biasing those topics' word distributions toward the
-        keywords (SeededLDA-style Dirichlet seeding) and pinning them to fixed slots; unseeded
-        topics are learned freely. `seed_prior="frequency"` (default) gives each matched seed word
-        a pseudocount of ``corpus_count(word) * seed_weight`` (scale-robust, a SOFT prior that still
-        learns beyond the seeds); ``"uniform"`` is a flat ``seed_weight`` per word (so the two
+        User supervision (issue #854), both orthogonal to the reply tree. `seed_words` biases
+        seeded topics' word distributions toward the keywords (SeededLDA-style Dirichlet seeding)
+        and pins them to fixed slots; unseeded topics are learned freely. Keys are EITHER int topic
+        indices (explicit slots) OR string topic names (which name the seeded topics and take the
+        leading slots in insertion order, as SeededLDA/KeyATM do, and populate `topic_names`); keys
+        must be all-int or all-string, not mixed. `weight` matches SeededLDA's `weight` (a ``[0, 1]`` fraction,
+        default ``0.01``). `seed_prior="frequency"` (default) gives each matched seed word a
+        pseudocount of ``corpus_count(word) * weight * 100`` (scale-robust, a SOFT prior that still
+        learns beyond the seeds); ``"uniform"`` is a flat ``weight * 100`` per word (so the two
         schemes relate as ``frequency = uniform * corpus_count(word)``); `seed_strength` overrides
-        both with a flat per-word pseudocount. `seed_match` is ``"fixed"`` (exact,
+        both with a flat RAW per-word pseudocount (unscaled). `seed_match` is ``"fixed"`` (exact,
         default), ``"glob"`` (``*``/``?`` wildcards), or ``"regex"``, with `case_insensitive`.
         Seeding is not supported together with a `content` covariate. Audit what glob/regex seeds
         matched with the `seed_matches` property. `prevalence_anchor` maps a covariate group to a
-        length-K target topic mix and shrinks that group's baseline toward it by `anchor_strength`
+        length-K target topic mix and shrinks that group's baseline toward it by `prevalence_strength`
         (0..1), steering topic prevalence (works with `content`); the key is either the encoded
         integer group index (first-seen order) or the string group label (as passed to
         `covariates=`). Note the fit is deterministic; `seed` does not vary it, so refitting across
@@ -3250,6 +3253,14 @@ class ThreadTM:
         ...
     @property
     def vocabulary(self) -> list[str]: ...
+    @property
+    def topic_names(self) -> list[str]:
+        """Per-topic names (length K), in ``topic_word`` row order. Positional ``topic_i`` unless the
+        fit used a string-keyed ``seed_words`` dict, whose keys name the seeded topics (issue #854).
+        Assignable (a full-length list) to rename topics, as in SeededLDA/AnchorLDA."""
+        ...
+    @topic_names.setter
+    def topic_names(self, names: Sequence[str]) -> None: ...
     def top_words(self, n: int = 10, *, topic: int | None = None, weights: bool = False) -> list:
         """Top-n words per topic. With ``topic=None`` returns a list per topic; with an integer
         ``topic`` returns that topic's words. ``weights=True`` returns ``(word, prob)`` pairs."""

--- a/src/python/thread_tm.rs
+++ b/src/python/thread_tm.rs
@@ -52,6 +52,9 @@ pub struct ThreadTM {
     fitted: bool,
     vocab: Vec<String>,
     group_names: Vec<String>,
+    // Per-topic names (length K). Positional `topic_i` unless seeded with a string-keyed
+    // `seed_words` dict, whose keys name the seeded topics (issue #854). Empty until fitted.
+    topic_names: Vec<String>,
     // Which fitted-vocabulary words each seeded topic's patterns actually matched (issue #856):
     // `seed_matches[t]` is topic `t`'s matched words, empty for an unseeded topic. Lets a user
     // audit what `seed_match="glob"`/`"regex"` resolved to. Empty when the fit was unseeded.
@@ -122,6 +125,8 @@ struct ThreadTmState {
     fitted: bool,
     vocab: Vec<String>,
     group_names: Vec<String>,
+    #[serde(default)]
+    topic_names: Vec<String>,
     #[serde(default)]
     seed_matches: Vec<Vec<String>>,
     beta: Vec<Vec<f64>>,
@@ -459,6 +464,7 @@ impl ThreadTM {
             fitted: false,
             vocab: Vec::new(),
             group_names: Vec::new(),
+            topic_names: Vec::new(),
             seed_matches: Vec::new(),
             beta: Vec::new(),
             doc_topic: Vec::new(),
@@ -499,15 +505,19 @@ impl ThreadTM {
     /// `min_count` drops words rarer than it (the same vocabulary knob `Corpus` spells `min_cf`).
     ///
     /// Seeding and prevalence anchoring (both orthogonal to the reply tree). `seed_words` is a
-    /// `{topic_index: [keywords]}` dict: it biases those topics' word distributions toward the
-    /// keywords and pins them to fixed slots, while unseeded topic indices are learned freely.
+    /// dict biasing seeded topics' word distributions toward the keywords and pinning them to
+    /// fixed slots, while unseeded topics are learned freely. Its keys are EITHER int topic
+    /// indices (`{0: [...]}`, explicit slots) OR string topic names (`{"space": [...]}`, which name
+    /// the seeded topics and take the leading slots in insertion order, as SeededLDA/KeyATM do, and
+    /// populate `topic_names`); keys must be all-int or all-string, not mixed.
+    /// `weight` matches SeededLDA's `weight` (a `[0, 1]` fraction, default `0.01`).
     /// `seed_prior="frequency"` (default) gives each matched seed word a pseudocount of
-    /// `corpus_count(word) * seed_weight`; `"uniform"` a flat `seed_weight` per word; `seed_strength`
-    /// (if set) overrides both with a flat per-word pseudocount (so it silently supersedes
-    /// `seed_prior`/`seed_weight`). `seed_match` is `"fixed"` (default), `"glob"`, or `"regex"`, one
+    /// `corpus_count(word) * weight * 100`; `"uniform"` a flat `weight * 100` per word;
+    /// `seed_strength` (if set) overrides both with a flat RAW per-word pseudocount (so it silently
+    /// supersedes `seed_prior`/`weight`). `seed_match` is `"fixed"` (default), `"glob"`, or `"regex"`, one
     /// strategy for the whole dict, with `case_insensitive`. Seeding is rejected together with a
     /// `content` covariate. `prevalence_anchor={group_index: [K-length mix]}` shrinks a group's
-    /// baseline topic mix toward the target by `anchor_strength` (0..1); the key is the ENCODED
+    /// baseline topic mix toward the target by `prevalence_strength` (0..1); the key is the ENCODED
     /// integer group id (covariates are encoded `0..num_groups` in FIRST-SEEN order, not the string
     /// label and not alphabetical — check `group_names`/`covariate_names`), and the mix need not sum
     /// to 1. NOTE: the fit is deterministic given the inputs; `seed` does NOT vary the fit (the
@@ -517,9 +527,9 @@ impl ThreadTM {
                         content=None, content_names=None, content_prior="l2".to_string(),
                         content_prior_var=0.5, content_smooth=0.0, depth_bins=None,
                         seed_words=None, seed_prior="frequency".to_string(),
-                        seed_weight=1.0, seed_strength=None,
+                        weight=0.01, seed_strength=None,
                         seed_match="fixed".to_string(), case_insensitive=false,
-                        prevalence_anchor=None, anchor_strength=0.5))]
+                        prevalence_anchor=None, prevalence_strength=0.5))]
     #[allow(clippy::too_many_arguments)]
     fn fit(
         mut slf: PyRefMut<'_, Self>,
@@ -536,20 +546,21 @@ impl ThreadTM {
         content_smooth: f64,
         depth_bins: Option<Vec<usize>>,
         // User supervision (issue #854). seed_words maps a topic index to keyword strings
-        // (Dirichlet β seeding). seed_prior="frequency" (default) sets each seed word's pseudocount
-        // to corpus_count(word) * seed_weight, so seeding is scale-robust and does not collapse a
-        // topic to its seeds (SeededLDA's scheme); "uniform" uses a flat seed_weight * 100. Passing
-        // seed_strength overrides both with that flat per-word pseudocount. seed_match/case_insensitive
-        // select how patterns match the vocabulary (shared with SeededLDA). prevalence_anchor maps a
-        // covariate-group index to a length-K target topic mix.
+        // (Dirichlet β seeding). `weight` matches SeededLDA's `weight` (a [0, 1] fraction, default
+        // 0.01): seed_prior="frequency" (default) sets each seed word's pseudocount to
+        // corpus_count(word) * weight * 100, so seeding is scale-robust and does not collapse a
+        // topic to its seeds (SeededLDA's scheme); "uniform" uses a flat weight * 100. Passing
+        // seed_strength overrides both with a flat RAW per-word pseudocount (unscaled).
+        // seed_match/case_insensitive select how patterns match the vocabulary (shared with
+        // SeededLDA). prevalence_anchor maps a covariate-group index to a length-K target topic mix.
         seed_words: Option<Bound<'_, PyAny>>,
         seed_prior: String,
-        seed_weight: f64,
+        weight: f64,
         seed_strength: Option<f64>,
         seed_match: String,
         case_insensitive: bool,
         prevalence_anchor: Option<Bound<'_, PyAny>>,
-        anchor_strength: f64,
+        prevalence_strength: f64,
     ) -> PyResult<Py<Self>> {
         require_experimental("ThreadTM")?;
         // Accept either a topica.Corpus (materialise its token strings) or raw token lists, so the
@@ -879,7 +890,7 @@ impl ThreadTM {
         // Build the seed/anchor supervision config (issue #854) from the fit-time vocabulary and
         // covariate groups. seed_words -> β pseudocounts on the matched (topic, word) cells;
         // prevalence_anchor -> per-group η targets (additive-log-ratio of the supplied mix).
-        let (seed_cfg, seed_matches_out) = {
+        let (seed_cfg, seed_matches_out, topic_names_out) = {
             // Seeding the topic-word channel is unsupported alongside a content covariate (SAGE):
             // with content the β M-step is replaced by per-level sparse deviations, so the seed
             // pseudocounts would only reach the initializer, not the fit. Reject the combination.
@@ -889,20 +900,13 @@ impl ThreadTM {
                      without content, or drop seed_words (prevalence_anchor works with content).",
                 ));
             }
-            // Parse seed_words into {topic_index: [words]} with a house-quality error (not the raw
-            // PyO3 "list cannot be converted to PyDict") when a non-dict is passed (issue #856).
-            let sw_map: Option<HashMap<usize, Vec<String>>> = match &seed_words {
-                None => None,
-                Some(obj) => Some(obj.extract().map_err(|_| {
-                    PyValueError::new_err(
-                        "seed_words must be a dict mapping an int topic index to a list of keyword \
-                         strings, e.g. {0: [\"orbit\", \"planet\"]}",
-                    )
-                })?),
-            };
             let mut beta_pseudo: Vec<(usize, usize, f64)> = Vec::new();
             let mut seed_matches: Vec<Vec<String>> = Vec::new();
-            if let Some(sw) = &sw_map {
+            // Topic names default to positional `topic_i`, overridden per slot when seed_words is
+            // string-keyed (a {name: [words]} dict names the seeded topics, as SeededLDA/KeyATM do).
+            // Always length-K so `topic_names` is defined for every fit, seeded or not.
+            let mut topic_names: Vec<String> = (0..k).map(|i| format!("topic_{i}")).collect();
+            if let Some(obj) = &seed_words {
                 // Validate the seeding knobs only on the path that uses them. Guard finiteness and
                 // sign so a NaN/negative pseudocount cannot silently poison β (a negative pseudocount
                 // makes a normalized β entry negative; f64::clamp would let a NaN through untouched).
@@ -911,8 +915,10 @@ impl ThreadTM {
                         "seed_prior must be \"frequency\" or \"uniform\"",
                     ));
                 }
-                if !seed_weight.is_finite() || seed_weight < 0.0 {
-                    return Err(PyValueError::new_err("seed_weight must be finite and >= 0"));
+                if !weight.is_finite() || !(0.0..=1.0).contains(&weight) {
+                    return Err(PyValueError::new_err(
+                        "weight must be finite and in [0, 1] (as in SeededLDA / the seededlda package)",
+                    ));
                 }
                 if let Some(s) = seed_strength {
                     if !s.is_finite() || s < 0.0 {
@@ -922,16 +928,55 @@ impl ThreadTM {
                     }
                 }
                 let mode = crate::python::SeedMatch::parse(&seed_match)?;
-                // Lay the dict out positionally (0..K) and resolve patterns with the shared matcher
-                // (fixed/glob/regex, dedup within a topic) SeededLDA/CorEx use.
+                // seed_words keys are EITHER int topic indices (explicit positional slots) OR string
+                // topic names (which name the seeded topics and take the leading slots 0..G in
+                // insertion order, as SeededLDA/KeyATM do). Keys must be all-int or all-string, not
+                // mixed. Values resolve against the vocabulary with the shared matcher (fixed/glob/
+                // regex, dedup within a topic) that SeededLDA/CorEx use. Dict iteration is
+                // insertion-ordered (Python 3.7+), so string-keyed slots are assigned deterministically.
+                let dict = obj.downcast::<PyDict>().map_err(|_| {
+                    PyValueError::new_err(
+                        "seed_words must be a dict mapping a topic (an int index or a string name) \
+                         to a list of keyword strings, e.g. {0: [\"orbit\", \"planet\"]} or \
+                         {\"space\": [\"orbit\", \"planet\"]}",
+                    )
+                })?;
                 let mut per_topic: Vec<Vec<String>> = vec![Vec::new(); k];
-                for (&t, words) in sw {
-                    if t >= k {
-                        return Err(PyValueError::new_err(format!(
-                            "seed_words topic index {t} is out of range for num_topics={k}"
-                        )));
+                let (mut saw_int, mut saw_str, mut str_slot) = (false, false, 0usize);
+                for (key, val) in dict.iter() {
+                    let words: Vec<String> = val.extract().map_err(|_| {
+                        PyValueError::new_err("seed_words values must be a list of keyword strings")
+                    })?;
+                    if let Ok(name) = key.extract::<String>() {
+                        saw_str = true;
+                        if str_slot >= k {
+                            return Err(PyValueError::new_err(format!(
+                                "seed_words names {} topics but num_topics={k}; pass at most K names",
+                                str_slot + 1
+                            )));
+                        }
+                        per_topic[str_slot] = words;
+                        topic_names[str_slot] = name;
+                        str_slot += 1;
+                    } else if let Ok(t) = key.extract::<usize>() {
+                        saw_int = true;
+                        if t >= k {
+                            return Err(PyValueError::new_err(format!(
+                                "seed_words topic index {t} is out of range for num_topics={k}"
+                            )));
+                        }
+                        per_topic[t] = words;
+                    } else {
+                        return Err(PyValueError::new_err(
+                            "seed_words keys must be an int topic index or a string topic name",
+                        ));
                     }
-                    per_topic[t] = words.clone();
+                }
+                if saw_int && saw_str {
+                    return Err(PyValueError::new_err(
+                        "seed_words keys must be all int topic indices or all string topic names, \
+                         not a mix",
+                    ));
                 }
                 let matched =
                     crate::python::seed_word_ids(&per_topic, &vocab, k, mode, case_insensitive)?;
@@ -945,16 +990,19 @@ impl ThreadTM {
                 for (t, ids) in matched.iter().enumerate() {
                     for &id in ids {
                         // Pseudocount per matched seed word. `seed_strength` (if given) overrides the
-                        // scheme with a flat count. Otherwise "frequency" = corpus_count(word) *
-                        // seed_weight (scale-robust, so a common seed word is trusted more) and
-                        // "uniform" = seed_weight (a flat count per word); the two schemes therefore
-                        // relate as frequency = uniform * corpus_count(word).
+                        // scheme with a flat RAW count (unscaled). Otherwise `weight` matches
+                        // SeededLDA's `weight`: "frequency" = corpus_count(word) * weight * 100
+                        // (scale-robust, so a common seed word is trusted more), "uniform" = a flat
+                        // weight * 100 per word; the two schemes relate as frequency =
+                        // uniform * corpus_count(word). The *100 is SeededLDA's unit convention that
+                        // lets `weight` be a tidy [0, 1] fraction while landing at a count-magnitude
+                        // pseudocount (weight=0.01 default => 1x corpus count).
                         let pc = match seed_strength {
                             Some(s) => s,
                             None if seed_prior == "frequency" => {
-                                counts[vocab[id].as_str()] as f64 * seed_weight
+                                counts[vocab[id].as_str()] as f64 * weight * 100.0
                             }
-                            None => seed_weight,
+                            None => weight * 100.0,
                         };
                         beta_pseudo.push((t, id, pc));
                         n_seeded_words += 1;
@@ -972,9 +1020,9 @@ impl ThreadTM {
             }
             let mut anchor_target: Vec<(usize, Vec<f64>, f64)> = Vec::new();
             if let Some(obj) = &prevalence_anchor {
-                if !anchor_strength.is_finite() || !(0.0..=1.0).contains(&anchor_strength) {
+                if !prevalence_strength.is_finite() || !(0.0..=1.0).contains(&prevalence_strength) {
                     return Err(PyValueError::new_err(
-                        "anchor_strength must be finite and in [0, 1]",
+                        "prevalence_strength must be finite and in [0, 1]",
                     ));
                 }
                 let dict = obj.downcast::<PyDict>().map_err(|_| {
@@ -991,7 +1039,7 @@ impl ThreadTM {
                     .enumerate()
                     .map(|(i, nm)| (nm.as_str(), i))
                     .collect();
-                let s = anchor_strength;
+                let s = prevalence_strength;
                 for (key, val) in dict.iter() {
                     let g: usize = if let Ok(lbl) = key.extract::<String>() {
                         *label_to_idx.get(lbl.as_str()).ok_or_else(|| {
@@ -1046,7 +1094,7 @@ impl ThreadTM {
                     anchor_target,
                 })
             };
-            (cfg, seed_matches)
+            (cfg, seed_matches, topic_names)
         };
 
         let m = py.allow_threads(move || {
@@ -1082,6 +1130,7 @@ impl ThreadTM {
         let gp = m.group_prevalence();
         slf.vocab = vocab;
         slf.group_names = group_names;
+        slf.topic_names = topic_names_out;
         slf.seed_matches = seed_matches_out;
         slf.doc_eta = m.lambda.clone();
         slf.doc_topic_var = m.doc_topic_var.clone();
@@ -1594,6 +1643,29 @@ impl ThreadTM {
         Ok(self.vocab.clone())
     }
 
+    /// Per-topic names (length K), in `topic_word` row order. Positional `topic_i` unless the fit
+    /// used a string-keyed `seed_words` dict, whose keys name the seeded topics (issue #854).
+    /// Assignable (a full-length list) to rename topics, as in SeededLDA/AnchorLDA.
+    #[getter]
+    fn topic_names(&self) -> PyResult<Vec<String>> {
+        self.require_fitted()?;
+        Ok(self.topic_names.clone())
+    }
+
+    #[setter]
+    fn set_topic_names(&mut self, names: Vec<String>) -> PyResult<()> {
+        self.require_fitted()?;
+        if names.len() != self.beta.len() {
+            return Err(PyValueError::new_err(format!(
+                "expected {} topic names, got {}",
+                self.beta.len(),
+                names.len()
+            )));
+        }
+        self.topic_names = names;
+        Ok(())
+    }
+
     /// Which fitted-vocabulary words each seeded topic's patterns actually matched (issue #856), as
     /// `{topic_index: [words]}` over the seeded topics only. Lets you audit what `seed_words` with
     /// `seed_match="glob"`/`"regex"` resolved to (e.g. confirm `"planet*"` caught `planet`,
@@ -1865,6 +1937,7 @@ impl ThreadTM {
                 fitted: self.fitted,
                 vocab: self.vocab.clone(),
                 group_names: self.group_names.clone(),
+                topic_names: self.topic_names.clone(),
                 seed_matches: self.seed_matches.clone(),
                 beta: self.beta.clone(),
                 doc_topic: self.doc_topic.clone(),
@@ -1911,6 +1984,7 @@ impl ThreadTM {
             fitted: s.fitted,
             vocab: s.vocab,
             group_names: s.group_names,
+            topic_names: s.topic_names,
             seed_matches: s.seed_matches,
             beta: s.beta,
             doc_topic: s.doc_topic,

--- a/src/python/thread_tm.rs
+++ b/src/python/thread_tm.rs
@@ -14,7 +14,7 @@
 
 use super::*;
 use numpy::{PyArray1, PyArray2, PyArray3, ToPyArray};
-use pyo3::types::{PyDict, PyList, PyType};
+use pyo3::types::{PyBool, PyDict, PyList, PyType};
 use rand::Rng;
 use rand_chacha::rand_core::SeedableRng;
 use rand_chacha::ChaCha8Rng;
@@ -504,12 +504,17 @@ impl ThreadTM {
     /// `covariate_names` names the groups for the readouts (overriding auto-encoded labels).
     /// `min_count` drops words rarer than it (the same vocabulary knob `Corpus` spells `min_cf`).
     ///
-    /// Seeding and prevalence anchoring (both orthogonal to the reply tree). `seed_words` is a
-    /// dict biasing seeded topics' word distributions toward the keywords and pinning them to
+    /// Two INDEPENDENT supervision axes, both orthogonal to the reply tree:
+    /// (A) WORD SEEDING — `seed_words` (+ `weight`/`seed_strength`, `seed_prior`, `seed_match`) shapes
+    /// what seeded topics MEAN; (B) PREVALENCE ANCHORING — `prevalence_anchor` (+ `prevalence_strength`)
+    /// steers a covariate group's topic MIX. They compose and never share a knob.
+    ///
+    /// (A) `seed_words` biases seeded topics' word distributions toward the keywords and pins them to
     /// fixed slots, while unseeded topics are learned freely. Its keys are EITHER int topic
     /// indices (`{0: [...]}`, explicit slots) OR string topic names (`{"space": [...]}`, which name
     /// the seeded topics and take the leading slots in insertion order, as SeededLDA/KeyATM do, and
-    /// populate `topic_names`); keys must be all-int or all-string, not mixed.
+    /// populate `topic_names`); keys must be all-int or all-string, not mixed. Audit which vocabulary
+    /// words each pattern matched with the `seed_matches` property after fitting.
     /// `weight` matches SeededLDA's `weight` (a `[0, 1]` fraction, default `0.01`).
     /// `seed_prior="frequency"` (default) gives each matched seed word a pseudocount of
     /// `corpus_count(word) * weight * 100`; `"uniform"` a flat `weight * 100` per word;
@@ -906,6 +911,28 @@ impl ThreadTM {
             // string-keyed (a {name: [words]} dict names the seeded topics, as SeededLDA/KeyATM do).
             // Always length-K so `topic_names` is defined for every fit, seeded or not.
             let mut topic_names: Vec<String> = (0..k).map(|i| format!("topic_{i}")).collect();
+            // Warn on an orphaned supervision knob: a strength set without its companion collection
+            // is a silent no-op, and usually a forgotten arg. Two independent axes — word seeding
+            // (weight/seed_strength ↔ seed_words) and prevalence anchoring (prevalence_strength ↔
+            // prevalence_anchor). `!= default` via abs-diff to dodge the float_cmp lint.
+            if seed_words.is_none() && ((weight - 0.01).abs() > 1e-12 || seed_strength.is_some()) {
+                PyErr::warn_bound(
+                    py,
+                    &py.get_type_bound::<pyo3::exceptions::PyUserWarning>(),
+                    "weight/seed_strength was set but seed_words is None; the word-seeding knobs \
+                     are ignored (pass seed_words to seed topics).",
+                    1,
+                )?;
+            }
+            if prevalence_anchor.is_none() && (prevalence_strength - 0.5).abs() > 1e-12 {
+                PyErr::warn_bound(
+                    py,
+                    &py.get_type_bound::<pyo3::exceptions::PyUserWarning>(),
+                    "prevalence_strength was set but prevalence_anchor is None; prevalence \
+                     anchoring is ignored (pass prevalence_anchor to steer prevalence).",
+                    1,
+                )?;
+            }
             if let Some(obj) = &seed_words {
                 // Validate the seeding knobs only on the path that uses them. Guard finiteness and
                 // sign so a NaN/negative pseudocount cannot silently poison β (a negative pseudocount
@@ -947,6 +974,14 @@ impl ThreadTM {
                     let words: Vec<String> = val.extract().map_err(|_| {
                         PyValueError::new_err("seed_words values must be a list of keyword strings")
                     })?;
+                    // A Python bool is a subclass of int, so it would slip into the usize branch and
+                    // be read as a topic index (True->1, False->0). Reject it explicitly.
+                    if key.is_instance_of::<PyBool>() {
+                        return Err(PyValueError::new_err(
+                            "seed_words keys must be an int topic index or a string topic name, \
+                             not a bool",
+                        ));
+                    }
                     if let Ok(name) = key.extract::<String>() {
                         saw_str = true;
                         if str_slot >= k {
@@ -954,6 +989,24 @@ impl ThreadTM {
                                 "seed_words names {} topics but num_topics={k}; pass at most K names",
                                 str_slot + 1
                             )));
+                        }
+                        // A string key NAMES a topic and takes the next leading slot, unlike an int
+                        // key that selects a slot. Warn when the name looks like a valid index, since
+                        // {"2": ...} and {2: ...} then diverge silently (the string seeds the next
+                        // leading slot, named "2", not index 2).
+                        if let Ok(as_idx) = name.parse::<usize>() {
+                            if as_idx < k {
+                                PyErr::warn_bound(
+                                    py,
+                                    &py.get_type_bound::<pyo3::exceptions::PyUserWarning>(),
+                                    &format!(
+                                        "seed_words key {name:?} is a string, so it NAMES a topic and \
+                                         takes the next leading slot (slot {str_slot}), not index \
+                                         {as_idx}; pass the int {as_idx} for a positional slot."
+                                    ),
+                                    1,
+                                )?;
+                            }
                         }
                         per_topic[str_slot] = words;
                         topic_names[str_slot] = name;
@@ -1971,7 +2024,12 @@ impl ThreadTM {
     /// Load a model saved with `save`.
     #[classmethod]
     fn load(_cls: &Bound<'_, PyType>, path: &str) -> PyResult<Self> {
-        let s: ThreadTmState = read_state(path, MODEL_TAG_THREADTM)?;
+        let mut s: ThreadTmState = read_state(path, MODEL_TAG_THREADTM)?;
+        // Preserve the "topic_names is length K when fitted" invariant for a state that predates the
+        // field (serde default -> empty): backfill positional names from the topic-word row count.
+        if s.fitted && s.topic_names.is_empty() {
+            s.topic_names = (0..s.beta.len()).map(|i| format!("topic_{i}")).collect();
+        }
         Ok(ThreadTM {
             num_topics: s.num_topics,
             em_iters: s.em_iters,

--- a/tests/test_thread_tm.py
+++ b/tests/test_thread_tm.py
@@ -1242,6 +1242,28 @@ def test_thread_tm_seed_words_unnamed_default_and_mixed_keys():
         _fit_seeded(docs, parents, groups, seed_words={0: block_words[0], "b1": block_words[1]})
 
 
+def test_thread_tm_seed_newbie_guards():
+    """Guards for natural mistakes (PR #862 review): orphaned strength knobs warn, an index-looking
+    string key warns that it names (not indexes) a topic, and a bool key is rejected."""
+    docs, parents, groups, block_words, _ = _planted_block_corpus(n_threads=20)
+
+    def fit(**kw):
+        return topica.ThreadTM(4, em_iters=40, seed=13, coupling="parent").fit(
+            docs, parents=parents, covariates=groups, covariate_names=["g0", "g1"],
+            min_count=1, **kw)
+
+    with pytest.warns(UserWarning, match="weight/seed_strength was set but seed_words is None"):
+        fit(weight=0.5)
+    with pytest.warns(UserWarning, match="prevalence_strength was set but prevalence_anchor is None"):
+        fit(prevalence_strength=0.9)
+    # An index-looking string key NAMES a topic at the next leading slot, not that index.
+    with pytest.warns(UserWarning, match="is a string, so it NAMES a topic"):
+        m = fit(seed_words={"2": block_words[0]})
+    assert list(m.topic_names)[0] == "2"  # slot 0, named "2" (NOT index 2)
+    with pytest.raises(ValueError, match="not a bool"):
+        fit(seed_words={True: block_words[0]})
+
+
 def test_thread_tm_seed_is_soft_learns_beyond_seeds():
     """Seeding only a FEW of a block's words still pulls the whole block in: seeded topics keep
     substantial mass on the UNSEEDED block words (a soft prior, not a lock on the seeds), while

--- a/tests/test_thread_tm.py
+++ b/tests/test_thread_tm.py
@@ -1216,6 +1216,32 @@ def test_thread_tm_seed_words_pin_topics_to_slots():
         assert masses[t] > 0.6
 
 
+def test_thread_tm_seed_words_string_keys_name_topics():
+    """A string-keyed seed_words dict names the seeded topics and assigns them leading slots in
+    insertion order (as SeededLDA/keyATM do), exposed via topic_names. Same recovery as int keys."""
+    docs, parents, groups, block_words, _ = _planted_block_corpus()
+    named = {f"block{t}": block_words[t] for t in range(4)}  # insertion order 0..3
+    m = _fit_seeded(docs, parents, groups, seed_words=named)
+    assert list(m.topic_names) == ["block0", "block1", "block2", "block3"]
+    for t in range(4):
+        masses = [_block_mass(m, t, block_words[b]) for b in range(4)]
+        assert int(np.argmax(masses)) == t, f"named topic {t} did not land in its slot"
+    # topic_names is assignable (rename), like SeededLDA/AnchorLDA.
+    m.topic_names = ["a", "b", "c", "d"]
+    assert list(m.topic_names) == ["a", "b", "c", "d"]
+    with pytest.raises(ValueError, match="expected 4"):
+        m.topic_names = ["only", "three", "names"]
+
+
+def test_thread_tm_seed_words_unnamed_default_and_mixed_keys():
+    """Int-keyed (or unseeded) fits get positional topic_i names; mixing int and string keys errors."""
+    docs, parents, groups, block_words, _ = _planted_block_corpus()
+    m = _fit_seeded(docs, parents, groups, seed_words={0: block_words[0]})
+    assert list(m.topic_names) == ["topic_0", "topic_1", "topic_2", "topic_3"]
+    with pytest.raises(ValueError, match="all-int or all-string|not a mix"):
+        _fit_seeded(docs, parents, groups, seed_words={0: block_words[0], "b1": block_words[1]})
+
+
 def test_thread_tm_seed_is_soft_learns_beyond_seeds():
     """Seeding only a FEW of a block's words still pulls the whole block in: seeded topics keep
     substantial mass on the UNSEEDED block words (a soft prior, not a lock on the seeds), while
@@ -1223,7 +1249,8 @@ def test_thread_tm_seed_is_soft_learns_beyond_seeds():
     single topic can occasionally shed its tail, but the soft-prior behavior holds in aggregate."""
     docs, parents, groups, block_words, _ = _planted_block_corpus()
     partial = {t: block_words[t][:3] for t in range(4)}  # 3 of 10 words per block
-    m = _fit_seeded(docs, parents, groups, seed_words=partial, seed_weight=0.5)
+    # weight matches SeededLDA's scale (x100): 0.005 => 0.5x corpus count, a gentle seed.
+    m = _fit_seeded(docs, parents, groups, seed_words=partial, weight=0.005)
     aligned = sum(int(np.argmax([_block_mass(m, t, block_words[b]) for b in range(4)]) == t)
                   for t in range(4))
     assert aligned == 4, "seeding a few words per block failed to recover the blocks in-slot"
@@ -1233,7 +1260,7 @@ def test_thread_tm_seed_is_soft_learns_beyond_seeds():
 
 def test_thread_tm_prevalence_anchor_steers_group():
     """Pulling a group's anchor toward a target mix moves its recovered prevalence toward the
-    target, monotonically in anchor_strength."""
+    target, monotonically in prevalence_strength."""
     docs, parents, groups, block_words, _ = _planted_block_corpus()
     base = _fit_seeded(docs, parents, groups, seed_words=block_words)
     gp0 = np.asarray(base.group_prevalence)[0]
@@ -1241,7 +1268,7 @@ def test_thread_tm_prevalence_anchor_steers_group():
     prev = None
     for s in (0.0, 0.5, 0.9):
         m = _fit_seeded(docs, parents, groups, seed_words=block_words,
-                        prevalence_anchor={0: target.tolist()}, anchor_strength=s)
+                        prevalence_anchor={0: target.tolist()}, prevalence_strength=s)
         d = abs(np.asarray(m.group_prevalence)[0][0] - target[0])
         if prev is not None:
             assert d <= prev + 1e-6, "stronger anchor did not move prevalence toward the target"
@@ -1270,16 +1297,18 @@ def test_thread_tm_seed_validation_and_content_guard():
         _fit_seeded(docs, parents, groups, prevalence_anchor={0: [0.5, 0.5]})
     with pytest.raises(ValueError, match="not supported together with a content"):
         _fit_seeded(docs, parents, groups, seed_words={0: ["w0"]}, content="depth")
-    # finiteness / sign guards on the strength knobs (f64::clamp would let NaN through)
+    # finiteness / range guards on the strength knobs (f64::clamp would let NaN through).
+    # weight mirrors SeededLDA: bounded to [0, 1]. seed_strength is a raw pseudocount: >= 0.
+    for bad in (float("nan"), -0.1, 1.5):
+        with pytest.raises(ValueError, match="weight"):
+            _fit_seeded(docs, parents, groups, seed_words={0: ["w0"]}, weight=bad)
     for bad in (float("nan"), -1.0):
-        with pytest.raises(ValueError, match="seed_weight"):
-            _fit_seeded(docs, parents, groups, seed_words={0: ["w0"]}, seed_weight=bad)
         with pytest.raises(ValueError, match="seed_strength"):
             _fit_seeded(docs, parents, groups, seed_words={0: ["w0"]}, seed_strength=bad)
     for bad in (float("nan"), 1.5, -0.1):
-        with pytest.raises(ValueError, match="anchor_strength"):
+        with pytest.raises(ValueError, match="prevalence_strength"):
             _fit_seeded(docs, parents, groups,
-                        prevalence_anchor={0: [0.25, 0.25, 0.25, 0.25]}, anchor_strength=bad)
+                        prevalence_anchor={0: [0.25, 0.25, 0.25, 0.25]}, prevalence_strength=bad)
     with pytest.raises(ValueError, match="non-negative topic mix"):
         _fit_seeded(docs, parents, groups, prevalence_anchor={0: [0.5, -0.2, 0.4, 0.3]})
 
@@ -1316,10 +1345,10 @@ def test_thread_tm_prevalence_anchor_accepts_string_label():
     target = [0.7, 0.1, 0.1, 0.1]
     by_label = topica.ThreadTM(4, em_iters=60, seed=13, coupling="parent").fit(
         docs, parents=parents, covariates=labels, min_count=1,
-        prevalence_anchor={"g0": target}, anchor_strength=0.9)
+        prevalence_anchor={"g0": target}, prevalence_strength=0.9)
     by_index = topica.ThreadTM(4, em_iters=60, seed=13, coupling="parent").fit(
         docs, parents=parents, covariates=labels, min_count=1,
-        prevalence_anchor={0: target}, anchor_strength=0.9)
+        prevalence_anchor={0: target}, prevalence_strength=0.9)
     assert np.allclose(np.asarray(by_label.group_prevalence),
                        np.asarray(by_index.group_prevalence))
     with pytest.raises(ValueError, match="is not one of the covariate groups"):


### PR DESCRIPTION
Makes ThreadTM's user-supervision surface consistent with the other keyword models (SeededLDA / keyATM / CorEx / GuidedNMF). ThreadTM is pre-1.0 and experimental, so these are hard renames with no back-compat shims.

## Changes

**1. Seed weight: `seed_weight` (1.0) → `weight` (0.01), SeededLDA scale.**
Adopts SeededLDA's `weight` name, `[0, 1]` bound, and `× 100` pseudocount scaling, so the same number means the same seeding strength in both models. **Default behaviour is unchanged** — old `seed_weight=1.0` and new `weight=0.01` both land at 1× corpus count. `seed_strength` stays as the raw flat-pseudocount override (unscaled). Also de-collides the name from GuidedNMF's differently-scaled `seed_weight`.

**2. Seed keys: `seed_words` accepts string keys + new `topic_names`.**
`seed_words` now takes either `{0: [...]}` (int index, explicit slot) or `{"space": [...]}` (string name → names the seeded topic and takes the leading slot in insertion order, as SeededLDA/keyATM do). Keys must be all-int or all-string. New `topic_names` property (getter + setter, serde-default field, save/load) populated from string keys, positional `topic_i` otherwise.

**3. Prevalence anchor: `anchor_strength` → `prevalence_strength`.**
So `anchor` / `anchor_strength` unambiguously mean word-level anchoring (CorEx's meaning) library-wide, not θ-prevalence shrinkage. CorEx's own `anchor_strength` is untouched.

Also fixes a stale `seed_weight * 100` comment (the code had no `× 100` before; it does now).

## Migration
Explicit `weight`/`seed_weight` values must be divided by 100 (e.g. `0.5` → `0.005`); `anchor_strength=` → `prevalence_strength=`. Defaults need no change.

## Verification
- 95 ThreadTM tests pass (2 new: string-key naming path + mixed-key rejection + setter).
- Preflight green: fmt, clippy, stub-sync (106), model tables, compat map, agent cheat sheet all in sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)