### PR TITLE
feat(stm): multi-start restarts= guard + beta_from_reference replication (#871)

### DIFF
--- a/docs/api/stm.md
+++ b/docs/api/stm.md
@@ -69,6 +69,18 @@ dropping any out-of-vocabulary tokens.
 
 ::: topica.design.align_corpus
 
+## Reproducing a reference (R `stm`) fit
+
+topica's spectral init and R `stm`'s default init converge to different, equally
+valid topic solutions, and R's default recovery is not a portably reproducible
+target (see the [STM replication notes](../replications/stm.md#initialization-what-is-and-isnt-a-reproducible-target)).
+To reproduce a *specific* R `stm` run, inject its topic-word matrix as the
+initialization via `STM.fit(beta_init=...)`; this helper aligns the reference β to
+topica's vocabulary. For robustness against catastrophic local optima without a
+reference, use `STM.fit(restarts=N)` (best-of-N by variational bound).
+
+::: topica.stm.beta_from_reference
+
 ## Model selection at fixed K
 
 Run multiple initializations at a fixed K and compare candidates on the

--- a/docs/guides/agent-cheatsheet.md
+++ b/docs/guides/agent-cheatsheet.md
@@ -149,7 +149,7 @@ TopicalNGrams(num_topics, *, alpha_sum=50.0, beta=0.01, gamma=0.01, delta1=1.0, 
 
 STM(num_topics, *, sigma_shrink=0.0, seed=13, init='spectral', variational='laplace')
     Structural topic model: relate topic prevalence and content to covariates.
-    .fit(corpus, prevalence=None, *, formula=None, data=None, prevalence_names=None, content=None, content_names=None, content_time=None, content_smooth=1.0, content_prior_var=0.5, content_prior='l2', iters=500, convergence_tol=1e-05, gamma_prior='pooled', gamma_enet=1.0, beta_init=None, em_tol=None, covariates=None, keep_eta_cov=True, num_threads=None, spectral_projection_threshold=10000, progress=None)
+    .fit(corpus, prevalence=None, *, formula=None, data=None, prevalence_names=None, content=None, content_names=None, content_time=None, content_smooth=1.0, content_prior_var=0.5, content_prior='l2', iters=500, convergence_tol=1e-05, gamma_prior='pooled', gamma_enet=1.0, beta_init=None, em_tol=None, covariates=None, keep_eta_cov=True, num_threads=None, spectral_projection_threshold=10000, restarts=1, progress=None)
 
 STS(num_topics, *, seed=13, init='spectral')
     Structural topic-and-sentiment model over document metadata.

--- a/docs/replications/stm.md
+++ b/docs/replications/stm.md
@@ -80,19 +80,44 @@ that the two optimizers split differently, never a systematic offset — the
 expected behavior of a non-convex model, where there is no single STM fit to
 reproduce.
 
-### Spectral initialization reproduces R's recovery exactly
+### Initialization: what is and isn't a reproducible target
 
 The cosines above are EM optima of a non-convex objective, so they differ across
-optimizers. The *initialization* underneath them is the deterministic Arora
-anchor-word recovery, and topica reproduces R `stm`'s `recoverL2()` step exactly:
-on identical documents the spectral topic-word matrix matches R's reference
-recovery at a cosine of **1.0** (`parity/spectral_recover_stm.py`). (Earlier
-topica's recovery used a fixed, too-large exponentiated-gradient step that diverged
-to vertices rather than the constrained optimum; the step is now scale-adaptive and
-runs to convergence — issue #234.) For a guaranteed "replicate the original" mode,
-`STM.fit(..., beta_init=)` / `CTM.fit(..., beta_init=)` inject an externally
-computed base β (for example R `stm`'s exact spectral β), so a fit can start from
-R's initialization and reproduce that run.
+optimizers *and* across initializations. The initialization underneath them is the
+Arora anchor-word recovery. topica's recovery runs a scale-adaptive exponentiated
+gradient to the **constrained optimum**, and on identical documents it matches R
+`stm`'s *reference* recovery (`recoverL2(recoverEG = FALSE)`, the quadratic-program
+solve) at a cosine of **1.0** (`parity/spectral_recover_stm.py`, issue #234).
+
+R `stm`'s **default** recovery is a different object: `recoverL2(recoverEG = TRUE)`,
+a fixed-step exponentiated gradient that runs a set number of iterations *without
+converging*. Its output is sensitive to floating-point order (a 1e-9 perturbation of
+the co-occurrence matrix moves it substantially), so it is **not a portably
+reproducible target** — R, and any reimplementation, land in different basins from
+identical inputs (issue #871). topica's converged recovery and R's default are two
+different, equally valid starting points; neither reproduces the other bit-for-bit.
+
+Two practical consequences:
+
+- **Reliability — use restarts.** At large vocabularies the logistic-normal EM has
+  catastrophic local optima (much worse held-out completion, and the *worst*
+  variational bound) that any single initialization — spectral or random — can fall
+  into. `STM.fit(..., restarts=N)` fits `N` independently-seeded starts and returns
+  the one with the best bound, a deterministic guard that avoids those basins.
+
+  ```python
+  model = topica.STM(20).fit(corpus, prevalence=X, restarts=8)  # keeps best-bound fit
+  ```
+
+- **Exact replication — inject the reference β.** To reproduce a *specific* R `stm`
+  run, start EM from that run's topic-word matrix via `beta_init=`.
+  `topica.stm.beta_from_reference` aligns R's `exp(fit$beta$logbeta[[1]])` to
+  topica's vocabulary:
+
+  ```python
+  binit = topica.stm.beta_from_reference(r_beta, r_vocab, corpus)
+  model = topica.STM(20).fit(corpus, prevalence=X, beta_init=binit)  # lands in R's basin
+  ```
 
 What replicates stably across optima is the substantive conclusion. On the
 2,000-document Poliblog fixture at K = 20, the committed gold now checks the whole

--- a/python/topica/stm.py
+++ b/python/topica/stm.py
@@ -2403,6 +2403,92 @@ def transform(model, docs, *, prevalence=None, data=None, formula=None, X=None):
     return model.transform(docs)
 
 
+def beta_from_reference(beta, ref_vocab, target, *, floor=1e-8):
+    """Align an externally-fit topic-word matrix to topica's vocabulary, ready to
+    seed :meth:`STM.fit` via ``beta_init=`` for exact replication of another fit.
+
+    topica's spectral init and R ``stm``'s converge to *different, equally valid*
+    topic solutions (R's default anchor recovery is a non-converging, machine-order
+    dependent iteration — not a portably reproducible target; see issue #871). To
+    reproduce a *specific* R ``stm`` fit's basin, take its topic-word matrix and
+    inject it as the initialization:
+
+    .. code-block:: r
+
+        # in R, on the same prepped documents:
+        fit  <- stm(documents, vocab, K = 20, prevalence = ~ ..., data = meta)
+        beta <- exp(fit$beta$logbeta[[1]])          # K x V, over `vocab`
+        write.csv(beta, "beta.csv"); writeLines(vocab, "vocab.txt")
+
+    .. code-block:: python
+
+        beta = np.loadtxt("beta.csv", delimiter=",", skiprows=1)
+        ref_vocab = open("vocab.txt").read().split()
+        binit = topica.stm.beta_from_reference(beta, ref_vocab, corpus)
+        m = topica.STM(20).fit(corpus, prevalence=X, beta_init=binit)  # lands in R's basin
+
+    Parameters
+    ----------
+    beta : array-like, shape (K, V_ref) or (V_ref, K)
+        The reference topic-word matrix (rows = topics). Transposed input is
+        detected and fixed from ``ref_vocab``'s length.
+    ref_vocab : sequence[str]
+        The reference model's vocabulary, in the column order of ``beta``.
+    target : Corpus, fitted model with ``.vocabulary``, or sequence[str]
+        Supplies topica's target vocabulary and its order.
+    floor : float, default 1e-8
+        Probability floor for target words absent from ``ref_vocab`` (rows are
+        renormalized after alignment).
+
+    Returns
+    -------
+    numpy.ndarray, shape (K, V_target)
+        A row-normalized topic-word matrix over topica's vocabulary, for
+        ``STM.fit(beta_init=...)``. Emits a warning if reference/target vocabulary
+        overlap is low (the injected init would be mostly floor).
+    """
+    import warnings as _warnings
+
+    beta = np.asarray(beta, dtype=np.float64)
+    ref_vocab = list(ref_vocab)
+    if beta.ndim != 2:
+        raise ValueError("beta must be 2-D (K x V_ref)")
+    if beta.shape[1] != len(ref_vocab):
+        if beta.shape[0] == len(ref_vocab):
+            beta = beta.T  # given as (V_ref, K); topics must be rows
+        else:
+            raise ValueError(
+                f"beta has shape {beta.shape} but ref_vocab has {len(ref_vocab)} "
+                "words; one axis must match ref_vocab."
+            )
+    k = beta.shape[0]
+
+    if hasattr(target, "vocabulary"):
+        target_vocab = list(target.vocabulary)
+    else:
+        target_vocab = list(target)
+    ref_index = {w: i for i, w in enumerate(ref_vocab)}
+
+    out = np.full((k, len(target_vocab)), floor, dtype=np.float64)
+    hit = 0
+    for j, w in enumerate(target_vocab):
+        i = ref_index.get(w)
+        if i is not None:
+            col = beta[:, i]
+            out[:, j] = np.where(col > 0, col, floor)
+            hit += 1
+    coverage = hit / max(len(target_vocab), 1)
+    if coverage < 0.5:
+        _warnings.warn(
+            f"beta_from_reference: only {coverage:.0%} of topica's vocabulary is "
+            "present in ref_vocab; the injected init is mostly floor. Check that "
+            "both were built from the same prepped documents.",
+            stacklevel=2,
+        )
+    out /= out.sum(axis=1, keepdims=True)
+    return np.ascontiguousarray(out)
+
+
 # ---------------------------------------------------------------------------
 # Back-compatibility: the general post-hoc diagnostics were moved to
 # ``topica.evaluate.diagnostics`` (they apply to any model, not just STM) and are
@@ -2464,6 +2550,28 @@ class STM(_STM):
     :meth:`fit`.
     """
 
+    def __init__(
+        self,
+        num_topics,
+        *,
+        sigma_shrink=0.0,
+        seed=13,
+        init="spectral",
+        variational="laplace",
+    ):
+        # The compiled ``_STM`` (a PyO3 class) is constructed in ``__new__`` from
+        # these same arguments; ``__init__`` only records them so ``fit(restarts=N)``
+        # can spawn fresh, independently-seeded models (the core fixes seed/init at
+        # construction). Do NOT forward to ``super().__init__`` — object.__init__
+        # rejects extra args once __new__ has already built the instance.
+        self._ctor_args = dict(
+            num_topics=num_topics,
+            sigma_shrink=sigma_shrink,
+            seed=seed,
+            init=init,
+            variational=variational,
+        )
+
     def fit(
         self,
         corpus,
@@ -2488,6 +2596,7 @@ class STM(_STM):
         keep_eta_cov=True,
         num_threads=None,
         spectral_projection_threshold=10000,
+        restarts=1,
         progress=None,
     ):
         """Fit the model. Same arguments as the compiled core (``prevalence``,
@@ -2507,6 +2616,17 @@ class STM(_STM):
         data : pandas.DataFrame, optional
             One row per document, holding the columns ``formula`` references.
             Required when ``formula`` is given, ignored otherwise.
+        restarts : int, default 1
+            Number of independently-seeded EM restarts. With ``restarts=1`` (the
+            default) a single fit runs from the configured init. With ``restarts=N``
+            the model is fit ``N`` times — restart 0 from the configured init
+            (spectral by default), the rest from fresh random seeds — and the fit
+            with the best variational bound is returned. At large vocabularies the
+            logistic-normal EM has catastrophic local optima that any single init
+            can land in; those carry the worst bound, so best-of-N is a robust,
+            deterministic guard (#871). ``restarts>1`` returns the best model, so
+            capture the return value (``model = STM(K).fit(corpus, restarts=8)``);
+            it is incompatible with a fixed ``beta_init``.
         """
         if formula is not None:
             if prevalence is not None or covariates is not None:
@@ -2526,10 +2646,8 @@ class STM(_STM):
             prevalence, names = design_matrix(formula, data)
             if prevalence_names is None:
                 prevalence_names = names
-        return _STM.fit(
-            self,
-            corpus,
-            prevalence,
+
+        fit_kwargs = dict(
             prevalence_names=prevalence_names,
             content=content,
             content_names=content_names,
@@ -2547,8 +2665,38 @@ class STM(_STM):
             keep_eta_cov=keep_eta_cov,
             num_threads=num_threads,
             spectral_projection_threshold=spectral_projection_threshold,
-            progress=progress,
         )
+
+        if restarts is not None and int(restarts) > 1:
+            # Multi-start EM: the logistic-normal EM has catastrophic local optima
+            # at large vocabularies that ANY single init (spectral or random) can
+            # fall into; those bad basins carry the worst variational bound, so
+            # keeping the best-bound restart reliably avoids them (#871). Restart 0
+            # uses the configured init (spectral by default); the rest use fresh
+            # random seeds. Returns the best-bound model — use the return value.
+            if beta_init is not None:
+                raise ValueError(
+                    "restarts>1 is for the default spectral/random init path; a "
+                    "fixed beta_init leaves every restart identical. Drop beta_init "
+                    "or use restarts=1."
+                )
+            base = getattr(self, "_ctor_args", None) or dict(
+                num_topics=self.num_topics, seed=13, init="spectral",
+            )
+            best, best_bound = None, float("-inf")
+            for i in range(int(restarts)):
+                args = dict(base)
+                args["seed"] = base.get("seed", 13) + i
+                if i > 0:
+                    args["init"] = "random"
+                cand = type(self)(**args)
+                _STM.fit(cand, corpus, prevalence, progress=progress, **fit_kwargs)
+                b = float(cand.bound)
+                if b > best_bound:
+                    best_bound, best = b, cand
+            return best
+
+        return _STM.fit(self, corpus, prevalence, progress=progress, **fit_kwargs)
 
 
 __all__ = [
@@ -2564,6 +2712,7 @@ __all__ = [
     "interaction",
     "align_corpus",
     "transform",
+    "beta_from_reference",
     "frex",
     "label_topics",
     "topic_correlation",

--- a/tests/test_stm.py
+++ b/tests/test_stm.py
@@ -635,6 +635,71 @@ def test_stm_beta_init_warm_start():
     np.testing.assert_allclose(warm.topic_word, default.topic_word, atol=1e-9)
 
 
+def test_stm_restarts_returns_best_bound():
+    """STM.fit(restarts=N) fits N seeded inits and returns the best-bound model
+    (the #871 multi-start reliability guard against catastrophic local optima)."""
+    import topica
+    rng = np.random.default_rng(0)
+    docs, x = _make_synthetic_corpus(rng, n_per_class=60)
+    X = x.reshape(-1, 1)
+    single = topica.STM(num_topics=2, seed=1).fit(docs, prevalence=X, iters=30)
+    multi = topica.STM(num_topics=2, seed=1).fit(docs, prevalence=X, iters=30, restarts=4)
+    assert isinstance(multi, topica.STM)
+    assert np.asarray(multi.topic_word).shape == np.asarray(single.topic_word).shape
+    # restart 0 reuses the single fit's seed+init, so best-of-N is never worse.
+    assert float(multi.bound) >= float(single.bound) - 1e-6
+
+
+def test_stm_restarts_rejects_beta_init():
+    """A fixed beta_init makes every restart identical, so it is rejected."""
+    import topica
+    rng = np.random.default_rng(0)
+    docs, x = _make_synthetic_corpus(rng, n_per_class=40)
+    X = x.reshape(-1, 1)
+    b = topica.STM(num_topics=2, seed=1).fit(docs, prevalence=X, iters=0).topic_word
+    with pytest.raises(ValueError, match="restarts"):
+        topica.STM(num_topics=2, seed=1).fit(docs, prevalence=X, restarts=3, beta_init=b)
+
+
+def test_beta_from_reference_aligns_normalizes_and_seeds():
+    """beta_from_reference maps an external topic-word matrix onto topica's
+    vocabulary (handling permutation + transpose) for beta_init replication (#871)."""
+    import topica
+    rng = np.random.default_rng(0)
+    docs, x = _make_synthetic_corpus(rng, n_per_class=40)
+    corpus = topica.Corpus.from_documents(docs)
+    vocab = list(corpus.vocabulary)
+    V = len(vocab)
+    ref_vocab = vocab[::-1]  # full permutation: every target word present
+    beta = rng.random((2, V))
+    beta /= beta.sum(axis=1, keepdims=True)
+    out = topica.stm.beta_from_reference(beta, ref_vocab, corpus)
+    assert out.shape == (2, V)
+    np.testing.assert_allclose(out.sum(axis=1), 1.0, atol=1e-9)
+    # a target word's column equals the reference column for that same word.
+    i = ref_vocab.index(vocab[0])
+    np.testing.assert_allclose(out[:, 0], beta[:, i], atol=1e-12)
+    # transposed (V x K) input is detected and fixed.
+    np.testing.assert_allclose(
+        topica.stm.beta_from_reference(beta.T, ref_vocab, corpus), out, atol=1e-12
+    )
+    # usable directly as a warm start.
+    m = topica.STM(num_topics=2, seed=1).fit(docs, prevalence=x.reshape(-1, 1),
+                                             iters=5, beta_init=out)
+    assert np.asarray(m.topic_word).shape == (2, V)
+
+
+def test_beta_from_reference_warns_on_low_overlap():
+    import topica
+    rng = np.random.default_rng(0)
+    docs, _ = _make_synthetic_corpus(rng, n_per_class=30)
+    corpus = topica.Corpus.from_documents(docs)
+    vocab = list(corpus.vocabulary)
+    beta = rng.random((2, 2))
+    with pytest.warns(UserWarning, match="vocabulary"):
+        topica.stm.beta_from_reference(beta, vocab[:2], corpus)
+
+
 def test_content_kappa_reconstructs_content_beta():
     """SAGE kappa decomposition (issue #237): m + kappa_topic + kappa_cov +
     kappa_interaction, softmax over words, reproduces the per-group topic-word."""


### PR DESCRIPTION
## Summary

Two additions to `topica.STM`, both from the #871 STM held-out investigation. On
threaded/thin-document corpora the logistic-normal EM has **catastrophic local
optima** that any single spectral or random init can fall into — much worse
held-out completion *and* the worst variational bound.

- **`STM.fit(restarts=N)`** — fit N independently-seeded starts (restart 0 = the
  configured init, rest = fresh random seeds) and return the **best-bound** model.
  Catastrophic basins carry the worst bound, so best-of-N reliably avoids them.
  Validated: a −6.354 spectral catastrophe → −6.189 with `restarts=5`, with no
  regression on well-behaved splits. Returns the best model (capture the return
  value); rejects a fixed `beta_init`.
- **`topica.stm.beta_from_reference(beta, ref_vocab, target)`** — align an
  externally fit topic-word matrix (e.g. R `stm`'s `exp(fit$beta$logbeta[[1]])`)
  to topica's vocabulary for `STM.fit(beta_init=)` **exact replication**. R `stm`'s
  default anchor recovery is a non-converging, machine-order-dependent iteration
  (not a portably reproducible target), so injecting its β is the faithful way to
  land in a specific R basin. Handles permutation/transpose, floors missing words,
  warns on low overlap.

## Why (the #871 finding)

R `stm`'s completion edge on thin-document corpora comes from its default anchor
recovery being **chaotic/under-converged** — it lands in a training-*worse* but
generalizes-*better* basin. topica's principled converged recovery lands in
training-better/generalizes-worse basins. No training-observable criterion selects
R's basin, so the residual is irreducible without injecting R's β. topica's *topics*
are better by the estimator-free oracle; the gap is a basin artifact, not a bug.
The catastrophic instability is **regime-specific to thin-document corpora**
(confirmed stable on the standard congress STM corpus at the same V>10000).

## Notes

- Pure Python-layer change; the compiled core is **untouched**.
- Corrected the STM replication vignette's init section and added an API entry.
- Adds tests for both features. `just pre-pr` gate green locally (pytest, mkdocs
  --strict, preflight/stub/table sync).

🤖 Generated with [Claude Code](https://claude.com/claude-code)