### PR TITLE
release: 0.57.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,23 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.57.0] - 2026-09-03
+
 ### Added
 
+- **ThreadTM blend-weight uncertainty and fair-scale coupling contrasts** (#863). The
+  three shares of each node's prior mean are now readable as fitted attributes:
+  `blend_anchor` (`= 1 - alpha - beta`) joins `blend_alpha`/`blend_beta`, and each carries
+  a thread-root-clustered sandwich SE (`blend_alpha_se`, `blend_beta_se`,
+  `blend_anchor_se`). `blend_weights()` returns all six as a dict, turning
+  `coupling="parent"|"root"|"blend"` into a publication-grade "which structure fits which
+  discourse" readout.
+- **ThreadTM seed-word API parity with SeededLDA** (#854). ThreadTM's user-supervision
+  surface now matches the other keyword models: `seed_weight` (1.0) becomes `weight`
+  (0.01) on SeededLDA's `[0, 1]` scale with `× 100` pseudocount scaling, so the same
+  number means the same seeding strength across models. Default behaviour is unchanged.
+  ThreadTM is pre-1.0 and experimental, so these are hard renames with no back-compat
+  shims.
 - **`reply_completion` gains `keyatm` and `rtm` off-the-shelf baselines** (#860). The
   two tools a reviewer reaches for after LDA and STM now fit on the SAME reduced corpus
   (identical vocabulary, `num_topics`, `min_count`, `seed`) and score through the

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,8 +1,8 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.56.0
-date-released: 2026-07-29
+version: 0.57.0
+date-released: 2026-09-03
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a
   numpy-native API, built for computational social scientists. More than forty

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.56.0"
+version = "0.57.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.56.0"
+version = "0.57.0"
 edition = "2021"
 description = "Fast, all-purpose topic modeling for Python, with a Rust core"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.56.0"
+version = "0.57.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Cuts **0.57.0**, publishing the ThreadTM and \`reply_completion\` work that landed on \`main\` since 0.56.0.

## Changelog (0.57.0)
- **ThreadTM blend-weight uncertainty + fair-scale coupling contrasts** (#863/#864) — \`blend_anchor\` joins \`blend_alpha\`/\`blend_beta\`, each with a thread-root-clustered sandwich SE; \`blend_weights()\` returns all six.
- **ThreadTM seed-word API parity with SeededLDA** (#854/#862) — \`seed_weight\` → \`weight\` on SeededLDA's scale; default behaviour unchanged; hard rename (pre-1.0, experimental).
- **\`reply_completion\` keyatm + rtm off-the-shelf baselines** (#860/#861) — keyATM and RTM fit on the same reduced corpus and held-out-leaf protocol as the lda/stm baselines.

## Version bumps
- \`Cargo.toml\`, \`pyproject.toml\`, \`Cargo.lock\` → 0.57.0
- \`CITATION.cff\` → 0.57.0, \`date-released: 2026-09-03\`
- \`CHANGELOG.md\` Unreleased entries moved under \`[0.57.0]\`

\`test_version_consistency\` passes locally. Merging + the \`v0.57.0\` tag triggers CI to publish wheels to PyPI.