### PR TITLE
release: 0.58.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ follow [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once released.
 
 ## [Unreleased]
 
+## [0.58.0] - 2026-09-03
+
 ### Added
 
 - **Smooth/spline prevalence terms for STM — parity with R `stm`** (#867). `topica.STM`

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,7 +1,7 @@
 cff-version: 1.2.0
 message: "If you use topica in published work, please cite it as below."
 title: "topica: fast, all-purpose topic modeling for Python"
-version: 0.57.0
+version: 0.58.0
 date-released: 2026-09-03
 abstract: >-
   A fast, all-purpose topic-modeling library for Python: a Rust core with a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -750,7 +750,7 @@ dependencies = [
 
 [[package]]
 name = "topica"
-version = "0.57.0"
+version = "0.58.0"
 dependencies = [
  "bhtsne",
  "bincode",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topica"
-version = "0.57.0"
+version = "0.58.0"
 edition = "2021"
 description = "Fast, all-purpose topic modeling for Python, with a Rust core"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "topica"
-version = "0.57.0"
+version = "0.58.0"
 description = "Topica: fast, all-purpose topic modeling for Python — a Rust core for LDA, STM, and more"
 readme = "README.md"
 requires-python = ">=3.9"


### PR DESCRIPTION
Release 0.58.0.

Bumps `Cargo.toml`, `pyproject.toml`, `CITATION.cff`, and `Cargo.lock` to 0.58.0
and moves the CHANGELOG entry into a dated `[0.58.0]` section.

### Highlights
- **Smooth/spline prevalence terms for STM — parity with R `stm`** (#867, PR #868):
  column-identical `topica.design.bs` / `topica.design.s` B-spline helpers, `s(...)` /
  `bs(...)` formula terms, and a fit-time `STM.fit(formula="~ party + s(day)", data=meta)`
  path so `topica.STM` is a fair full-strength comparator to R `stm`.

On merge, tag `v0.58.0` to publish to PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)