### PR TITLE
feat(threadtm): blend-weight uncertainty + fair-scale coupling contrasts (#863)

### DIFF
--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -848,7 +848,7 @@ shrinks each node toward BOTH its parent and its thread root:
 ```python
 m = topica.ThreadTM(num_topics=25, seed=13, coupling="blend")
 m.fit(docs, parents=parents)
-m.blend_alpha, m.blend_beta   # fitted parent weight and root weight
+m.blend_weights()   # {"alpha", "beta", "anchor", "alpha_se", "beta_se", "anchor_se"}
 ```
 
 The prior mean is `alpha * parent + beta * root + (1 - alpha - beta) * anchor`. The weights
@@ -861,11 +861,44 @@ weights or use `coupling="parent"`/`"root"`. Blend also needs enough tokens per 
 very short replies the leaf's own η is too noisy for the two-regressor weight estimator, and
 blend can underperform plain `coupling="parent"`; on short-reply corpora prefer `"parent"` or
 `"root"`, or pin the weights. `kappa`/`kappa_ci` are `NaN` under blend, since
-the mix is described by the two weights instead of a single reversion. To let the data say which structure fits, fit
-these variants and compare them on held-out replies with the `"root"` and `"blend"` baselines
-in `reply_completion` below: `delta["root"]` is parent-coupling minus root-coupling, positive
-where the reply edge matters more than the thread topic and negative where it does not, and
-`delta["blend"]` is parent-coupling minus the estimated blend.
+the mix is described by the two weights instead of a single reversion.
+
+**The blend mix as a structural estimand.** The three shares — `blend_alpha` (parent),
+`blend_beta` (root), `blend_anchor` (= `1 - alpha - beta`) — *characterize how a discourse
+space is organized*, with no hand coding: parent-chained (α large, the reply edge carries the
+topic), broadcast-around-the-root (β large, replies track the thread topic), or context-free
+(anchor large, the group baseline dominates). Each carries a thread-root-clustered sandwich
+standard error (`blend_alpha_se`, `blend_beta_se`, `blend_anchor_se`; `blend_weights()` returns
+all six together), so a community's position on the parent–root axis comes with an interval.
+The SEs are asymptotic and conditional on the topic fit; like any Wald interval they are not
+strictly valid when a weight sits on a boundary (0 or the `α+β=1` simplex edge), and a pinned
+weight reports SE `0`. For a paired parent-vs-root contrast on the fair held-out scale (rather
+than a within-fit weight), use `reply_completion` below.
+
+**Letting the data pick the coupling on the held-out scale.** To let the data say which
+structure fits, fit these variants and compare them on held-out replies with the `"root"` and
+`"blend"` baselines in `reply_completion` below. Every ThreadTM baseline is scored with the
+same posterior-predictive `E[softmax(η)]` (issue #838) as the parent tree, so the couplings are
+compared on one fair estimator. `delta["root"]` is parent-coupling minus root-coupling, positive
+where the reply edge matters more than the thread topic and negative where it does not;
+`delta["blend"]` is parent-coupling minus the estimated blend. Any *other* pairing — for
+instance `root` versus `no_tree`, or `blend` versus `root` — comes with a thread-clustered CI
+by naming it in `contrasts=` (issue #852):
+
+```python
+res = topica.evaluate.reply_completion(
+    docs, parents, num_topics=25,
+    baselines=("no_tree", "root", "blend"),
+    contrasts=[("root", "no_tree"), ("blend", "root")],
+)
+res.delta["root"], res.delta["blend"]        # each vs the parent tree, with CIs
+res.contrast["root-no_tree"], res.contrast["blend-root"]   # arbitrary coupling pairings
+res.paired                                    # per-leaf, per-model held-out log-likelihoods
+```
+
+`res.paired` is the per-thread paired held-out matrix (leaves × models): it lets you cluster
+*any* coupling contrast yourself on the thread root, so the whole parent/root/blend comparison
+comes off one matched fit on one held-out split.
 
 **Content drift: how a topic's words shift downstream.** The covariate above shapes topic
 *prevalence* (which topics a group's threads use). A **content** covariate instead shapes the

--- a/docs/guides/models.md
+++ b/docs/guides/models.md
@@ -872,8 +872,11 @@ standard error (`blend_alpha_se`, `blend_beta_se`, `blend_anchor_se`; `blend_wei
 all six together), so a community's position on the parent–root axis comes with an interval.
 The SEs are asymptotic and conditional on the topic fit; like any Wald interval they are not
 strictly valid when a weight sits on a boundary (0 or the `α+β=1` simplex edge), and a pinned
-weight reports SE `0`. For a paired parent-vs-root contrast on the fair held-out scale (rather
-than a within-fit weight), use `reply_completion` below.
+weight reports SE `0`. On a shallow tree where the α-vs-β split is not identified (the same
+condition that raises the identifiability warning), `blend_alpha_se` and `blend_beta_se` are
+`NaN` while `blend_anchor_se` stays finite — the anchor share depends only on the identified
+combined weight `α + β`, not on how it splits. For a paired parent-vs-root contrast on the fair
+held-out scale (rather than a within-fit weight), use `reply_completion` below.
 
 **Letting the data pick the coupling on the held-out scale.** To let the data say which
 structure fits, fit these variants and compare them on held-out replies with the `"root"` and

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3197,8 +3197,9 @@ class ThreadTM:
     @property
     def blend_alpha_se(self) -> float:
         """Cluster-robust (thread-root) sandwich SE of blend_alpha (issue #863). NaN unless
-        coupling="blend" fitted with >=2 threads; 0 when blend_alpha was pinned. Asymptotic and
-        conditional on the topic fit; not strictly valid at a weight boundary."""
+        coupling="blend" fitted with >=2 threads; 0 when blend_alpha was pinned; NaN when the tree
+        lacks depth-3 structure so the alpha-vs-beta split is unidentified (read blend_anchor_se there).
+        Asymptotic and conditional on the topic fit; not strictly valid at a weight boundary."""
         ...
     @property
     def blend_beta_se(self) -> float:
@@ -3206,7 +3207,8 @@ class ThreadTM:
         ...
     @property
     def blend_anchor_se(self) -> float:
-        """SE of the anchor weight 1-alpha-beta, propagated from the joint (alpha, beta) covariance."""
+        """Cluster-robust sandwich SE of the anchor weight 1-alpha-beta (the SE of the identified
+        combined share alpha+beta). Stays finite even when the alpha-vs-beta split is unidentified."""
         ...
     def blend_weights(self) -> dict[str, float]:
         """The estimated blend mix as {"alpha", "beta", "anchor", "alpha_se", "beta_se", "anchor_se"}:

--- a/python/topica/_topica.pyi
+++ b/python/topica/_topica.pyi
@@ -3189,6 +3189,32 @@ class ThreadTM:
         """Blend root weight beta (NaN unless fit with coupling="blend"); the anchor takes 1-alpha-beta."""
         ...
     @property
+    def blend_anchor(self) -> float:
+        """Blend anchor weight 1-alpha-beta: how much a node reverts to its covariate-group baseline
+        rather than to its parent or root (NaN unless fit with coupling="blend"). With blend_alpha and
+        blend_beta, a hand-coding-free structural readout of how a discourse space is organised."""
+        ...
+    @property
+    def blend_alpha_se(self) -> float:
+        """Cluster-robust (thread-root) sandwich SE of blend_alpha (issue #863). NaN unless
+        coupling="blend" fitted with >=2 threads; 0 when blend_alpha was pinned. Asymptotic and
+        conditional on the topic fit; not strictly valid at a weight boundary."""
+        ...
+    @property
+    def blend_beta_se(self) -> float:
+        """Cluster-robust (thread-root) sandwich SE of blend_beta; same conventions as blend_alpha_se."""
+        ...
+    @property
+    def blend_anchor_se(self) -> float:
+        """SE of the anchor weight 1-alpha-beta, propagated from the joint (alpha, beta) covariance."""
+        ...
+    def blend_weights(self) -> dict[str, float]:
+        """The estimated blend mix as {"alpha", "beta", "anchor", "alpha_se", "beta_se", "anchor_se"}:
+        the parent, root, and anchor shares of each node's prior mean, each with its thread-root-
+        clustered SE (issue #863). All NaN unless fit with coupling="blend"; a pinned weight reads its
+        fixed value with SE 0."""
+        ...
+    @property
     def topic_word(self) -> numpy.typing.NDArray[numpy.float64]: ...
     @property
     def doc_topic(self) -> numpy.typing.NDArray[numpy.float64]:

--- a/python/topica/evaluate.py
+++ b/python/topica/evaluate.py
@@ -1139,6 +1139,17 @@ def reply_completion(
       the mix estimated. ``delta["blend"]`` is parent-coupling minus blend-coupling;
       a negative value means the blend of edge and thread structure predicts better
       than the reply edge alone.
+
+    Every ThreadTM baseline above (``no_tree``, ``permuted``, ``root``, ``blend``) is a
+    matched fit scored with the *same* posterior-predictive ``E[softmax(η)]`` estimator
+    as the ``tree`` (issue #838), so all the coupling contrasts sit on one fair
+    held-out scale. ``delta`` reports each against the parent ``tree``; for any *other*
+    coupling pairing (``root - no_tree``, ``blend - root``, …) name it in ``contrasts``
+    to get the thread-clustered CI directly, or read ``result.paired`` — the per-leaf,
+    per-model held-out log-likelihood matrix — and cluster it yourself. This is the
+    surface for turning the genre boundary into a "which structure fits which
+    discourse" result (issue #863): one matched fit on one held-out split, every
+    parent/root/blend contrast on the posterior-predictive scale.
     - ``lda`` / ``stm`` (issue #828): off-the-shelf comparators — a plain
       ``LDA(K)``, and an ``STM(K)`` with the ``covariates`` one-hot encoded as
       prevalence — fit on the same reduced corpus (pinned to the tree model's

--- a/src/python/thread_tm.rs
+++ b/src/python/thread_tm.rs
@@ -49,6 +49,11 @@ pub struct ThreadTM {
     // Effective (fitted or pinned) blend weights after fit; NaN unless coupling="blend" and fitted.
     blend_alpha: f64,
     blend_beta: f64,
+    // Cluster-robust (thread-root) sandwich SEs of the fitted blend weights + their covariance
+    // (issue #863); NaN unless blend fitted with >=2 threads, 0 for a pinned weight.
+    blend_alpha_se: f64,
+    blend_beta_se: f64,
+    blend_ab_cov: f64,
     fitted: bool,
     vocab: Vec<String>,
     group_names: Vec<String>,
@@ -122,6 +127,12 @@ struct ThreadTmState {
     blend_alpha: f64,
     #[serde(default = "default_nan")]
     blend_beta: f64,
+    #[serde(default = "default_nan")]
+    blend_alpha_se: f64,
+    #[serde(default = "default_nan")]
+    blend_beta_se: f64,
+    #[serde(default = "default_nan")]
+    blend_ab_cov: f64,
     fitted: bool,
     vocab: Vec<String>,
     group_names: Vec<String>,
@@ -461,6 +472,9 @@ impl ThreadTM {
             blend_beta_fixed: blend_beta,
             blend_alpha: f64::NAN,
             blend_beta: f64::NAN,
+            blend_alpha_se: f64::NAN,
+            blend_beta_se: f64::NAN,
+            blend_ab_cov: f64::NAN,
             fitted: false,
             vocab: Vec::new(),
             group_names: Vec::new(),
@@ -1195,6 +1209,9 @@ impl ThreadTM {
         slf.kappa_ci = m.kappa_ci;
         slf.blend_alpha = m.blend_alpha;
         slf.blend_beta = m.blend_beta;
+        slf.blend_alpha_se = m.blend_alpha_se;
+        slf.blend_beta_se = m.blend_beta_se;
+        slf.blend_ab_cov = m.blend_ab_cov;
         slf.sigma2 = m.sigma2;
         slf.p0 = m.p0;
         slf.sigma_root = m.sigma_root;
@@ -1987,6 +2004,9 @@ impl ThreadTM {
                 blend_beta_fixed: self.blend_beta_fixed,
                 blend_alpha: self.blend_alpha,
                 blend_beta: self.blend_beta,
+                blend_alpha_se: self.blend_alpha_se,
+                blend_beta_se: self.blend_beta_se,
+                blend_ab_cov: self.blend_ab_cov,
                 fitted: self.fitted,
                 vocab: self.vocab.clone(),
                 group_names: self.group_names.clone(),
@@ -2039,6 +2059,9 @@ impl ThreadTM {
             blend_beta_fixed: s.blend_beta_fixed,
             blend_alpha: s.blend_alpha,
             blend_beta: s.blend_beta,
+            blend_alpha_se: s.blend_alpha_se,
+            blend_beta_se: s.blend_beta_se,
+            blend_ab_cov: s.blend_ab_cov,
             fitted: s.fitted,
             vocab: s.vocab,
             group_names: s.group_names,
@@ -2348,6 +2371,78 @@ impl ThreadTM {
         self.blend_beta
     }
 
+    /// Blend anchor weight `1 - α - β` (how much a node reverts to its covariate-group baseline
+    /// rather than to its parent or root), `NaN` unless the model was fit with `coupling="blend"`.
+    /// Together with `blend_alpha`/`blend_beta` these three shares are a hand-coding-free structural
+    /// readout of how a discourse space is organised: parent-chained (α large), broadcast-around-the-
+    /// root (β large), or context-free (anchor large).
+    #[getter]
+    fn blend_anchor(&self) -> f64 {
+        1.0 - self.blend_alpha - self.blend_beta
+    }
+
+    /// Asymptotic cluster-robust (sandwich) standard error of `blend_alpha`, clustered on the thread
+    /// root (issue #863). `NaN` unless `coupling="blend"` was fitted with at least two threads; `0`
+    /// when `blend_alpha` was pinned in the constructor (it was fixed, not estimated). Conditional on
+    /// the topic fit; like any Wald SE it is not strictly valid at a boundary (a weight at 0 or on the
+    /// `α+β=1` edge). For a paired parent-vs-root contrast on the held-out scale, use
+    /// `evaluate.reply_completion` with the `"root"`/`"blend"` baselines instead.
+    #[getter]
+    fn blend_alpha_se(&self) -> f64 {
+        self.blend_alpha_se
+    }
+
+    /// Asymptotic cluster-robust (sandwich) SE of `blend_beta`, clustered on the thread root; same
+    /// conventions and caveats as `blend_alpha_se`.
+    #[getter]
+    fn blend_beta_se(&self) -> f64 {
+        self.blend_beta_se
+    }
+
+    /// SE of the anchor weight `1 - α - β`, propagated from the joint `(α, β)` sandwich covariance as
+    /// `√(seα² + seβ² + 2·covαβ)`. `NaN` / `0` under the same conditions as `blend_alpha_se`.
+    #[getter]
+    fn blend_anchor_se(&self) -> f64 {
+        // Var(1-α-β) = Var(α) + Var(β) + 2·Cov(α,β). NaN-safe (a plain `.max(0.0)` on a NaN
+        // returns 0.0 in Rust, which would wrongly read as a zero-width anchor interval).
+        let v = self.blend_alpha_se * self.blend_alpha_se
+            + self.blend_beta_se * self.blend_beta_se
+            + 2.0 * self.blend_ab_cov;
+        if v.is_nan() {
+            f64::NAN
+        } else {
+            v.max(0.0).sqrt()
+        }
+    }
+
+    /// The estimated blend mix as a labelled dict: `{"alpha", "beta", "anchor", "alpha_se", "beta_se",
+    /// "anchor_se"}` — the parent, root, and anchor shares of each node's prior mean, each with its
+    /// thread-root-clustered SE (issue #863). All `NaN` unless the model was fit with
+    /// `coupling="blend"`. A pinned weight reads its fixed value with SE `0`. This is the structural
+    /// characterisation a discourse space earns from `coupling="blend"`: whether topics track the
+    /// reply chain (α), the thread root (β), or neither (anchor).
+    fn blend_weights<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
+        self.require_fitted()?;
+        let d = PyDict::new_bound(py);
+        d.set_item("alpha", self.blend_alpha)?;
+        d.set_item("beta", self.blend_beta)?;
+        d.set_item("anchor", 1.0 - self.blend_alpha - self.blend_beta)?;
+        d.set_item("alpha_se", self.blend_alpha_se)?;
+        d.set_item("beta_se", self.blend_beta_se)?;
+        let anchor_var = self.blend_alpha_se * self.blend_alpha_se
+            + self.blend_beta_se * self.blend_beta_se
+            + 2.0 * self.blend_ab_cov;
+        d.set_item(
+            "anchor_se",
+            if anchor_var.is_nan() {
+                f64::NAN
+            } else {
+                anchor_var.max(0.0).sqrt()
+            },
+        )?;
+        Ok(d)
+    }
+
     /// Per-edge (OU step) variance: the mean marginal variance of the fitted full edge covariance
     /// Σ_edge (a scalar summary; the edge prior is the full Σ_edge, on the same footing as the root
     /// Σ_root). `NaN` when there are no reply edges / the field was not fit.
@@ -2435,9 +2530,14 @@ impl ThreadTM {
     fn __repr__(&self) -> String {
         if self.fitted && self.coupling == "blend" {
             return format!(
-                "ThreadTM(num_topics={}, coupling=\"blend\", fitted, alpha={:.3}, beta={:.3}, \
-                 sigma2={:.3})",
-                self.num_topics, self.blend_alpha, self.blend_beta, self.sigma2
+                "ThreadTM(num_topics={}, coupling=\"blend\", fitted, alpha={:.3}±{:.3}, \
+                 beta={:.3}±{:.3}, sigma2={:.3})",
+                self.num_topics,
+                self.blend_alpha,
+                self.blend_alpha_se,
+                self.blend_beta,
+                self.blend_beta_se,
+                self.sigma2
             );
         }
         if self.fitted {

--- a/src/python/thread_tm.rs
+++ b/src/python/thread_tm.rs
@@ -49,11 +49,12 @@ pub struct ThreadTM {
     // Effective (fitted or pinned) blend weights after fit; NaN unless coupling="blend" and fitted.
     blend_alpha: f64,
     blend_beta: f64,
-    // Cluster-robust (thread-root) sandwich SEs of the fitted blend weights + their covariance
-    // (issue #863); NaN unless blend fitted with >=2 threads, 0 for a pinned weight.
+    // Cluster-robust (thread-root) sandwich SEs of the fitted blend weights and the anchor share
+    // (issue #863); NaN unless blend fitted with >=2 threads, 0 for a pinned weight, and the
+    // individual weight SEs NaN (anchor SE kept) when the α/β split is not identified.
     blend_alpha_se: f64,
     blend_beta_se: f64,
-    blend_ab_cov: f64,
+    blend_anchor_se: f64,
     fitted: bool,
     vocab: Vec<String>,
     group_names: Vec<String>,
@@ -132,7 +133,7 @@ struct ThreadTmState {
     #[serde(default = "default_nan")]
     blend_beta_se: f64,
     #[serde(default = "default_nan")]
-    blend_ab_cov: f64,
+    blend_anchor_se: f64,
     fitted: bool,
     vocab: Vec<String>,
     group_names: Vec<String>,
@@ -474,7 +475,7 @@ impl ThreadTM {
             blend_beta: f64::NAN,
             blend_alpha_se: f64::NAN,
             blend_beta_se: f64::NAN,
-            blend_ab_cov: f64::NAN,
+            blend_anchor_se: f64::NAN,
             fitted: false,
             vocab: Vec::new(),
             group_names: Vec::new(),
@@ -1211,7 +1212,7 @@ impl ThreadTM {
         slf.blend_beta = m.blend_beta;
         slf.blend_alpha_se = m.blend_alpha_se;
         slf.blend_beta_se = m.blend_beta_se;
-        slf.blend_ab_cov = m.blend_ab_cov;
+        slf.blend_anchor_se = m.blend_anchor_se;
         slf.sigma2 = m.sigma2;
         slf.p0 = m.p0;
         slf.sigma_root = m.sigma_root;
@@ -2006,7 +2007,7 @@ impl ThreadTM {
                 blend_beta: self.blend_beta,
                 blend_alpha_se: self.blend_alpha_se,
                 blend_beta_se: self.blend_beta_se,
-                blend_ab_cov: self.blend_ab_cov,
+                blend_anchor_se: self.blend_anchor_se,
                 fitted: self.fitted,
                 vocab: self.vocab.clone(),
                 group_names: self.group_names.clone(),
@@ -2061,7 +2062,7 @@ impl ThreadTM {
             blend_beta: s.blend_beta,
             blend_alpha_se: s.blend_alpha_se,
             blend_beta_se: s.blend_beta_se,
-            blend_ab_cov: s.blend_ab_cov,
+            blend_anchor_se: s.blend_anchor_se,
             fitted: s.fitted,
             vocab: s.vocab,
             group_names: s.group_names,
@@ -2383,8 +2384,10 @@ impl ThreadTM {
 
     /// Asymptotic cluster-robust (sandwich) standard error of `blend_alpha`, clustered on the thread
     /// root (issue #863). `NaN` unless `coupling="blend"` was fitted with at least two threads; `0`
-    /// when `blend_alpha` was pinned in the constructor (it was fixed, not estimated). Conditional on
-    /// the topic fit; like any Wald SE it is not strictly valid at a boundary (a weight at 0 or on the
+    /// when `blend_alpha` was pinned in the constructor (it was fixed, not estimated); and `NaN` when
+    /// the tree lacks depth-3 structure so the α-vs-β split is not identified (the fit warns) — read
+    /// `blend_anchor_se` there, which stays finite because `α+β` is identified. Conditional on the
+    /// topic fit; like any Wald SE it is not strictly valid at a boundary (a weight at 0 or on the
     /// `α+β=1` edge). For a paired parent-vs-root contrast on the held-out scale, use
     /// `evaluate.reply_completion` with the `"root"`/`"blend"` baselines instead.
     #[getter]
@@ -2399,28 +2402,23 @@ impl ThreadTM {
         self.blend_beta_se
     }
 
-    /// SE of the anchor weight `1 - α - β`, propagated from the joint `(α, β)` sandwich covariance as
-    /// `√(seα² + seβ² + 2·covαβ)`. `NaN` / `0` under the same conditions as `blend_alpha_se`.
+    /// Cluster-robust (sandwich) SE of the anchor weight `1 - α - β` — the SE of the identified
+    /// combined share `α + β`. `NaN` unless fitted with `coupling="blend"` and ≥2 threads; `0` when
+    /// both weights are pinned. Unlike the individual weight SEs, this stays finite even when the
+    /// α-vs-β split is unidentified (shallow trees), since the anchor share does not depend on the
+    /// split.
     #[getter]
     fn blend_anchor_se(&self) -> f64 {
-        // Var(1-α-β) = Var(α) + Var(β) + 2·Cov(α,β). NaN-safe (a plain `.max(0.0)` on a NaN
-        // returns 0.0 in Rust, which would wrongly read as a zero-width anchor interval).
-        let v = self.blend_alpha_se * self.blend_alpha_se
-            + self.blend_beta_se * self.blend_beta_se
-            + 2.0 * self.blend_ab_cov;
-        if v.is_nan() {
-            f64::NAN
-        } else {
-            v.max(0.0).sqrt()
-        }
+        self.blend_anchor_se
     }
 
     /// The estimated blend mix as a labelled dict: `{"alpha", "beta", "anchor", "alpha_se", "beta_se",
     /// "anchor_se"}` — the parent, root, and anchor shares of each node's prior mean, each with its
     /// thread-root-clustered SE (issue #863). All `NaN` unless the model was fit with
-    /// `coupling="blend"`. A pinned weight reads its fixed value with SE `0`. This is the structural
-    /// characterisation a discourse space earns from `coupling="blend"`: whether topics track the
-    /// reply chain (α), the thread root (β), or neither (anchor).
+    /// `coupling="blend"`. A pinned weight reads its fixed value with SE `0`; on a shallow tree where
+    /// the α-vs-β split is unidentified, `alpha_se`/`beta_se` are `NaN` but `anchor_se` is finite.
+    /// This is the structural characterisation a discourse space earns from `coupling="blend"`:
+    /// whether topics track the reply chain (α), the thread root (β), or neither (anchor).
     fn blend_weights<'py>(&self, py: Python<'py>) -> PyResult<Bound<'py, PyDict>> {
         self.require_fitted()?;
         let d = PyDict::new_bound(py);
@@ -2429,17 +2427,7 @@ impl ThreadTM {
         d.set_item("anchor", 1.0 - self.blend_alpha - self.blend_beta)?;
         d.set_item("alpha_se", self.blend_alpha_se)?;
         d.set_item("beta_se", self.blend_beta_se)?;
-        let anchor_var = self.blend_alpha_se * self.blend_alpha_se
-            + self.blend_beta_se * self.blend_beta_se
-            + 2.0 * self.blend_ab_cov;
-        d.set_item(
-            "anchor_se",
-            if anchor_var.is_nan() {
-                f64::NAN
-            } else {
-                anchor_var.max(0.0).sqrt()
-            },
-        )?;
+        d.set_item("anchor_se", self.blend_anchor_se)?;
         Ok(d)
     }
 

--- a/src/thread_tm.rs
+++ b/src/thread_tm.rs
@@ -72,6 +72,15 @@ pub struct ThreadTmModel {
     /// Blend coupling root weight `β` (`NaN` unless `coupling="blend"`): how much a node's prior mean
     /// tracks its thread root. The anchor gets the remaining `1 - α - β`.
     pub blend_beta: f64,
+    /// Asymptotic cluster-robust (sandwich) standard errors of the blend weights `(α, β)` and their
+    /// covariance, from the blend M-step estimating equations clustered on the reply-tree root. All
+    /// `NaN` unless `coupling="blend"` fitted with at least two threads; a PINNED weight gets SE `0`
+    /// (it was fixed, not estimated). Conditional on the topic fit, and — like any Wald SE — not
+    /// strictly valid when a weight sits on a boundary (0 or the `α+β=1` simplex edge); interpret
+    /// with care there. The anchor-weight SE is derived downstream as `√(seα² + seβ² + 2·covαβ)`.
+    pub blend_alpha_se: f64,
+    pub blend_beta_se: f64,
+    pub blend_ab_cov: f64,
     /// Reported per-edge variance: the mean marginal variance of the fitted full edge covariance
     /// `sigma_edge` (a scalar summary; the edge prior is the full `sigma_edge`).
     pub sigma2: f64,
@@ -875,6 +884,105 @@ pub fn fit_thread_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         }
     }
 
+    // Blend-weight uncertainty (issue #863): asymptotic cluster-robust (sandwich) SEs of the fitted
+    // (α, β), clustered on the thread root exactly as anchor_se is. The M-step solves the
+    // errors-in-variables normal equations G·[α,β] = [spy, sry] with the de-attenuated Gram
+    // G = [[a11, a12], [a12, a22]]; the sandwich pairs that "bread" G⁻¹ with a "meat" built from the
+    // per-thread score contributions s_c = Σ_{(node,topic) in c} x·(y − α·xp − β·xr), so within-thread
+    // correlation does not deflate the interval. A pinned weight is fixed (SE 0); its free partner
+    // gets the conditional 1-D sandwich. NaN unless blend was actually fitted with ≥2 threads.
+    let (mut blend_alpha_se, mut blend_beta_se, mut blend_ab_cov) = (f64::NAN, f64::NAN, f64::NAN);
+    if let Some(bc) = blend {
+        if field_fit_ran && n_edges > 0 {
+            let (mut spp, mut spr, mut srr) = (0.0, 0.0, 0.0f64);
+            let (mut snu_p, mut snu_r, mut snu_pr) = (0.0, 0.0, 0.0f64);
+            let mut score: HashMap<usize, [f64; 2]> = HashMap::new();
+            for c in 0..d {
+                let par = parents[c];
+                if par < 0 || !has_tokens[c] {
+                    continue;
+                }
+                let (p, r) = (par as usize, bc.root[c]);
+                if !has_tokens[p] || !has_tokens[r] {
+                    continue;
+                }
+                let ag = &anchor[groups[c]];
+                let s = score.entry(thread_root[c]).or_insert([0.0, 0.0]);
+                for i in 0..km1 {
+                    let xp = lambda[p][i] - ag[i];
+                    let xr = lambda[r][i] - ag[i];
+                    let y = lambda[c][i] - ag[i];
+                    let e = y - alpha * xp - beta_w * xr;
+                    spp += xp * xp;
+                    spr += xp * xr;
+                    srr += xr * xr;
+                    snu_p += last_nu_diag[p][i];
+                    snu_r += last_nu_diag[r][i];
+                    if p == r {
+                        snu_pr += last_nu_diag[p][i];
+                    }
+                    s[0] += xp * e;
+                    s[1] += xr * e;
+                }
+            }
+            let n_clusters = score.len();
+            if n_clusters >= 2 {
+                let cf = n_clusters as f64 / (n_clusters as f64 - 1.0); // small-cluster correction
+                let ridge = 1e-6 * (spp + srr) + 1e-9;
+                let a11 = (spp - snu_p).max(0.0) + ridge;
+                let a22 = (srr - snu_r).max(0.0) + ridge;
+                let a12 = spr - snu_pr;
+                let (mut m11, mut m12, mut m22) = (0.0, 0.0, 0.0f64);
+                for s in score.values() {
+                    m11 += s[0] * s[0];
+                    m12 += s[0] * s[1];
+                    m22 += s[1] * s[1];
+                }
+                m11 *= cf;
+                m12 *= cf;
+                m22 *= cf;
+                match (bc.fixed_alpha, bc.fixed_beta) {
+                    // Both pinned: no weight was estimated, so neither carries sampling variance.
+                    (Some(_), Some(_)) => {
+                        blend_alpha_se = 0.0;
+                        blend_beta_se = 0.0;
+                        blend_ab_cov = 0.0;
+                    }
+                    // One pinned: the free weight's conditional 1-D sandwich (bread = its own
+                    // de-attenuated Gram diagonal); the pinned partner is fixed, so its SE and the
+                    // covariance are 0.
+                    (Some(_), None) => {
+                        blend_alpha_se = 0.0;
+                        blend_beta_se = m22.sqrt() / a22;
+                        blend_ab_cov = 0.0;
+                    }
+                    (None, Some(_)) => {
+                        blend_beta_se = 0.0;
+                        blend_alpha_se = m11.sqrt() / a11;
+                        blend_ab_cov = 0.0;
+                    }
+                    // Both free: the 2×2 sandwich Cov = G⁻¹ · M · G⁻¹.
+                    (None, None) => {
+                        let det = a11 * a22 - a12 * a12;
+                        if det.abs() > 1e-12 {
+                            let (g11, g12, g22) = (a22 / det, -a12 / det, a11 / det);
+                            let gm11 = g11 * m11 + g12 * m12;
+                            let gm12 = g11 * m12 + g12 * m22;
+                            let gm21 = g12 * m11 + g22 * m12;
+                            let gm22 = g12 * m12 + g22 * m22;
+                            let cov11 = gm11 * g11 + gm12 * g12;
+                            let cov12 = gm11 * g12 + gm12 * g22;
+                            let cov22 = gm21 * g12 + gm22 * g22;
+                            blend_alpha_se = cov11.max(0.0).sqrt();
+                            blend_beta_se = cov22.max(0.0).sqrt();
+                            blend_ab_cov = cov12;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
     // κ CI is the dominant per-fit cost (a 99-point profile, each an inner Nelder-Mead), and it is
     // usually not read (persistence() supersedes it). Compute it here only when explicitly asked;
     // otherwise the binding computes it lazily from the stored fit via `kappa_profile_ci`.
@@ -928,6 +1036,9 @@ pub fn fit_thread_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         kappa: kappa_out,
         blend_alpha: alpha_out,
         blend_beta: beta_out,
+        blend_alpha_se,
+        blend_beta_se,
+        blend_ab_cov,
         sigma2,
         p0,
         sigma_root,

--- a/src/thread_tm.rs
+++ b/src/thread_tm.rs
@@ -72,15 +72,17 @@ pub struct ThreadTmModel {
     /// Blend coupling root weight `β` (`NaN` unless `coupling="blend"`): how much a node's prior mean
     /// tracks its thread root. The anchor gets the remaining `1 - α - β`.
     pub blend_beta: f64,
-    /// Asymptotic cluster-robust (sandwich) standard errors of the blend weights `(α, β)` and their
-    /// covariance, from the blend M-step estimating equations clustered on the reply-tree root. All
-    /// `NaN` unless `coupling="blend"` fitted with at least two threads; a PINNED weight gets SE `0`
-    /// (it was fixed, not estimated). Conditional on the topic fit, and — like any Wald SE — not
-    /// strictly valid when a weight sits on a boundary (0 or the `α+β=1` simplex edge); interpret
-    /// with care there. The anchor-weight SE is derived downstream as `√(seα² + seβ² + 2·covαβ)`.
+    /// Asymptotic cluster-robust (sandwich) standard errors of the blend weights, from the blend
+    /// M-step estimating equations clustered on the reply-tree root. `blend_anchor_se` is the SE of
+    /// the anchor share `1-α-β`. All `NaN` unless `coupling="blend"` fitted with at least two threads;
+    /// a PINNED weight gets SE `0` (it was fixed, not estimated). When the tree lacks depth-3
+    /// structure the α-vs-β split is not identified (the fit warns), so `blend_alpha_se`/
+    /// `blend_beta_se` are `NaN` there while `blend_anchor_se` — the SE of the identified combined
+    /// share `α+β` — stays finite. Conditional on the topic fit, and — like any Wald SE — not
+    /// strictly valid when a weight sits on a boundary (0 or the `α+β=1` simplex edge).
     pub blend_alpha_se: f64,
     pub blend_beta_se: f64,
-    pub blend_ab_cov: f64,
+    pub blend_anchor_se: f64,
     /// Reported per-edge variance: the mean marginal variance of the fitted full edge covariance
     /// `sigma_edge` (a scalar summary; the edge prior is the full `sigma_edge`).
     pub sigma2: f64,
@@ -885,18 +887,29 @@ pub fn fit_thread_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
     }
 
     // Blend-weight uncertainty (issue #863): asymptotic cluster-robust (sandwich) SEs of the fitted
-    // (α, β), clustered on the thread root exactly as anchor_se is. The M-step solves the
-    // errors-in-variables normal equations G·[α,β] = [spy, sry] with the de-attenuated Gram
-    // G = [[a11, a12], [a12, a22]]; the sandwich pairs that "bread" G⁻¹ with a "meat" built from the
-    // per-thread score contributions s_c = Σ_{(node,topic) in c} x·(y − α·xp − β·xr), so within-thread
-    // correlation does not deflate the interval. A pinned weight is fixed (SE 0); its free partner
-    // gets the conditional 1-D sandwich. NaN unless blend was actually fitted with ≥2 threads.
-    let (mut blend_alpha_se, mut blend_beta_se, mut blend_ab_cov) = (f64::NAN, f64::NAN, f64::NAN);
+    // (α, β) and of the anchor share 1-α-β, clustered on the thread root exactly as anchor_se is. The
+    // M-step solves the errors-in-variables estimating equation Σ ψ_i = 0 with
+    //   ψ_i = [ xp·y − (xp²−ν_p)·α − (xp·xr−ν_pr)·β ,  xr·y − (xp·xr−ν_pr)·α − (xr²−ν_r)·β ],
+    // whose Jacobian is the de-attenuated Gram G = [[a11, a12], [a12, a22]] (a11 = spp−Σν_p, etc.).
+    // The sandwich pairs that "bread" G⁻¹ with a "meat" built from the per-THREAD score ψ_c = Σ_{i∈c}
+    // ψ_i, so within-thread correlation does not deflate the interval. ψ_i must be the SAME estimating
+    // function that produced the point estimate: the residual part xp·(y−α·xp−β·xr) plus the ν
+    // "add-back" α·ν_p + β·ν_pr (and the mirror for the root regressor), or the meat would not be the
+    // score of the de-attenuated estimator the bread differentiates (its cluster scores would not sum
+    // to zero at the solution). A pinned weight is fixed (SE 0); its free partner gets the conditional
+    // 1-D sandwich. NaN unless blend was actually fitted with ≥2 threads.
+    let (mut blend_alpha_se, mut blend_beta_se, mut blend_anchor_se) =
+        (f64::NAN, f64::NAN, f64::NAN);
     if let Some(bc) = blend {
         if field_fit_ran && n_edges > 0 {
             let (mut spp, mut spr, mut srr) = (0.0, 0.0, 0.0f64);
             let (mut snu_p, mut snu_r, mut snu_pr) = (0.0, 0.0, 0.0f64);
-            let mut score: HashMap<usize, [f64; 2]> = HashMap::new();
+            // Per-cluster accumulators: [Σ xp·e, Σ xr·e, Σ ν_p, Σ ν_r, Σ ν_pr]. The ν sums turn the
+            // residual score into the de-attenuated estimating-function score below. A BTreeMap (not a
+            // HashMap) keeps the meat summation order deterministic across fits, so the SE is
+            // reproducible to the ULP like every other topica estimate (determinism contract, #410).
+            let mut acc: std::collections::BTreeMap<usize, [f64; 5]> =
+                std::collections::BTreeMap::new();
             for c in 0..d {
                 let par = parents[c];
                 if par < 0 || !has_tokens[c] {
@@ -907,7 +920,7 @@ pub fn fit_thread_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                     continue;
                 }
                 let ag = &anchor[groups[c]];
-                let s = score.entry(thread_root[c]).or_insert([0.0, 0.0]);
+                let s = acc.entry(thread_root[c]).or_insert([0.0; 5]);
                 for i in 0..km1 {
                     let xp = lambda[p][i] - ag[i];
                     let xr = lambda[r][i] - ag[i];
@@ -916,52 +929,70 @@ pub fn fit_thread_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                     spp += xp * xp;
                     spr += xp * xr;
                     srr += xr * xr;
-                    snu_p += last_nu_diag[p][i];
-                    snu_r += last_nu_diag[r][i];
-                    if p == r {
-                        snu_pr += last_nu_diag[p][i];
-                    }
+                    let (nup, nur) = (last_nu_diag[p][i], last_nu_diag[r][i]);
+                    snu_p += nup;
+                    snu_r += nur;
                     s[0] += xp * e;
                     s[1] += xr * e;
+                    s[2] += nup;
+                    s[3] += nur;
+                    if p == r {
+                        snu_pr += nup;
+                        s[4] += nup;
+                    }
                 }
             }
-            let n_clusters = score.len();
+            // The α-vs-β split is identified only with depth-3+ structure (a node whose parent is not
+            // its thread root); with fewer than two such nodes the fit warns and the split is
+            // arbitrary. Match that threshold: when unidentified we report NaN for the individual
+            // weight SEs but keep the anchor SE, since α+β (hence 1-α-β) IS identified there.
+            let n_deep = (0..d)
+                .filter(|&c| parents[c] >= 0 && bc.root[c] != parents[c] as usize)
+                .count();
+            let split_identified = n_deep >= 2;
+            let n_clusters = acc.len();
             if n_clusters >= 2 {
                 let cf = n_clusters as f64 / (n_clusters as f64 - 1.0); // small-cluster correction
                 let ridge = 1e-6 * (spp + srr) + 1e-9;
                 let a11 = (spp - snu_p).max(0.0) + ridge;
                 let a22 = (srr - snu_r).max(0.0) + ridge;
                 let a12 = spr - snu_pr;
+                // De-attenuated per-cluster scores ψ_c = [s0 + α·Σν_p + β·Σν_pr, s1 + α·Σν_pr + β·Σν_r].
                 let (mut m11, mut m12, mut m22) = (0.0, 0.0, 0.0f64);
-                for s in score.values() {
-                    m11 += s[0] * s[0];
-                    m12 += s[0] * s[1];
-                    m22 += s[1] * s[1];
+                for s in acc.values() {
+                    let psi0 = s[0] + alpha * s[2] + beta_w * s[4];
+                    let psi1 = s[1] + alpha * s[4] + beta_w * s[3];
+                    m11 += psi0 * psi0;
+                    m12 += psi0 * psi1;
+                    m22 += psi1 * psi1;
                 }
                 m11 *= cf;
                 m12 *= cf;
                 m22 *= cf;
                 match (bc.fixed_alpha, bc.fixed_beta) {
-                    // Both pinned: no weight was estimated, so neither carries sampling variance.
+                    // Both pinned: no weight was estimated, so nothing carries sampling variance.
                     (Some(_), Some(_)) => {
                         blend_alpha_se = 0.0;
                         blend_beta_se = 0.0;
-                        blend_ab_cov = 0.0;
+                        blend_anchor_se = 0.0;
                     }
                     // One pinned: the free weight's conditional 1-D sandwich (bread = its own
-                    // de-attenuated Gram diagonal); the pinned partner is fixed, so its SE and the
-                    // covariance are 0.
+                    // de-attenuated Gram diagonal). Pinning one weight also identifies the split, so
+                    // the anchor SE equals the free weight's SE (the pinned partner is a constant).
                     (Some(_), None) => {
                         blend_alpha_se = 0.0;
                         blend_beta_se = m22.sqrt() / a22;
-                        blend_ab_cov = 0.0;
+                        blend_anchor_se = blend_beta_se;
                     }
                     (None, Some(_)) => {
                         blend_beta_se = 0.0;
                         blend_alpha_se = m11.sqrt() / a11;
-                        blend_ab_cov = 0.0;
+                        blend_anchor_se = blend_alpha_se;
                     }
-                    // Both free: the 2×2 sandwich Cov = G⁻¹ · M · G⁻¹.
+                    // Both free: the 2×2 sandwich Cov = G⁻¹ · M · G⁻¹. Var(1-α-β) = Var(α+β) =
+                    // cov11 + cov22 + 2·cov12 is identified even when the α/β split is not, so the
+                    // anchor SE stays finite while the individual weight SEs are NaN'd under
+                    // non-identification.
                     (None, None) => {
                         let det = a11 * a22 - a12 * a12;
                         if det.abs() > 1e-12 {
@@ -973,9 +1004,11 @@ pub fn fit_thread_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
                             let cov11 = gm11 * g11 + gm12 * g12;
                             let cov12 = gm11 * g12 + gm12 * g22;
                             let cov22 = gm21 * g12 + gm22 * g22;
-                            blend_alpha_se = cov11.max(0.0).sqrt();
-                            blend_beta_se = cov22.max(0.0).sqrt();
-                            blend_ab_cov = cov12;
+                            blend_anchor_se = (cov11 + cov22 + 2.0 * cov12).max(0.0).sqrt();
+                            if split_identified {
+                                blend_alpha_se = cov11.max(0.0).sqrt();
+                                blend_beta_se = cov22.max(0.0).sqrt();
+                            }
                         }
                     }
                 }
@@ -1038,7 +1071,7 @@ pub fn fit_thread_tm<R: Rng, F: FnMut(usize, usize, f64) -> bool>(
         blend_beta: beta_out,
         blend_alpha_se,
         blend_beta_se,
-        blend_ab_cov,
+        blend_anchor_se,
         sigma2,
         p0,
         sigma_root,

--- a/tests/test_thread_tm.py
+++ b/tests/test_thread_tm.py
@@ -1745,6 +1745,33 @@ def test_blend_se_nan_without_blend_coupling():
     assert np.isnan(w["alpha"]) and np.isnan(w["alpha_se"])
 
 
+def test_blend_split_se_nan_when_unidentified_but_anchor_finite():
+    """On a shallow (depth-2-only) tree the alpha-vs-beta split is not identified (the fit warns).
+    The individual weight SEs must be NaN there rather than reading as a spuriously tight interval,
+    while the anchor SE — the SE of the identified combined share alpha+beta — stays finite (#863)."""
+    docs, parents, cov, vocab = _threaded_corpus(n_threads=40, depth=2)
+    m = topica.ThreadTM(2, em_iters=30, seed=13, coupling="blend")
+    with pytest.warns(UserWarning, match="not separately identified"):
+        m.fit(docs, parents=parents)
+    assert np.isnan(m.blend_alpha_se) and np.isnan(m.blend_beta_se)
+    assert np.isfinite(m.blend_anchor_se) and m.blend_anchor_se >= 0.0
+    w = m.blend_weights()
+    assert np.isnan(w["alpha_se"]) and np.isnan(w["beta_se"])
+    assert np.isfinite(w["anchor_se"])
+
+
+def test_blend_se_is_deterministic():
+    """The clustered SE must be bit-identical across two identical fits (determinism contract):
+    the meat is summed in a fixed cluster order, not HashMap iteration order (#863)."""
+    docs, parents = _mixed_corpus(n_threads=80)
+    ses = []
+    for _ in range(4):
+        m = topica.ThreadTM(4, em_iters=60, seed=13, coupling="blend")
+        m.fit(docs, parents=parents)
+        ses.append((m.blend_alpha_se, m.blend_beta_se, m.blend_anchor_se))
+    assert all(s == ses[0] for s in ses), ses
+
+
 def test_blend_se_survives_save_load(tmp_path):
     """The clustered SEs round-trip through save/load (issue #863)."""
     docs, parents = _mixed_corpus(n_threads=60)

--- a/tests/test_thread_tm.py
+++ b/tests/test_thread_tm.py
@@ -1695,6 +1695,69 @@ def test_blend_estimates_both_weights_positive():
     assert m.blend_alpha > 0.01 and m.blend_beta > 0.01
 
 
+def test_blend_weights_have_clustered_se():
+    """The estimated (alpha, beta, anchor) blend mix comes with a thread-root-clustered SE
+    (issue #863): finite and positive for a both-free fit, the three shares sum to 1, and
+    blend_weights() bundles the six numbers consistently with the scalar getters."""
+    docs, parents = _mixed_corpus()
+    m = topica.ThreadTM(4, em_iters=80, seed=13, coupling="blend")
+    m.fit(docs, parents=parents)
+    w = m.blend_weights()
+    assert set(w) == {"alpha", "beta", "anchor", "alpha_se", "beta_se", "anchor_se"}
+    # scalar getters agree with the dict
+    assert w["alpha"] == m.blend_alpha and w["beta"] == m.blend_beta
+    assert w["anchor"] == pytest.approx(m.blend_anchor)
+    assert w["alpha_se"] == m.blend_alpha_se and w["beta_se"] == m.blend_beta_se
+    assert w["anchor_se"] == pytest.approx(m.blend_anchor_se)
+    # the three shares are a convex mix
+    assert w["alpha"] + w["beta"] + w["anchor"] == pytest.approx(1.0)
+    # both weights estimated, so both SEs are finite and strictly positive
+    assert np.isfinite(m.blend_alpha_se) and m.blend_alpha_se > 0.0
+    assert np.isfinite(m.blend_beta_se) and m.blend_beta_se > 0.0
+    assert np.isfinite(m.blend_anchor_se) and m.blend_anchor_se >= 0.0
+    # a plausibly tight interval on a strong planted signal (not a spuriously huge SE)
+    assert m.blend_alpha_se < 0.2 and m.blend_beta_se < 0.2
+
+
+def test_blend_pinned_weight_has_zero_se():
+    """A pinned weight was fixed, not estimated, so its SE is 0 while the free partner keeps a
+    finite positive SE (issue #863)."""
+    docs, parents = _mixed_corpus()
+    ma = topica.ThreadTM(4, em_iters=60, seed=13, coupling="blend", blend_alpha=0.6)
+    ma.fit(docs, parents=parents)
+    assert ma.blend_alpha_se == 0.0
+    assert np.isfinite(ma.blend_beta_se) and ma.blend_beta_se > 0.0
+    mb = topica.ThreadTM(4, em_iters=60, seed=13, coupling="blend", blend_beta=0.3)
+    mb.fit(docs, parents=parents)
+    assert mb.blend_beta_se == 0.0
+    assert np.isfinite(mb.blend_alpha_se) and mb.blend_alpha_se > 0.0
+
+
+def test_blend_se_nan_without_blend_coupling():
+    """The blend readouts are NaN for a non-blend fit (nothing to report)."""
+    docs, parents = _mixed_corpus(n_threads=40)
+    m = topica.ThreadTM(4, em_iters=40, seed=13)  # parent coupling
+    m.fit(docs, parents=parents)
+    assert np.isnan(m.blend_alpha_se) and np.isnan(m.blend_beta_se)
+    assert np.isnan(m.blend_anchor) and np.isnan(m.blend_anchor_se)
+    # blend_weights() on a fitted non-blend model returns NaNs rather than raising
+    w = m.blend_weights()
+    assert np.isnan(w["alpha"]) and np.isnan(w["alpha_se"])
+
+
+def test_blend_se_survives_save_load(tmp_path):
+    """The clustered SEs round-trip through save/load (issue #863)."""
+    docs, parents = _mixed_corpus(n_threads=60)
+    m = topica.ThreadTM(4, em_iters=50, seed=13, coupling="blend")
+    m.fit(docs, parents=parents)
+    p = tmp_path / "blend_se.bin"
+    m.save(str(p))
+    m2 = topica.ThreadTM.load(str(p))
+    assert m2.blend_alpha_se == m.blend_alpha_se
+    assert m2.blend_beta_se == m.blend_beta_se
+    assert m2.blend_anchor_se == pytest.approx(m.blend_anchor_se)
+
+
 def test_blend_fixed_weights_respected():
     docs, parents = _mixed_corpus(n_threads=30)
     m = topica.ThreadTM(4, em_iters=40, seed=13, coupling="blend", blend_alpha=0.6, blend_beta=0.3)


### PR DESCRIPTION
Consumes #831's shipped `coupling="parent"|"root"|"blend"` capability and turns it into the publication-grade "which structure fits which discourse" readout #863 asked for. Maps to the issue's dreamlist:

## B — blend weights as fitted attributes with uncertainty (the code deliverable)
- `blend_anchor` (= `1 - alpha - beta`) joins `blend_alpha`/`blend_beta`, so all three shares of each node's prior mean are readable.
- Each share carries a **thread-root-clustered sandwich SE** (`blend_alpha_se`, `blend_beta_se`, `blend_anchor_se`); `blend_weights()` returns all six as a dict. The SE pairs the blend M-step's de-attenuated (errors-in-variables) Gram as the "bread" with a per-thread score "meat" — the same clustering `anchor_se` already uses, so within-thread correlation does not deflate the interval.
- A pinned weight reports SE `0` (fixed, not estimated); the readouts are `NaN` for a non-blend fit. Asymptotic and conditional on the topic fit, with the boundary caveat documented. SEs round-trip through save/load.

## C / F — the mix documented as a structural estimand + coupling guidance
`docs/guides/models.md` now frames `(alpha, beta, anchor)` as a hand-coding-free characterization of how a discourse space is organized — parent-chained (α large), broadcast-around-the-root (β large), or context-free (anchor large) — each with an interval.

## A / E — fair-scale coupling contrasts made discoverable (no new surface needed)
The `root`/`blend` baselines (#831) are already matched ThreadTM fits scored with the **same posterior-predictive `E[softmax(η)]`** estimator (#838) as the parent tree, and `contrasts=` (#852) forms any paired baseline-vs-baseline clustered CI, with `result.paired` exposing the per-leaf per-model held-out matrix. So `parent−root`, `parent−blend`, `root−no_tree`, `blend−root` all come off **one matched fit on one held-out split on the posterior-predictive scale** — closing the "plug-in only" gap the issue reported (which came from an external script, not the surface). The `reply_completion` docstring and the guide now spell this out with a worked example.

End-to-end check on planted mixed discourse:
```
delta root            +0.085 [+0.068, +0.102]
contrast root-no_tree +0.083 [+0.073, +0.094]   # the fair-scale number for the paper
contrast blend-root   +0.084 [+0.076, +0.093]
paired models ['tree','no_tree','root','blend']  n_leaves 960
```

## Out of scope (tracked follow-up)
**D** — per-thread `mu_thread` random effect in η-space (#831 option 3) — is genuinely new modeling work (loopy-Gaussian / random effect) and remains a separate issue.

## Validation
Tests +5 (clustered SE finite/positive on planted recovery, pinned=0, non-blend=NaN, save/load round-trip). 100 ThreadTM tests pass; `cargo test --lib` (354), `scripts/preflight.sh`, and `mkdocs build --strict` all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)